### PR TITLE
hotfix for mutation type column search functionality

### DIFF
--- a/portal/src/main/webapp/js/lib/mutationMapper.js
+++ b/portal/src/main/webapp/js/lib/mutationMapper.js
@@ -13000,6 +13000,13 @@ function MutationDetailsTable(options, gene, mutationUtil, dataProxies)
 			"proteinChange": function(datum) {
 				return datum.mutation.proteinChange;
 			},
+			"mutationType": function(datum) {
+				// use display value for mutation type, not the sort value
+				var mutationType = MutationDetailsTableFormatter.getMutationType(
+					datum.mutation.mutationType);
+
+				return mutationType.text;
+			},
 			"cosmic": function(datum) {
 				return datum.mutation.cosmicCount;
 			},


### PR DESCRIPTION
This fixes the search functionality for the mutation type column.

See https://github.com/cBioPortal/mutation-mapper/issues/9 for more details.