### PR TITLE
Fix #341 patient view limit height tooltips

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -550,7 +550,10 @@ function addMoreClinicalTooltip(elem) {
                     "sInfoFiltered": "",
                     "sLengthMenu": "Show _MENU_ per page"
                 },
-                "iDisplayLength": -1
+                "iDisplayLength": -1,
+                "headerCallback": function(nHead, aData, iStart, iEnd, aiDisplay) {
+                    $(nHead).remove();
+                }
             };
         } else {
             var caseId = $(this).attr('alt');
@@ -585,8 +588,15 @@ function addMoreClinicalTooltip(elem) {
                     "sInfoFiltered": "",
                     "sLengthMenu": "Show _MENU_ per page"
                 },
-                "iDisplayLength": -1
+                "iDisplayLength": -1,
+                "headerCallback": function(nHead, aData, iStart, iEnd, aiDisplay) {
+                    $(nHead).remove();
+                }
             };
+        }
+        if (clinicalData.length > 13) {
+            dataTable["scrollY"] = "350px";
+            dataTable["scrollCollapse"] = true;
         }
 
         if (clinicalData.length===0) {


### PR DESCRIPTION
Change max height of tooltips at the top in the patient view. If the number of
clinical attributes in the tooltip is bigger than 13, set the height to 350
pixels.

The header bar of the datatables in the tooltips has been removed, since it
does not become wide enough when setting the max scroll. Unfortunately when
setting the scroll height on the datatable it will create a div at fixed height
around the table, so if there are too few items to fit the div a white
background is shown. The original idea was to determine size of the datatable
and add the scrollbar accordingly, but there does not seem to be a callback
function in datatables where the height is known, therefore a limit of 13 items
was chosen instead.