### PR TITLE
fix oncoprint fading issue

### DIFF
--- a/portal/src/main/webapp/js/src/oncoprint/setup-oncoprint-improved.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup-oncoprint-improved.js
@@ -212,20 +212,22 @@ window.setUpOncoprint = function(ctr_id, config) {
 		var update_covering_block_interval;
 		
 		oncoprintFadeTo = function (f) {
-			update_covering_block_interval = setInterval(function() {
-				oncoprint_covering_block.css({'display':'block', 'width':$(ctr_selector).width()+'px', 'height':$(ctr_selector).height()+'px'});
-			}, 200);
-			$(config.toolbar_selector).fadeTo('fast', 0);
+			if (!update_covering_block_interval) {
+				update_covering_block_interval = setInterval(function() {
+					oncoprint_covering_block.css({'display':'block', 'width':$(ctr_selector).width()+'px', 'height':$(ctr_selector).height()+'px'});
+				}, 200);
+			}
+			$(config.toolbar_selector).stop().fadeTo('fast', 0);
 			return $.when(oncoprint_covering_block.fadeTo('fast', f));
 		};
 		oncoprintFadeIn = function () {
-			if (update_covering_block_interval) {
-				clearInterval(update_covering_block_interval);
-				update_covering_block_interval = undefined;
-			}
-			$(config.toolbar_selector).fadeTo('fast', 1);
-			var hide_covering_block_promise = $.when(oncoprint_covering_block.fadeTo('fast', 0));
+			$(config.toolbar_selector).stop().fadeTo('fast', 1);
+			var hide_covering_block_promise = $.when(oncoprint_covering_block.stop().fadeTo('fast', 0));
 			hide_covering_block_promise.then(function() {
+				if (update_covering_block_interval) {
+					clearInterval(update_covering_block_interval);
+					update_covering_block_interval = undefined;
+				}
 				oncoprint_covering_block.css('display','none');
 			});
 			return hide_covering_block_promise;


### PR DESCRIPTION
In order to have the oncoprint visually fade out to half opacity, without incurring huge amounts of computational time, we can fade IN a white div to half opacity, so that way the calculations are only done for one DOM element instead of the potentially tens of thousands in the oncoprint.

I implemented this in a previous pull request but messed up the way the block size updating is done by generating too many setIntervals. The result was that the oncoprint would fade in but would not be usable because the elements would be blocked by a div that was invisible but still display:block instead of display:none. This PR fixes that.