### PR TITLE
Patient view topbar extensions

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -1275,8 +1275,8 @@ function fillColorAndLabelForCase(circle, caseId) {
     var color = caseMetaData.color[caseId];
     circle.select("circle").attr("fill",color);
     circle.append("text")
-        .attr("x",-3)
         .attr("y",4)
+        .attr("text-anchor","middle")
         .attr("font-size",10)
         .attr("fill","white")
         .text(label);

--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -371,7 +371,9 @@ if (patientViewError!=null) {
         color: #428bca;
         padding: 0 5px;
     }
-    
+    .sample-record-inline:last-child .sample-record-delimiter {
+		visibility: hidden;
+	}
     #page_wrapper_table {
         background-color: white;
     }
@@ -890,7 +892,7 @@ function outputClinicalData() {
         //var row = "<tr><td><b>Patient</b></td>";
         //$("#clinical_table").append(row);
 
-        row = "<div style='white-space: nowrap;'><span id='more-patient-info'><b><u><a href='"+cbio.util.getLinkToPatientView(cancerStudyId,patientId)+"'>"+patientId+"</a></b></u><a>&nbsp;";
+        row = "<span id='more-patient-info'><b><u><a href='"+cbio.util.getLinkToPatientView(cancerStudyId,patientId)+"'>"+patientId+"</a></b></u><a>&nbsp;";
         var info = [];
         var loc;
         if ("PRIMARY_SITE" in patientInfo) {loc = (" (" + patientInfo["PRIMARY_SITE"] + ")")} else {loc=""};
@@ -898,16 +900,15 @@ function outputClinicalData() {
         var info = info.concat(formatDiseaseInfo(patientInfo));
         var info = info.concat(formatPatientStatus(patientInfo));
         row += info.join(", ");
-        row += "</a></span><span style='float: right'>" + formatCancerStudyInfo()+ "</span></div>";
+        row += "</a></span><span style='float: right'>" + formatCancerStudyInfo()+ "</span><br />";
         $("#clinical_div").append(row);
         
         var head_recs = "";
         var tail_recs = "";
         var sample_recs = "";
         var nr_in_head = 5;
-        var max_in_tail = 20;
         var is_expanded = false;
-        for (var i=0; i<Math.min(n, nr_in_head+max_in_tail); i++) {
+        for (var i=0; i<n; i++) {
             var caseId = caseIds[i];
             
             sample_recs += "<div class='sample-record-inline more-sample-info' alt='"+caseId+"'>";
@@ -925,7 +926,7 @@ function outputClinicalData() {
             var info = [];
             info = info.concat(formatStateInfo(sampleData));
             sample_recs += info.join(",&nbsp;");
-            sample_recs += "</a>, </div>";
+            sample_recs += "</a><span class='sample-record-delimiter'>, </span></div>";
             
             if ((n > nr_in_head && i == nr_in_head-1) || (n <= nr_in_head && i == n-1)) {
                 head_recs = sample_recs;

--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -366,10 +366,6 @@ if (patientViewError!=null) {
 		cursor: pointer;
 	}
     /* Sample records style */
-    .sample-record {
-        color: #428bca;
-        text-align: left;
-    }
     .sample-record-inline {
         display: inline-block;
         color: #428bca;
@@ -584,9 +580,6 @@ function addMoreClinicalTooltip(elem) {
             thisElem.remove();
         } else {
             var pos = {my:'top right',at:'bottom right',viewport: $(window)};
-            if (thisElem.attr('class') && thisElem.attr('class').indexOf("sample-record ") > -1) {
-                pos = {my:'right center',at:'left center',viewport: $(window)};
-            }
             thisElem.qtip({
                 content: {
                     text: table_text
@@ -913,10 +906,11 @@ function outputClinicalData() {
         var sample_recs = "";
         var nr_in_head = 5;
         var max_in_tail = 20;
+        var is_expanded = false;
         for (var i=0; i<Math.min(n, nr_in_head+max_in_tail); i++) {
             var caseId = caseIds[i];
             
-            sample_recs += "<div class='sample-record more-sample-info' alt='"+caseId+"'>";
+            sample_recs += "<div class='sample-record-inline more-sample-info' alt='"+caseId+"'>";
             if (n>1) {
                 sample_recs += "<svg width='12' height='12' class='case-label-header' alt='"+caseId+"'></svg>&nbsp;";
             }
@@ -931,40 +925,30 @@ function outputClinicalData() {
             var info = [];
             info = info.concat(formatStateInfo(sampleData));
             sample_recs += info.join(",&nbsp;");
-            sample_recs += "</a></div>";
+            sample_recs += "</a>, </div>";
             
             if ((n > nr_in_head && i == nr_in_head-1) || (n <= nr_in_head && i == n-1)) {
-                head_recs = sample_recs.replace(/sample-record/g, 'sample-record-inline').replace(/<\/div>/g, ", </div>");
+                head_recs = sample_recs;
                 sample_recs = "";
             }
         }
         var svg_corner = '<svg width="20" height="15" style="top: -10px;"><line x1="10" y1="0" x2="10" y2="10" stroke="gray" stroke-width="2"></line><line x1="10" y1="10" x2="50" y2="10" stroke="gray" stroke-width="2"></line></svg>';
         if (n > nr_in_head) {
             tail_recs = sample_recs;
-            $("#clinical_div").append(svg_corner + head_recs + "<b><a id='sample-btn-topbar' style='cursor:pointer'>("+(n-nr_in_head)+" more)</a></b>");
-            $("#sample-btn-topbar").qtip({
-                content: {
-                    text: "sample_extra_info"
-                },
-                events: {
-                    render: function(event, api) {
-                        $(this).html(tail_recs + "<b><a id='sample-btn-tail' style='cursor:pointer'>Show all (" + n + " total)</a></b>");
-                        $("#sample-btn-tail").click(function () {
-                            $("#link-samples-table").click();
-                        });
-                        addMoreClinicalTooltip(".more-sample-info");
-                        plotCaseLabel('.case-label-header', false, true);
-                    }
-                },
-                    show: {event: "mouseover"},
-                hide: {fixed: true, delay: 100, event: "mouseout"},
-                style: { classes: 'qtip-light qtip-rounded' },
-                position: {my:'top right',at:'bottom right',viewport: $(window)}
+            $("#clinical_div").append(svg_corner + head_recs + "<a id='sample-btn-topbar' style='font-weight: bold; cursor:pointer'>(Show "+(n-nr_in_head)+" more)</a>");
+            $("#sample-btn-topbar").click(function() {
+                if (!is_expanded) {
+                    $("<span id='sample-tail-records'>"+tail_recs+"</span>").insertBefore("#sample-btn-topbar");
+                    addMoreClinicalTooltip(".more-sample-info");
+                    plotCaseLabel('.case-label-header', false, true);
+                    $("#sample-btn-topbar").text("(Show less)");
+                    is_expanded = true;
+                } else {
+                    $("#sample-tail-records").remove();
+                    $("#sample-btn-topbar").text("(Show "+(n-nr_in_head)+" more)");
+                    is_expanded = false;
+                }
             });
-            $("#sample-btn-topbar").click(function () {
-                $("#link-samples-table").click();
-            });
-            
         } else if (n > 1) {
             $("#clinical_div").append(svg_corner + head_recs.replace(/, <\/div>$/, "</div>"));
         }

--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/summary.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/summary.jsp
@@ -219,6 +219,9 @@ legend.legend-border {
     color:#1974b8;
     margin-bottom: 0px;
 }
+#mutation_summary_table tbody tr div {
+    white-space: nowrap;
+}
 </style>
 
 <%if(showTimeline){%>


### PR DESCRIPTION
- Collapse/Expand feature for samples at the top of the patient view. Feature was removed by a force push to the main repo. This PR adds the feature again.

    ![topbar_collapse_expand](https://cloud.githubusercontent.com/assets/1334004/7813445/3fefc60a-0389-11e5-9bc8-b56235f8cfb1.gif)

- Removes trailing comma from last sample when all samples are shown in expand mode as requested by @zhx828 

- Moves study name to the top right in Firefox as it is in Chrome. Before the study name would be one line below the top line.

- Center the text on all sample labels in patient view. They were slightly to the right before. Sample labels are the circles with a number on them.

- Fix multiline sample labels in mutations summary table. The sample labels in the mutation summary table are on a single line in Chrome. In Firefox they were on mutliple lines. This PR puts them on a single line.