### PR TITLE
add NA to genetic alteration tracks

### DIFF
--- a/portal/src/main/webapp/js/src/oncoprint/new/RuleSet.js
+++ b/portal/src/main/webapp/js/src/oncoprint/new/RuleSet.js
@@ -253,7 +253,6 @@ window.oncoprint_RuleSet = (function() {
 		var vocab = ['full-rect', 'middle-rect', 'large-right-arrow', 'small-up-arrow', 'small-down-arrow'];
 		var self = this;
 		self.type = GENETIC_ALTERATION;
-
 		var makeStaticShapeRule = function(rule_spec, key, value) {
 			var condition = typeof key !== 'undefined' && typeof value !== 'undefined' ? (function(_key, _value) {
 				if (_value === ANY) {
@@ -324,6 +323,9 @@ window.oncoprint_RuleSet = (function() {
 		_.each(params.default, function(rule_spec) {
 			makeStaticShapeRule(rule_spec);
 		});
+		self.addStaticRule(makeNARuleParams(function(d) {
+			return d.hasOwnProperty("na");
+		}, 'NA'));
 		self.getLegendDiv = function(active_rules, cell_width, cell_height) {
 			var div = d3.select(document.createElement('div'));
 			_.each(self.getRules(), function(rule) {

--- a/portal/src/main/webapp/js/src/oncoprint/setup-oncoprint-improved.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup-oncoprint-improved.js
@@ -70,8 +70,11 @@ window.setUpOncoprint = function(ctr_id, config) {
 		};
 		_.each(sample_data, function (d) {
 			var patient_id = sample_to_patient[d.sample];
-			ret[patient_id] = ret[patient_id] || {patient: patient_id, gene:d.gene};
+			ret[patient_id] = ret[patient_id] || {patient: patient_id, gene:d.gene, na: true};
 			var new_datum = ret[patient_id];
+			if (!d.hasOwnProperty("na")) {
+				delete new_datum["na"];
+			}
 			_.each(d, function(val, key) {
 				if (key === 'mutation') {
 					new_datum['mutation'] = (new_datum['mutation'] && (new_datum['mutation']+','+val)) || val;


### PR DESCRIPTION
With this pull request, you can mark a datum for oncoprint as being unsequenced or otherwise having unavailable data by adding to that object the member "na" with any value ("true" may be a logical choice going forward)