### PR TITLE
display multiline clinical attributes

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/samples_table.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/tumormap/patient_view/samples_table.jsp
@@ -125,7 +125,8 @@
     -webkit-appearance: searchfield;
 }
 .clinical-attr-table table.dataTable>tbody>tr>td {
-    white-space: nowrap;
+    white-space: pre-wrap;
+    max-width: 800px;
 }
 .clinical-attr-table .DTTT_container.ui-buttonset.ui-buttonset-multi a {
     width: 50px;


### PR DESCRIPTION
and , set max-width on sample clinical attribute value to 800px.
This allows us to use very long clinical attributes (pathology reports) for samples and have sane formatting 
![image](https://cloud.githubusercontent.com/assets/5654699/12949161/e4e0081a-d006-11e5-8dd1-90f76e09a877.png)

