### PR TITLE
Don't copy url intercepts on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_script:
     - mkdir -p ~/.m2
     - cp .travis/settings.xml ~/.m2
     - mysql --user travis --password= <<< 'CREATE DATABASE cgds_test'
-    - cp src/main/resources/spring.security.url.intercepts .travis/src/main/resources
     - phantomjs --version
 
 script:


### PR DESCRIPTION
The spring security intercepts are now in applicationcontext-security, so copying url intercepts on travis is no longer necessary.