### PR TITLE
Fix #546 Allow deployment on Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 # cBioPortal
 
 [![Build Status](https://travis-ci.org/cBioPortal/cbioportal.svg?branch=master)](https://travis-ci.org/cBioPortal/cbioportal)

--- a/app.json
+++ b/app.json
@@ -1,0 +1,31 @@
+{
+  "name": "cBioPortal",
+  "description":"The cBioPortal for Cancer Genomics provides visualization, analysis and download of large-scale cancer genomics data sets.",
+  "repository":"https://github.com/cbioportal/cbioportal",
+  "logo":"http://www.cbioportal.org/images/cbioportal_logo.png",
+  "keywords": [
+    "java",
+    "tomcat",
+    "javascript",
+    "cancer",
+    "genomics"
+  ],
+  "env": {
+    "JAVA_OPTS": {
+      "description":"options for jvm",
+      "value": "-Xmx300m -Xms300m -XX:+UseCompressedOops"
+    },
+    "MAVEN_CUSTOM_OPTS": {
+        "description":"set heroku profile for mvn",
+        "value":"-Pheroku,public -DskipTests -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test -Ddb.connection_string=jdbc:mysql://cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com:3306/ -Ddb.host=cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com"
+    }
+  },
+  "buildpacks": [
+    {
+      "url": "https://github.com/inodb/cbioportal-buildpack"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-java"
+    }
+  ]
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -353,7 +353,7 @@
 				<!-- username & password gets put in .m2/settings.xml -->
 				<settingsKey>settingsKey</settingsKey>
 				<driver>com.mysql.jdbc.Driver</driver>
-				<url>jdbc:mysql://localhost:3306/cgds_test</url>
+                <url>jdbc:mysql://localhost:3306/cgds_test</url>
 				<sqlCommand>SET storage_engine=INNODB</sqlCommand>
 				<sqlCommand>SET SESSION sql_mode = 'ANSI_QUOTES'</sqlCommand>
 				<srcFiles>
@@ -363,10 +363,36 @@
 				<!-- added encoding to prevent Unknown initial character set index '192' received from server error -->
 				<encoding>UTF-8</encoding>
 				<driverProperties>characterEncoding=utf8, connectionCollation=utf8_general_ci</driverProperties>
+                <!--all executions are ignored if -DskipTests -->
+                <skip>${skipTests}</skip>
 			  </configuration>
 			</execution>
 		  </executions>
 		</plugin>
+
+          <!-- remove temp build files -->
+          <plugin>
+              <artifactId>maven-clean-plugin</artifactId>
+              <version>2.5</version>
+              <executions>
+                  <execution>
+                      <id>clean-artifacts</id>
+                      <phase>install</phase>
+                      <goals><goal>clean</goal></goals>
+                      <configuration>
+                          <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                          <filesets>
+                              <fileset>
+                                  <directory>target</directory>
+                                  <excludes>
+                                      <exclude>*.war</exclude>
+                                  </excludes>
+                              </fileset>
+                          </filesets>
+                      </configuration>
+                  </execution>
+              </executions>
+          </plugin>
 
 	  </plugins>
 

--- a/heroku/.profile.d/cbioportal.sh
+++ b/heroku/.profile.d/cbioportal.sh
@@ -1,0 +1,1 @@
+export PORTAL_HOME=/app

--- a/heroku/Procfile
+++ b/heroku/Procfile
@@ -1,0 +1,1 @@
+web: java $JAVA_OPTS -Ddbconnector=dbcp -jar portal/target/dependency/webapp-runner.jar --expand-war --port $PORT portal/target/cbioportal.war

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,57 @@
 		<final-war-name>cbioportal</final-war-name>
 	  </properties>
 	</profile>
+    <profile>
+      <!-- copy files in heroku/ to root dir -->
+      <id>heroku</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.7</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-filtering</artifactId>
+                <version>1.3</version>
+              </dependency>
+            </dependencies>
+            <executions>
+              <execution>
+                <id>copy-resources</id>
+                <phase>validate</phase>
+                <goals><goal>copy-resources</goal></goals>
+                <configuration>
+                  <outputDirectory>.</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>heroku/</directory>
+                      <filtering>true</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+              <phase>validate</phase>
+              <goals><goal>run</goal></goals>
+              <configuration>
+                <tasks>
+                  <copy file="${PORTAL_HOME}/src/main/resources/portal.properties.EXAMPLE"
+                    tofile="${PORTAL_HOME}/src/main/resources/portal.properties" />
+                </tasks>
+              </configuration>
+              </execution>
+            </executions>
+            </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <!-- properties -->

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -130,9 +130,52 @@
 			  </resources>
             </configuration>
 		  </execution>
-		</executions>
-	  </plugin>
-
+      </executions>
+  </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals><goal>copy</goal></goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.github.jsimone</groupId>
+                                    <artifactId>webapp-runner</artifactId>
+                                    <version>8.0.24.0</version>
+                                    <destFileName>webapp-runner.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>2.5</version>
+                <executions>
+                    <execution>
+                        <id>clean-jar-artifacts</id>
+                        <phase>install</phase>
+                        <goals><goal>clean</goal></goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>${PORTAL_HOME}/portal/target</directory>
+                                    <excludes>
+                                        <exclude>*.war</exclude>
+                                        <exclude>dependency/webapp-runner.jar</exclude>
+                                    </excludes>
+                                </fileset>
+                            </filesets>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
 	</plugins>
 
 	<!-- properties file used for filtering our context file in resources -->

--- a/portal/src/main/resources/applicationContext-security.xml
+++ b/portal/src/main/resources/applicationContext-security.xml
@@ -34,7 +34,7 @@
         <b:constructor-arg ref="dataSource"/>
     </b:bean>
     <b:bean id="dataSource" class="org.springframework.jndi.JndiObjectFactoryBean">
-        <b:property name="jndiName" value="java:comp/env/${db.tomcat_resource_name}"/>
+        <b:property name="jndiName" value="java:comp/env/${db.tomcat_resource_name}" />
     </b:bean>
 
     <!-- static resources not processed by spring security filters -->

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -22,11 +22,11 @@
     <!-- jndi profile is defined here to prevent exceptions during war deployment -->
     <context-param>
         <param-name>spring.profiles.active</param-name>
-        <param-value>jndi,${authenticate}</param-value>
+        <param-value>${dbconnector:jndi},${authenticate}</param-value>
     </context-param>
     <context-param>  
         <param-name>spring.liveBeansView.mbeanDomain</param-name>  
-        <param-value>jndi,${authenticate}</param-value>  
+        <param-value>${dbconnector:jndi},${authenticate}</param-value>
     </context-param> 
 
     <context-param>
@@ -41,7 +41,7 @@
 
     <context-param>
       <param-name>log4jConfigLocation</param-name>
-      <param-value>file://${PORTAL_HOME}/log4j.properties</param-value>
+      <param-value>file://${PORTAL_HOME}/src/main/resources/log4j.properties</param-value>
     </context-param> 
 
     <!-- listeners -->


### PR DESCRIPTION
- Add webapp-runner.jar as dependency (used by heroku to run war)
- Add deploy to heroku button to README
- Remove unnecessary target directories after building war to decrease heroku's
  slug size (basically size repo + war)
- Add dbconnector spring property to allow using jndi or dbcp at runtime.
  Heroku's webapp-runner.jar does not seem to work with our setup of jndi.
- There is a heroku profile in pom.xml that copies all heroku specific files to
  the root dir of the portal when building the war. Only app.json has to be in
  the root dir for the deploy to heroku button to work. Copy EXAMPLE property
  file to src/main/resources/portal.properties. Set custom properties on
  command line with maven in app.json (i.e. use amazon public db).
- There was a problem with PORTAL_HOME both being required at run time and build
  time. At Heroku the build directory is different from the run directory and
  currently there is no dynamic way to get the name of this dir. Scripts in
  profile.d are run on heroku before the war is started. This allows one to set
  the PORTAL_HOME variable there. The PORTAL_HOME variable at build time is set
  through a buildpack on github inodb/cbioportal-buildpack. This is why the
  extra buildpack is required.