### PR TITLE
Fix bug in client cache

### DIFF
--- a/portal/src/main/webapp/js/api/cbioportal-client.js
+++ b/portal/src/main/webapp/js/api/cbioportal-client.js
@@ -186,12 +186,12 @@ window.cbioportal_client = (function() {
 					if (Object.prototype.toString.call(obj) === '[object Array]') {
 						ret = ret.concat(obj);
 					} else {
-                                                var keys = key_list_list[key_list_index] || Object.keys(obj);
-                                                for (k = 0; k<keys.length; k++) {
-                                                        if (obj.hasOwnProperty(keys[k])) {
-                                                                tmp_intermediate.push(obj[keys[k]]);
-                                                        }
-                                                }
+						var keys = (key_list_index < key_list_list.length && key_list_list[key_list_index]) || Object.keys(obj);
+						for (k = 0; k<keys.length; k++) {
+							if (obj.hasOwnProperty(keys[k])) {
+								tmp_intermediate.push(obj[keys[k]]);
+							}
+						}
 					}
 				}
 				intermediate = tmp_intermediate;


### PR DESCRIPTION
Implementing desired behavior:

e.g.
If you ask for genetic profile data with only genetic_profile_ids and genes, it should give it to you for all samples. It wasn't working, it would only work if you gave the sample_ids. Now it should work.