### PR TITLE
Add space between sex and age patient view topbar

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -896,7 +896,7 @@ function outputClinicalData() {
         var info = [];
         var loc;
         if ("PRIMARY_SITE" in patientInfo) {loc = (" (" + patientInfo["PRIMARY_SITE"] + ")")} else {loc=""};
-        var info = info.concat(formatPatientInfo(patientInfo) + loc);
+        var info = info.concat(formatPatientInfo(patientInfo).join(", ") + loc);
         var info = info.concat(formatDiseaseInfo(patientInfo));
         var info = info.concat(formatPatientStatus(patientInfo));
         row += info.join(", ");


### PR DESCRIPTION
Adds a space between sex and age in the top bar of the patient view. Fixes issue in attached image:

![pasted_image_at_2015_05_26_11_56_pm](https://cloud.githubusercontent.com/assets/1334004/7837391/a3423c26-0454-11e5-8887-5f3743d98a94.png)