### PR TITLE
Fixes to allow running within Eclipse Jetty container

### DIFF
--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -132,10 +132,6 @@
         <servlet-name>portal</servlet-name>
         <url-pattern>/api/*</url-pattern>
     </servlet-mapping>
-    <servlet-mapping>
-      <servlet-name>portal</servlet-name>                                                                                                                                                 
-      <url-pattern>/</url-pattern>
-    </servlet-mapping>                                                                                                                                                                    
 
     <servlet>
         <servlet-name>query_builder</servlet-name>

--- a/web/src/main/resources/applicationContext-web.xml
+++ b/web/src/main/resources/applicationContext-web.xml
@@ -36,6 +36,6 @@
     <mvc:resources mapping="/content/**" location="/content/"/>
     <mvc:resources mapping="/gfx/**" location="/gfx/"/>
     <mvc:resources mapping="/swf/**" location="/swf/"/>
-    <mvc:view-controller path="/api" view-name="redirect:/swagger-ui.html"/>
+    <mvc:view-controller path="/api" view-name="redirect:/api/swagger-ui.html"/>
     <mvc:annotation-driven enable-matrix-variables="true"/>
 </beans>


### PR DESCRIPTION
Address issue #960 

- drop mapping of "/" directory to DispatcherServlet (clashed with DefaultServlet)
- redirect "/api" to "/api/swagger-ui.html"
Note that there is now a visible "/swagger-ui.html" which contains only example data