### PR TITLE
Updating code to reflect jstree study selection

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/query_form.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/query_form.jsp
@@ -191,7 +191,7 @@
                         "style=\"height: 34px;\" " +
                         "title=\"Send data matrix to GenomeSpace.\" " +
                         "href=\"#\" onclick=\"prepGSLaunch($('#main_form'), " +
-                        "$('#select_cancer_type').val(), " +
+                        "$('#select_single_study').val(), " +
                         "$('#genomic_profiles'));\"><img src=\"images/send-to-gs.png\" alt=\"\"/></a>");
         }
     }

--- a/portal/src/main/webapp/js/src/gistic.js
+++ b/portal/src/main/webapp/js/src/gistic.js
@@ -313,7 +313,7 @@ Gistic.UI = ( function() {
 
             var genes = GeneSet($('#gene_list').val()).getAllGenes();
 
-            var current_selection = $('#select_cancer_type').val();
+            var current_selection = $('#select_single_study').val();
 
             // if Gistic has never been run then Gistic.last_selection =
             // undefined, otherwise, check to prevent multiple AJAXs for the

--- a/portal/src/main/webapp/js/src/mutsig.js
+++ b/portal/src/main/webapp/js/src/mutsig.js
@@ -37,7 +37,7 @@
 //              gene symbol, num mutations, q-value
 //
 // Dynamic jQuery:
-//          Handles changes in select_cancer_type:
+//          Handles changes in select_single_study:
 //              shows/hides "Recurrently Mutated Genes" button
 //              shows/hides table containing MutSig information.
 //          Takes user-selected mutated genes and adds them to the Gene Symbol box.
@@ -105,10 +105,10 @@ var initMutsigDialogue = function() {
 // handle appropriately
 // todo: refactor this
 var listenCancerStudy = function() {
-    $('#select_cancer_type').change( function() {
+    $('#select_single_study').change( function() {
 
         // get the cancer study (i.e. tcga_gbm)
-        var cancerStudyId = $('#select_cancer_type').val();
+        var cancerStudyId = $('#select_single_study').val();
 
         // if the selected cancer study has mutsig data,
         // show the mutsig button
@@ -152,7 +152,7 @@ var promptMutsigTable = function() {
     "use strict";
 
     // grab data to be sent to the server
-    var cancerStudyId = $('#select_cancer_type').val();
+    var cancerStudyId = $('#select_single_study').val();
 
     // open the dialog box
     $('#mutsig_dialog').dialog('open');


### PR DESCRIPTION
Fixing bugs in mutsig.js and gistic.js associated with trying to access selected study via the old selector, $('#select_cancer_type'). This pull request updates that code, and query_form.jsp, to reflect the new place where that information is found: $('#select_single_study')