### PR TITLE
Fixes along the lines required for python import tool to work after u…

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportClinicalTrialData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportClinicalTrialData.java
@@ -34,8 +34,8 @@ package org.mskcc.cbio.portal.scripts;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.mskcc.cbio.portal.dao.DaoClinicalTrial;
-import org.mskcc.cbio.portal.dao.DaoException;
+import org.mskcc.cbio.portal.dao.*;
+import org.mskcc.cbio.portal.util.SpringUtil;
 import org.mskcc.cbio.portal.model.ClinicalTrial;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -93,6 +93,7 @@ public class ImportClinicalTrialData {
     public static void importFilesFromFolder(File folder)
             throws ParserConfigurationException, IOException, SAXException, DaoException
     {
+		SpringUtil.initDataSource();
         daoClinicalTrial = DaoClinicalTrial.getInstance();
 
         log.debug("Reseting the clinical trials table. ");

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportCosmicData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportCosmicData.java
@@ -32,24 +32,13 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import org.mskcc.cbio.portal.dao.DaoException;
-import org.mskcc.cbio.portal.dao.DaoCosmicData;
-import org.mskcc.cbio.portal.dao.MySQLbulkLoader;
-import org.mskcc.cbio.portal.util.ConsoleUtil;
-import org.mskcc.cbio.portal.util.FileUtil;
-import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.mskcc.cbio.portal.dao.*;
+import org.mskcc.cbio.portal.util.*;
+import org.mskcc.cbio.portal.model.*;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.*;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import org.mskcc.cbio.portal.dao.DaoGeneOptimized;
-import org.mskcc.cbio.portal.model.CanonicalGene;
-import org.mskcc.cbio.portal.model.CosmicMutationFrequency;
-import org.mskcc.cbio.portal.util.MutationKeywordUtils;
+import java.util.regex.*;
 
 public class ImportCosmicData {
     private ProgressMonitor pMonitor;
@@ -134,6 +123,7 @@ public class ImportCosmicData {
             System.out.println("command line usage:  importCosmicData.pl <CosmicCodingMuts.vcf>");
             return;
         }
+		SpringUtil.initDataSource();
         DaoCosmicData.deleteAllRecords();
         ProgressMonitor pMonitor = new ProgressMonitor();
         pMonitor.setConsoleMode(true);

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportDrugs.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportDrugs.java
@@ -32,18 +32,11 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import org.mskcc.cbio.portal.util.ProgressMonitor;
-import org.mskcc.cbio.portal.util.FileUtil;
-import org.mskcc.cbio.portal.util.ConsoleUtil;
-import org.mskcc.cbio.portal.dao.DaoException;
-import org.mskcc.cbio.portal.dao.DaoDrug;
-import org.mskcc.cbio.portal.dao.DaoGeneOptimized;
+import org.mskcc.cbio.portal.util.*;
+import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.CanonicalGene;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.FileReader;
-import java.io.BufferedReader;
+import java.io.*;
 
 /**
  * Command Line tool to import background drug information.
@@ -92,6 +85,7 @@ public class ImportDrugs {
         }
         ProgressMonitor pMonitor = new ProgressMonitor();
         pMonitor.setConsoleMode(true);
+		SpringUtil.initDataSource();
 
         File file = new File(args[0]);
         System.out.println("Reading drug data from:  " + file.getAbsolutePath());

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGeneData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGeneData.java
@@ -32,25 +32,12 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import org.mskcc.cbio.portal.dao.DaoException;
-import org.mskcc.cbio.portal.dao.DaoGeneOptimized;
-import org.mskcc.cbio.portal.dao.MySQLbulkLoader;
+import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.CanonicalGene;
-import org.mskcc.cbio.portal.util.ConsoleUtil;
-import org.mskcc.cbio.portal.util.FileUtil;
-import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.mskcc.cbio.portal.util.*;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.ArrayList;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.BitSet;
+import java.io.*;
+import java.util.*;
 
 /**
  * Command Line Tool to Import Background Gene Data.
@@ -195,6 +182,7 @@ public class ImportGeneData {
     }
 
     public static void main(String[] args) throws Exception {
+		SpringUtil.initDataSource();
         DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
         daoGene.deleteAllRecords();
         if (args.length == 0) {

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportHprd.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportHprd.java
@@ -32,19 +32,11 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import org.mskcc.cbio.portal.util.ProgressMonitor;
-import org.mskcc.cbio.portal.util.ConsoleUtil;
-import org.mskcc.cbio.portal.util.FileUtil;
-import org.mskcc.cbio.portal.dao.DaoException;
-import org.mskcc.cbio.portal.dao.DaoInteraction;
-import org.mskcc.cbio.portal.dao.MySQLbulkLoader;
-import org.mskcc.cbio.portal.dao.DaoGeneOptimized;
+import org.mskcc.cbio.portal.util.*;
+import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.CanonicalGene;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.FileReader;
-import java.io.BufferedReader;
+import java.io.*;
 
 /**
  * Command Line to Import HPRD Interactions.
@@ -138,6 +130,7 @@ public class ImportHprd {
         }
         ProgressMonitor pMonitor = new ProgressMonitor();
         pMonitor.setConsoleMode(true);
+		SpringUtil.initDataSource();
 
         try {
             File geneFile = new File(args[0]);

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportMicroRNAIDs.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportMicroRNAIDs.java
@@ -32,20 +32,11 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import org.mskcc.cbio.portal.dao.DaoException;
-import org.mskcc.cbio.portal.dao.DaoGeneOptimized;
-import org.mskcc.cbio.portal.dao.MySQLbulkLoader;
+import java.io.*;
+import java.util.*;
+import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.CanonicalGene;
-import org.mskcc.cbio.portal.util.ConsoleUtil;
-import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.mskcc.cbio.portal.util.*;
 
 /**
  * Command Line Tool to Import Background Gene Data.
@@ -57,6 +48,7 @@ public class ImportMicroRNAIDs {
         FileReader reader = new FileReader(geneFile);
         BufferedReader buf = new BufferedReader(reader);
         String line = buf.readLine(); // skip first line
+		SpringUtil.initDataSource();
         DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
         
         List<CanonicalGene> mirnas = new ArrayList<CanonicalGene>();

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportPdbUniprotResidueMappingFromMA.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportPdbUniprotResidueMappingFromMA.java
@@ -32,36 +32,16 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.biojava.bio.structure.AminoAcid;
-import org.biojava.bio.structure.Chain;
-import org.biojava.bio.structure.Group;
-import org.biojava.bio.structure.ResidueNumber;
-import org.biojava.bio.structure.Structure;
+import java.io.*;
+import java.util.*;
+import org.biojava.bio.structure.*;
 import org.biojava.bio.structure.align.util.AtomCache;
 import org.biojava.bio.structure.io.FileParsingParameters;
-import org.biojava3.core.sequence.compound.AminoAcidCompound;
-import org.biojava3.core.sequence.compound.AminoAcidCompoundSet;
+import org.biojava3.core.sequence.compound.*;
 import org.biojava3.core.sequence.loader.UniprotProxySequenceReader;
-import org.mskcc.cbio.portal.dao.DaoPdbUniprotResidueMapping;
-import org.mskcc.cbio.portal.dao.DaoException;
-import org.mskcc.cbio.portal.dao.DaoUniProtIdMapping;
-import org.mskcc.cbio.portal.dao.MySQLbulkLoader;
-import org.mskcc.cbio.portal.model.PdbUniprotAlignment;
-import org.mskcc.cbio.portal.model.PdbUniprotResidueMapping;
-import org.mskcc.cbio.portal.util.ConsoleUtil;
-import org.mskcc.cbio.portal.util.FileUtil;
-import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.mskcc.cbio.portal.dao.*;
+import org.mskcc.cbio.portal.model.*;
+import org.mskcc.cbio.portal.util.*;
 
 /**
  *
@@ -193,6 +173,8 @@ public final class ImportPdbUniprotResidueMappingFromMA {
         
         ProgressMonitor pMonitor = new ProgressMonitor();
         pMonitor.setConsoleMode(true);
+
+		SpringUtil.initDataSource();
         
         double identpThrehold = 50;
         try {

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportPdbUniprotResidueMappingFromSifts.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportPdbUniprotResidueMappingFromSifts.java
@@ -32,34 +32,16 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import org.biojava.bio.structure.AminoAcid;
-import org.biojava.bio.structure.Chain;
-import org.biojava.bio.structure.Group;
-import org.biojava.bio.structure.ResidueNumber;
-import org.biojava.bio.structure.Structure;
+import java.io.*;
+import java.util.*;
+import org.biojava.bio.structure.*;
 import org.biojava.bio.structure.align.util.AtomCache;
 import org.biojava.bio.structure.io.FileParsingParameters;
-import org.biojava3.core.sequence.compound.AminoAcidCompound;
-import org.biojava3.core.sequence.compound.AminoAcidCompoundSet;
+import org.biojava3.core.sequence.compound.*;
 import org.biojava3.core.sequence.loader.UniprotProxySequenceReader;
-import org.mskcc.cbio.portal.dao.DaoPdbUniprotResidueMapping;
-import org.mskcc.cbio.portal.dao.DaoException;
-import org.mskcc.cbio.portal.dao.DaoUniProtIdMapping;
-import org.mskcc.cbio.portal.dao.MySQLbulkLoader;
-import org.mskcc.cbio.portal.model.PdbUniprotAlignment;
-import org.mskcc.cbio.portal.model.PdbUniprotResidueMapping;
-import org.mskcc.cbio.portal.util.ConsoleUtil;
-import org.mskcc.cbio.portal.util.FileUtil;
-import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.mskcc.cbio.portal.dao.*;
+import org.mskcc.cbio.portal.model.*;
+import org.mskcc.cbio.portal.util.*;
 
 /**
  *
@@ -311,6 +293,8 @@ public final class ImportPdbUniprotResidueMappingFromSifts {
     
         ProgressMonitor pMonitor = new ProgressMonitor();
         pMonitor.setConsoleMode(true);
+
+		SpringUtil.initDataSource();
         
         double identpThrehold = 80;
 

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportPfamGraphicsData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportPfamGraphicsData.java
@@ -32,16 +32,11 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import org.mskcc.cbio.portal.dao.DaoException;
-import org.mskcc.cbio.portal.dao.DaoPfamGraphics;
-import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.mskcc.cbio.portal.dao.*;
+import org.mskcc.cbio.portal.util.*;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
+import java.io.*;
+import java.util.*;
 
 /**
  * Imports a pfam graphics mapping file.
@@ -118,6 +113,7 @@ public class ImportPfamGraphicsData
 		}
 
 		ProgressMonitor pMonitor = new ProgressMonitor(); // TODO pMonitor is not used at all
+		SpringUtil.initDataSource();
 		File input = new File(args[0]);
 		ImportPfamGraphicsData importer = new ImportPfamGraphicsData(input, pMonitor);
 

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportSangerCensusData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportSangerCensusData.java
@@ -32,19 +32,11 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import org.mskcc.cbio.portal.dao.DaoException;
-import org.mskcc.cbio.portal.dao.DaoGeneOptimized;
-import org.mskcc.cbio.portal.dao.MySQLbulkLoader;
-import org.mskcc.cbio.portal.dao.DaoSangerCensus;
+import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.CanonicalGene;
-import org.mskcc.cbio.portal.util.ConsoleUtil;
-import org.mskcc.cbio.portal.util.FileUtil;
-import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.mskcc.cbio.portal.util.*;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.*;
 
 /**
  * Command Line Tool to Import Sanger Cancer Gene Census Data.
@@ -123,6 +115,8 @@ public class ImportSangerCensusData {
         }
         ProgressMonitor pMonitor = new ProgressMonitor();
         pMonitor.setConsoleMode(true);
+
+		SpringUtil.initDataSource();
 
         File geneFile = new File(args[0]);
         System.out.println("Reading data from:  " + geneFile.getAbsolutePath());

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportSif.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportSif.java
@@ -32,21 +32,12 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import org.mskcc.cbio.portal.util.ProgressMonitor;
-import org.mskcc.cbio.portal.util.ConsoleUtil;
-import org.mskcc.cbio.portal.util.FileUtil;
-import org.mskcc.cbio.portal.dao.DaoException;
-import org.mskcc.cbio.portal.dao.MySQLbulkLoader;
-import org.mskcc.cbio.portal.dao.DaoGeneOptimized;
-import org.mskcc.cbio.portal.dao.DaoInteraction;
+import org.mskcc.cbio.portal.util.*;
+import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.CanonicalGene;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.FileReader;
-import java.io.BufferedReader;
-import java.util.Set;
-import java.util.HashSet;
+import java.io.*;
+import java.util.*;
 
 /**
  * Command Line to Import SIF Interactions.
@@ -168,6 +159,8 @@ public class ImportSif {
         }
         ProgressMonitor pMonitor = new ProgressMonitor();
         pMonitor.setConsoleMode(true);
+
+		SpringUtil.initDataSource();
 
         try {
             File geneFile = new File(args[0]);

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportUniProtIdMapping.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportUniProtIdMapping.java
@@ -33,28 +33,13 @@
 package org.mskcc.cbio.portal.scripts;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.URL;
-import java.net.URLConnection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
+import java.io.*;
+import java.net.*;
+import java.util.*;
+import org.apache.commons.httpclient.*;
 import org.apache.commons.httpclient.methods.GetMethod;
-import org.mskcc.cbio.portal.dao.DaoException;
-import org.mskcc.cbio.portal.dao.DaoUniProtIdMapping;
-import org.mskcc.cbio.portal.dao.MySQLbulkLoader;
-import org.mskcc.cbio.portal.util.ConsoleUtil;
-import org.mskcc.cbio.portal.util.FileUtil;
-import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.mskcc.cbio.portal.dao.*;
+import org.mskcc.cbio.portal.util.*;
 import org.mskcc.cbio.portal.web_api.ConnectionManager;
 
 /**
@@ -142,6 +127,7 @@ public final class ImportUniProtIdMapping {
         }
         ProgressMonitor progressMonitor = new ProgressMonitor();
         progressMonitor.setConsoleMode(true);
+		SpringUtil.initDataSource();
         try {
             DaoUniProtIdMapping.deleteAllRecords();
             File uniProtIdMapping = new File(args[0]);

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportUsers.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportUsers.java
@@ -33,19 +33,12 @@
 package org.mskcc.cbio.portal.scripts;
 
 // imports
-import org.mskcc.cbio.portal.model.User;
-import org.mskcc.cbio.portal.dao.DaoUser;
-import org.mskcc.cbio.portal.model.UserAuthorities;
-import org.mskcc.cbio.portal.dao.DaoUserAuthorities;
+import org.mskcc.cbio.portal.model.*;
+import org.mskcc.cbio.portal.dao.*;
+import org.mskcc.cbio.portal.util.*;
 
-import org.mskcc.cbio.portal.util.ConsoleUtil;
-import org.mskcc.cbio.portal.util.ProgressMonitor;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.util.List;
-import java.util.Arrays;
+import java.io.*;
+import java.util.*;
 
 /**
  * Import a file of users and their authorities.
@@ -69,6 +62,8 @@ public class ImportUsers {
 
         ProgressMonitor pMonitor = new ProgressMonitor();
         pMonitor.setConsoleMode(true);
+
+		SpringUtil.initDataSource();
 
         File file = new File(args[0]);
         FileReader reader = new FileReader(file);

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ResetDatabase.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ResetDatabase.java
@@ -33,7 +33,7 @@
 package org.mskcc.cbio.portal.scripts;
 
 import org.mskcc.cbio.portal.dao.*;
-import org.mskcc.cbio.portal.util.ImportDataUtil;
+import org.mskcc.cbio.portal.util.*;
 
 /**
  * Empty the database.
@@ -109,6 +109,7 @@ public class ResetDatabase {
     }
 
     public static void main(String[] args) throws DaoException {
+		SpringUtil.initDataSource();
         StatDatabase.statDb();
         ResetDatabase.resetDatabase();
         System.err.println("Database Cleared and Reset.");

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/UpdateMetaData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/UpdateMetaData.java
@@ -32,10 +32,8 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import org.mskcc.cbio.portal.dao.DaoGeneticProfile;
-import org.mskcc.cbio.portal.util.ConsoleUtil;
-import org.mskcc.cbio.portal.util.GeneticProfileReader;
-import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.mskcc.cbio.portal.dao.*;
+import org.mskcc.cbio.portal.util.*;
 import org.mskcc.cbio.portal.model.GeneticProfile;
 
 import java.io.File;
@@ -54,6 +52,7 @@ public class UpdateMetaData {
 
         ProgressMonitor pMonitor = new ProgressMonitor();
         pMonitor.setConsoleMode(true);
+		SpringUtil.initDataSource();
         File descriptorFile = new File(args[0]);
 
         GeneticProfile geneticProfile = GeneticProfileReader.loadGeneticProfileFromMeta(descriptorFile);


### PR DESCRIPTION
…pdates to resurrect junit tests, although these classes are not used by the python import tool, but for internal use only.