### PR TITLE
Support for authentication with LDAP

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/authentication/ldap/LDAPUserDetailsContextMapper.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/authentication/ldap/LDAPUserDetailsContextMapper.java
@@ -1,0 +1,199 @@
+package org.mskcc.cbio.portal.authentication.ldap;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.mskcc.cbio.portal.authentication.PortalUserDetails;
+import org.mskcc.cbio.portal.dao.PortalUserDAO;
+import org.mskcc.cbio.portal.model.User;
+import org.mskcc.cbio.portal.model.UserAuthorities;
+import org.springframework.ldap.core.DirContextAdapter;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
+import org.springframework.security.ldap.SpringSecurityLdapTemplate;
+import org.springframework.security.ldap.userdetails.UserDetailsContextMapper;
+
+import com.google.inject.internal.Lists;
+
+/**
+ * Mapping between details from an LDAP server and the user name used for authentication.
+ *
+ * Pull first name, given name, and email from the LDAP server.
+ *
+ * @author Manuel Holtgrewe <manuel.holtgrewe@bihealth.de>
+ */
+public class LDAPUserDetailsContextMapper implements UserDetailsContextMapper {
+
+    /** {@link Log} to use */
+    private static final Log LOG = LogFactory.getLog(LDAPUserDetailsContextMapper.class);
+
+    /** {@link DefaultSpringSecurityContextSource} with the LDAP connection */
+    private DefaultSpringSecurityContextSource ldapServer;
+    /** data access object to use for retrieving the authorities from the database */
+    private PortalUserDAO portalUserDAO;
+
+    /** base path to search users in */
+    private String baseDn;
+    /** attribute name to use for finding users in directory */
+    private String usernameAttribute = "sAMAccountName";
+    /** attribute name of the first / given name in directory */
+    private String givenNameAttribute = "givenName";
+    /** attribute name of the last name in the directory */
+    private String lastNameAttribute = "sn";
+    /** attribute name of the email address in the directory */
+    private String emailAttribute = "mail";
+
+    /** Default constructor */
+    public LDAPUserDetailsContextMapper() {
+    }
+
+    /**
+     * Initialize the {@link LDAPUserDetailsContextMapper} with the given {@link DefaultSpringSecurityContextSource} and
+     * {@link PortalUserDAO}.
+     */
+    public LDAPUserDetailsContextMapper(DefaultSpringSecurityContextSource ldapServer, PortalUserDAO portalUserDAO) {
+        this.ldapServer = ldapServer;
+        this.portalUserDAO = portalUserDAO;
+    }
+
+    @Override
+    public UserDetails mapUserFromContext(DirContextOperations ctx, String username,
+            Collection<? extends GrantedAuthority> authorities) {
+        // Query LDAP server for user details, including first/given name and email.
+        SpringSecurityLdapTemplate ldapTemplate = new SpringSecurityLdapTemplate(ldapServer);
+        // ArrayList<String> attributesToRetrieve = Lists.newArrayList("givenname", "sn", "mail");
+        String query = MessageFormat.format("({0}='{'0'}')", usernameAttribute);
+        DirContextOperations user = ldapTemplate.searchForSingleEntry(baseDn, query, new String[] { username });
+        String givenName = (String) user.getAttributeSortedStringSet(givenNameAttribute).first();
+        String lastName = (String) user.getAttributeSortedStringSet(lastNameAttribute).first();
+        String email = (String) user.getAttributeSortedStringSet(emailAttribute).first();
+        email = email.toLowerCase();
+
+        // Construct the resulting PortalUserDetails object.
+        PortalUserDetails result = new PortalUserDetails(username, getGrantedAuthorities(email));
+        result.setEmail(email);
+        result.setName(MessageFormat.format("{0} {1}", givenName, lastName));
+        return result;
+    }
+
+    /**
+     * Retrieve List of {@link GrantedAuthority} objects for a user's email.
+     *
+     * This list is loaded from the cBioPortal database.
+     *
+     * @param email
+     *            email to use for the querying
+     * @return resulting list of granted authorities
+     */
+    private List<GrantedAuthority> getGrantedAuthorities(String email) {
+        User user = null;
+        try {
+            user = portalUserDAO.getPortalUser(email);
+        } catch (Exception e) {
+            // ignore, handle below with user == null
+        }
+
+        if (user == null || !user.isEnabled()) {
+            LOG.debug("user not found or not enabled " + email);
+            return AuthorityUtils.createAuthorityList(new String[0]);
+        } else {
+            LOG.debug("getGrantedAuthorities(), attempting to fetch portal user authorities, email: " + email);
+            UserAuthorities authorities = null;
+            try {
+                authorities = portalUserDAO.getPortalUserAuthorities(email);
+            } catch (Exception e) {
+                LOG.debug("problem with database query:" + e.getMessage());
+                throw new UsernameNotFoundException("Could not retrieve authorities for " + email, e);
+            }
+            if (authorities != null)
+                return AuthorityUtils.createAuthorityList(
+                        authorities.getAuthorities().toArray(new String[authorities.getAuthorities().size()]));
+            else
+                return AuthorityUtils.createAuthorityList(new String[0]);
+        }
+    }
+
+    @Override
+    public void mapUserToContext(UserDetails user, DirContextAdapter ctx) {
+        throw new UnsupportedOperationException();
+    }
+
+    /** @return {@link DefaultSpringSecurityContextSource} with the LDAP connection */
+    public DefaultSpringSecurityContextSource getLdapServer() {
+        return ldapServer;
+    }
+
+    /** Set {@link DefaultSpringSecurityContextSource} with the LDAP connection */
+    public void setLdapServer(DefaultSpringSecurityContextSource ldapServer) {
+        this.ldapServer = ldapServer;
+    }
+
+    /** @return data access object to use for retrieving the authorities from the database */
+    public PortalUserDAO getPortalUserDAO() {
+        return portalUserDAO;
+    }
+
+    /** Set data access object to use for retrieving the authorities from the database */
+    public void setPortalUserDAO(PortalUserDAO portalUserDAO) {
+        this.portalUserDAO = portalUserDAO;
+    }
+
+    /** @return base path to search users in */
+    public String getBaseDn() {
+        return baseDn;
+    }
+
+    /** Set base path to search users in */
+    public void setBaseDn(String baseDn) {
+        this.baseDn = baseDn;
+    }
+
+    /** @return username attribute name to use for finding users in directory */
+    public String getUsernameAttribute() {
+        return usernameAttribute;
+    }
+
+    /** Set username attribute name to use for finding users in directory */
+    public void setUsernameAttribute(String usernameAttribute) {
+        this.usernameAttribute = usernameAttribute;
+    }
+
+    /** @return attribute name of the first / given name in directory */
+    public String getGivenNameAttribute() {
+        return givenNameAttribute;
+    }
+
+    /** Set attribute name of the first / given name in directory */
+    public void setGivenNameAttribute(String givenNameAttribute) {
+        this.givenNameAttribute = givenNameAttribute;
+    }
+
+    /** @return attribute name of the last name in the directory */
+    public String getLastNameAttribute() {
+        return lastNameAttribute;
+    }
+
+    /** Set attribute name of the last name in the directory */
+    public void setLastNameAttribute(String lastNameAttribute) {
+        this.lastNameAttribute = lastNameAttribute;
+    }
+
+    /** @return attribute name of the email address in the directory */
+    public String getEmailAttribute() {
+        return emailAttribute;
+    }
+
+    /** Set attribute name of the email address in the directory */
+    public void setEmailAttribute(String emailAttribute) {
+        this.emailAttribute = emailAttribute;
+    }
+
+}

--- a/portal/src/main/resources/applicationContext-security.xml
+++ b/portal/src/main/resources/applicationContext-security.xml
@@ -10,7 +10,7 @@
 
 
     <!-- beans shared across any authentication system -->
-    <b:beans profile="googleplus,openid,saml,ad">
+    <b:beans profile="googleplus,openid,saml,ad,ldap">
 
     <!-- support for general annotations within class definitions (used in AccessControl) -->
     <context:annotation-config/>
@@ -451,8 +451,18 @@
 
     <!-- authenticate with Active Directory -->
     <b:beans profile="ad">
-        <http use-expressions="true" auto-config="true">
+        <b:bean
+            class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+            <b:property name="staticMethod"
+                value="org.mskcc.cbio.portal.util.SpringUtil.setAccessControl" />
+            <b:property name="arguments">
+                <b:list>
+                    <b:ref bean="accessControl" />
+                </b:list>
+            </b:property>
+        </b:bean>
 
+        <http use-expressions="true" auto-config="true">
             <form-login login-page="/login.jsp" login-processing-url="/j_spring_security_check" default-target-url="/index.do" />
             <logout     logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID" />
 
@@ -471,6 +481,57 @@
             <b:constructor-arg value="${ad.domain}"/>
             <b:constructor-arg value="${ad.url}"/>
         </b:bean>
+    </b:beans>
+
+    <!-- begin ldap beans -->
+    <b:beans profile="ldap">
+        <b:bean
+            class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+            <b:property name="staticMethod"
+                value="org.mskcc.cbio.portal.util.SpringUtil.setAccessControl" />
+            <b:property name="arguments">
+                <b:list>
+                    <b:ref bean="accessControl" />
+                </b:list>
+            </b:property>
+        </b:bean>
+
+        <http use-expressions="true" auto-config="true">
+            <form-login login-page="/login.jsp" login-processing-url="/j_spring_security_check" default-target-url="/index.do" />
+            <logout     logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID" />
+
+            ${url.intercepts}
+
+            <!-- HTTP Login Form, allows logout-login to refresh authorities
+                in session -->
+            <!-- to enable access from matlab, r, python, etc clients -->
+            <session-management session-fixation-protection="none" />
+        </http>
+
+        <ldap-server id="ldapServer" url="${ldap.url}"
+            manager-dn="${ldap.manager.dn}" manager-password="${ldap.manager.password}" />
+
+        <!-- Loading full name and email from AD after authentication -->
+        <b:bean id="userDetailsService"
+            class="org.mskcc.cbio.portal.authentication.ldap.LDAPUserDetailsContextMapper">
+            <b:constructor-arg ref="ldapServer" />
+            <b:constructor-arg ref="portalUserDAO" />
+
+            <b:property name="baseDn" value="${ldap.user_search_base}" />
+            <b:property name="usernameAttribute" value="${ldap.attributes.username}" />
+            <b:property name="givenNameAttribute" value="${ldap.attributes.given_name}" />
+            <b:property name="lastNameAttribute" value="${ldap.attributes.last_name}" />
+            <b:property name="emailAttribute" value="${ldap.attributes.email}" />
+        </b:bean>
+
+        <authentication-manager>
+            <ldap-authentication-provider
+                server-ref="ldapServer" user-search-filter="(${ldap.attributes.username}={0})"
+                user-search-base="${ldap.user_search_base}"
+                group-search-base="#{ null }" user-context-mapper-ref="userDetailsService" />
+        </authentication-manager>
+
+        <!-- end ldap beans -->
     </b:beans>
 
     <!-- authenticate is off beans --> 

--- a/portal/src/main/webapp/WEB-INF/jsp/global/header_bar.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/header_bar.jsp
@@ -36,7 +36,7 @@
 <%
 	String principal = "";
     String authenticationMethod = GlobalProperties.authenticationMethod();
-	if (authenticationMethod.equals("openid")) {
+	if (authenticationMethod.equals("openid") || authenticationMethod.equals("ldap")) {
 		principal = "principal.name";
 	}
 	else if (authenticationMethod.equals("googleplus") || authenticationMethod.equals("saml") || authenticationMethod.equals("ad")) {

--- a/portal/src/main/webapp/login.jsp
+++ b/portal/src/main/webapp/login.jsp
@@ -117,7 +117,7 @@
                   <input type="hidden" name="action" value="verify" />
                   <p/>
 
-                <% } else if (authenticationMethod.equals("ad")) { %>
+                <% } else if (authenticationMethod.equals("ad") || authenticationMethod.equals("ldap")) { %>
                   <form name='loginForm' action="<c:url value='j_spring_security_check' />" method='POST'>
                 <% } %>
 
@@ -163,7 +163,7 @@
                   </p>
                 </fieldset>
 
-                <% } else if (authenticationMethod.equals("ad")){ %>
+                <% } else if (authenticationMethod.equals("ad") || authenticationMethod.equals("ldap")){ %>
                   <div>
                     <label for=username>Username: </label> <input type='text' id='username' name='j_username' value=''>  <br/>
                     <label for=password>Password: </label> <input type='password' name='j_password' /> <br/>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -94,6 +94,18 @@ saml.keystore.default-key=
 ## settings to connect to an Active Directory domain controller
 ad.domain=
 ad.url=
+## configuration for the LDAP access
+ldap.user_search_base=DC=example,DC=com
+ldap.url=ldap://ldap.example.com
+ldap.manager.dn=CN=manager-user,DC=example,DC=com
+ldap.manager.password=PASSWORD
+## The following attributes for are good for ActiveDirectory, for OpenLDAP use "uid" for username
+ldap.attributes.username=sAMAccountName
+#ldap.attributes.username=uid
+ldap.attributes.last_name=sn
+ldap.attributes.given_name=givenName
+ldap.attributes.email=mail
+
 # always show studies with this group
 always_show_study_group=
 


### PR DESCRIPTION
This PR is a rewrite of #102 for the current `master` of cBioPortal. Also, it fixes the "ad" authentication by setting the `accessControl` into `SpringUtil`.

We could not get the "ad" authentication method by @juleskers to work with the clinic-wide ActiveDirectory controller. Also, setting up an LDAP-backed OpenID/SAMML solution (as proposed by @morungos) is not possible in our environment.

Thus, supporting LDAP by this patch is the only way to use cBioPortal in our environment.