### PR TITLE
Validator and loader prelastrc

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
@@ -85,9 +85,8 @@ public class DumpPortalInfo {
         // check args
         if (args.length != 1 || args[0] == "-h" || args[0] == "--help") {
             System.err.println(
-                    "command line usage:  dumpPortalInfo.pl " +
+                    "Command line usage:  dumpPortalInfo.pl " +
                     "<name for the output directory>");
-            System.err.println();
             System.err.println();
             System.exit(EX_USAGE);
         }
@@ -103,7 +102,7 @@ public class DumpPortalInfo {
         File outputDir = new File(outputDirName);
         if (!outputDir.mkdir()) {
             System.err.printf(
-                    "Could not create new directory '%s'." +
+                    "Could not create new directory '%s'.\n",
                     outputDir.getPath());
             System.exit(EX_CANTCREAT);
         }

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
@@ -84,10 +84,17 @@ public class DumpPortalInfo {
 
         // check args
         if (args.length != 1 || args[0] == "-h" || args[0] == "--help") {
-            System.err.println(
-                    "Command line usage:  dumpPortalInfo.pl " +
-                    "<name for the output directory>");
-            System.err.println();
+            System.err.print(
+                    "Command line usage:  dumpPortalInfo.pl" +
+                    " <name for the output directory>\n" +
+                    "\n" +
+                    "Generate a folder of files describing the portal " +
+                    "configuration.\n" +
+                    "\n" +
+                    "This is a subset of the information provided by the " +
+                    "web API,\n" +
+                    "intended for offline use of the validation script for " +
+                    "study data.\n");
             System.exit(EX_USAGE);
         }
         String outputDirName = args[0];

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2016 The Hyve B.V.
+ *
+ * This code is licensed under the GNU Affero General Public License (AGPL),
+ * version 3, or (at your option) any later version.
+ *
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mskcc.cbio.portal.scripts;
+
+import java.util.List;
+import java.io.Serializable;
+import java.io.File;
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.mskcc.cbio.portal.util.SpringUtil;
+import org.mskcc.cbio.portal.util.ConsoleUtil;
+import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.mskcc.cbio.portal.service.ApiService;
+
+/**
+ * Command line tool to generate JSON files used by the validation script.
+ */
+public class DumpPortalInfo {
+
+    // exit status codes for the script
+    private static final int EX_USAGE = 64;
+    private static final int EX_CANTCREAT = 73;
+    private static final int EX_IOERR = 74;
+
+    // these names are defined in annotations to the methods of ApiController,
+    // in org.mskcc.cbio.portal.web
+    private static final String API_CANCER_TYPES = "/cancertypes";
+    private static final String API_SAMPLE_ATTRS = "/clinicalattributes/samples";
+    private static final String API_PATIENT_ATTRS = "/clinicalattributes/patients";
+    private static final String API_GENES = "/genes";
+    private static final String API_GENE_ALIASES = "/genesaliases";
+
+    public ApiService apiService;
+
+    private static File nameJsonFile(File dirName, String apiName) {
+        // Determine the first alphabetic character
+        int i;
+        for (
+                i = 0;
+                !Character.isLetter(apiName.charAt(i));
+                i++) {}
+        // make a string without the initial non-alphanumeric characters
+        String fileName = apiName.substring(i).replace('/', '_') + ".json";
+        return new File(dirName, fileName);
+    }
+
+    private static void writeJsonFile(
+            List<? extends Serializable> objectList,
+            File outputFile) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+            try {
+                mapper.writeValue(outputFile, objectList);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(
+                        "Error converting API data to JSON file: " +
+                        e.getMessage());
+            }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        // check args
+        if (args.length != 1 || args[0] == "-h" || args[0] == "--help") {
+            System.err.println(
+                    "command line usage:  dumpPortalInfo.pl " +
+                    "<name for the output directory>");
+            System.err.println();
+            System.err.println();
+            System.exit(EX_USAGE);
+        }
+        String outputDirName = args[0];
+
+        // initialize progress monitor to print status output
+        ProgressMonitor.setConsoleMode(true);
+        // initialize application context, including database connection
+        SpringUtil.initDataSource();
+        ApiService apiService = SpringUtil.getApplicationContext().getBean(
+                ApiService.class);
+
+        File outputDir = new File(outputDirName);
+        if (!outputDir.mkdir()) {
+            System.err.printf(
+                    "Could not create new directory '%s'." +
+                    outputDir.getPath());
+            System.exit(EX_CANTCREAT);
+        }
+
+        try {
+            writeJsonFile(
+                    apiService.getCancerTypes(),
+                    nameJsonFile(outputDir, API_CANCER_TYPES));
+            writeJsonFile(
+                    apiService.getSampleClinicalAttributes(),
+                    nameJsonFile(outputDir, API_SAMPLE_ATTRS));
+            writeJsonFile(
+                    apiService.getPatientClinicalAttributes(),
+                    nameJsonFile(outputDir, API_PATIENT_ATTRS));
+            writeJsonFile(
+                    apiService.getGenes(),
+                    nameJsonFile(outputDir, API_GENES));
+            writeJsonFile(
+                    apiService.getGenesAliases(),
+                    nameJsonFile(outputDir, API_GENE_ALIASES));
+        } catch (IOException e) {
+            System.err.println(
+                    "Error writing portal info file: " +
+                    e.getMessage());
+            System.exit(EX_IOERR);
+        }
+
+        ConsoleUtil.showWarnings();
+        System.err.println("Done.");
+
+   }
+
+}

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
@@ -111,9 +111,12 @@ public class DumpPortalInfo {
                 ApiService.class);
 
         File outputDir = new File(outputDirName);
-        if (!outputDir.mkdir()) {
+        // this will do nothing if the directory already exists:
+        // the files will simply be overwritten
+        outputDir.mkdir();
+        if (!outputDir.isDirectory()) {
             System.err.printf(
-                    "Could not create new directory '%s'.\n",
+                    "Could not create directory '%s'.\n",
                     outputDir.getPath());
             System.exit(EX_CANTCREAT);
         }

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
@@ -83,7 +83,8 @@ public class DumpPortalInfo {
     public static void main(String[] args) throws Exception {
 
         // check args
-        if (args.length != 1 || args[0] == "-h" || args[0] == "--help") {
+        if (args.length != 1 ||
+                args[0].equals("-h") || args[0].equals("--help")) {
             System.err.print(
                     "Command line usage:  dumpPortalInfo.pl" +
                     " <name for the output directory>\n" +
@@ -98,6 +99,9 @@ public class DumpPortalInfo {
             System.exit(EX_USAGE);
         }
         String outputDirName = args[0];
+        System.err.printf(
+                "Writing portal info files to directory '%s'...\n",
+                outputDirName);
 
         // initialize progress monitor to print status output
         ProgressMonitor.setConsoleMode(true);

--- a/core/src/main/java/org/mskcc/cbio/portal/util/SpringUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/SpringUtil.java
@@ -64,4 +64,13 @@ public class SpringUtil
 		}
 	}
 
+    /**
+     * Get the app context as initialized or refreshed by initDataSource()
+     *
+     * @return the Spring Framework application context
+     */
+    public static ApplicationContext getApplicationContext() {
+        return context;
+    }
+
 }

--- a/core/src/main/scripts/dumpPortalInfo.pl
+++ b/core/src/main/scripts/dumpPortalInfo.pl
@@ -1,4 +1,4 @@
 #!/usr/bin/perl
 require "../scripts/envSimple.pl";
 
-system ("$JAVA_HOME/bin/java -Xmx1524M -Dspring.profiles.active=dbcp -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.dumpPortalInfo @ARGV");
+system ("$JAVA_HOME/bin/java -Xmx1524M -Dspring.profiles.active=dbcp -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.DumpPortalInfo @ARGV");

--- a/core/src/main/scripts/dumpPortalInfo.pl
+++ b/core/src/main/scripts/dumpPortalInfo.pl
@@ -1,4 +1,4 @@
 #!/usr/bin/perl
 require "../scripts/envSimple.pl";
 
-system ("$JAVA_HOME/bin/java -Xmx1524M -Dspring.profiles.active=dbcp -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.DumpPortalInfo @ARGV");
+exec("$JAVA_HOME/bin/java -Xmx1524M -Dspring.profiles.active=dbcp -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.DumpPortalInfo @ARGV");

--- a/core/src/main/scripts/dumpPortalInfo.pl
+++ b/core/src/main/scripts/dumpPortalInfo.pl
@@ -1,0 +1,4 @@
+#!/usr/bin/perl
+require "../scripts/envSimple.pl";
+
+system ("$JAVA_HOME/bin/java -Xmx1524M -Dspring.profiles.active=dbcp -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.dumpPortalInfo @ARGV");


### PR DESCRIPTION
Hi @priti88, I hadn't sent a pull request yet, but here's the script to dump the JSON files required by the validator in one go. It uses the Java layer (reusing the functions that serve the information to the web API itself), so you'll have to recompile. After that, you can `cd` to `core/src/main/scripts/`, set and export the `JAVA_HOME` and `PORTAL_HOME` environment variables as appropriate, and run `./dumpPortalInfo.pl`. The usage message should be clear enough, and I will also document the functionality on The Hyve's fork of the wiki.  @pieterlukasse @ecerami 