### PR TITLE
Validate oql on frontend

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/query_form.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/query_form.jsp
@@ -148,8 +148,7 @@
         <p/>
         <% conditionallyOutputTransposeMatrixOption (localTabIndex, clientTranspose, out); %>
         &nbsp;<br/>
-        <input id="main_submit" class="ui-button ui-widget ui-state-default ui-corner-all" style="height: 34px;"
-					onclick="getMapping()" name="<%= QueryBuilder.ACTION_NAME%>" value="<%= QueryBuilder.ACTION_SUBMIT %>"/>
+        <input id="main_submit" class="ui-button ui-widget ui-state-default ui-corner-all" onclick="submitHandler()" style="height: 34px;" name="<%= QueryBuilder.ACTION_NAME%>" value="<%= QueryBuilder.ACTION_SUBMIT %>"/>
         <% conditionallyOutputGenomespaceOption(localTabIndex, out); %>
 
         </form>

--- a/portal/src/main/webapp/WEB-INF/jsp/query_form.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/query_form.jsp
@@ -109,7 +109,7 @@
 //    String caseIdsKey = (String) request.getAttribute(QueryBuilder.CASE_IDS_KEY);
 %>
 
-
+<script type="text/javascript" src="js/lib/oql/oql-parser.js" charset="utf-8"></script>
 <script type="text/javascript">
     // Store the currently selected options as global variables;
     window.cancer_study_id_selected = '<%= localCancerTypeId%>';

--- a/portal/src/main/webapp/js/lib/oql/oql-parser.js
+++ b/portal/src/main/webapp/js/lib/oql/oql-parser.js
@@ -38,112 +38,114 @@ oql_parser = (function() {
         peg$c3 = { type: "class", value: "[\\n]", description: "[\\n]" },
         peg$c4 = ";",
         peg$c5 = { type: "literal", value: ";", description: "\";\"" },
-        peg$c6 = null,
-        peg$c7 = /^[\-]/,
-        peg$c8 = { type: "class", value: "[\\-]", description: "[\\-]" },
-        peg$c9 = [],
-        peg$c10 = /^[0-9]/,
-        peg$c11 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c12 = ".",
-        peg$c13 = { type: "literal", value: ".", description: "\".\"" },
-        peg$c14 = function(word) { return word.join(""); },
-        peg$c15 = function(number) { return number.join("");},
-        peg$c16 = /^[\-_.@\/a-zA-Z0-9]/,
-        peg$c17 = { type: "class", value: "[\\-_.@\\/a-zA-Z0-9]", description: "[\\-_.@\\/a-zA-Z0-9]" },
-        peg$c18 = function(word) { return word.join("") },
-        peg$c19 = /^[GPAVLIMCFYWHKRQNEDST]/,
-        peg$c20 = { type: "class", value: "[GPAVLIMCFYWHKRQNEDST]", description: "[GPAVLIMCFYWHKRQNEDST]" },
-        peg$c21 = function(letter) { return letter; },
-        peg$c22 = /^[ \t\r]/,
-        peg$c23 = { type: "class", value: "[ \\t\\r]", description: "[ \\t\\r]" },
-        peg$c24 = "amp",
-        peg$c25 = { type: "literal", value: "AMP", description: "\"AMP\"" },
-        peg$c26 = "homdel",
-        peg$c27 = { type: "literal", value: "HOMDEL", description: "\"HOMDEL\"" },
-        peg$c28 = "gain",
-        peg$c29 = { type: "literal", value: "GAIN", description: "\"GAIN\"" },
-        peg$c30 = "hetloss",
-        peg$c31 = { type: "literal", value: "HETLOSS", description: "\"HETLOSS\"" },
-        peg$c32 = "mut",
-        peg$c33 = { type: "literal", value: "MUT", description: "\"MUT\"" },
-        peg$c34 = "exp",
-        peg$c35 = { type: "literal", value: "EXP", description: "\"EXP\"" },
-        peg$c36 = "prot",
-        peg$c37 = { type: "literal", value: "PROT", description: "\"PROT\"" },
-        peg$c38 = function(listofgenes) { return listofgenes.map(function(gene) { return {"gene":gene, "alterations":false}; }); },
-        peg$c39 = function(first, rest) { return [first].concat(rest); },
-        peg$c40 = function(first) { return [first]; },
-        peg$c41 = function(geneName, rest) { return [geneName].concat(rest);},
-        peg$c42 = function(geneName1, geneName2) { return [geneName1, geneName2]; },
-        peg$c43 = ":",
-        peg$c44 = { type: "literal", value: ":", description: "\":\"" },
-        peg$c45 = function(geneName, alts) { return {"gene": geneName, "alterations": alts}; },
-        peg$c46 = function(geneName) { return {"gene": geneName, "alterations":false}; },
-        peg$c47 = function(a1, a2) { return [a1].concat(a2);},
-        peg$c48 = function(a1) { return [a1]; },
-        peg$c49 = function(cmd) { return cmd; },
-        peg$c50 = "AMP",
-        peg$c51 = function() { return {"alteration_type":"cna", "constr_val": "AMP"}; },
-        peg$c52 = "HOMDEL",
-        peg$c53 = function() { return {"alteration_type":"cna", "constr_val": "HOMDEL"}; },
-        peg$c54 = "GAIN",
-        peg$c55 = function() { return {"alteration_type":"cna", "constr_val": "GAIN"}; },
-        peg$c56 = "HETLOSS",
-        peg$c57 = function() { return {"alteration_type":"cna", "constr_val": "HETLOSS"}; },
-        peg$c58 = "MUT",
-        peg$c59 = "=",
-        peg$c60 = { type: "literal", value: "=", description: "\"=\"" },
-        peg$c61 = function(mutation) { return {"alteration_type":"mut", "constr_rel": "=", "constr_type":mutation.type, "constr_val":mutation.value}; },
-        peg$c62 = "!=",
-        peg$c63 = { type: "literal", value: "!=", description: "\"!=\"" },
-        peg$c64 = function(mutation) { return {"alteration_type":"mut", "constr_rel": "!=", "constr_type":mutation.type, "constr_val":mutation.value}; },
-        peg$c65 = function() { return {"alteration_type":"mut"}; },
-        peg$c66 = "EXP",
-        peg$c67 = function(op, constrval) { return {"alteration_type":"exp", "constr_rel":op, "constr_val":parseFloat(constrval)}; },
-        peg$c68 = "PROT",
-        peg$c69 = function(op, constrval) { return {"alteration_type":"prot", "constr_rel":op, "constr_val":parseFloat(constrval)}; },
-        peg$c70 = ">=",
-        peg$c71 = { type: "literal", value: ">=", description: "\">=\"" },
-        peg$c72 = function() { return ">="; },
-        peg$c73 = "<=",
-        peg$c74 = { type: "literal", value: "<=", description: "\"<=\"" },
-        peg$c75 = function() { return "<="; },
-        peg$c76 = ">",
-        peg$c77 = { type: "literal", value: ">", description: "\">\"" },
-        peg$c78 = function() { return ">"; },
-        peg$c79 = "<",
-        peg$c80 = { type: "literal", value: "<", description: "\"<\"" },
-        peg$c81 = function() { return "<"; },
-        peg$c82 = "missense",
-        peg$c83 = { type: "literal", value: "MISSENSE", description: "\"MISSENSE\"" },
-        peg$c84 = function() { return {"type":"class", "value":"MISSENSE"}; },
-        peg$c85 = "nonsense",
-        peg$c86 = { type: "literal", value: "NONSENSE", description: "\"NONSENSE\"" },
-        peg$c87 = function() { return {"type":"class", "value":"NONSENSE"}; },
-        peg$c88 = "nonstart",
-        peg$c89 = { type: "literal", value: "NONSTART", description: "\"NONSTART\"" },
-        peg$c90 = function() { return {"type":"class", "value":"NONSTART"}; },
-        peg$c91 = "nonstop",
-        peg$c92 = { type: "literal", value: "NONSTOP", description: "\"NONSTOP\"" },
-        peg$c93 = function() { return {"type":"class", "value":"NONSTOP"}; },
-        peg$c94 = "frameshift",
-        peg$c95 = { type: "literal", value: "FRAMESHIFT", description: "\"FRAMESHIFT\"" },
-        peg$c96 = function() { return {"type":"class", "value":"FRAMESHIFT"}; },
-        peg$c97 = "inframe",
-        peg$c98 = { type: "literal", value: "INFRAME", description: "\"INFRAME\"" },
-        peg$c99 = function() { return {"type":"class", "value":"INFRAME"}; },
-        peg$c100 = "splice",
-        peg$c101 = { type: "literal", value: "SPLICE", description: "\"SPLICE\"" },
-        peg$c102 = function() { return {"type":"class", "value":"SPLICE"}; },
-        peg$c103 = "trunc",
-        peg$c104 = { type: "literal", value: "TRUNC", description: "\"TRUNC\"" },
-        peg$c105 = function() { return {"type":"class", "value":"TRUNC"}; },
-        peg$c106 = "fusion",
-        peg$c107 = { type: "literal", value: "FUSION", description: "\"FUSION\"" },
-        peg$c108 = function() { return {"type":"class", "value":"FUSION"}; },
-        peg$c109 = function(letter, position, string) { return {"type":"name" , "value":(letter+position+string)};},
-        peg$c110 = function(letter, position) { return {"type":"position", "value":parseInt(position)}; },
-        peg$c111 = function(mutation_name) { return {"type":"name", "value":mutation_name}; },
+        peg$c6 = [],
+        peg$c7 = /^[0-9]/,
+        peg$c8 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c9 = function(number) { return number.join("");},
+        peg$c10 = "-",
+        peg$c11 = { type: "literal", value: "-", description: "\"-\"" },
+        peg$c12 = function(number) { return "-"+number;},
+        peg$c13 = ".",
+        peg$c14 = { type: "literal", value: ".", description: "\".\"" },
+        peg$c15 = function(whole_part, decimal_part) { return whole_part + "." + decimal_part;},
+        peg$c16 = function(decimal_part) { return "."+decimal_part;},
+        peg$c17 = function(whole_part) {return whole_part;},
+        peg$c18 = /^[\-_.@\/a-zA-Z0-9]/,
+        peg$c19 = { type: "class", value: "[\\-_.@\\/a-zA-Z0-9]", description: "[\\-_.@\\/a-zA-Z0-9]" },
+        peg$c20 = function(word) { return word.join("") },
+        peg$c21 = /^[GPAVLIMCFYWHKRQNEDST]/,
+        peg$c22 = { type: "class", value: "[GPAVLIMCFYWHKRQNEDST]", description: "[GPAVLIMCFYWHKRQNEDST]" },
+        peg$c23 = function(letter) { return letter; },
+        peg$c24 = /^[ \t\r]/,
+        peg$c25 = { type: "class", value: "[ \\t\\r]", description: "[ \\t\\r]" },
+        peg$c26 = "amp",
+        peg$c27 = { type: "literal", value: "AMP", description: "\"AMP\"" },
+        peg$c28 = "homdel",
+        peg$c29 = { type: "literal", value: "HOMDEL", description: "\"HOMDEL\"" },
+        peg$c30 = "gain",
+        peg$c31 = { type: "literal", value: "GAIN", description: "\"GAIN\"" },
+        peg$c32 = "hetloss",
+        peg$c33 = { type: "literal", value: "HETLOSS", description: "\"HETLOSS\"" },
+        peg$c34 = "mut",
+        peg$c35 = { type: "literal", value: "MUT", description: "\"MUT\"" },
+        peg$c36 = "exp",
+        peg$c37 = { type: "literal", value: "EXP", description: "\"EXP\"" },
+        peg$c38 = "prot",
+        peg$c39 = { type: "literal", value: "PROT", description: "\"PROT\"" },
+        peg$c40 = function(listofgenes) { return listofgenes.map(function(gene) { return {"gene":gene, "alterations":false}; }); },
+        peg$c41 = function(first, rest) { return [first].concat(rest); },
+        peg$c42 = function(first) { return [first]; },
+        peg$c43 = function(geneName, rest) { return [geneName].concat(rest);},
+        peg$c44 = function(geneName1, geneName2) { return [geneName1, geneName2]; },
+        peg$c45 = ":",
+        peg$c46 = { type: "literal", value: ":", description: "\":\"" },
+        peg$c47 = function(geneName, alts) { return {"gene": geneName, "alterations": alts}; },
+        peg$c48 = function(geneName) { return {"gene": geneName, "alterations":false}; },
+        peg$c49 = function(a1, a2) { return [a1].concat(a2);},
+        peg$c50 = function(a1) { return [a1]; },
+        peg$c51 = function(cmd) { return cmd; },
+        peg$c52 = "AMP",
+        peg$c53 = function() { return {"alteration_type":"cna", "constr_val": "AMP"}; },
+        peg$c54 = "HOMDEL",
+        peg$c55 = function() { return {"alteration_type":"cna", "constr_val": "HOMDEL"}; },
+        peg$c56 = "GAIN",
+        peg$c57 = function() { return {"alteration_type":"cna", "constr_val": "GAIN"}; },
+        peg$c58 = "HETLOSS",
+        peg$c59 = function() { return {"alteration_type":"cna", "constr_val": "HETLOSS"}; },
+        peg$c60 = "MUT",
+        peg$c61 = "=",
+        peg$c62 = { type: "literal", value: "=", description: "\"=\"" },
+        peg$c63 = function(mutation) { return {"alteration_type":"mut", "constr_rel": "=", "constr_type":mutation.type, "constr_val":mutation.value}; },
+        peg$c64 = "!=",
+        peg$c65 = { type: "literal", value: "!=", description: "\"!=\"" },
+        peg$c66 = function(mutation) { return {"alteration_type":"mut", "constr_rel": "!=", "constr_type":mutation.type, "constr_val":mutation.value}; },
+        peg$c67 = function() { return {"alteration_type":"mut"}; },
+        peg$c68 = "EXP",
+        peg$c69 = function(op, constrval) { return {"alteration_type":"exp", "constr_rel":op, "constr_val":parseFloat(constrval)}; },
+        peg$c70 = "PROT",
+        peg$c71 = function(op, constrval) { return {"alteration_type":"prot", "constr_rel":op, "constr_val":parseFloat(constrval)}; },
+        peg$c72 = ">=",
+        peg$c73 = { type: "literal", value: ">=", description: "\">=\"" },
+        peg$c74 = function() { return ">="; },
+        peg$c75 = "<=",
+        peg$c76 = { type: "literal", value: "<=", description: "\"<=\"" },
+        peg$c77 = function() { return "<="; },
+        peg$c78 = ">",
+        peg$c79 = { type: "literal", value: ">", description: "\">\"" },
+        peg$c80 = function() { return ">"; },
+        peg$c81 = "<",
+        peg$c82 = { type: "literal", value: "<", description: "\"<\"" },
+        peg$c83 = function() { return "<"; },
+        peg$c84 = "missense",
+        peg$c85 = { type: "literal", value: "MISSENSE", description: "\"MISSENSE\"" },
+        peg$c86 = function() { return {"type":"class", "value":"MISSENSE"}; },
+        peg$c87 = "nonsense",
+        peg$c88 = { type: "literal", value: "NONSENSE", description: "\"NONSENSE\"" },
+        peg$c89 = function() { return {"type":"class", "value":"NONSENSE"}; },
+        peg$c90 = "nonstart",
+        peg$c91 = { type: "literal", value: "NONSTART", description: "\"NONSTART\"" },
+        peg$c92 = function() { return {"type":"class", "value":"NONSTART"}; },
+        peg$c93 = "nonstop",
+        peg$c94 = { type: "literal", value: "NONSTOP", description: "\"NONSTOP\"" },
+        peg$c95 = function() { return {"type":"class", "value":"NONSTOP"}; },
+        peg$c96 = "frameshift",
+        peg$c97 = { type: "literal", value: "FRAMESHIFT", description: "\"FRAMESHIFT\"" },
+        peg$c98 = function() { return {"type":"class", "value":"FRAMESHIFT"}; },
+        peg$c99 = "inframe",
+        peg$c100 = { type: "literal", value: "INFRAME", description: "\"INFRAME\"" },
+        peg$c101 = function() { return {"type":"class", "value":"INFRAME"}; },
+        peg$c102 = "splice",
+        peg$c103 = { type: "literal", value: "SPLICE", description: "\"SPLICE\"" },
+        peg$c104 = function() { return {"type":"class", "value":"SPLICE"}; },
+        peg$c105 = "trunc",
+        peg$c106 = { type: "literal", value: "TRUNC", description: "\"TRUNC\"" },
+        peg$c107 = function() { return {"type":"class", "value":"TRUNC"}; },
+        peg$c108 = "fusion",
+        peg$c109 = { type: "literal", value: "FUSION", description: "\"FUSION\"" },
+        peg$c110 = function() { return {"type":"class", "value":"FUSION"}; },
+        peg$c111 = function(letter, position, string) { return {"type":"name" , "value":(letter+position+string)};},
+        peg$c112 = function(letter, position) { return {"type":"position", "value":parseInt(position)}; },
+        peg$c113 = function(mutation_name) { return {"type":"name", "value":mutation_name}; },
 
         peg$currPos          = 0,
         peg$reportedPos      = 0,
@@ -397,11 +399,11 @@ oql_parser = (function() {
       return s0;
     }
 
-    function peg$parseNumber() {
-      var s0, s1, s2, s3, s4, s5, s6, s7;
+    function peg$parseNaturalNumber() {
+      var s0, s1, s2;
 
       s0 = peg$currPos;
-      s1 = peg$currPos;
+      s1 = [];
       if (peg$c7.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
@@ -409,125 +411,117 @@ oql_parser = (function() {
         s2 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c8); }
       }
-      if (s2 === peg$FAILED) {
-        s2 = peg$c6;
-      }
       if (s2 !== peg$FAILED) {
-        s3 = [];
-        if (peg$c10.test(input.charAt(peg$currPos))) {
-          s4 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c11); }
-        }
-        while (s4 !== peg$FAILED) {
-          s3.push(s4);
-          if (peg$c10.test(input.charAt(peg$currPos))) {
-            s4 = input.charAt(peg$currPos);
+        while (s2 !== peg$FAILED) {
+          s1.push(s2);
+          if (peg$c7.test(input.charAt(peg$currPos))) {
+            s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c11); }
+            s2 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c8); }
           }
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$currPos;
-          if (input.charCodeAt(peg$currPos) === 46) {
-            s5 = peg$c12;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c13); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = [];
-            if (peg$c10.test(input.charAt(peg$currPos))) {
-              s7 = input.charAt(peg$currPos);
-              peg$currPos++;
-            } else {
-              s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c11); }
-            }
-            while (s7 !== peg$FAILED) {
-              s6.push(s7);
-              if (peg$c10.test(input.charAt(peg$currPos))) {
-                s7 = input.charAt(peg$currPos);
-                peg$currPos++;
-              } else {
-                s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c11); }
-              }
-            }
-            if (s6 !== peg$FAILED) {
-              s5 = [s5, s6];
-              s4 = s5;
-            } else {
-              peg$currPos = s4;
-              s4 = peg$c1;
-            }
-          } else {
-            peg$currPos = s4;
-            s4 = peg$c1;
-          }
-          if (s4 === peg$FAILED) {
-            s4 = peg$c6;
-          }
-          if (s4 !== peg$FAILED) {
-            s2 = [s2, s3, s4];
-            s1 = s2;
-          } else {
-            peg$currPos = s1;
-            s1 = peg$c1;
-          }
-        } else {
-          peg$currPos = s1;
-          s1 = peg$c1;
         }
       } else {
-        peg$currPos = s1;
         s1 = peg$c1;
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c14(s1);
+        s1 = peg$c9(s1);
       }
       s0 = s1;
 
       return s0;
     }
 
-    function peg$parseNaturalNumber() {
-      var s0, s1, s2;
+    function peg$parseNumber() {
+      var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      s1 = [];
-      if (peg$c10.test(input.charAt(peg$currPos))) {
-        s2 = input.charAt(peg$currPos);
+      if (input.charCodeAt(peg$currPos) === 45) {
+        s1 = peg$c10;
         peg$currPos++;
       } else {
-        s2 = peg$FAILED;
+        s1 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c11); }
       }
-      if (s2 !== peg$FAILED) {
-        while (s2 !== peg$FAILED) {
-          s1.push(s2);
-          if (peg$c10.test(input.charAt(peg$currPos))) {
-            s2 = input.charAt(peg$currPos);
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseNumber();
+        if (s2 !== peg$FAILED) {
+          peg$reportedPos = s0;
+          s1 = peg$c12(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c1;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$c1;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseNaturalNumber();
+        if (s1 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 46) {
+            s2 = peg$c13;
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c11); }
+            if (peg$silentFails === 0) { peg$fail(peg$c14); }
+          }
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parseNaturalNumber();
+            if (s3 !== peg$FAILED) {
+              peg$reportedPos = s0;
+              s1 = peg$c15(s1, s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c1;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c1;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c1;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 46) {
+            s1 = peg$c13;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c14); }
+          }
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parseNaturalNumber();
+            if (s2 !== peg$FAILED) {
+              peg$reportedPos = s0;
+              s1 = peg$c16(s2);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c1;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c1;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parseNaturalNumber();
+            if (s1 !== peg$FAILED) {
+              peg$reportedPos = s0;
+              s1 = peg$c17(s1);
+            }
+            s0 = s1;
           }
         }
-      } else {
-        s1 = peg$c1;
       }
-      if (s1 !== peg$FAILED) {
-        peg$reportedPos = s0;
-        s1 = peg$c15(s1);
-      }
-      s0 = s1;
 
       return s0;
     }
@@ -537,22 +531,22 @@ oql_parser = (function() {
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c16.test(input.charAt(peg$currPos))) {
+      if (peg$c18.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        if (peg$silentFails === 0) { peg$fail(peg$c19); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c16.test(input.charAt(peg$currPos))) {
+          if (peg$c18.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+            if (peg$silentFails === 0) { peg$fail(peg$c19); }
           }
         }
       } else {
@@ -560,7 +554,7 @@ oql_parser = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c18(s1);
+        s1 = peg$c20(s1);
       }
       s0 = s1;
 
@@ -571,16 +565,16 @@ oql_parser = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (peg$c19.test(input.charAt(peg$currPos))) {
+      if (peg$c21.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c20); }
+        if (peg$silentFails === 0) { peg$fail(peg$c22); }
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c21(s1);
+        s1 = peg$c23(s1);
       }
       s0 = s1;
 
@@ -591,22 +585,22 @@ oql_parser = (function() {
       var s0, s1;
 
       s0 = [];
-      if (peg$c22.test(input.charAt(peg$currPos))) {
+      if (peg$c24.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c23); }
+        if (peg$silentFails === 0) { peg$fail(peg$c25); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
-          if (peg$c22.test(input.charAt(peg$currPos))) {
+          if (peg$c24.test(input.charAt(peg$currPos))) {
             s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c23); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
         }
       } else {
@@ -620,21 +614,21 @@ oql_parser = (function() {
       var s0, s1;
 
       s0 = [];
-      if (peg$c22.test(input.charAt(peg$currPos))) {
+      if (peg$c24.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c23); }
+        if (peg$silentFails === 0) { peg$fail(peg$c25); }
       }
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c22.test(input.charAt(peg$currPos))) {
+        if (peg$c24.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c23); }
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
         }
       }
 
@@ -644,23 +638,9 @@ oql_parser = (function() {
     function peg$parseAMP() {
       var s0;
 
-      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c24) {
+      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c26) {
         s0 = input.substr(peg$currPos, 3);
         peg$currPos += 3;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c25); }
-      }
-
-      return s0;
-    }
-
-    function peg$parseHOMDEL() {
-      var s0;
-
-      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c26) {
-        s0 = input.substr(peg$currPos, 6);
-        peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c27); }
@@ -669,12 +649,12 @@ oql_parser = (function() {
       return s0;
     }
 
-    function peg$parseGAIN() {
+    function peg$parseHOMDEL() {
       var s0;
 
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c28) {
-        s0 = input.substr(peg$currPos, 4);
-        peg$currPos += 4;
+      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c28) {
+        s0 = input.substr(peg$currPos, 6);
+        peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c29); }
@@ -683,12 +663,12 @@ oql_parser = (function() {
       return s0;
     }
 
-    function peg$parseHETLOSS() {
+    function peg$parseGAIN() {
       var s0;
 
-      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c30) {
-        s0 = input.substr(peg$currPos, 7);
-        peg$currPos += 7;
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c30) {
+        s0 = input.substr(peg$currPos, 4);
+        peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c31); }
@@ -697,12 +677,12 @@ oql_parser = (function() {
       return s0;
     }
 
-    function peg$parseMUT() {
+    function peg$parseHETLOSS() {
       var s0;
 
-      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c32) {
-        s0 = input.substr(peg$currPos, 3);
-        peg$currPos += 3;
+      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c32) {
+        s0 = input.substr(peg$currPos, 7);
+        peg$currPos += 7;
       } else {
         s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c33); }
@@ -711,7 +691,7 @@ oql_parser = (function() {
       return s0;
     }
 
-    function peg$parseEXP() {
+    function peg$parseMUT() {
       var s0;
 
       if (input.substr(peg$currPos, 3).toLowerCase() === peg$c34) {
@@ -725,15 +705,29 @@ oql_parser = (function() {
       return s0;
     }
 
+    function peg$parseEXP() {
+      var s0;
+
+      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c36) {
+        s0 = input.substr(peg$currPos, 3);
+        peg$currPos += 3;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c37); }
+      }
+
+      return s0;
+    }
+
     function peg$parsePROT() {
       var s0;
 
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c36) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c38) {
         s0 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c37); }
+        if (peg$silentFails === 0) { peg$fail(peg$c39); }
       }
 
       return s0;
@@ -746,7 +740,7 @@ oql_parser = (function() {
       s1 = peg$parseListOfGenes();
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c38(s1);
+        s1 = peg$c40(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -762,7 +756,7 @@ oql_parser = (function() {
                 s5 = peg$parseQuery();
                 if (s5 !== peg$FAILED) {
                   peg$reportedPos = s0;
-                  s1 = peg$c39(s2, s5);
+                  s1 = peg$c41(s2, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -795,7 +789,7 @@ oql_parser = (function() {
                 s4 = peg$parsebr();
                 if (s4 !== peg$FAILED) {
                   peg$reportedPos = s0;
-                  s1 = peg$c40(s2);
+                  s1 = peg$c42(s2);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -822,7 +816,7 @@ oql_parser = (function() {
                 s3 = peg$parsemsp();
                 if (s3 !== peg$FAILED) {
                   peg$reportedPos = s0;
-                  s1 = peg$c40(s2);
+                  s1 = peg$c42(s2);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -856,7 +850,7 @@ oql_parser = (function() {
             s4 = peg$parseListOfGenes();
             if (s4 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c41(s2, s4);
+              s1 = peg$c43(s2, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -887,7 +881,7 @@ oql_parser = (function() {
                 s5 = peg$parsemsp();
                 if (s5 !== peg$FAILED) {
                   peg$reportedPos = s0;
-                  s1 = peg$c42(s2, s4);
+                  s1 = peg$c44(s2, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -923,11 +917,11 @@ oql_parser = (function() {
         s2 = peg$parsemsp();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s3 = peg$c43;
+            s3 = peg$c45;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            if (peg$silentFails === 0) { peg$fail(peg$c46); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parsemsp();
@@ -935,7 +929,7 @@ oql_parser = (function() {
               s5 = peg$parseAlterations();
               if (s5 !== peg$FAILED) {
                 peg$reportedPos = s0;
-                s1 = peg$c45(s1, s5);
+                s1 = peg$c47(s1, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -962,7 +956,7 @@ oql_parser = (function() {
         s1 = peg$parseString();
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c46(s1);
+          s1 = peg$c48(s1);
         }
         s0 = s1;
       }
@@ -981,7 +975,7 @@ oql_parser = (function() {
           s3 = peg$parseAlterations();
           if (s3 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c47(s1, s3);
+            s1 = peg$c49(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1000,7 +994,7 @@ oql_parser = (function() {
         s1 = peg$parseAlteration();
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c48(s1);
+          s1 = peg$c50(s1);
         }
         s0 = s1;
       }
@@ -1015,7 +1009,7 @@ oql_parser = (function() {
       s1 = peg$parseCNACommand();
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c49(s1);
+        s1 = peg$c51(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1023,7 +1017,7 @@ oql_parser = (function() {
         s1 = peg$parseEXPCommand();
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c49(s1);
+          s1 = peg$c51(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -1031,7 +1025,7 @@ oql_parser = (function() {
           s1 = peg$parsePROTCommand();
           if (s1 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c49(s1);
+            s1 = peg$c51(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -1039,7 +1033,7 @@ oql_parser = (function() {
             s1 = peg$parseMUTCommand();
             if (s1 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c49(s1);
+              s1 = peg$c51(s1);
             }
             s0 = s1;
           }
@@ -1053,58 +1047,58 @@ oql_parser = (function() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3) === peg$c50) {
-        s1 = peg$c50;
+      if (input.substr(peg$currPos, 3) === peg$c52) {
+        s1 = peg$c52;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c25); }
+        if (peg$silentFails === 0) { peg$fail(peg$c27); }
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c51();
+        s1 = peg$c53();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 6) === peg$c52) {
-          s1 = peg$c52;
+        if (input.substr(peg$currPos, 6) === peg$c54) {
+          s1 = peg$c54;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c27); }
+          if (peg$silentFails === 0) { peg$fail(peg$c29); }
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c53();
+          s1 = peg$c55();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 4) === peg$c54) {
-            s1 = peg$c54;
+          if (input.substr(peg$currPos, 4) === peg$c56) {
+            s1 = peg$c56;
             peg$currPos += 4;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+            if (peg$silentFails === 0) { peg$fail(peg$c31); }
           }
           if (s1 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c55();
+            s1 = peg$c57();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 7) === peg$c56) {
-              s1 = peg$c56;
+            if (input.substr(peg$currPos, 7) === peg$c58) {
+              s1 = peg$c58;
               peg$currPos += 7;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c31); }
+              if (peg$silentFails === 0) { peg$fail(peg$c33); }
             }
             if (s1 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c57();
+              s1 = peg$c59();
             }
             s0 = s1;
           }
@@ -1118,22 +1112,22 @@ oql_parser = (function() {
       var s0, s1, s2, s3, s4, s5;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3) === peg$c58) {
-        s1 = peg$c58;
+      if (input.substr(peg$currPos, 3) === peg$c60) {
+        s1 = peg$c60;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c33); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsemsp();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 61) {
-            s3 = peg$c59;
+            s3 = peg$c61;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c60); }
+            if (peg$silentFails === 0) { peg$fail(peg$c62); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parsemsp();
@@ -1141,7 +1135,7 @@ oql_parser = (function() {
               s5 = peg$parseMutation();
               if (s5 !== peg$FAILED) {
                 peg$reportedPos = s0;
-                s1 = peg$c61(s5);
+                s1 = peg$c63(s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1165,22 +1159,22 @@ oql_parser = (function() {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 3) === peg$c58) {
-          s1 = peg$c58;
+        if (input.substr(peg$currPos, 3) === peg$c60) {
+          s1 = peg$c60;
           peg$currPos += 3;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c33); }
+          if (peg$silentFails === 0) { peg$fail(peg$c35); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parsemsp();
           if (s2 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c62) {
-              s3 = peg$c62;
+            if (input.substr(peg$currPos, 2) === peg$c64) {
+              s3 = peg$c64;
               peg$currPos += 2;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c63); }
+              if (peg$silentFails === 0) { peg$fail(peg$c65); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parsemsp();
@@ -1188,7 +1182,7 @@ oql_parser = (function() {
                 s5 = peg$parseMutation();
                 if (s5 !== peg$FAILED) {
                   peg$reportedPos = s0;
-                  s1 = peg$c64(s5);
+                  s1 = peg$c66(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1212,16 +1206,16 @@ oql_parser = (function() {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 3) === peg$c58) {
-            s1 = peg$c58;
+          if (input.substr(peg$currPos, 3) === peg$c60) {
+            s1 = peg$c60;
             peg$currPos += 3;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c33); }
+            if (peg$silentFails === 0) { peg$fail(peg$c35); }
           }
           if (s1 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c65();
+            s1 = peg$c67();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -1229,7 +1223,7 @@ oql_parser = (function() {
             s1 = peg$parseMutation();
             if (s1 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c61(s1);
+              s1 = peg$c63(s1);
             }
             s0 = s1;
           }
@@ -1243,56 +1237,9 @@ oql_parser = (function() {
       var s0, s1, s2, s3, s4, s5;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3) === peg$c66) {
-        s1 = peg$c66;
-        peg$currPos += 3;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c35); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parsemsp();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseComparisonOp();
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parsemsp();
-            if (s4 !== peg$FAILED) {
-              s5 = peg$parseNumber();
-              if (s5 !== peg$FAILED) {
-                peg$reportedPos = s0;
-                s1 = peg$c67(s3, s5);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$c1;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$c1;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$c1;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$c1;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$c1;
-      }
-
-      return s0;
-    }
-
-    function peg$parsePROTCommand() {
-      var s0, s1, s2, s3, s4, s5;
-
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c68) {
+      if (input.substr(peg$currPos, 3) === peg$c68) {
         s1 = peg$c68;
-        peg$currPos += 4;
+        peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c37); }
@@ -1333,62 +1280,109 @@ oql_parser = (function() {
       return s0;
     }
 
+    function peg$parsePROTCommand() {
+      var s0, s1, s2, s3, s4, s5;
+
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4) === peg$c70) {
+        s1 = peg$c70;
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsemsp();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseComparisonOp();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parsemsp();
+            if (s4 !== peg$FAILED) {
+              s5 = peg$parseNumber();
+              if (s5 !== peg$FAILED) {
+                peg$reportedPos = s0;
+                s1 = peg$c71(s3, s5);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c1;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c1;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c1;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$c1;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$c1;
+      }
+
+      return s0;
+    }
+
     function peg$parseComparisonOp() {
       var s0, s1;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c70) {
-        s1 = peg$c70;
+      if (input.substr(peg$currPos, 2) === peg$c72) {
+        s1 = peg$c72;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c71); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c72();
+        s1 = peg$c74();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c73) {
-          s1 = peg$c73;
+        if (input.substr(peg$currPos, 2) === peg$c75) {
+          s1 = peg$c75;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c75();
+          s1 = peg$c77();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c76;
+            s1 = peg$c78;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c77); }
+            if (peg$silentFails === 0) { peg$fail(peg$c79); }
           }
           if (s1 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c78();
+            s1 = peg$c80();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 60) {
-              s1 = peg$c79;
+              s1 = peg$c81;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c80); }
+              if (peg$silentFails === 0) { peg$fail(peg$c82); }
             }
             if (s1 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c81();
+              s1 = peg$c83();
             }
             s0 = s1;
           }
@@ -1402,128 +1396,128 @@ oql_parser = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 8).toLowerCase() === peg$c82) {
+      if (input.substr(peg$currPos, 8).toLowerCase() === peg$c84) {
         s1 = input.substr(peg$currPos, 8);
         peg$currPos += 8;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c83); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c84();
+        s1 = peg$c86();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 8).toLowerCase() === peg$c85) {
+        if (input.substr(peg$currPos, 8).toLowerCase() === peg$c87) {
           s1 = input.substr(peg$currPos, 8);
           peg$currPos += 8;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+          if (peg$silentFails === 0) { peg$fail(peg$c88); }
         }
         if (s1 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c87();
+          s1 = peg$c89();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 8).toLowerCase() === peg$c88) {
+          if (input.substr(peg$currPos, 8).toLowerCase() === peg$c90) {
             s1 = input.substr(peg$currPos, 8);
             peg$currPos += 8;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c89); }
+            if (peg$silentFails === 0) { peg$fail(peg$c91); }
           }
           if (s1 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c90();
+            s1 = peg$c92();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 7).toLowerCase() === peg$c91) {
+            if (input.substr(peg$currPos, 7).toLowerCase() === peg$c93) {
               s1 = input.substr(peg$currPos, 7);
               peg$currPos += 7;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c92); }
+              if (peg$silentFails === 0) { peg$fail(peg$c94); }
             }
             if (s1 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c93();
+              s1 = peg$c95();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 10).toLowerCase() === peg$c94) {
+              if (input.substr(peg$currPos, 10).toLowerCase() === peg$c96) {
                 s1 = input.substr(peg$currPos, 10);
                 peg$currPos += 10;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c95); }
+                if (peg$silentFails === 0) { peg$fail(peg$c97); }
               }
               if (s1 !== peg$FAILED) {
                 peg$reportedPos = s0;
-                s1 = peg$c96();
+                s1 = peg$c98();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 7).toLowerCase() === peg$c97) {
+                if (input.substr(peg$currPos, 7).toLowerCase() === peg$c99) {
                   s1 = input.substr(peg$currPos, 7);
                   peg$currPos += 7;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c98); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c100); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$reportedPos = s0;
-                  s1 = peg$c99();
+                  s1 = peg$c101();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  if (input.substr(peg$currPos, 6).toLowerCase() === peg$c100) {
+                  if (input.substr(peg$currPos, 6).toLowerCase() === peg$c102) {
                     s1 = input.substr(peg$currPos, 6);
                     peg$currPos += 6;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c101); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c103); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$reportedPos = s0;
-                    s1 = peg$c102();
+                    s1 = peg$c104();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
-                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c103) {
+                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c105) {
                       s1 = input.substr(peg$currPos, 5);
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c104); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c106); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$reportedPos = s0;
-                      s1 = peg$c105();
+                      s1 = peg$c107();
                     }
                     s0 = s1;
                     if (s0 === peg$FAILED) {
                       s0 = peg$currPos;
-                      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c106) {
+                      if (input.substr(peg$currPos, 6).toLowerCase() === peg$c108) {
                         s1 = input.substr(peg$currPos, 6);
                         peg$currPos += 6;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c109); }
                       }
                       if (s1 !== peg$FAILED) {
                         peg$reportedPos = s0;
-                        s1 = peg$c108();
+                        s1 = peg$c110();
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
@@ -1535,7 +1529,7 @@ oql_parser = (function() {
                             s3 = peg$parseString();
                             if (s3 !== peg$FAILED) {
                               peg$reportedPos = s0;
-                              s1 = peg$c109(s1, s2, s3);
+                              s1 = peg$c111(s1, s2, s3);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -1556,7 +1550,7 @@ oql_parser = (function() {
                             s2 = peg$parseNaturalNumber();
                             if (s2 !== peg$FAILED) {
                               peg$reportedPos = s0;
-                              s1 = peg$c110(s1, s2);
+                              s1 = peg$c112(s1, s2);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -1571,7 +1565,7 @@ oql_parser = (function() {
                             s1 = peg$parseString();
                             if (s1 !== peg$FAILED) {
                               peg$reportedPos = s0;
-                              s1 = peg$c111(s1);
+                              s1 = peg$c113(s1);
                             }
                             s0 = s1;
                           }

--- a/portal/src/main/webapp/js/lib/oql/oql_basic.pegjs
+++ b/portal/src/main/webapp/js/lib/oql/oql_basic.pegjs
@@ -7,8 +7,11 @@ br	= [\n] b:br
         / [\n]
 	/ ";"
 
-Number = word:([-]?[0-9]*("."[0-9]*)?) { return word.join(""); }
 NaturalNumber = number:[0-9]+ { return number.join("");}
+Number = "-" number: Number { return "-"+number;}
+        / whole_part:NaturalNumber "." decimal_part:NaturalNumber { return whole_part + "." + decimal_part;}
+        / "." decimal_part:NaturalNumber { return "."+decimal_part;}
+        / whole_part:NaturalNumber {return whole_part;}
 String = word:[-_.@/a-zA-Z0-9]+ { return word.join("") }
 AminoAcid = letter:[GPAVLIMCFYWHKRQNEDST] { return letter; }
 

--- a/portal/src/main/webapp/js/src/dynamicQuery.js
+++ b/portal/src/main/webapp/js/src/dynamicQuery.js
@@ -301,16 +301,23 @@ function reviewCurrentSelections(){
    }
 }
 
+
+var submitHandler = (function() {
+	var sample_mapping_completed = false;
+	return function() {
+		if (sample_mapping_completed) {
+			$('#main_form').submit();
+			sample_mapping_completed = false;
+		} else {
+			getMapping().then(function() {
+				sample_mapping_completed = true;
+				submitHandler();
+			});
+		}
+	};
+})();
 // Get mapping if necessary
 function getMapping() {
-    if ($("#main_form").find("input[name=patient_case_select]:checked").val() === "patient") {
-	getMap().then(function() {
-            $("#main_form").submit();
-        });
-    }
-    else {	
-        $("#main_form").submit();
-    }
     function setPatientSampleIdMap(_sampleMap) {
         var samples_string = "";
         for (var i=0,_len=_sampleMap.length; i<_len; i++) 
@@ -340,14 +347,38 @@ function getMapping() {
         
         return def;
     }
-    
+    if ($("#main_form").find("input[name=patient_case_select]:checked").val() === "patient") {
+	    return getMap();
+    } else {	
+	var def = new $.Deferred();
+	def.resolve();
+	return def.promise();
+    }
 }
 //  Determine whether to submit a cross-cancer query or
 //  a study-specific query
 function chooseAction(evt) {
-	alert("wtf");
     var haveExpInQuery = $("#gene_list").val().toUpperCase().search("EXP") > -1;
-    $("#error_box").remove();
+    $(".error_box").remove();
+    
+        
+    // validate OQL
+    try {
+	    oql_parser.parse($('#gene_list').val());
+    } catch (err) {
+	    var offset = err.offset;
+	    if (offset === $('#gene_list').val().length) {
+		createAnError("OQL syntax error after selected character; please fix and submit again.", $('#gene_list'));
+		$('#gene_list')[0].setSelectionRange(err.offset-1, err.offset);
+	    } else if (offset === 0) {
+		createAnError("OQL syntax error before selected character; please fix and submit again.", $('#gene_list'));
+		$('#gene_list')[0].setSelectionRange(err.offset, err.offset+1);
+	    } else {
+		createAnError("OQL syntax error at selected character; please fix and submit again.", $('#gene_list'));
+		$('#gene_list')[0].setSelectionRange(err.offset, err.offset+1);
+	    }
+	    return false;
+    }
 
     var selected_studies = $("#jstree").jstree(true).get_selected_leaves();
     while (selected_studies.length === 0 && !window.changingTabs) {
@@ -356,6 +387,10 @@ function chooseAction(evt) {
             selected_studies = $("#jstree").jstree(true).get_selected_leaves()
     }    
     if (selected_studies.length > 1) {
+	if ( haveExpInQuery ) {
+            createAnError("Expression filtering in the gene list is not supported when doing cross cancer queries.",  $('#gene_list'));
+            return false;
+        }
         $("#main_form").find("#select_multiple_studies").val("");
         if ($("#tab_index").val() == 'tab_download') {
             $("#main_form").get(0).setAttribute('action','index.do');
@@ -367,10 +402,7 @@ function chooseAction(evt) {
                 window.location = 'cross_cancer.do?' + newSearch;
             //$("#main_form").get(0).setAttribute('action','cross_cancer.do');
         }
-        if ( haveExpInQuery ) {
-            createAnError("Expression filtering in the gene list is not supported when doing cross cancer queries.",  $('#gene_list'));
-            evt.preventDefault();
-        }
+        
     } else if (selected_studies.length === 1) {
         $("#main_form").find("#select_single_study").val(selected_studies[0]);
         $("#main_form").get(0).setAttribute('action','index.do');
@@ -389,19 +421,11 @@ function chooseAction(evt) {
             }
         }
     }
-    
-    
-    // validate OQL
-    try {
-	    oql_parser.parse($('#gene_list').val());
-    } catch (err) {
-	    createAnError("We've got a problem, bro");
-	    evt.preventDefault();
-    }
+
 }
 
 function createAnError(errorText, targetElt) {
-	var errorBox = $("<div id='error_box'>").addClass("ui-state-error ui-corner-all exp_error_box");
+	var errorBox = $("<div class='error_box'>").addClass("ui-state-error ui-corner-all exp_error_box");
 	var errorButton = $("<span>").addClass("ui-icon ui-icon-alert exp_error_button");
 	var strongErrorText = $("<small>").html("Error: " + errorText + "<br>");
 	var errorTextBox = $("<span>").addClass("exp_error_text");
@@ -1212,7 +1236,7 @@ initialize_jstree(window.tab_index === "tab_download" ? flat_jstree_data : jstre
 		return window.localStorage.getItem(selectedStudiesStorageKey);
 	}
 	var onJSTreeChange = function () {
-		$("#error_box").remove();
+		$(".error_box").remove();
 		var select_single_study = $("#main_form").find("#select_single_study");
 		var select_multiple_studies = $("#main_form").find("#select_multiple_studies");
 		var selected_studies = $("#jstree").jstree(true).get_selected_leaves();

--- a/portal/src/main/webapp/js/src/dynamicQuery.js
+++ b/portal/src/main/webapp/js/src/dynamicQuery.js
@@ -304,6 +304,7 @@ function reviewCurrentSelections(){
 //  Determine whether to submit a cross-cancer query or
 //  a study-specific query
 function chooseAction(evt) {
+	alert("wtf");
     var haveExpInQuery = $("#gene_list").val().toUpperCase().search("EXP") > -1;
     $("#error_box").remove();
 
@@ -346,6 +347,15 @@ function chooseAction(evt) {
                 evt.preventDefault();
             }
         }
+    }
+    
+    
+    // validate OQL
+    try {
+	    oql_parser.parse($('#gene_list').val());
+    } catch (err) {
+	    createAnError("We've got a problem, bro");
+	    evt.preventDefault();
     }
 }
 


### PR DESCRIPTION
Since we're using frontend OQL to filter, it fits that we also need to use the frontend OQL parser to validate OQL. This PR implements that, with a (semi-)descriptive error message (i.e. the place where the error is is selected) generated using the frontend oql parser.