### PR TITLE
Skip looking at first item in ProteinArrayData

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportProteinArrayData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportProteinArrayData.java
@@ -76,7 +76,8 @@ public class ImportProteinArrayData {
         FileReader reader = new FileReader(arrayData);
         BufferedReader buf = new BufferedReader(reader);
         String line = buf.readLine();
-        String[] sampleIds = line.split("\t");
+        String[] firstLine = line.split("\t");
+        String[] sampleIds = Arrays.copyOfRange(firstLine, 1, firstLine.length-1);
         ImportDataUtil.addPatients(sampleIds, profile.getGeneticProfileId());
         ImportDataUtil.addSamples(sampleIds, profile.getGeneticProfileId());
         Sample[] samples = new Sample[sampleIds.length-1];


### PR DESCRIPTION
This field is not data - it is a header. This caused weird fields to show up as Patients.