### PR TITLE
Quick fix for proper direct URL access to tab_images (Tissue Images)

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/patient_view.jsp
@@ -458,14 +458,14 @@ function initTabs() {
 
 function fixCytoscapeWebRedraw() {
     // to initially hide the network tab
-    $("#pathways").attr('style', 'display: none !important; height: 0px; width: 0px; visibility: hidden;');
+    $("#tab_pathways").attr('style', 'display: none !important; height: 0px; width: 0px; visibility: hidden;');
 
     // to fix problem of flash repainting
     $("a.patient-tab").click(function(){
-        if($(this).attr("href")==="#pathways") {
-            $("#pathways").removeAttr('style');
+        if($(this).attr("href")==="#tab_pathways") {
+            $("#tab_pathways").removeAttr('style');
         } else {
-            $("#pathways").attr('style', 'display: block !important; height: 0px; width: 0px; visibility: hidden;');
+            $("#tab_pathways").attr('style', 'display: block !important; height: 0px; width: 0px; visibility: hidden;');
         }
     });
 }
@@ -476,7 +476,7 @@ function switchToTab(toTab) {
     $('#patient-tabs').tabs("option",
 		"active",
 		$('#patient-tabs ul a[href="#'+toTab+'"]').parent().index());
-    if (toTab==='images') {
+    if (toTab==='tab_images') {
         loadImages();
     }
 }


### PR DESCRIPTION
fix element name references in javascript code to match actual element names
also corrected pathways tab, although this is not currently in use

This is a short term fix to allow direct URL access to the tissue images tab on the patient view to load properly.

Other improvements are needed, such as adopting the approach of only doing expensive tab loading when tabs are visible. (see #642, #721)

Issue from issuetracker: #709