### PR TITLE
Fix #830 make portal pom cleanup heroku specific

### DIFF
--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -153,29 +153,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>2.5</version>
-                <executions>
-                    <execution>
-                        <id>clean-jar-artifacts</id>
-                        <phase>install</phase>
-                        <goals><goal>clean</goal></goals>
-                        <configuration>
-                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
-                            <filesets>
-                                <fileset>
-                                    <directory>${PORTAL_HOME}/portal/target</directory>
-                                    <excludes>
-                                        <exclude>*.war</exclude>
-                                        <exclude>dependency/webapp-runner.jar</exclude>
-                                    </excludes>
-                                </fileset>
-                            </filesets>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
 	</plugins>
 
 	<!-- properties file used for filtering our context file in resources -->
@@ -206,6 +183,41 @@
 	</resources>
 
   </build>
+
+  <!-- remove portal temp build files when building heroku -->
+  <profiles>
+    <profile>
+      <id>heroku</id>
+        <build>
+          <plugins>
+            <plugin>
+              <artifactId>maven-clean-plugin</artifactId>
+              <version>2.5</version>
+              <executions>
+                <execution>
+                  <id>clean-jar-artifacts</id>
+                  <phase>install</phase>
+                  <goals><goal>clean</goal></goals>
+                  <configuration>
+                    <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                    <filesets>
+                      <fileset>
+                        <directory>${PORTAL_HOME}/portal/target</directory>
+                        <excludes>
+                          <exclude>*.war</exclude>
+                          <exclude>dependency/webapp-runner.jar</exclude>
+                        </excludes>
+                      </fileset>
+                    </filesets>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+    </profile>
+  </profiles>
+
     <properties>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>


### PR DESCRIPTION
Currently the temporary built files in `portal/target/portal` are deleted. This deletes the files only in case the heroku profile is selected.