### PR TITLE
Patient view fixes

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -554,7 +554,22 @@ function addMoreClinicalTooltip(elem) {
                 }
             };
         } else {
+            // check if sample has clinical data
             var caseId = $(this).attr('alt');
+            if (!clinicalDataMap[caseId]) {
+                var pos = {my:'top left',at:'bottom left'};
+                thisElem.qtip({
+                    content: {
+                        text: "No clinical data"
+                    },
+                    show: {event: "mouseover"},
+                    hide: {fixed: true, delay: 100, event: "mouseout"},
+                    style: { classes: 'qtip-light qtip-rounded qtip-wide' },
+                    position: pos,
+                });
+                return;
+            }
+            // if it does have clinical data, make datatable
             clinicalData = [];
             for (var key in clinicalDataMap[caseId]) {
                 clinicalData.push([clinicalAttributes && clinicalAttributes[key]["displayName"] || key, clinicalDataMap[caseId][key]]);

--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/summary.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/summary.jsp
@@ -322,7 +322,7 @@ legend.legend-border {
 <%}%>
 
 <%if(showGenomicOverview){%>
-<fieldset class="fieldset-border">
+<fieldset class="fieldset-border ui-widget-content">
 <legend class="legend-border">Genomic Overview</legend>
 <table>
     <tr>


### PR DESCRIPTION
- Fix #682 If a patient has samples with and without clinical data. The tooltip in the samples w/o clinical data displays "no clinical data" instead of removing the entire sample:

    ![screen shot 2015-12-24 at 6 50 39 pm](https://cloud.githubusercontent.com/assets/1334004/11998491/443c99bc-aa6f-11e5-9e86-7b2a26b0f6e6.png)
- Make the genomic overview border lighter

    Before:
    ![screen shot 2015-12-24 at 6 51 58 pm](https://cloud.githubusercontent.com/assets/1334004/11998494/71a144fc-aa6f-11e5-9175-2dabaa6ea1e8.png)

    After:
    ![screen shot 2015-12-24 at 6 51 50 pm](https://cloud.githubusercontent.com/assets/1334004/11998496/7760c1a6-aa6f-11e5-85ed-2073dfe7b327.png)

