### PR TITLE
Fix divide by zero error in allele freq plot

### DIFF
--- a/portal/src/main/webapp/js/jasmine/allele-freq/AlleleFreqPlot.js
+++ b/portal/src/main/webapp/js/jasmine/allele-freq/AlleleFreqPlot.js
@@ -61,8 +61,8 @@ var AlleleFreqPlotUtils = (function() {
     // for all sample in samples
     var kernelDensityEstimator = function(kernel, x) {
         return function(sample) {
-            return x.map(function(x) {
-                return [x, d3.mean(sample, function(v) { return kernel(x - v); })];
+            return x.map(function(d) {
+                return [d, d3.mean(sample, function(v) { return kernel(d - v); })];
             });
         };
     };

--- a/portal/src/main/webapp/js/src/patient-view/AlleleFreqPlot.js
+++ b/portal/src/main/webapp/js/src/patient-view/AlleleFreqPlot.js
@@ -192,7 +192,7 @@ var AlleleFreqPlotMulti = function(div, data, options, order) {
     var plot_data = {};
     for (var k in data) {
         if (data.hasOwnProperty(k)) {
-            bandwidth[k] = utils.calculate_bandwidth(data[k]);
+            bandwidth[k] = Math.max(utils.calculate_bandwidth(data[k]), 0.01);
             kde[k] = utils.kernelDensityEstimator(utils.gaussianKernel(bandwidth[k]), x.ticks(100));
             plot_data[k] = kde[k](data[k]);
         }


### PR DESCRIPTION
...by imposing minimum bandwidth for kernel density estimate

Also, clean up variable names so no shadowing, for clarity