### PR TITLE
Fix oncoprint issues from #609

### DIFF
--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -214,15 +214,9 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 			    var mutation_type_key = config.mutation_type_key;
 			    matching_mutations.sort(function(a,b) { return mutation_rendering_priority[a[mutation_type_key]] - mutation_rendering_priority[b[mutation_type_key]]; });
 			    ret[config.mutation_type_key] = matching_mutations[0][config.mutation_type_key];
-			    var type = ret[config.mutation_type_key];
-			    ret[config.mutation_key] = "";
-			    for (var j=0; j<matching_mutations.length; j++) {
-				if (matching_mutations[j][config.mutation_type_key] !== type) {
-				    break;
-				} else {
-				    ret[config.mutation_key] += matching_mutations[j][config.mutation_amino_acid_change_key];
-				}
-			    }
+			    ret[config.mutation_key] = matching_mutations.map(function(m) {
+				return m[config.mutation_amino_acid_change_key];
+			    }).join(",");
 			}
 			if (altered) {
 				markDatumAltered(ret);
@@ -494,6 +488,7 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 				case "nonframeshift":
 				case "nonframeshift insertion":
 				case "nonframeshift_insertion":
+				case "targeted_region":
 				    ret = "INFRAME";
 				    break;
 				default:

--- a/portal/src/main/webapp/js/src/oncoprint/new/RuleSet.js
+++ b/portal/src/main/webapp/js/src/oncoprint/new/RuleSet.js
@@ -260,9 +260,16 @@ window.oncoprint_RuleSet = (function() {
 						return typeof d[_key] !== 'undefined';
 					}
 				} else {
-					return function(d) {
-						return d[_key] === _value;
-					};
+					if (_value[0] === "-") {
+					    var actual_value = _value.substring(1);
+					    return function(d) {
+						    return typeof d[_key] !== 'undefined' && d[_key] !== actual_value;
+					    };
+					} else {
+					    return function(d) {
+						    return d[_key] === _value;
+					    };
+					}
 				}
 			})(key, value) : undefined;
 			var shape, attrs, styles, z_index;

--- a/portal/src/main/webapp/js/src/oncoprint/new/defaults.js
+++ b/portal/src/main/webapp/js/src/oncoprint/new/defaults.js
@@ -5,12 +5,17 @@ window.oncoprint_defaults = (function() {
 		var cna_order = utils.invert_array(['AMPLIFIED', 'HOMODELETED', 'GAINED', 'HEMIZYGOUSLYDELETED', 'DIPLOID', undefined]);
 		var mut_type_key = 'mut_type';
 		var mut_order = (function() {
+			var _order = utils.invert_array(['FUSION', 'TRUNC', 'INFRAME', 'MISSENSE', undefined, true, false]); 
 			if (!distinguish_mutations) {
 				return function(m) {
-					return +(typeof m === 'undefined');
+					if (m === 'FUSION') {
+					    return 0;
+					} else {
+					    return _order[!!m];
+					}
+					//return +(typeof m === 'undefined');
 				}
-			} else {
-				var _order = utils.invert_array(['TRUNC', 'INFRAME', 'MISSENSE', undefined]); 
+			} else { 
 				return function(m) {
 					return _order[m];
 				}
@@ -99,7 +104,12 @@ window.oncoprint_defaults = (function() {
 	};
 	var genetic_alteration_config_nondistinct_mutations = $.extend(true,{},genetic_alteration_config_base);
 	genetic_alteration_config_nondistinct_mutations.altered.mut_type = {
-		'*': {
+		'FUSION':{
+			shape: 'large-right-arrow',
+			color: 'black',
+			legend_label: 'Fusion'
+		},
+		'-FUSION':{
 			shape: 'middle-rect',
 			color: 'green',
 			legend_label: 'Mutation'


### PR DESCRIPTION
Fixes #609 

(1) Order fusions before other mutations
(2) When 'show all mutations with the same color', fusions should still be different color and glyph
(3) Treat "Targeted_Region" mutations as Inframe, both in rendering and OQL filtering

also..
(4) If, for example, a sample has a truncating mutation and an inframe mutation, the oncoprint will render it as having truncating. But when you rollover the sample, both of the mutations amino acid changes are now listed, separated by commas.