### PR TITLE
Solve .editorconfig auto-formating issue; This closes issue #757

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,8 +21,8 @@ indent_size = 4
 # Unix-style newlines with a newline ending every file
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
+trim_trailing_whitespace = false
+insert_final_newline = false
 
 # Formats for markdown files only
 [*.md]


### PR DESCRIPTION
trim_trailing_whitespace and insert_final_newline should be set to true
when first initialize the project. But due to years of development,
these two parameters will cause massive code style changes and then
should be disabled for cBioPortal.