### PR TITLE
Fix #344 Wrong primary site on patient view

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -1052,9 +1052,11 @@ function outputClinicalData() {
             ret = "<font color='"+getCaseColor(caseType)+"'>"+caseType+"</font>";
             var loc;
             if (normalizedCaseType(caseType.toLowerCase()) === "metastasis") {
-                loc = guessClinicalData(patientInfo, ["TUMOR_SITE","METASTATIC_SITE"]) || guessClinicalData(clinicalData, ["TUMOR_SITE","METASTATIC_SITE"]);
+                loc = guessClinicalData(clinicalData, ["METASTATIC_SITE", "TUMOR_SITE"]) || guessClinicalData(patientInfo, ["METASTATIC_SITE"]);
+            } else if (normalizedCaseType(caseType.toLowerCase()) === "primary") {
+                loc = guessClinicalData(clinicalData, ["PRIMARY_SITE", "TUMOR_SITE"]) || guessClinicalData(patientInfo, ["PRIMARY_SITE"]);
             } else {
-                loc = guessClinicalData(patientInfo, ["TUMOR_SITE","PRIMARY_SITE"]) || guessClinicalData(clinicalData, ["TUMOR_SITE","PRIMARY_SITE"]);
+                loc = guessClinicalData(clinicalData, ["TUMOR_SITE"]);
             }
             if (loc!==null)
                 ret += " ("+loc+")";


### PR DESCRIPTION
Display PRIMARY_SITE/METASTATIC_SITE from sample or patient attribute (in that
order). Only if the sample is not of SAMPLE_TYPE primary or metastasis display
TUMOR_SITE from sample attribute (never from patient).