### PR TITLE
Fix patient view topbar samples not showing type

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -919,9 +919,12 @@ function outputClinicalData() {
             
             var sampleData = {};
             if (Object.keys(clinicalDataMap).length > 0) {
-                sampleData = {"SAMPLE_TYPE":clinicalDataMap[caseId].SAMPLE_TYPE || "N/A",
-                              "METASTATIC_SITE":clinicalDataMap[caseId].METASTATIC_SITE || "N/A",
-                              "PRIMARY_SITE":clinicalDataMap[caseId].PRIMARY_SITE || "N/A"};
+                var info_keys = ["SAMPLE_TYPE", "METASTATIC_SITE", "PRIMARY_SITE"];
+                for (var j=0; j < info_keys.length; j++) {
+                    if (info_keys[j] in clinicalDataMap[caseId]) {
+                        sampleData[info_keys[j]] = clinicalDataMap[caseId][info_keys[j]];
+                    }
+                }
             }
             var info = [];
             info = info.concat(formatStateInfo(sampleData));

--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -918,7 +918,7 @@ function outputClinicalData() {
             sample_recs += "<b><u><a style='color: #1974b8;' href='"+cbio.util.getLinkToSampleView(cancerStudyId,caseId)+"'>"+caseId+"</a></b></u><a>&nbsp;"
             
             var sampleData = {};
-            if (clinicalDataMap.length > 0) {
+            if (Object.keys(clinicalDataMap).length > 0) {
                 sampleData = {"SAMPLE_TYPE":clinicalDataMap[caseId].SAMPLE_TYPE || "N/A",
                               "METASTATIC_SITE":clinicalDataMap[caseId].METASTATIC_SITE || "N/A",
                               "PRIMARY_SITE":clinicalDataMap[caseId].PRIMARY_SITE || "N/A"};


### PR DESCRIPTION
In patient view top bar change 

![screen shot 2015-05-27 at 6 15 34 pm](https://cloud.githubusercontent.com/assets/1334004/7848736/6f83f148-049c-11e5-842e-804a58853be9.png)

to

![screen shot 2015-05-27 at 6 15 40 pm](https://cloud.githubusercontent.com/assets/1334004/7848734/6b81b6fc-049c-11e5-8be7-f65614fa76ad.png)

(Does not remove corner symbol at start, just adds the sample type info)
