### PR TITLE
Changes top bar of patient view for patients with multiple samples 

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoClinicalData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoClinicalData.java
@@ -358,6 +358,15 @@ public final class DaoClinicalData {
         return getDataByInternalIds(cancerStudyId, SAMPLE_TABLE, sampleIdsInt, Collections.singletonList(attr.getAttrId()));
     }
 
+    public static List<ClinicalData> getSampleData(int cancerStudyId, Collection<String> sampleIds) throws DaoException
+    {
+        List<Integer> sampleIdsInt = new ArrayList<Integer>();
+        for (String sampleId : sampleIds) {
+            sampleIdsInt.add(DaoSample.getSampleByCancerStudyAndSampleId(cancerStudyId, sampleId).getInternalId());
+        }
+        return getDataByInternalIds(cancerStudyId, SAMPLE_TABLE, sampleIdsInt);
+    }
+
     public static List<ClinicalData> getData(String cancerStudyId, Collection<String> patientIds, ClinicalAttribute attr) throws DaoException
     {
         int internalCancerStudyId = getInternalCancerStudyId(cancerStudyId);

--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -547,7 +547,7 @@ function addMoreClinicalTooltip(elem) {
             var caseId = $(this).attr('alt');
             clinicalData = [];
             for (var key in clinicalDataMap[caseId]) {
-                clinicalData.push([clinicalAttributes[key]["displayName"], clinicalDataMap[caseId][key]]);
+                clinicalData.push([clinicalAttributes && clinicalAttributes[key]["displayName"] || key, clinicalDataMap[caseId][key]]);
             }
             table_text = "<table id='more-sample-info-table-"+caseId+"'></table>";
             dataTable = {
@@ -922,9 +922,12 @@ function outputClinicalData() {
             }
             sample_recs += "<b><u><a style='color: #1974b8;' href='"+cbio.util.getLinkToSampleView(cancerStudyId,caseId)+"'>"+caseId+"</a></b></u><a>&nbsp;"
             
-            var sampleData = {"SAMPLE_TYPE":clinicalDataMap[caseId].SAMPLE_TYPE,
+            var sampleData = {};
+            if (clinicalDataMap.length > 0) {
+                sampleData = {"SAMPLE_TYPE":clinicalDataMap[caseId].SAMPLE_TYPE || "N/A",
                               "METASTATIC_SITE":clinicalDataMap[caseId].METASTATIC_SITE || "N/A",
                               "PRIMARY_SITE":clinicalDataMap[caseId].PRIMARY_SITE || "N/A"};
+            }
             var info = [];
             info = info.concat(formatStateInfo(sampleData));
             sample_recs += info.join(",&nbsp;");
@@ -962,11 +965,15 @@ function outputClinicalData() {
                 $("#link-samples-table").click();
             });
             
-        } else {
+        } else if (n > 1) {
             $("#clinical_div").append(svg_corner + head_recs.replace(/, <\/div>$/, "</div>"));
         }
-        addMoreClinicalTooltip("#more-patient-info");
-        addMoreClinicalTooltip(".more-sample-info");
+        if (patientInfo.length > 0) {
+            addMoreClinicalTooltip("#more-patient-info");
+        }
+        if (clinicalDataMap.length > 0) {
+            addMoreClinicalTooltip(".more-sample-info");
+        }
             
     
     } else {
@@ -990,6 +997,7 @@ function outputClinicalData() {
 
             row += "</td><td align='right'><a href='#' class='more-clinical-a' alt='"+caseId+"'>More about this tumor</a></td></tr>";
             $("#clinical_table").append(row);
+            addMoreClinicalTooltip(".more-clinical-a");
 
         }
     }

--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -968,10 +968,10 @@ function outputClinicalData() {
         } else if (n > 1) {
             $("#clinical_div").append(svg_corner + head_recs.replace(/, <\/div>$/, "</div>"));
         }
-        if (patientInfo.length > 0) {
+        if (Object.keys(patientInfo).length > 0) {
             addMoreClinicalTooltip("#more-patient-info");
         }
-        if (clinicalDataMap.length > 0) {
+        if (Object.keys(clinicalDataMap).length > 0) {
             addMoreClinicalTooltip(".more-sample-info");
         }
             

--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -512,7 +512,7 @@ function addMoreClinicalTooltip(elem) {
         if (thisElem.attr('id') === "more-patient-info") {
             clinicalData = [];
             for (var key in patientInfo) {
-                clinicalData.push([clinicalAttributes[key]["displayName"], patientInfo[key]]);
+                clinicalData.push([(key in clinicalAttributes && clinicalAttributes[key]["displayName"]) || key, patientInfo[key]]);
             }
             table_text = '<table id="more-patient-info-table-'+patientId+'"></table>';
             dataTable = {

--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/samples_table.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/samples_table.jsp
@@ -189,7 +189,7 @@
                 "sInfo": "&nbsp;&nbsp;(_START_ to _END_ of _TOTAL_)&nbsp;&nbsp;",
                 "sInfoFiltered": "",
                 "sLengthMenu": "Show _MENU_ per page",
-                "sEmptyTable": "Could not find any samples."
+                "sEmptyTable": "Could not find any clinical information on samples."
             },
             tableTools: {
                 "sSwfPath": "/swf/copy_csv_xls_pdf.swf",
@@ -209,7 +209,7 @@
         
         clinicalData = [];
         for (var key in patientInfo) {
-            clinicalData.push([key, patientInfo[key]]);
+            clinicalData.push([clinicalAttributes[key]["displayName"], patientInfo[key]]);
         }
         table_text = '<table id="patient-table"></table>';
         var patientDataTable = $("#patient-table").dataTable({
@@ -237,7 +237,7 @@
                 "sInfo": "&nbsp;&nbsp;(_START_ to _END_ of _TOTAL_)&nbsp;&nbsp;",
                 "sInfoFiltered": "",
                 "sLengthMenu": "Show _MENU_ per page",
-                "sEmptyTable": "Could not find any patient."
+                "sEmptyTable": "Could not find any clinical information on patient."
             },
             tableTools: {
                 "sSwfPath": "/swf/copy_csv_xls_pdf.swf",

--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/samples_table.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/samples_table.jsp
@@ -169,14 +169,23 @@
         };
         var all_keys = [];
         all_keys = arrayUnique(($.map(clinicalDataMap, function (o) {return Object.keys(o)})));
+        var samples = Object.keys(clinicalDataMap);
         clinicalData = all_keys.map(function(k) {
             clicopy = {};
             clicopy["ATTR"] = clinicalAttributes[k]["displayName"];
-            Object.keys(clinicalDataMap).forEach(function(k2) {
-               clicopy[k2] =  clinicalDataMap[k2][k] || "N/A";
-            });
+            Object.keys(samples).forEach(function (i) {
+                clicopy[i]
+            })
+            for (var i=0; i<samples.length; ++i) {
+                clicopy[i] =  clinicalDataMap[samples[i]][k] || "N/A";
+            }
             return clicopy;
         });
+        // Columns for datatable
+        var columns = [];
+        for (var i=0; i<samples.length; ++i) {
+            columns.push({"sTitle":samples[i],"mData":i});
+        }
         var samplesDataTable = $("#samples-table").dataTable({
             "bSort": false,
             "sDom": '<"H"TC<"dataTableReset">f>rt',
@@ -184,7 +193,7 @@
             "bDestroy": true,
             "autoWidth": true,
             "aaData": clinicalData,
-            "aoColumns": [{"sTitle":"Attribute","mData":"ATTR"}].concat(Object.keys(clinicalDataMap).map(function(k){return {"sTitle":k.replace(/_/g, ' '),"mData":k}})),
+            "aoColumns": [{"sTitle":"Attribute","mData":"ATTR"}].concat(columns),
             "oLanguage": {
                 "sInfo": "&nbsp;&nbsp;(_START_ to _END_ of _TOTAL_)&nbsp;&nbsp;",
                 "sInfoFiltered": "",
@@ -209,7 +218,7 @@
         
         clinicalData = [];
         for (var key in patientInfo) {
-            clinicalData.push([clinicalAttributes[key]["displayName"], patientInfo[key]]);
+            clinicalData.push([(key in clinicalAttributes && clinicalAttributes[key]["displayName"]) || key, patientInfo[key]]);
         }
         table_text = '<table id="patient-table"></table>';
         var patientDataTable = $("#patient-table").dataTable({

--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/samples_table.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/samples_table.jsp
@@ -1,0 +1,305 @@
+<%--
+ - Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ -
+ - This library is distributed in the hope that it will be useful, but WITHOUT
+ - ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ - FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ - is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ - obligations to provide maintenance, support, updates, enhancements or
+ - modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ - liable to any party for direct, indirect, special, incidental or
+ - consequential damages, including lost profits, arising out of the use of this
+ - software and its documentation, even if Memorial Sloan-Kettering Cancer
+ - Center has been advised of the possibility of such damage.
+ --%>
+
+<%--
+ - This file is part of cBioPortal.
+ -
+ - cBioPortal is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+--%>
+
+<%--
+  ~ Copyright (c) 2012 Memorial Sloan-Kettering Cancer Center.
+  ~ This library is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as published
+  ~ by the Free Software Foundation; either version 2.1 of the License, or
+  ~ any later version.
+  ~
+  ~ This library is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF
+  ~ MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.  The software and
+  ~ documentation provided hereunder is on an "as is" basis, and
+  ~ Memorial Sloan-Kettering Cancer Center
+  ~ has no obligations to provide maintenance, support,
+  ~ updates, enhancements or modifications.  In no event shall
+  ~ Memorial Sloan-Kettering Cancer Center
+  ~ be liable to any party for direct, indirect, special,
+  ~ incidental or consequential damages, including lost profits, arising
+  ~ out of the use of this software and its documentation, even if
+  ~ Memorial Sloan-Kettering Cancer Center
+  ~ has been advised of the possibility of such damage.  See
+  ~ the GNU Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this library; if not, write to the Free Software Foundation,
+  ~ Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+  --%>
+
+<%@ page import="org.mskcc.cbio.portal.dao.DaoTypeOfCancer" %>
+<%@ page import="org.mskcc.cbio.portal.model.TypeOfCancer" %>
+<%@ page import="org.mskcc.cbio.portal.dao.DaoException" %><%
+    String cancerTypeId = cancerStudy.getTypeOfCancerId().trim();
+    TypeOfCancer typeOfCancerById = DaoTypeOfCancer.getTypeOfCancerById(cancerTypeId);
+    String trialKeywords = typeOfCancerById.getClinicalTrialKeywords();
+%>
+
+<style type="text/css">
+@import "css/data_table_jui.css?<%=GlobalProperties.getAppVersion()%>";
+@import "css/data_table_ColVis.css?<%=GlobalProperties.getAppVersion()%>";
+.clinical-attr-table .ColVis {
+        float: left;
+        margin-bottom: 0
+}
+.clinical-attr-table .dataTables_length {
+        width: auto;
+        float: right;
+}
+.clinical-attr-table .dataTables_info {
+        clear: none;
+        width: auto;
+        float: right;
+}
+.clinical-attr-table .dataTables_filter {
+        width: 40%;
+}
+.clinical-attr-table .div.datatable-paging {
+        width: auto;
+        float: right;
+}
+.clinical-attr-table .data-table-name {
+        float: left;
+        font-weight: bold;
+        font-size: 120%;
+        vertical-align: middle;
+}
+.clinical-attr-table .ColVis_collection {
+    width: 500px;
+}
+.clinical-attr-table .ColVis_Button {
+    white-space: nowrap;
+}
+.clinical-attr-table .ColVis_Button.TableTools_Button.ColVis_MasterButton{
+    outline: none;
+    background-color: white;
+/*    color: #2986e2;
+    border: 1px solid #2986e2;
+    border-radius: 5px;
+    -webkit-border-radius: 5px;
+    -moz-border-radius: 5px;*/
+    cursor: pointer;
+    height: 23px;
+    padding: 0;
+}
+.clinical-attr-table .ColVis_Button.TableTools_Button.ColVis_MasterButton span{
+    padding: 2px 6px 3px 6px;
+}
+.clinical-attr-table #dataTables_filter {
+    width:auto;
+    float: right;
+}
+.clinical-attr-table .dataTables_filter label input {
+    appearance: searchfield;
+    -moz-appearance: searchfield;
+    -webkit-appearance: searchfield;
+}
+.clinical-attr-table table.dataTable>tbody>tr>td {
+    white-space: nowrap;
+}
+.clinical-attr-table .DTTT_container.ui-buttonset.ui-buttonset-multi a {
+    width: 50px;
+    height: 20px;
+    line-height: 20px;
+}
+.clinical-attr-table .DTTT_container.ui-buttonset.ui-buttonset-multi {
+    float: left;
+}
+.table-link {
+    color: #428bca;
+    cursor: pointer;
+}
+</style>
+<script type="text/javascript" src="js/lib/jquery.highlight-4.js?<%=GlobalProperties.getAppVersion()%>"></script>
+<script type="text/javascript">
+    /* Get attribute to display name mapping */
+    /*
+    var xmlhttp = new XMLHttpRequest();
+    var url = "js/src/patient-view/norm2display.json";
+
+    xmlhttp.onreadystatechange = function() {
+        if (xmlhttp.readyState == 4 && xmlhttp.status == 200) {
+            var myArr = JSON.parse(xmlhttp.responseText);
+            myFunction(myArr);
+        }
+    }
+    xmlhttp.open("GET", url, true);
+    xmlhttp.send();*/
+   
+    // Build the table
+    var populateSamplesTable = function() {
+        $("#samples_table_wait").hide();
+        
+        table_text = '<table id="samples-table"></table>';
+        var arrayUnique = function(a) {
+            return a.reduce(function(p, c) {
+                if (p.indexOf(c) < 0) p.push(c);
+                return p;
+            }, []);
+        };
+        var all_keys = [];
+        all_keys = arrayUnique(($.map(clinicalDataMap, function (o) {return Object.keys(o)})));
+        clinicalData = all_keys.map(function(k) {
+            clicopy = {};
+            clicopy["ATTR"] = clinicalAttributes[k]["displayName"];
+            Object.keys(clinicalDataMap).forEach(function(k2) {
+               clicopy[k2] =  clinicalDataMap[k2][k] || "N/A";
+            });
+            return clicopy;
+        });
+        var samplesDataTable = $("#samples-table").dataTable({
+            "bSort": false,
+            "sDom": '<"H"TC<"dataTableReset">f>rt',
+            "bJQueryUI": true,
+            "bDestroy": true,
+            "autoWidth": true,
+            "aaData": clinicalData,
+            "aoColumns": [{"sTitle":"Attribute","mData":"ATTR"}].concat(Object.keys(clinicalDataMap).map(function(k){return {"sTitle":k.replace(/_/g, ' '),"mData":k}})),
+            "oLanguage": {
+                "sInfo": "&nbsp;&nbsp;(_START_ to _END_ of _TOTAL_)&nbsp;&nbsp;",
+                "sInfoFiltered": "",
+                "sLengthMenu": "Show _MENU_ per page",
+                "sEmptyTable": "Could not find any samples."
+            },
+            tableTools: {
+                "sSwfPath": "/swf/copy_csv_xls_pdf.swf",
+                "aButtons": [
+                    "copy",
+                    "csv"
+                ]
+            },
+            "iDisplayLength": -1
+        }); 
+        samplesDataTable.css("width","100%");
+        $("#samples-table_wrapper").addClass("clinical-attr-table");
+    };
+    
+    var populatePatientTable = function() {
+        $("#patient_table_wait").hide();
+        
+        clinicalData = [];
+        for (var key in patientInfo) {
+            clinicalData.push([key, patientInfo[key]]);
+        }
+        table_text = '<table id="patient-table"></table>';
+        var patientDataTable = $("#patient-table").dataTable({
+            "bSort": false,
+            "sDom": '<"H"TC<"dataTableReset">f>rt',
+            "bJQueryUI": true,
+            "bDestroy": true,
+            "autoWidth": true,
+            "aaData": clinicalData,
+            "aoColumnDefs": [
+                {
+                    "sTitle": "Attribute",
+                    "aTargets": [ 0 ],
+                    "sClass": "left-align-td",
+                },
+                {
+                    "sTitle": "Value",
+                    "aTargets": [ 1 ],
+                    "sClass": "left-align-td",
+                    "bSortable": false
+                }
+            ],
+            "aaSorting": [[0,'asc']],
+            "oLanguage": {
+                "sInfo": "&nbsp;&nbsp;(_START_ to _END_ of _TOTAL_)&nbsp;&nbsp;",
+                "sInfoFiltered": "",
+                "sLengthMenu": "Show _MENU_ per page",
+                "sEmptyTable": "Could not find any patient."
+            },
+            tableTools: {
+                "sSwfPath": "/swf/copy_csv_xls_pdf.swf",
+                "aButtons": [
+                    "copy",
+                    "csv"
+                ]
+            },
+            "iDisplayLength": -1
+        });
+        patientDataTable.css("width","100%");
+        $("#patient-table_wrapper").addClass("clinical-attr-table");
+    };
+    
+    var patientTableLoaded = false;
+    function loadPatientTable() {
+        if (patientTableLoaded) return;
+        populatePatientTable();
+        patientTableLoaded = true;
+    }
+    
+    var samplesTableLoaded = false;
+    function loadSamplesTable() {
+        if (samplesTableLoaded) return;
+        populateSamplesTable();
+        samplesTableLoaded = true;
+    }
+    
+    $("#link-samples-table").click( function() {
+        loadSamplesTable();
+        loadPatientTable();
+
+        $("#load-samples-table").click( function() {
+            $("#patient-table_wrapper").hide();
+            $("#samples-table_wrapper").show();
+            $(this).css("color", "black");
+            $(this).css("font-weight", "bold");
+            $(this).css("cursor", "text");
+            $("#load-patient-table").css("color", "#428bca");
+            $("#load-patient-table").css("cursor", "pointer");
+            $("#load-patient-table").css("font-weight", "normal");
+        });
+        $("#load-samples-table").click();
+        
+        $("#load-patient-table").click( function() {
+            $("#samples-table_wrapper").hide();
+            $("#patient-table_wrapper").show();
+            $(this).css("color", "black");
+            $(this).css("font-weight", "bold");
+            $(this).css("cursor", "text");
+            $("#load-samples-table").css("color", "#428bca");
+            $("#load-samples-table").css("cursor", "pointer");
+            $("#load-samples-table").css("font-weight", "normal");
+        });
+    });
+</script>
+
+<h3 style="color: black;">Clinical Information</h3>
+<a id="load-samples-table" class="table-link activated">Samples</a> / <a id="load-patient-table" class="table-link">Patient</a>
+<table id="samples-table">
+</table>
+<div id="samples_table_wait"><img src="images/ajax-loader.gif"/></div>
+<table id="patient-table">
+</table>
+<div id="patient_table_wait"><img src="images/ajax-loader.gif"/></div>


### PR DESCRIPTION
This PR does the following:
- Adds sample clinical attributes for multiple samples on a single line
- Change styling sightly
- Add extra tab with downloadable patient/sample table

An example with many patients can be seen on the dev server at ```patient-view-topbar/case.do?cancer_study_id=prad_fhcrc&case_id=05-144``` (not sure if it's alright to post the full link publicly).