### PR TITLE
Add github pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+# What? Why?
+Fix # .
+
+Changes proposed in this pull request:
+- a
+- b
+
+# Checks
+- [ ] Runs on Heroku.
+- [ ] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
+- [ ] Make sure your commit messages end with a Signed-off-by string (this line
+  can be automatically added by git if you run the `git-commit` command with
+  the `-s` option)
+- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
+  hotfix.
+
+# Any screenshots or GIFs?
+If this is a new visual feature please add a before/after screenshot or gif
+here with e.g. [GifGrabber](http://www.gifgrabber.com/).
+
+# Notify reviewers
+If your pull request involves changes to an existing file, one or more of the
+people that edited before you might be good candidates to review it. Please use
+`git blame <filename>` to determine that and notify them here. Otherwise notify
+everybody in the core team:
+@cBioPortal/core-developers


### PR DESCRIPTION
# What? Why?
Since the CONTRIBUTING.md is a bit hidden when submitting a PR, it will be more clear to use a [github PR template](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/). The template will always be pasted in the web form when making a new PR, so it would save us from having to reiterate the procedures.This PR also serves as an example of what the proposed PR template looks like. I put one together based on [airbnb's example](http://nerds.airbnb.com/github-pull-request-bookmarklet/)

Changes proposed in this pull request:
- add a `PULL_REQUEST_TEMPLATE.md`

# Checks
- [x] Runs on Heroku.
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
If your pull request involves changes to an existing file, one or more of the
people that edited before you might be good candidates to review it. Please use
`git blame <filename>` to determine that and notify them here. Otherwise notify
everybody in the core team.
@jjgao @n1zea144 @ecerami