### PR TITLE
OncoKB update

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/mutations.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/mutations.jsp
@@ -53,7 +53,7 @@
     };
     
     var oncoKBDataInject = function(oTable, tableId) {
-        if(!genomicEventObs.oncoKBBuilt) {
+        if(!oncoKBDataReady) {
             OncoKBConnector.init({'url': oncokbUrl||''});
             OncoKBConnector.oncokbAccess(function(flag){
                 console.log(flag);
@@ -63,7 +63,6 @@
                     addOncoKBListener(oTable, tableId);
                 }
             });
-            genomicEventObs.oncoKBBuilt = true;
         }else {
             addOncoKBListener(oTable, tableId);
         }

--- a/portal/src/main/webapp/js/src/patient-view/OncoKBConnector.js
+++ b/portal/src/main/webapp/js/src/patient-view/OncoKBConnector.js
@@ -70,7 +70,8 @@ var OncoKBConnector = (function(){
             url: oncokbUrl + 'evidence.json',
             data: {
                 'hugoSymbol' : geneStr.substring(0, geneStr.length - 1),
-                'alteration': alterationStr.substring(0, alterationStr.length - 1)
+                'alteration': alterationStr.substring(0, alterationStr.length - 1),
+                'geneStatus': 'complete'
             },
             crossDomain: true,
             dataType: 'json',

--- a/portal/src/main/webapp/js/src/patient-view/genomic-event-observer.js
+++ b/portal/src/main/webapp/js/src/patient-view/genomic-event-observer.js
@@ -43,7 +43,6 @@ function GenomicEventObserver(hasMut, hasCna, hasSeg) {
     this.mutBuilt = false;
     this.cnaBuilt = false;
     this.pancanFreqBuilt = false;
-    this.oncoKBBuilt = false;
     this.mutations = new GenomicEventContainer;
     this.cnas = new GenomicEventContainer;
 }


### PR DESCRIPTION
Added geneStatus to OncoKB url, only pull evidence from completed genes;
Removed oncoKBBuilt;
If data is available, don’t need to pull from OncoKB again;