### PR TITLE
fix for standalone MutationMapper page init issue

### DIFF
--- a/portal/src/main/webapp/mutation_mapper.jsp
+++ b/portal/src/main/webapp/mutation_mapper.jsp
@@ -204,8 +204,10 @@ $(document).ready(function() {
 			},
 			proxy: {
 				mutationProxy: {
-					lazy: false,
-					data: mutationData
+					options: {
+						initMode: "full",
+						data: mutationData
+					}
 				}
 			},
 			view: {


### PR DESCRIPTION
A fix related to recent changes in the data proxy options of MutationMapper