### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/OPEN-SOURCE-DOCUMENTATION
+++ b/OPEN-SOURCE-DOCUMENTATION
@@ -35,7 +35,7 @@ cbioportal@googlegroups.com.
 * batik-xml-1.6
 * collections-generic-4.01
 * commons-codec-1.2
-* commons-collections-3.2.1
+* commons-collections-3.2.2
 * commons-dbcp-1.2.2
 * commons-discovery-0.4_1
 * commons-fileupload-1.2.2
@@ -5351,7 +5351,7 @@ Apache License
    See the License for the specific language governing permissions and
    limitations under the License.
 
-commons-collections-3.2.1
+commons-collections-3.2.2
 -------------------------
 Available under license:
 

--- a/business/pom.xml
+++ b/business/pom.xml
@@ -17,7 +17,7 @@
 	<dependency>
 	  <groupId>commons-collections</groupId>
 	  <artifactId>commons-collections</artifactId>
-	  <version>3.2.1</version>
+	  <version>3.2.2</version>
 	</dependency>
   </dependencies>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,7 +50,7 @@
 	<dependency>
 	  <groupId>commons-collections</groupId>
 	  <artifactId>commons-collections</artifactId>
-	  <version>3.2.1</version>
+	  <version>3.2.2</version>
 	</dependency>
 	<dependency>
 	  <groupId>org.apache.geronimo.bundles</groupId>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/