### PR TITLE
Active directory

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/AccessControl.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/AccessControl.java
@@ -49,6 +49,7 @@ import java.util.List;
 public interface AccessControl {
 
     public static final String ALL_CANCER_STUDIES_ID = "all";
+    public static final String PUBLIC_CANCER_STUDIES_GROUP = "public";
     public static final String ALL_TCGA_CANCER_STUDIES_ID = "all_tcga";
     public static final String ALL_TARGET_CANCER_STUDIES_ID = "all_nci_target";
     public static final String MULTIPLE_CANCER_STUDIES_ID = "multiple";

--- a/core/src/main/java/org/mskcc/cbio/portal/util/CancerStudyPermissionEvaluator.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/CancerStudyPermissionEvaluator.java
@@ -199,12 +199,16 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
         String appName = GlobalProperties.getAppName().toUpperCase();
         Set<String> allAuthorities = AuthorityUtils.authorityListToSet(user.getAuthorities());
         Set<String> grantedAuthorities = new HashSet<>();
-        for (String au : allAuthorities) {
-            if (au.toUpperCase().startsWith(appName + ":")) {
-                grantedAuthorities.add(au.substring(appName.length() + 1));
+        if (GlobalProperties.filterGroupsByAppName()) {
+            for (String au : allAuthorities) {
+                if (au.toUpperCase().startsWith(appName + ":")) {
+                    grantedAuthorities.add(au.substring(appName.length() + 1));
+                }
             }
+            return grantedAuthorities;
+        } else {
+            return allAuthorities;
         }
-        return grantedAuthorities;
     }
 }
 

--- a/core/src/main/java/org/mskcc/cbio/portal/util/CancerStudyPermissionEvaluator.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/CancerStudyPermissionEvaluator.java
@@ -37,6 +37,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.mskcc.cbio.portal.model.CancerStudy;
@@ -57,157 +58,154 @@ import org.springframework.security.core.userdetails.User;
  */
 class CancerStudyPermissionEvaluator implements PermissionEvaluator {
 
-	// ref to log
-	private static Log log = LogFactory.getLog(CancerStudyPermissionEvaluator.class);
+    // ref to log
+    private static Log log = LogFactory.getLog(CancerStudyPermissionEvaluator.class);
 
     /**
-	 * Implementation of {@code PermissionEvaluator}.
-	 * We do not support this method call.
-	 */
-        @Override
-	public boolean hasPermission(Authentication authentication, Serializable targetId,
-								 String targetType, Object permission) {
-		throw new UnsupportedOperationException();
-	}
+     * Implementation of {@code PermissionEvaluator}.
+     * We do not support this method call.
+     */
+    @Override
+    public boolean hasPermission(Authentication authentication, Serializable targetId,
+                                 String targetType, Object permission) {
+        throw new UnsupportedOperationException();
+    }
 
-	/**
-	 * Implementation of {@code PermissionEvaluator}.
-	 */
-	public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
+    /**
+     * Implementation of {@code PermissionEvaluator}.
+     */
+    public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
 
-		if (GlobalProperties.usersMustBeAuthorized()) {
+        if (GlobalProperties.usersMustBeAuthorized()) {
 
-			if (log.isDebugEnabled()) {
-				log.debug("hasPermission(), authorization is true, checking permissions...");
-			}
+            if (log.isDebugEnabled()) {
+                log.debug("hasPermission(), authorization is true, checking permissions...");
+            }
 
-			CancerStudy cancerStudy = null;
-			if (targetDomainObject instanceof CancerStudy) {
-				cancerStudy = ((CancerStudy)targetDomainObject);
-			}
+            CancerStudy cancerStudy = null;
+            if (targetDomainObject instanceof CancerStudy) {
+                cancerStudy = ((CancerStudy) targetDomainObject);
+            }
 
-			if (log.isDebugEnabled()) {
-				if (cancerStudy == null) {
-					log.debug("hasPermission(), stable cancer study ID is null.");
-				} 
-				if (authentication == null) {
-					log.debug("hasPermission(), authentication is null.");
-				}
-			}
-
-			// nothing to do if stable cancer study is null or authentication is null
-			// return false as spring-security document specifies
-			if (cancerStudy == null || authentication == null) {
-				return false;
-			}
-
-			User user = (User) authentication.getPrincipal();
-			if (user != null) {
-				return hasPermission(cancerStudy, user);
-			}
-			else {
-				return false;
-			}
-		}		else {
-			if (log.isDebugEnabled()) {
-				log.debug("hasPermission(), authorization is false, returning true...");
-			}
-			return true;
-		}
-	}
-
-	/**
-	 * Helper function to determine if given user has access to given cancer study.
-	 *
-	 * @param stableStudyID String
-	 * @param user SocialUserDetails
-	 * @return boolean
-	 */
-	private boolean hasPermission(CancerStudy cancerStudy, User user) {
-
-        Set<String> grantedAuthorities = getGrantedAuthorities(user);
-                
-        String stableStudyID = cancerStudy.getCancerStudyStableId();
-
-		if (log.isDebugEnabled()) {
-			log.debug("hasPermission(), cancer study stable id: " + stableStudyID);
-			log.debug("hasPermission(), user: " + user.getUsername());
-			for (String authority : grantedAuthorities) {
-				log.debug("hasPermission(), authority: " + authority);
-			}
-		}
-
-		// a user has permission to access the 'all' cancer study (everybody does)
-		if (stableStudyID.equalsIgnoreCase(AccessControl.ALL_CANCER_STUDIES_ID)) {
-			return true;
-		}
-		// if a user has access to 'all', simply return true
-		if (grantedAuthorities.contains(AccessControl.ALL_CANCER_STUDIES_ID.toUpperCase())) {
-			if (log.isDebugEnabled()) {
-				log.debug("hasPermission(), user has access to ALL cancer studies, return true");
-			}
-			return true;
-		}
-		// if a user has access to 'all_tcga', simply return true for tcga studies
-		if (grantedAuthorities.contains(AccessControl.ALL_TCGA_CANCER_STUDIES_ID.toUpperCase()) &&
-			stableStudyID.toUpperCase().endsWith("_TCGA")) {
-			if (log.isDebugEnabled()) {
-				log.debug("hasPermission(), user has access to ALL_TCGA cancer studies return true");
-			}
-			return true;
-		}
-		// if a user has access to 'all_target', simply return true for target studies
-		if (grantedAuthorities.contains(AccessControl.ALL_TARGET_CANCER_STUDIES_ID.toUpperCase()) &&
-			(stableStudyID.toUpperCase().endsWith("_TARGET")
-                         || stableStudyID.equalsIgnoreCase("ALL_TARGET_PHASE1")
-                         || stableStudyID.equalsIgnoreCase("ALL_TARGET_PHASE2"))) {
-			if (log.isDebugEnabled()) {
-				log.debug("hasPermission(), user has access to ALL_NCI_TARGET cancer studies return true");
-			}
-			return true;
-		}
-                
-                // for groups
-				Set<String> groups = Collections.emptySet();
-				try {
-                	groups = cancerStudy.getFreshGroups();
+            if (log.isDebugEnabled()) {
+                if (cancerStudy == null) {
+                    log.debug("hasPermission(), stable cancer study ID is null.");
                 }
-                catch (DaoException e) {
-					groups = cancerStudy.getGroups();
-                }
-                if (!Collections.disjoint(groups, grantedAuthorities)) {
-			if (log.isDebugEnabled()) {
-				log.debug("hasPermission(), user has access by groups return true");
-			}
-			return true;
-                }
-
-		boolean toReturn = grantedAuthorities.contains(stableStudyID.toUpperCase());
-
-		if (log.isDebugEnabled()) {
-			if (toReturn == true) {
-				log.debug("hasPermission(), user has access to this cancer study: '" + stableStudyID + "', returning true.");
-			}
-			else {
-				log.debug("hasPermission(), user does not have access to the cancer study: '" + stableStudyID + "', returning false.");
-			}
-		}
-
-		// outta here
-		return toReturn;
-	}
-        
-        private Set<String> getGrantedAuthorities(User user) {
-            String appName = GlobalProperties.getAppName().toUpperCase();
-            Set<String> allAuthorities = AuthorityUtils.authorityListToSet(user.getAuthorities());
-            Set<String> grantedAuthorities = new HashSet<>();
-            for (String au : allAuthorities) {
-                if (au.toUpperCase().startsWith(appName+":")) {
-                    grantedAuthorities.add(au.substring(appName.length()+1));
+                if (authentication == null) {
+                    log.debug("hasPermission(), authentication is null.");
                 }
             }
-            return grantedAuthorities;
+
+            // nothing to do if stable cancer study is null or authentication is null
+            // return false as spring-security document specifies
+            if (cancerStudy == null || authentication == null) {
+                return false;
+            }
+
+            User user = (User) authentication.getPrincipal();
+            if (user != null) {
+                return hasPermission(cancerStudy, user);
+            } else {
+                return false;
+            }
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("hasPermission(), authorization is false, returning true...");
+            }
+            return true;
         }
+    }
+
+    /**
+     * Helper function to determine if given user has access to given cancer study.
+     *
+     * @param stableStudyID String
+     * @param user SocialUserDetails
+     * @return boolean
+     */
+    private boolean hasPermission(CancerStudy cancerStudy, User user) {
+
+        Set<String> grantedAuthorities = getGrantedAuthorities(user);
+
+        String stableStudyID = cancerStudy.getCancerStudyStableId();
+
+        if (log.isDebugEnabled()) {
+            log.debug("hasPermission(), cancer study stable id: " + stableStudyID);
+            log.debug("hasPermission(), user: " + user.getUsername());
+            for (String authority : grantedAuthorities) {
+                log.debug("hasPermission(), authority: " + authority);
+            }
+        }
+
+        // a user has permission to access the 'all' cancer study (everybody does)
+        if (stableStudyID.equalsIgnoreCase(AccessControl.ALL_CANCER_STUDIES_ID)) {
+            return true;
+        }
+        // if a user has access to 'all', simply return true
+        if (grantedAuthorities.contains(AccessControl.ALL_CANCER_STUDIES_ID.toUpperCase())) {
+            if (log.isDebugEnabled()) {
+                log.debug("hasPermission(), user has access to ALL cancer studies, return true");
+            }
+            return true;
+        }
+        // if a user has access to 'all_tcga', simply return true for tcga studies
+        if (grantedAuthorities.contains(AccessControl.ALL_TCGA_CANCER_STUDIES_ID.toUpperCase()) &&
+                stableStudyID.toUpperCase().endsWith("_TCGA")) {
+            if (log.isDebugEnabled()) {
+                log.debug("hasPermission(), user has access to ALL_TCGA cancer studies return true");
+            }
+            return true;
+        }
+        // if a user has access to 'all_target', simply return true for target studies
+        if (grantedAuthorities.contains(AccessControl.ALL_TARGET_CANCER_STUDIES_ID.toUpperCase()) &&
+                (stableStudyID.toUpperCase().endsWith("_TARGET")
+                        || stableStudyID.equalsIgnoreCase("ALL_TARGET_PHASE1")
+                        || stableStudyID.equalsIgnoreCase("ALL_TARGET_PHASE2"))) {
+            if (log.isDebugEnabled()) {
+                log.debug("hasPermission(), user has access to ALL_NCI_TARGET cancer studies return true");
+            }
+            return true;
+        }
+
+        // for groups
+        Set<String> groups = Collections.emptySet();
+        try {
+            groups = cancerStudy.getFreshGroups();
+        } catch (DaoException e) {
+            groups = cancerStudy.getGroups();
+        }
+        if (!Collections.disjoint(groups, grantedAuthorities)) {
+            if (log.isDebugEnabled()) {
+                log.debug("hasPermission(), user has access by groups return true");
+            }
+            return true;
+        }
+
+        boolean toReturn = grantedAuthorities.contains(stableStudyID.toUpperCase());
+
+        if (log.isDebugEnabled()) {
+            if (toReturn == true) {
+                log.debug("hasPermission(), user has access to this cancer study: '" + stableStudyID + "', returning true.");
+            } else {
+                log.debug("hasPermission(), user does not have access to the cancer study: '" + stableStudyID + "', returning false.");
+            }
+        }
+
+        // outta here
+        return toReturn;
+    }
+
+    private Set<String> getGrantedAuthorities(User user) {
+        String appName = GlobalProperties.getAppName().toUpperCase();
+        Set<String> allAuthorities = AuthorityUtils.authorityListToSet(user.getAuthorities());
+        Set<String> grantedAuthorities = new HashSet<>();
+        for (String au : allAuthorities) {
+            if (au.toUpperCase().startsWith(appName + ":")) {
+                grantedAuthorities.add(au.substring(appName.length() + 1));
+            }
+        }
+        return grantedAuthorities;
+    }
 }
 
 

--- a/core/src/main/java/org/mskcc/cbio/portal/util/CancerStudyPermissionEvaluator.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/CancerStudyPermissionEvaluator.java
@@ -181,6 +181,7 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
             return true;
         }
 
+        // finally, check if the user has this study specifically listed in his 'groups' (a 'group' of this study only)
         boolean toReturn = grantedAuthorities.contains(stableStudyID.toUpperCase());
 
         if (log.isDebugEnabled()) {
@@ -199,16 +200,21 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
         String appName = GlobalProperties.getAppName().toUpperCase();
         Set<String> allAuthorities = AuthorityUtils.authorityListToSet(user.getAuthorities());
         Set<String> grantedAuthorities = new HashSet<>();
+
         if (GlobalProperties.filterGroupsByAppName()) {
             for (String au : allAuthorities) {
                 if (au.toUpperCase().startsWith(appName + ":")) {
                     grantedAuthorities.add(au.substring(appName.length() + 1));
                 }
             }
-            return grantedAuthorities;
         } else {
-            return allAuthorities;
+            grantedAuthorities = allAuthorities;
         }
+
+        // all users are allowed access to PUBLIC studies
+        grantedAuthorities.add(AccessControl.PUBLIC_CANCER_STUDIES_GROUP.toUpperCase());
+
+        return grantedAuthorities;
     }
 }
 

--- a/core/src/main/java/org/mskcc/cbio/portal/util/CancerStudyPermissionEvaluator.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/CancerStudyPermissionEvaluator.java
@@ -45,7 +45,7 @@ import org.mskcc.cbio.portal.dao.DaoException;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 
 
 /**
@@ -102,7 +102,7 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
                 return false;
             }
 
-            User user = (User) authentication.getPrincipal();
+            UserDetails user = (UserDetails) authentication.getPrincipal();
             if (user != null) {
                 return hasPermission(cancerStudy, user);
             } else {
@@ -119,11 +119,11 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
     /**
      * Helper function to determine if given user has access to given cancer study.
      *
-     * @param stableStudyID String
-     * @param user SocialUserDetails
+     * @param cancerStudy String ID of the cancer study to check for
+     * @param user Spring UserDetails of the logged-in user.
      * @return boolean
      */
-    private boolean hasPermission(CancerStudy cancerStudy, User user) {
+    private boolean hasPermission(CancerStudy cancerStudy, UserDetails user) {
 
         Set<String> grantedAuthorities = getGrantedAuthorities(user);
 
@@ -195,7 +195,7 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
         return toReturn;
     }
 
-    private Set<String> getGrantedAuthorities(User user) {
+    private Set<String> getGrantedAuthorities(UserDetails user) {
         String appName = GlobalProperties.getAppName().toUpperCase();
         Set<String> allAuthorities = AuthorityUtils.authorityListToSet(user.getAuthorities());
         Set<String> grantedAuthorities = new HashSet<>();

--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -60,6 +60,7 @@ public class GlobalProperties {
 	public static final String IGV_BAM_LINKING_STUDIES = "igv.bam.linking.studies";
     public static final String AUTHENTICATE = "authenticate";
     public static final String AUTHORIZATION = "authorization";
+    public static final String FILTER_GROUPS_BY_APPNAME = "filter_groups_by_appname";
     public static final String INCLUDE_NETWORKS = "include_networks";
     public static final String GOOGLE_ANALYTICS_PROFILE_ID = "google_analytics_profile_id";
     public static final String GENOMESPACE = "genomespace";
@@ -582,5 +583,10 @@ public class GlobalProperties {
     public static String getOncoKBUrl()
     {
         return properties.getProperty(ONCOKB_URL);
+    }
+
+    public static boolean filterGroupsByAppName() {
+        String filterGroupsByNameFlag = properties.getProperty(FILTER_GROUPS_BY_APPNAME);
+        return filterGroupsByNameFlag == null || Boolean.parseBoolean(filterGroupsByNameFlag);
     }
 }

--- a/portal/src/main/resources/applicationContext-security.xml
+++ b/portal/src/main/resources/applicationContext-security.xml
@@ -10,7 +10,7 @@
 
 
     <!-- beans shared across any authentication system -->
-    <b:beans profile="googleplus,openid,saml">
+    <b:beans profile="googleplus,openid,saml,ad">
 
     <!-- support for general annotations within class definitions (used in AccessControl) -->
     <context:annotation-config/>
@@ -447,6 +447,30 @@
     <b:bean id="parserPoolHolder" class="org.springframework.security.saml.parser.ParserPoolHolder"/>
 
     <!-- end saml beans -->
+    </b:beans>
+
+    <!-- authenticate with AD -->
+    <b:beans profile="ad">
+        <http use-expressions="true" auto-config="true">
+
+            <form-login login-processing-url="/j_spring_security_check" default-target-url="/index.do" />
+            <logout     logout-url="/j_spring_security_logout" logout-success-url="/index.do"/>
+
+            ${url.intercepts}
+
+            <!-- to enable access from matlab, r, python, etc clients -->
+            <session-management session-fixation-protection="none"/>
+        </http>
+
+        <!-- Add Authentication Manager -->
+        <authentication-manager>
+            <authentication-provider ref="adAuthenticationProvider" />
+        </authentication-manager>
+
+        <b:bean id="adAuthenticationProvider" class="org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider">
+            <b:constructor-arg value="${ad.domain}"/>
+            <b:constructor-arg value="${ad.url}"/>
+        </b:bean>
     </b:beans>
 
     <!-- authenticate is off beans --> 

--- a/portal/src/main/resources/applicationContext-security.xml
+++ b/portal/src/main/resources/applicationContext-security.xml
@@ -52,7 +52,7 @@
 
     <!-- googleplus beans -->
     <b:beans profile="googleplus">
-	
+
 	<b:bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
 	    <b:property name="staticMethod" value="org.mskcc.cbio.portal.util.SpringUtil.setAccessControl"/>
 	    <b:property name="arguments">
@@ -478,14 +478,15 @@
     <global-method-security pre-post-annotations="disabled"/>
     <http pattern="/**" security="none"/>
     <b:bean id="accessControl" class="org.mskcc.cbio.portal.util.internal.AccessControlImpl"/>
-	<b:bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
-	    <b:property name="staticMethod" value="org.mskcc.cbio.portal.util.SpringUtil.setAccessControl"/>
-	    <b:property name="arguments">
-	        <b:list>
-	            <b:ref bean="accessControl"/>
-	        </b:list>
-	   </b:property>
-	</b:bean>
+
+    <b:bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <b:property name="staticMethod" value="org.mskcc.cbio.portal.util.SpringUtil.setAccessControl"/>
+        <b:property name="arguments">
+            <b:list>
+                <b:ref bean="accessControl"/>
+            </b:list>
+        </b:property>
+    </b:bean>
     </b:beans>
 
 </b:beans>

--- a/portal/src/main/resources/applicationContext-security.xml
+++ b/portal/src/main/resources/applicationContext-security.xml
@@ -449,12 +449,12 @@
     <!-- end saml beans -->
     </b:beans>
 
-    <!-- authenticate with AD -->
+    <!-- authenticate with Active Directory -->
     <b:beans profile="ad">
         <http use-expressions="true" auto-config="true">
 
-            <form-login login-processing-url="/j_spring_security_check" default-target-url="/index.do" />
-            <logout     logout-url="/j_spring_security_logout" logout-success-url="/index.do"/>
+            <form-login login-page="/login.jsp" login-processing-url="/j_spring_security_check" default-target-url="/index.do" />
+            <logout     logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID" />
 
             ${url.intercepts}
 

--- a/portal/src/main/webapp/WEB-INF/jsp/global/header_bar.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/header_bar.jsp
@@ -39,7 +39,7 @@
 	if (authenticationMethod.equals("openid")) {
 		principal = "principal.name";
 	}
-	else if (authenticationMethod.equals("googleplus") || authenticationMethod.equals("saml")) {
+	else if (authenticationMethod.equals("googleplus") || authenticationMethod.equals("saml") || authenticationMethod.equals("ad")) {
 		principal = "principal.username";
 	}
 	String tagLineImage = (authenticationMethod.equals("saml")) ?

--- a/portal/src/main/webapp/login.jsp
+++ b/portal/src/main/webapp/login.jsp
@@ -67,105 +67,117 @@
 %>
 </head>
 <body>
-    <center>
-    <div id="page_wrapper">
-    <table width="860px" cellpadding="0px" cellspacing="5px" border="0px">
-      <tr valign="top">
-        <td colspan="3">
+  <center>
+  <div id="page_wrapper">
+  <table width="860px" cellpadding="0px" cellspacing="5px" border="0px">
+    <tr valign="top">
+      <td colspan="3">
         <div id="login_header_wrapper">
-        <div id="login_header_top">
-        <jsp:include page="WEB-INF/jsp/global/header_bar.jsp" flush="true" />
+          <div id="login_header_top">
+            <jsp:include page="WEB-INF/jsp/global/header_bar.jsp" flush="true" />
+          </div>
         </div>
-        </div>
+      </td>
+    </tr>
+    
+    <tr valign="top">
+      <td>
+        <div>
+
+          <% if (logout_success != null) { %>
+          <div class="ui-state-highlight ui-corner-all" style="padding: 0 .7em;width:90%;margin-top:50px">
+            <p><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span>
+            <strong>You are now signed out.</strong></p>
+          </div>
+          <% } %>
+          
+          <% if (login_error != null) { %>
+          <div class="ui-state-highlight ui-corner-all" style="padding: 0 .7em;width:90%;margin-top:50px">
+            <p><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span>
+            <strong>You are not authorized to access this resource.&nbsp;
+            
+              <% if (authenticationMethod.equals("googleplus")) { %>
+              You have attempted to log in as <%= DynamicState.INSTANCE.getFailedUser() %>.
+              <% } %>
+
+              <!-- removed hard-coded login contact html, instead calling GlobalProperties -->
+              <%= GlobalProperties.getLoginContactHtml() %>
+            </strong></p>
+          </div>
+          <% } %>
+
+          <br>
+
+          <table cellspacing="2px" width="100%">
+            <tr>
+              <td>
+                <% if (authenticationMethod.equals("openid")) { %>
+                  <!-- Simple OpenID Selector -->
+                  <form style="width:  100%;" action="<c:url value='j_spring_openid_security_check'/>" method="post" id="openid_form">
+                  <input type="hidden" name="action" value="verify" />
+                  <p/>
+                <% } %>
+
+                <fieldset>
+                  <legend style="width:96px;border-bottom:none;color:#666666;font-family:verdana,arial,sans-serif;font-size:12px;">
+                      Login to Portal:
+                  </legend>
+                  <p>
+                    <span style="color:#666666;font-family:verdana,arial,sans-serif;font-size:145%">
+                      <%= GlobalProperties.getAuthorizationMessage() %>
+                    </span>
+                  </p>
+
+                <% if (authenticationMethod.equals("openid")) { %>
+                  <div id="openid_choice">
+                    <p>Please click your account provider:</p>
+                    <div id="openid_btns"></div>
+                  </div>
+                  <div id="openid_input_area">
+                    <input id="openid_identifier" name="openid_identifier" type="text" value="http://" />
+                    <input id="openid_submit" type="submit" value="Sign-In"/>
+                  </div>
+                  <noscript>
+                    <p>OpenID is a service that allows you to log-on to many different websites using a single identity.
+                    Find out <a href="http://openid.net/what/">more about OpenID</a> and <a href="http://openid.net/get/">how to get an OpenID enabled account</a>.</p>
+                  </noscript>
+                </fieldset>
+                </form>
+
+                <% } else if (authenticationMethod.equals("saml")) { %>
+                  <p>
+                    <!-- removed the hard-coded saml registration html and calling GlobalProperties instead -->
+                    <button id="saml_login_button" type="button" class="btn btn-danger btn-lg" onclick="window.location = 'login?idp=<%= GlobalProperties.getSamlIdpMetadataEntityid() %>'" >
+                    <%= GlobalProperties.getLoginSamlRegistrationHtml() %></button>
+                  </p>
+                </fieldset>
+
+                <% } else if (authenticationMethod.equals("googleplus")) { %>
+                  <p>
+                    <button onclick="window.location = 'auth/google'" style="padding: 0; border:none; background: none" >
+                      <IMG alt="Google+" src="images/login/googleplus_signin.png"  />
+                    </button>
+                  </p>
+                </fieldset>
+                <% } %>
+
+              </td>
+            </tr>
+          </table>
         </td>
       </tr>
 
-      <tr valign="top">
-        <td>
-            <div>
-
-    <% if (logout_success != null) { %>
-    <div class="ui-state-highlight ui-corner-all" style="padding: 0 .7em;width:90%;margin-top:50px">
-        <p><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span>
-            <strong>You are now signed out.</strong></p>
-    </div>
-    <% } %>
-    <% if (login_error != null) { %>
-
-        <div class="ui-state-highlight ui-corner-all" style="padding: 0 .7em;width:90%;margin-top:50px">
-            <p><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span>
-            <strong>You are not authorized to access this resource.&nbsp;
-            <% if (authenticationMethod.equals("googleplus")) { %>
-            You have attempted to log in as <%= DynamicState.INSTANCE.getFailedUser() %>.
-            <% } %>
-            <!-- removed hard-coded login contact html, instead calling GlobalProperties -->
-            <%= GlobalProperties.getLoginContactHtml() %>
-            </strong></p>
-    </div>
-    <% } %>
-    <br>
-
-        <table cellspacing="2px" width="100%">
-            <tr>
-                <td>
-                <% if (authenticationMethod.equals("openid")) { %>
-                    <!-- Simple OpenID Selector -->
-                    <form style="width:  100%;" action="<c:url value='j_spring_openid_security_check'/>" method="post" id="openid_form">
-                    <input type="hidden" name="action" value="verify" />
-                    <p/>
-                <% } %>
-                    <fieldset>
-                    <legend style="width:96px;border-bottom:none;color:#666666;font-family:verdana,arial,sans-serif;font-size:12px;">
-                        Login to Portal:
-                    </legend>
-                    <p>
-                        <span style="color:#666666;font-family:verdana,arial,sans-serif;font-size:145%">
-                            <%= GlobalProperties.getAuthorizationMessage() %>
-                        </span>
-                    </p>
-                    <% if (authenticationMethod.equals("openid")) { %>
-                        <div id="openid_choice">
-                            <p>Please click your account provider:</p>
-                            <div id="openid_btns"></div>
-                        </div>
-                        <div id="openid_input_area">
-                            <input id="openid_identifier" name="openid_identifier" type="text" value="http://" />
-                            <input id="openid_submit" type="submit" value="Sign-In"/>
-                        </div>
-                        <noscript>
-                            <p>OpenID is a service that allows you to log-on to many different websites using a single identity.
-                            Find out <a href="http://openid.net/what/">more about OpenID</a> and <a href="http://openid.net/get/">how to get an OpenID enabled account</a>.</p>
-                        </noscript>
-                    </fieldset>
-                    </form>
-                    <% } else if (authenticationMethod.equals("saml")) { %>
-                        <p>
-                            <!-- removed the hard-coded saml registration html and calling GlobalProperties instead -->
-                            <button id="saml_login_button" type="button" class="btn btn-danger btn-lg" onclick="window.location = 'login?idp=<%= GlobalProperties.getSamlIdpMetadataEntityid() %>'" >
-                                <%= GlobalProperties.getLoginSamlRegistrationHtml() %></button>
-                        </p>
-                    </fieldset>
-                    <% } else if (authenticationMethod.equals("googleplus")) { %>
-                        <p>
-                            <button onclick="window.location = 'auth/google'" style="padding: 0; border:none; background: none" >
-                                <IMG alt="Google+" src="images/login/googleplus_signin.png"  /></button>
-                        </p>
-                    </fieldset>
-                    <% } %>
-                </td>
-            </tr>
-
-        </table>
+      <tr>
+        <td colspan="3">
+          <jsp:include page="WEB-INF/jsp/global/footer.jsp" flush="true" />
         </td>
-        </tr>
-        <tr>
-            <td colspan="3">
-                <jsp:include page="WEB-INF/jsp/global/footer.jsp" flush="true" />
-            </td>
-        </tr>
-        </table>
-        </center>
-        </div>
-        <jsp:include page="WEB-INF/jsp/global/xdebug.jsp" flush="true" />
-        </body>
+      </tr>
+
+    </table>
+  </div>
+  </center>
+
+  <jsp:include page="WEB-INF/jsp/global/xdebug.jsp" flush="true" />
+
+</body>
 </html>

--- a/portal/src/main/webapp/login.jsp
+++ b/portal/src/main/webapp/login.jsp
@@ -79,7 +79,7 @@
         </div>
       </td>
     </tr>
-    
+
     <tr valign="top">
       <td>
         <div>
@@ -90,12 +90,12 @@
             <strong>You are now signed out.</strong></p>
           </div>
           <% } %>
-          
+
           <% if (login_error != null) { %>
           <div class="ui-state-highlight ui-corner-all" style="padding: 0 .7em;width:90%;margin-top:50px">
             <p><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span>
             <strong>You are not authorized to access this resource.&nbsp;
-            
+
               <% if (authenticationMethod.equals("googleplus")) { %>
               You have attempted to log in as <%= DynamicState.INSTANCE.getFailedUser() %>.
               <% } %>
@@ -116,6 +116,9 @@
                   <form style="width:  100%;" action="<c:url value='j_spring_openid_security_check'/>" method="post" id="openid_form">
                   <input type="hidden" name="action" value="verify" />
                   <p/>
+
+                <% } else if (authenticationMethod.equals("ad")) { %>
+                  <form name='loginForm' action="<c:url value='j_spring_security_check' />" method='POST'>
                 <% } %>
 
                 <fieldset>
@@ -159,6 +162,15 @@
                     </button>
                   </p>
                 </fieldset>
+
+                <% } else if (authenticationMethod.equals("ad")){ %>
+                  <div>
+                    <label for=username>Username: </label> <input type='text' id='username' name='j_username' value=''>  <br/>
+                    <label for=password>Password: </label> <input type='password' name='j_password' /> <br/>
+                    <input name="submit" type="submit" value="submit" />
+                  </div>
+                </fieldset>
+                </form>
                 <% } %>
 
               </td>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -64,10 +64,17 @@ skin.right_nav.show_examples=true
 skin.right_nav.show_testimonials=true
 
 # authentication
+## is authentication enabled at all? (true, false)
 authenticate=false
+## which method of authentication to use (false, googleplus, saml, openid)
 authorization=false
+## Should the permissions for groups and users be filtered by this instance's app.name?
+## (true means the system only handles "CBIOPORTAL:someGroupPermission" groups, false means "someGroupPermission" works)
+filter_groups_by_appname=true
+## settings to connect to googleplus auth infrastructure
 googleplus.consumer.key=
 googleplus.consumer.secret=
+## settings to connect to SAML auth server
 saml.sp.metadata.entityid=
 saml.idp.metadata.location=
 saml.idp.metadata.entityid=

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -83,6 +83,9 @@ saml.keystore.password=
 saml.keystore.private-key.key=
 saml.keystore.private-key.password=
 saml.keystore.default-key=
+## settings to connect to an Active Directory domain controller
+ad.domain=
+ad.url=
 
 # patient view settings
 patient_view_placeholder=false


### PR DESCRIPTION
Add initial Active Directory authentication support to cBio.

This is the basic spring configuration to allow cBio to log-in via Active Directory accounts.
It adds the relevant portal.properties settings, spring Config and makes minor changes to the CancerStudyPermissionEvaluator to enable alternative spring-security authentication-providers.
APP.NAME:permission filtering was made optional (portal.properties setting) so that existing AD-groups need not be prefixed with "CBIOPORTAL:" to make them work.

The first whitespace-fix is really only running the IntelliJ codeformatter on the file.
This fixes several odd indents and the mixed use of tab-indenting and space-indenting. The tabs-to-spaces is sadly enough to confuse the github comparator, which makes this diff look needlessly complex.
Local diffing tools like meld handle this better.

Still ToDo: update the login screen with username and password boxes, currently uses the auto-generated barebones spring-security password entry screen.