### PR TITLE
Adjustments to OQL and Oncoprint

### DIFF
--- a/portal/src/main/webapp/js/src/oncoprint/new/defaults.js
+++ b/portal/src/main/webapp/js/src/oncoprint/new/defaults.js
@@ -126,6 +126,11 @@ window.oncoprint_defaults = (function() {
 			shape: 'large-right-arrow',
 			color: 'black',
 			legend_label: 'Fusion'
+		},
+		'OTHER':{
+			shape: 'middle-rect',
+			color: '#90EE90',
+			legend_label: 'Mutation'
 		}
 	};
 	

--- a/portal/src/main/webapp/js/src/oncoprint/oncoprint-analysis-setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/oncoprint-analysis-setup.js
@@ -7,17 +7,18 @@ $(document).ready(function() {
 	$('#oncoprint_controls').html(_.template($('#main-controls-template').html())());
 
 	
-	$.when(window.QuerySession.getGenomicEventData(), window.QuerySession.getPatientSampleIdMap()).then(function(genomic_event_data, sample_patient_map) {
+	$.when(window.QuerySession.getGenomicEventData(), window.QuerySession.getPatientSampleIdMap(), window.QuerySession.getCombinedPatientGenomicEventData()).then(function(sample_genomic_event_data, sample_patient_map, patient_genomic_event_data) {
 			(function invokeOldDataManagers() {
 				var genes = window.QuerySession.getQueryGenes();
-				window.PortalDataColl.setOncoprintData(utils.process_data(genomic_event_data, genes));
-				PortalDataColl.setOncoprintStat(utils.alteration_info(genomic_event_data));
+				window.PortalDataColl.setOncoprintData(utils.process_data(sample_genomic_event_data, genes));
+				PortalDataColl.setOncoprintStat(utils.alteration_info(sample_genomic_event_data));
 			})();
 			$('#outer_loader_img').hide();
 			$('#oncoprint #everything').show();
 			window.onc_obj = setUpOncoprint('oncoprint_body', {
 				sample_to_patient: sample_patient_map,
-				gene_data: genomic_event_data,
+				sample_gene_data: sample_genomic_event_data,
+				patient_gene_data: patient_genomic_event_data,
 				toolbar_selector: '#oncoprint-diagram-toolbar-buttons',
 				toolbar_fade_hitzone_selector: '#oncoprint',
 				sample_list: window.QuerySession.getSampleIds(),

--- a/portal/src/main/webapp/js/src/oncoprint/setup-oncoprint-improved.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup-oncoprint-improved.js
@@ -5,99 +5,12 @@ window.setUpOncoprint = function(ctr_id, config) {
 	var sampleViewUrl, patientViewUrl;
 	
 	var sample_to_patient = config.sample_to_patient;
-	var gene_data = config.gene_data;
+	var sample_gene_data = config.sample_gene_data;
+	var patient_gene_data = config.patient_gene_data;
 	
 	var genetic_alteration_tracks = [];
 	var clinical_tracks = [];
 	
-	var splitIdString = function(str) {
-		str = str.trim();
-		if (str.length > 0) {
-			return str.split(/\s+/);
-		} else {
-			return [];
-		}
-	};
-	var annotateMutationTypes = function(data) {
-		var ret = _.map(data, function (d) {
-			if (d.mutation) {
-				var mutations = d.mutation.split(",");
-				var hasIndel = false;
-				if (mutations.length > 1) {
-					for (var i = 0, _len = mutations.length; i < _len; i++) {
-						if (/\bfusion\b/i.test(mutations[i])) {
-							d.mut_type = 'FUSION';
-						} else if (!(/^[A-z]([0-9]+)[A-z]$/g).test(mutations[i])) {
-							d.mut_type = 'TRUNC';
-						} else if ((/^([A-Z]+)([0-9]+)((del)|(ins))$/g).test(mutations[i])) {
-							hasIndel = true;
-						}
-					}
-					d.mut_type = d.mut_type || (hasIndel ? 'INFRAME' : 'MISSENSE');
-				} else {
-					if (/\bfusion\b/i.test(mutations)) {
-						d.mut_type = 'FUSION';
-					} else if ((/^[A-z]([0-9]+)[A-z]$/g).test(mutations)) {
-						d.mut_type = 'MISSENSE';
-					} else if ((/^([A-Z]+)([0-9]+)((del)|(ins))$/g).test(mutations)) {
-						d.mut_type = 'INFRAME';
-					} else {
-						d.mut_type = 'TRUNC';
-					}
-				}
-			}
-			return d;
-		});
-		return ret;
-	};
-
-	var makePatientData__Gene = function(sample_data) {
-		var ret = {};
-		// TEMPORARY: just use an arbitrary sample. TODO: fix this properly
-		var extremeness = {
-			cna: {
-				'AMPLIFIED': 2,
-				'GAINED': 1,
-				'HEMIZYGOUSLYDELETED': 1,
-				'HOMODELETED': 2,
-				undefined: 0
-			},
-			mrna: {
-				'UPREGULATED': 1,
-				'DOWNREGULATED': 1,
-				undefined: 0
-			},
-			rppa: {
-				'UPREGULATED': 1,
-				'DOWNREGULATED': 1,
-				undefined: 0
-			}
-		};
-		_.each(sample_data, function (d) {
-			var patient_id = sample_to_patient[d.sample];
-			ret[patient_id] = ret[patient_id] || {patient: patient_id, gene:d.gene, na: true};
-			var new_datum = ret[patient_id];
-			if (!d.hasOwnProperty("na")) {
-				delete new_datum["na"];
-			}
-			_.each(d, function(val, key) {
-				if (key === 'mutation') {
-					new_datum['mutation'] = (new_datum['mutation'] && (new_datum['mutation']+','+val)) || val;
-				} else if (extremeness.hasOwnProperty(key)) {
-					if (extremeness[key][val] > extremeness[key][new_datum[key]]) {
-						new_datum[key] = val;
-					}
-				}
-			});
-		});
-		return _.map(Object.keys(ret), function (k) {
-			var d = ret[k];
-			if (d.mutation) {
-				d.mutation = _.uniq(d.mutation.split(',').filter(function(x) { return x.trim().length > 0; })).join(",");
-			}
-			return d;
-		});
-	};
 	var makePatientData__Clinical = function(sample_data, aggregation_method) {
 		var ret = {};
 		if (aggregation_method === 'category') {
@@ -310,21 +223,28 @@ window.setUpOncoprint = function(ctr_id, config) {
 	})();
 	(function createGeneticAlterationTracks() {
 		var genes = {};
-		_.each(gene_data, function (d) {
+		_.each(sample_gene_data, function (d) {
 			genes[d.gene] = true;
 		});
 		genes = Object.keys(genes);
-		_.each(gene_data, function (d) {
+		_.each(sample_gene_data, function (d) {
 			var gene = d.gene;
 			sample_data__gene[gene] = sample_data__gene[gene] || [];
 			sample_data__gene[gene].push(d);
 		});
-		_.each(sample_data__gene, function (data, gene) {
-			sample_data__gene[gene] = annotateMutationTypes(data);
+		if (patient_gene_data) {
+		    _.each(patient_gene_data, function(d) {
+			    var gene = d.gene;
+			    patient_data__gene[gene] = patient_data__gene[gene] || [];
+			    patient_data__gene[gene].push(d);
+		    });
+		}
+		/*_.each(sample_data__gene, function (data, gene) {
+			sample_data__gene[gene] = data;
 			if (config.swap_patient_sample) {
 				patient_data__gene[gene] = annotateMutationTypes(makePatientData__Gene(data));
 			}
-		});
+		});*/
 		genes = config.gene_order || genes;
 		
 		(function populateOncoprintWithProgressUpdates() {


### PR DESCRIPTION
Adjust how sample data is processed and thus how OQL filtering is done, all in the service of fixing bug where INFRAMEs registered as TRUNCs in the oncoprint.