### PR TITLE
Fix #332 Patient view unreadable qtip datatable

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -592,7 +592,7 @@ function addMoreClinicalTooltip(elem) {
         if (clinicalData.length===0) {
             thisElem.remove();
         } else {
-            var pos = {my:'top right',at:'bottom right',viewport: $(window)};
+            var pos = {my:'top left',at:'bottom left'};
             thisElem.qtip({
                 content: {
                     text: table_text


### PR DESCRIPTION
Place clinical attributes qtip datatable table below the patient/sample text so one can scroll down if the table does not fit inside the browser window.