### PR TITLE
Only remove built core files with heroku profile

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -260,6 +260,37 @@
 
   </dependencies>
 
+	<profiles>
+		<profile>
+			<id>heroku</id>
+			<build>
+				<plugins>
+					<!-- remove core temp build files -->
+					<plugin>
+						<artifactId>maven-clean-plugin</artifactId>
+						<version>2.5</version>
+						<executions>
+							<execution>
+								<id>clean-artifacts</id>
+								<phase>install</phase>
+								<goals><goal>clean</goal></goals>
+								<configuration>
+									<excludeDefaultDirectories>true</excludeDefaultDirectories>
+									<filesets>
+										<fileset>
+											<directory>target</directory>
+										</fileset>
+									</filesets>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
+
 	<!-- plugins -->
 	<build>
 
@@ -365,29 +396,6 @@
 		  </executions>
 		</plugin>
 
-          <!-- remove temp build files -->
-          <plugin>
-              <artifactId>maven-clean-plugin</artifactId>
-              <version>2.5</version>
-              <executions>
-                  <execution>
-                      <id>clean-artifacts</id>
-                      <phase>install</phase>
-                      <goals><goal>clean</goal></goals>
-                      <configuration>
-                          <excludeDefaultDirectories>true</excludeDefaultDirectories>
-                          <filesets>
-                              <fileset>
-                                  <directory>target</directory>
-                                  <excludes>
-                                      <exclude>*.war</exclude>
-                                  </excludes>
-                              </fileset>
-                          </filesets>
-                      </configuration>
-                  </execution>
-              </executions>
-          </plugin>
 
 	  </plugins>
 


### PR DESCRIPTION
Currently the core jar gets deleted after building, which is required for
importing data into the portal. This commit makes sure the core jar is only
deleted when the heroku profile is activated.