### PR TITLE
changed meta-file flag for ImportCopyNumberSegmentData

### DIFF
--- a/core/src/main/scripts/cbioportal_common.py
+++ b/core/src/main/scripts/cbioportal_common.py
@@ -32,7 +32,7 @@ IMPORTER_CLASSNAME_BY_ALTERATION_TYPE = { "CLINICAL" : "org.mskcc.cbio.portal.sc
                                             "TIMELINE" : "org.mskcc.cbio.portal.scripts.ImportTimelineData" }
 
 IMPORTER_REQUIRES_METADATA = { "org.mskcc.cbio.portal.scripts.ImportClinicalData" : False,
-                                "org.mskcc.cbio.portal.scripts.ImportCopyNumberSegmentData" : False,
+                                "org.mskcc.cbio.portal.scripts.ImportCopyNumberSegmentData" : True,
                                 "org.mskcc.cbio.portal.scripts.ImportGisticData" : False,
                                 "org.mskcc.cbio.portal.scripts.ImportMutSigData" : False,
                                 "org.mskcc.cbio.portal.scripts.ImportProteinArrayData" : False,

--- a/core/src/test/java/org/mskcc/cbio/portal/pancancer/LargeTestSetGenerator.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/pancancer/LargeTestSetGenerator.java
@@ -43,6 +43,9 @@ public class LargeTestSetGenerator {
 		System.out.println("Generating CNA data....");
 		generateDataCNA(dataCNAfile, outputDir, sampleList);
 
+		System.out.println("Generating CNA SEG data....");
+		generateDataCNA_SEG(dataCNAfile + ".seg", outputDir, sampleList);
+		
 		System.out.println("Generating cases_all.txt....");
 		generateCasesAll(outputDir, sampleList, studyId);
 		
@@ -67,6 +70,11 @@ public class LargeTestSetGenerator {
         
         System.out.println("Generating meta_CNA.txt....");
         generateMetaCna(outputDir, studyId);
+        
+        System.out.println("Generating meta_CNA_seg.txt....");
+        generateMetaCnaSEG(outputDir, studyId);
+        
+        
         
         
         System.out.println("Done. You will find the files in " + outputDir);
@@ -124,7 +132,23 @@ public class LargeTestSetGenerator {
 			"stable_id: " + studyId+ "_gistic\n"+
 			"show_profile_in_analysis_tab: true\n"+
 			"profile_description: Putative copy-number from GISTIC 2.0. Values: -2 = homozygous deletion; -1 = hemizygous deletion; 0 = neutral / no change; 1 = gain; 2 = high level amplification.\n"+
-			"profile_name: Putative copy-number alterations from GISTIC " + studyId);
+			"profile_name: Putative copy-number alterations from GISTIC " + studyId );
+		
+		resultFile.close();
+	}
+	
+	private static void generateMetaCnaSEG(String outputDir, String studyId) throws IOException {
+		FileWriter resultFile = new FileWriter(outputDir + "/meta_CNA_seg.txt");
+		resultFile.write("cancer_study_identifier: " + studyId+ "\n"+
+				"genetic_alteration_type: SEGMENT\n"+
+				"datatype: SEGMENT\n"+
+				"stable_id: " + studyId+ "_segment\n"+
+				"show_profile_in_analysis_tab: false\n"+
+				"profile_description: Segment data for the study " + studyId+ "\n"+
+				"profile_name: Segment data values " + studyId+ "\n"+ 
+				"reference_genome_id: hg19\n"+
+				"data_filename: data_CNA_txt.seg\n"+
+				"description: Segment data for the study " + studyId );
 		resultFile.close();
 	}
 
@@ -289,6 +313,82 @@ public class LargeTestSetGenerator {
 		
 		
 	}
+	
+	
+	private static void generateDataCNA_SEG(String dataCNASegfile, String outputDir, List<String> sampleList) throws IOException {
+		// Hugo_Symbol	Entrez_Gene_Id sample1 sample2 ....
+		FileWriter resultFile = new FileWriter(outputDir + "/" + new File(dataCNASegfile).getName());
+		//write header: 
+		resultFile.write("Sample\tchrom\tloc.start\tloc.end\tnum.mark\tseg.mean\n");
+		
+		//example:
+		//Sample			chrom	loc.start	loc.end		num.mark	seg.mean
+		//TCGA-A1-A0SB-01		1	1737357		39975142	17096		0.009
+		
+		
+		for (String sample : sampleList) {
+			
+			int nrChrom = random(10,20); //some of the chromosomes 
+			for (int i = 1; i < nrChrom; i ++) {
+				double seg_mean = random(-200,200)/100.0;
+				resultFile.write(sample + "\t" + i + "\t" +"13684348\t" +"13833633\t" +"17096\t" + seg_mean + "\n"); 
+				seg_mean = random(-200,200)/100.0;
+				resultFile.write(sample + "\t" + i + "\t" +"13833728\t" +"15413875\t" +"17096\t" + seg_mean + "\n"); 
+				seg_mean = random(-200,200)/100.0;
+				resultFile.write(sample + "\t" + i + "\t" +"15416808\t" +"16121303\t" +"17096\t" + seg_mean + "\n"); 
+				seg_mean = random(-200,200)/100.0;
+				resultFile.write(sample + "\t" + i + "\t" +"16124160\t" +"16764830\t" +"17096\t" + seg_mean + "\n"); 
+				seg_mean = random(-200,200)/100.0;
+				resultFile.write(sample + "\t" + i + "\t" +"16769801\t" +"18101891\t" +"17096\t" + seg_mean + "\n"); 
+				seg_mean = random(-200,200)/100.0;
+				resultFile.write(sample + "\t" + i + "\t" +"18104300\t" +"18657376\t" +"17096\t" + seg_mean + "\n"); 
+				seg_mean = random(-200,200)/100.0;
+				resultFile.write(sample + "\t" + i + "\t" +"18658403\t" +"25343371\t" +"17096\t" + seg_mean + "\n"); 
+				seg_mean = random(-200,200)/100.0;
+				resultFile.write(sample + "\t" + i + "\t" +"25346379\t" +"27014651\t" +"17096\t" + seg_mean + "\n");
+				
+				seg_mean = random(-200,200)/100.0;
+				resultFile.write(sample + "\t" + i + "\t" +"27021371\t" +"27182923\t" +"17096\t" + seg_mean + "\n"); 
+				seg_mean = random(-200,200)/100.0;
+				resultFile.write(sample + "\t" + i + "\t" +"27182944\t" +"27339665\t" +"17096\t" + seg_mean + "\n"); 
+				seg_mean = random(-200,200)/100.0;
+				resultFile.write(sample + "\t" + i + "\t" +"27340606\t" +"29923280\t" +"17096\t" + seg_mean + "\n"); 
+
+				//TODO the segments above cover only a small portion of the chromosomes. Ideally we base this on a table
+				//with chromosome size and try to cover a large portion...perhaps something to add later if really necessary for a specific test...
+				
+			}
+
+//			TCGA-GI-A2C8-01	17	13684348	13833633	115	-1.0971
+//			TCGA-GI-A2C8-01	17	13833728	15413875	1243	-0.0309
+//			TCGA-GI-A2C8-01	17	15416808	16121303	185	-0.9382
+//			TCGA-GI-A2C8-01	17	16124160	16764830	213	-0.2745
+//			TCGA-GI-A2C8-01	17	16769801	18101891	668	0.2376
+//			TCGA-GI-A2C8-01	17	18104300	18657376	41	0.4776
+//			TCGA-GI-A2C8-01	17	18658403	25343371	868	-0.2243
+//			TCGA-GI-A2C8-01	17	25346379	27014651	810	0.1167
+			
+			
+//			TCGA-GI-A2C8-01	17	27021371	27182923	55	0.5718
+//			TCGA-GI-A2C8-01	17	27182944	27339665	74	0.2509
+//			TCGA-GI-A2C8-01	17	27340606	29923280	1067	-0.217
+			
+//			TCGA-GI-A2C8-01	17	29926532	30117305	108	0.2985
+//			TCGA-GI-A2C8-01	17	30117461	30347325	107	-0.2215
+//			TCGA-GI-A2C8-01	17	30347502	30579182	108	0.9076
+//			TCGA-GI-A2C8-01	17	30580272	30974499	163	1.5428
+//			TCGA-GI-A2C8-01	17	30976522	31180523	116	-0.2454
+//			TCGA-GI-A2C8-01	17	31182534	31250961	38	1.1809
+//			TCGA-GI-A2C8-01	17	31259041	31284664	22	-0.1943
+//			TCGA-GI-A2C8-01	17	31285744	31351121	57	1.0972
+			
+		}
+		resultFile.close();
+		
+		
+	}
+	
+	
 	
 	private static void generateCasesAll(String outputDir, List<String> sampleList, String studyId) throws IOException {
 		


### PR DESCRIPTION
small fix to make sure the import process via cbioportalImporter.py is aligned with the requirement for a meta file in the underlying java process (specific fix for ImportCopyNumberSegmentData)

(same as #529, but now pointing to rc ;)