### PR TITLE
get raw gene list parameter to deal with Xss

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/CrossCancerJSON.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/CrossCancerJSON.java
@@ -89,6 +89,9 @@ public class CrossCancerJSON extends HttpServlet {
 
             // Get the gene list
             String geneList = request.getParameter(QueryBuilder.GENE_LIST);
+            if (request instanceof XssRequestWrapper) {
+            	geneList = ((XssRequestWrapper)request).getRawParameter(QueryBuilder.GENE_LIST);
+            }
 	    String cancerStudyIdListString = request.getParameter(QueryBuilder.CANCER_STUDY_LIST);
 	    String[] cancerStudyIdList = cancerStudyIdListString.split(",");
 


### PR DESCRIPTION
The XSS system gives newline characters (\n) an extra backslash (\\n), thus rendering them not newline characters, but literally the string "\n", which causes problems in OQL parsing.

This gets around that problem by requesting the raw parameter.