### PR TITLE
Fix #939 patient view topbar show SAMPLE_CLASS

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/patient_view/patient_view.jsp
@@ -1094,6 +1094,10 @@ function outputClinicalData() {
             if (loc!==null)
                 ret += " ("+loc+")";
         }
+        var sampleClass = guessClinicalData(clinicalData, ["SAMPLE_CLASS"]);
+        if (sampleClass!==null) {
+            ret += ", "+sampleClass;
+        }
         return ret;
     }
 


### PR DESCRIPTION
Show SAMPLE_CLASS clnical attribute in the sample/patient section of patient
view. Original issue was "Display SAMPLE_CLASS rather than SAMPLE_TYPE for
non-tumors", but since there is a lot of variation in SAMPLE_CLASS we decided
to display it always.