### PR TITLE
Issue #938

### DIFF
--- a/business/pom.xml
+++ b/business/pom.xml
@@ -74,7 +74,7 @@
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${PORTAL_HOME}/src/main/resources</directory>
+                  <directory>${project.parent.basedir}/src/main/resources</directory>
                   <includes>
                     <include>**/*.properties</include>
                   </includes>
@@ -91,17 +91,12 @@
       </plugin>
     </plugins>
 
-    <!-- properties file used to filter our context file in resources -->
-    <filters>
-      <filter>${PORTAL_HOME}/src/main/resources/portal.properties</filter>
-    </filters>
-
     <!-- prevent some resources from getting into package -->
     <resources>
       <resource>
         <directory>src/main/resources</directory>
-        <!-- we want to filter application context files with values from portal.properties -->
-        <filtering>true</filtering>
+        <!-- we do not want to filter application context files with values from portal.properties -->
+        <filtering>false</filtering>
       </resource>
     </resources>
   </build>

--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -17,8 +17,8 @@
             <property name="ignoreResourceNotFound" value="true" />
             <property name="locations">
               <list>
-                <value>classpath:/portal.properties</value>
                 <value>file:///${PORTAL_HOME}/src/main/resources/portal.properties</value>
+                <value>classpath:/portal.properties</value>
               </list>
             </property>
           </bean>

--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -17,7 +17,7 @@
             <property name="ignoreResourceNotFound" value="true" />
             <property name="locations">
               <list>
-                <value>file:///${PORTAL_HOME}/src/main/resources/portal.properties</value>
+                <value>file:///${PORTAL_HOME}/portal.properties</value>
                 <value>classpath:/portal.properties</value>
               </list>
             </property>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -332,11 +332,11 @@
           <systemProperties>
             <property>
               <name>log4j.configuration</name>
-              <value>file:${PORTAL_HOME}/src/main/resources/log4j.properties</value>
+              <value>file:${project.parent.basedir}/src/main/resources/log4j.properties</value>
             </property>
           </systemProperties>
           <additionalClasspathElements>
-            <additionalClasspathElement>${PORTAL_HOME}/src/main/resources/</additionalClasspathElement>
+            <additionalClasspathElement>${project.parent.basedir}/src/main/resources/</additionalClasspathElement>
           </additionalClasspathElements>
         </configuration>
       </plugin>
@@ -378,6 +378,36 @@
           </execution>
         </executions>
       </plugin>
+      <!-- this plugin lets us grab shared resources from our parent -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-parent-resources</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/classes</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.parent.basedir}/src/main/resources</directory>
+                  <includes>
+                    <include>**/*.properties</include>
+                  </includes>
+                  <excludes>
+                    <exclude>**/portal.properties.*</exclude>
+                    <exclude>**/log4j.properties.*</exclude>
+                    <exclude>**/*.EXAMPLE</exclude>
+                  </excludes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <!-- prevent some resources from getting into jar -->
@@ -388,6 +418,13 @@
           <exclude>sample_data/**</exclude>
           <exclude>db/**</exclude>
         </excludes>
+      </resource>
+      <resource>
+        <directory>../src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+            <include>**/portal.properties</include>
+        </includes>
       </resource>
     </resources>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
                 </goals>
                 <configuration>
                   <tasks>
-                    <copy file="${PORTAL_HOME}/src/main/resources/portal.properties.EXAMPLE" tofile="${PORTAL_HOME}/src/main/resources/portal.properties" />
+                    <copy file="src/main/resources/portal.properties.EXAMPLE" tofile="src/main/resources/portal.properties" />
                   </tasks>
                 </configuration>
               </execution>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -116,7 +116,6 @@
                   <filtering>true</filtering>
                   <includes>
                     <include>**/*.properties</include>
-                    <include>**/spring.security.url.intercepts</include>
                   </includes>
                   <excludes>
                     <exclude>**/portal.properties.*</exclude>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -67,13 +67,21 @@
           <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
           <webResources>
             <resource>
-              <directory>${PORTAL_HOME}/business/src/main/resources</directory>
+              <directory>${project.parent.basedir}/business/src/main/resources</directory>
               <targetPath>WEB-INF/classes</targetPath>
               <filtering>true</filtering>
             </resource>
             <resource>
-              <directory>${PORTAL_HOME}/web/src/main/resources</directory>
+              <directory>${project.parent.basedir}/web/src/main/resources</directory>
               <targetPath>WEB-INF/classes</targetPath>
+              <filtering>true</filtering>
+            </resource>
+            <resource>
+              <directory>src/main/webapp/WEB-INF</directory>
+              <includes>
+                <include>**/web.xml</include>
+              </includes>
+              <targetPath>WEB-INF</targetPath>
               <filtering>true</filtering>
             </resource>
           </webResources>
@@ -104,10 +112,11 @@
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${PORTAL_HOME}/src/main/resources</directory>
+                  <directory>${project.parent.basedir}/src/main/resources</directory>
                   <filtering>true</filtering>
                   <includes>
                     <include>**/*.properties</include>
+                    <include>**/spring.security.url.intercepts</include>
                   </includes>
                   <excludes>
                     <exclude>**/portal.properties.*</exclude>
@@ -157,7 +166,7 @@
               <excludeDefaultDirectories>true</excludeDefaultDirectories>
               <filesets>
                 <fileset>
-                  <directory>${PORTAL_HOME}/portal/target</directory>
+                  <directory>${project.parent.basedir}/portal/target</directory>
                   <excludes>
                     <exclude>*.war</exclude>
                     <exclude>dependency/webapp-runner.jar</exclude>
@@ -170,12 +179,10 @@
       </plugin>
     </plugins>
 
-    <!-- properties file used for filtering our context file in resources -->
     <filters>
-      <filter>${PORTAL_HOME}/src/main/resources/portal.properties</filter>
-      <filter>${PORTAL_HOME}/src/main/resources/spring.security.url.intercepts</filter>
+        <filter>../src/main/resources/portal.properties</filter>
     </filters>
-
+    
     <!-- prevent some resources from getting into war -->
     <resources>
       <resource>
@@ -193,7 +200,22 @@
         <filtering>false</filtering>
         <includes>
           <include>**/*.jks</include>
+          <include>**/applicationContext-security.xml</include>
         </includes>
+      </resource>
+      <resource>
+        <directory>src/main/webapp/WEB-INF</directory>
+        <filtering>true</filtering>
+        <includes>
+            <include>**/web.xml</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>src/main/webapp/WEB-INF</directory>
+        <filtering>false</filtering>
+        <excludes>
+            <exclude>**/web.xml</exclude>
+        </excludes>
       </resource>
     </resources>
   </build>
@@ -224,7 +246,7 @@
                   <excludeDefaultDirectories>true</excludeDefaultDirectories>
                   <filesets>
                     <fileset>
-                      <directory>${PORTAL_HOME}/portal/target</directory>
+                      <directory>${project.parent.basedir}/portal/target</directory>
                       <excludes>
                         <exclude>*.war</exclude>
                         <exclude>dependency/webapp-runner.jar</exclude>

--- a/portal/src/main/resources/applicationContext-security.xml
+++ b/portal/src/main/resources/applicationContext-security.xml
@@ -17,7 +17,7 @@
            <b:property name="ignoreResourceNotFound" value="true" />
            <b:property name="locations">
              <b:list>
-               <b:value>file:///${PORTAL_HOME}/src/main/resources/portal.properties</b:value>
+               <b:value>file:///${PORTAL_HOME}/portal.properties</b:value>
                <b:value>classpath:portal.properties</b:value>
              </b:list>
            </b:property>

--- a/portal/src/main/resources/applicationContext-security.xml
+++ b/portal/src/main/resources/applicationContext-security.xml
@@ -11,6 +11,26 @@
 
     <!-- beans shared across any authentication system -->
     <b:beans profile="googleplus,openid,saml,ad">
+        <b:bean id="propertyPlaceholderConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+           <b:property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE" />
+           <b:property name="searchSystemEnvironment" value="true" />
+           <b:property name="ignoreResourceNotFound" value="true" />
+           <b:property name="locations">
+             <b:list>
+               <b:value>file:///${PORTAL_HOME}/src/main/resources/portal.properties</b:value>
+               <b:value>classpath:portal.properties</b:value>
+             </b:list>
+           </b:property>
+        </b:bean>
+
+    <!-- support for general annotations within class definitions (used in AccessControl) -->
+    <context:annotation-config/>
+
+    <!-- we do post filtering within AccessControl -->
+    <global-method-security pre-post-annotations="enabled">
+        <expression-handler ref="expressionHandler"/>
+    </global-method-security>
+
 
     <!-- support for general annotations within class definitions (used in AccessControl) -->
     <context:annotation-config/>
@@ -63,8 +83,7 @@
 	</b:bean>
 
     <http entry-point-ref="authenticationEntryPoint" use-expressions="true"> 
-        ${url.intercepts}
-
+<intercept-url pattern="/auth/*" access="permitAll"/><intercept-url pattern="/favicon.ico" access="permitAll"/><intercept-url pattern="/login.jsp*" access="permitAll"/><intercept-url pattern="/webservice.do*" access="isAuthenticated() or hasIpAddress('127.0.0.1')"/><intercept-url pattern="/**" access="isAuthenticated()"/>
         <!-- used for google+ authentication (spring social) -->
         <custom-filter ref="socialAuthenticationFilter" before="PRE_AUTH_FILTER" />
 
@@ -154,7 +173,6 @@
 	</b:bean>
 
     <http use-expressions="true"> 
-        ${url.intercepts}
 
         <openid-login login-page="/login.jsp" default-target-url="/index.do" user-service-ref="customUserService" authentication-failure-url="/login.jsp?login_error=true">
             <attribute-exchange identifier-match="https://www.google.com/.*">
@@ -200,8 +218,7 @@
 	</b:bean>
 
     <http entry-point-ref="samlEntryPoint" use-expressions="true">
-        ${url.intercepts}
-
+<intercept-url pattern="/auth/*" access="permitAll"/><intercept-url pattern="/favicon.ico" access="permitAll"/><intercept-url pattern="/login.jsp*" access="permitAll"/><intercept-url pattern="/webservice.do*" access="isAuthenticated() or hasIpAddress('127.0.0.1')"/><intercept-url pattern="/**" access="isAuthenticated()"/>
         <!-- used for saml authentication -->
         <custom-filter after="FIRST" ref="metadataGeneratorFilter"/>
         <custom-filter after="BASIC_AUTH_FILTER" ref="samlFilter"/>
@@ -455,9 +472,7 @@
 
             <form-login login-page="/login.jsp" login-processing-url="/j_spring_security_check" default-target-url="/index.do" />
             <logout     logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID" />
-
-            ${url.intercepts}
-
+<intercept-url pattern="/auth/*" access="permitAll"/><intercept-url pattern="/favicon.ico" access="permitAll"/><intercept-url pattern="/login.jsp*" access="permitAll"/><intercept-url pattern="/webservice.do*" access="isAuthenticated() or hasIpAddress('127.0.0.1')"/><intercept-url pattern="/**" access="isAuthenticated()"/>
             <!-- to enable access from matlab, r, python, etc clients -->
             <session-management session-fixation-protection="none"/>
         </http>

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -41,7 +41,7 @@
 
     <context-param>
       <param-name>log4jConfigLocation</param-name>
-      <param-value>file://${PORTAL_HOME}/src/main/resources/log4j.properties</param-value>
+      <param-value>file://${PORTAL_HOME}/log4j.properties</param-value>
     </context-param> 
 
     <!-- listeners -->

--- a/src/main/resources/spring.security.url.intercepts
+++ b/src/main/resources/spring.security.url.intercepts
@@ -1,5 +1,0 @@
-url.intercepts=<intercept-url pattern="/auth/*" access="permitAll"/>${line.separator} \
-    <intercept-url pattern="/favicon.ico" access="permitAll"/>${line.separator} \
-    <intercept-url pattern="/login.jsp*" access="permitAll"/>${line.separator} \
-    <intercept-url pattern="/webservice.do*" access="isAuthenticated() or hasIpAddress('127.0.0.1')"/>${line.separator} \
-    <intercept-url pattern="/**" access="isAuthenticated()"/>

--- a/web/src/main/resources/applicationContext-web.xml
+++ b/web/src/main/resources/applicationContext-web.xml
@@ -16,8 +16,8 @@
         <property name="ignoreUnresolvablePlaceholders" value="true" />
         <property name="locations">
           <list>
-            <value>classpath:/portal.properties</value>
             <value>file:///${PORTAL_HOME}/portal.properties</value>
+            <value>classpath:/portal.properties</value>
             <value>classpath:springfox.properties</value>
           </list>
         </property>


### PR DESCRIPTION
Filter at runtime spring config files

Add filtering of portal.properties for core module

Search order for spring context is $PORTAL_HOME/.. then classpath:...

Removed $PORTAL_HOME from poms

Put spring security intercepts directly into applicationcontext-security to simplify filtering.