### PR TITLE
Use display name to label graphs on study view

### DIFF
--- a/portal/src/main/webapp/js/src/study-view/data/StudyViewProxy.js
+++ b/portal/src/main/webapp/js/src/study-view/data/StudyViewProxy.js
@@ -159,7 +159,10 @@ var StudyViewProxy = (function() {
                 for(var i= 0; i < a1[0].attributes.length; i++){
                     var caseAttr = new CaseAttr();
                     caseAttr.attr_id =  a1[0].attributes[i].attr_id.toUpperCase();
-                    if(! a1[0].attributes[i].hasOwnProperty('display_name') ||  a1[0].attributes[i].display_name){
+                    if(a1[0].attributes[i].hasOwnProperty('display_name') && a1[0].attributes[i].display_name){
+                        caseAttr.display_name = a1[0].attributes[i].display_name;
+                    } else {
+                        //Fallback to using ID if there is no display_name
                         caseAttr.display_name =  a1[0].attributes[i].attr_id;
                     }
                     caseAttr.display_name = toPascalCase(caseAttr.display_name);


### PR DESCRIPTION
Only if display name is not defined or is blank fallback to using attribute id. Solves #538