### PR TITLE
fix http servelt typo

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/LinkOut.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/LinkOut.java
@@ -55,7 +55,7 @@ public class LinkOut extends HttpServlet {
      * Handles HTTP GET Request.
      *
      * @param httpServletRequest  Http Servlet Request Object.
-     * @param httpServletResponse Http Servelt Response Object.
+     * @param httpServletResponse Http Servlet Response Object.
      * @throws javax.servlet.ServletException Servlet Error.
      * @throws java.io.IOException      IO Error.
      */
@@ -82,7 +82,7 @@ public class LinkOut extends HttpServlet {
      * Handles HTTP POST Request.
      *
      * @param httpServletRequest  Http Servlet Request Object.
-     * @param httpServletResponse Http Servelt Response Object.
+     * @param httpServletResponse Http Servlet Response Object.
      * @throws javax.servlet.ServletException Servlet Error.
      * @throws java.io.IOException      IO Error.
      */

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/PortalMetaDataJSON.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/PortalMetaDataJSON.java
@@ -145,7 +145,7 @@ public class PortalMetaDataJSON extends HttpServlet {
      * Handles HTTP GET Request.
      *
      * @param httpServletRequest Http Servlet Request Object.
-     * @param httpServletResponse Http Servelt Response Object.
+     * @param httpServletResponse Http Servlet Response Object.
      * @throws javax.servlet.ServletException Servlet Error.
      * @throws java.io.IOException IO Error.
      */

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
@@ -137,7 +137,7 @@ public class QueryBuilder extends HttpServlet {
      * Handles HTTP GET Request.
      *
      * @param httpServletRequest  Http Servlet Request Object.
-     * @param httpServletResponse Http Servelt Response Object.
+     * @param httpServletResponse Http Servlet Response Object.
      * @throws ServletException Servlet Error.
      * @throws IOException      IO Error.
      */
@@ -151,7 +151,7 @@ public class QueryBuilder extends HttpServlet {
      * Handles HTTP POST Request.
      *
      * @param httpServletRequest  Http Servlet Request Object.
-     * @param httpServletResponse Http Servelt Response Object.
+     * @param httpServletResponse Http Servlet Response Object.
      * @throws ServletException Servlet Error.
      * @throws IOException      IO Error.
      */

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/ShowData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/ShowData.java
@@ -56,7 +56,7 @@ public class ShowData extends HttpServlet {
      * Handles HTTP GET Request.
      *
      * @param request  Http Servlet Request Object.
-     * @param response Http Servelt Response Object.
+     * @param response Http Servlet Response Object.
      * @throws javax.servlet.ServletException Servlet Error.
      * @throws java.io.IOException            IO Error.
      */


### PR DESCRIPTION
Fixed a repeated typo in the servlet javadocs: "Http Servelt"

Signed-off-by: Jules Kerssemakers <j.kerssemakers@dkfz-heidelberg.de>