### PR TITLE
Update Biojava dependency version to 4.2.0, fixes #1038

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,17 +11,6 @@
   <name>Portal Core</name>
   <description>Core libraries shared among other modules</description>
 
-  <repositories>
-    <repository>
-      <id>biojava-maven-repo</id>
-      <name>BioJava repository</name>
-      <url>http://www.biojava.org/download/maven/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>org.mskcc.cbio</groupId>
@@ -163,17 +152,18 @@
       <version>2.3</version>
     </dependency>
 
-    <!-- BioJava3 -->
+    <!-- BioJava 4.x -->
     <dependency>
       <groupId>org.biojava</groupId>
-      <artifactId>biojava3-core</artifactId>
-      <version>3.0.7</version>
+      <artifactId>biojava-core</artifactId>
+      <version>4.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.biojava</groupId>
-      <artifactId>biojava3-structure</artifactId>
-      <version>3.0.7</version>
+      <artifactId>biojava-structure</artifactId>
+      <version>4.2.0</version>
     </dependency>
+
     <!-- Mockito -->
     <dependency>
       <groupId>org.mockito</groupId>

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportPdbUniprotResidueMappingFromMA.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportPdbUniprotResidueMappingFromMA.java
@@ -34,11 +34,6 @@ package org.mskcc.cbio.portal.scripts;
 
 import java.io.*;
 import java.util.*;
-import org.biojava.bio.structure.*;
-import org.biojava.bio.structure.align.util.AtomCache;
-import org.biojava.bio.structure.io.FileParsingParameters;
-import org.biojava3.core.sequence.compound.*;
-import org.biojava3.core.sequence.loader.UniprotProxySequenceReader;
 import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.*;
 import org.mskcc.cbio.portal.util.*;

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportPdbUniprotResidueMappingFromSifts.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportPdbUniprotResidueMappingFromSifts.java
@@ -34,11 +34,11 @@ package org.mskcc.cbio.portal.scripts;
 
 import java.io.*;
 import java.util.*;
-import org.biojava.bio.structure.*;
-import org.biojava.bio.structure.align.util.AtomCache;
-import org.biojava.bio.structure.io.FileParsingParameters;
-import org.biojava3.core.sequence.compound.*;
-import org.biojava3.core.sequence.loader.UniprotProxySequenceReader;
+import org.biojava.nbio.structure.*;
+import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.io.FileParsingParameters;
+import org.biojava.nbio.core.sequence.compound.*;
+import org.biojava.nbio.core.sequence.loader.UniprotProxySequenceReader;
 import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.*;
 import org.mskcc.cbio.portal.util.*;
@@ -237,7 +237,6 @@ public final class ImportPdbUniprotResidueMappingFromSifts {
     private static AtomCache getAtomCache(String dirCache) {
         AtomCache atomCache = new AtomCache(dirCache, true);
         FileParsingParameters params = new FileParsingParameters();
-        params.setLoadChemCompInfo(false);
         params.setAlignSeqRes(true);
         params.setParseSecStruc(false);
         params.setUpdateRemediatedFiles(false);

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/PfamSequenceServlet.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/PfamSequenceServlet.java
@@ -32,9 +32,9 @@
 
 package org.mskcc.cbio.portal.servlet;
 
-import org.biojava3.core.sequence.compound.AminoAcidCompound;
-import org.biojava3.core.sequence.compound.AminoAcidCompoundSet;
-import org.biojava3.core.sequence.loader.UniprotProxySequenceReader;
+import org.biojava.nbio.core.sequence.compound.AminoAcidCompound;
+import org.biojava.nbio.core.sequence.compound.AminoAcidCompoundSet;
+import org.biojava.nbio.core.sequence.loader.UniprotProxySequenceReader;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;


### PR DESCRIPTION
The Biojava maven repository is currently unavailable, leading
to artifact resolution errors.  This commit removes the repository
declaration and updates biojava-core and biojava-structure versions
to 4.2.0, the latest 4.x releases available in the Maven Central Repository.

As version 4.2.0 is binary incompatible with 3.x, dependency package
names were also updated.