### PR TITLE
Display cBioPortal version number in the footer

### DIFF
--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -77,6 +77,12 @@
               <filtering>true</filtering>
             </resource>
             <resource>
+              <directory>src/main/webapp/WEB-INF/jsp/global</directory>
+              <include>footer.jsp</include>
+              <targetPath>WEB-INF/jsp/global</targetPath>
+              <filtering>true</filtering>
+            </resource>
+            <resource>
               <directory>src/main/webapp/WEB-INF</directory>
               <includes>
                 <include>**/web.xml</include>

--- a/portal/src/main/webapp/WEB-INF/jsp/global/footer.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/footer.jsp
@@ -34,6 +34,7 @@
 
 <div id="footer">
     <a href="http://cbioportal.org">cBioPortal</a>
+    <span id="footer-span-version"> Version ${project.version}</span>
     <%= GlobalProperties.getFooter() %>
     <br/>
     Questions and feedback: <%= GlobalProperties.getEmailContact() %>

--- a/test/end-to-end/make_screenshot.js
+++ b/test/end-to-end/make_screenshot.js
@@ -22,6 +22,13 @@ takeScreenshot = function(url, screenshot, delay) {
                 phantom.exit(1);
             } else {
                 window.setTimeout(function () {
+                    // Do not display version number
+                    page.evaluate(function() {
+                        var spanVersion = document.getElementById("footer-span-version");
+                        if (spanVersion) {
+                            spanVersion.style.display = "none";
+                        }
+                    });
                     page.render(screenshot);
                     phantom.exit(0);
                 }, delay);

--- a/test/end-to-end/test_make_screenshots.sh
+++ b/test/end-to-end/test_make_screenshots.sh
@@ -2,6 +2,13 @@
 # halt on error
 set -e
 
+# make sure screenshot is still the same as the one in the repo, if not upload
+# the image
+upload_screenshot_if_different() {
+    git diff --quiet -- $1 || \
+        (echo "screenshot differs see:" && curl -F "clbin=@$1" https://clbin.com && exit 1)
+}
+
 # dir of bash script http://stackoverflow.com/questions/59895
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -9,20 +16,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 phantomjs --ignore-ssl-errors=true ${DIR}/make_screenshot.js 'http://localhost:8080/case.do?cancer_study_id=lgg_ucsf_2014&case_id=P04' \
                               "${DIR}/screenshots/patient_view_lgg_ucsf_2014_case_id_P04.png" \
                               5000
-# upload the image
-curl -F "clbin=@${DIR}/screenshots/patient_view_lgg_ucsf_2014_case_id_P04.png" https://clbin.com
-
-# make sure screenshot is still the same as the one in the repo, if not upload
-# the image
-git diff --quiet -- ${DIR}/screenshots/patient_view_lgg_ucsf_2014_case_id_P04.png || \
-    (echo "screenshot differs see:" && curl -F "clbin=@${DIR}/screenshots/patient_view_lgg_ucsf_2014_case_id_P04.png" https://clbin.com && exit 1)
+upload_screenshot_if_different ${DIR}/screenshots/patient_view_lgg_ucsf_2014_case_id_P04.png
 
 # studie view screenshot
 phantomjs --ignore-ssl-errors=true --web-security=false ${DIR}/make_screenshot.js 'http://localhost:8080/study.do?cancer_study_id=lgg_ucsf_2014' \
                               "${DIR}/screenshots/study_view_lgg_ucsf_2014.png" \
                               5000
-
-# make sure screenshot is still the same as the one in the repo, if not upload
-# the image
-git diff --quiet -- ${DIR}/screenshots/study_view_lgg_ucsf_2014.png || \
-    (echo "screenshot differs see:" && curl -F "clbin=@${DIR}/screenshots/study_view_lgg_ucsf_2014.png" https://clbin.com && exit 1)
+upload_screenshot_if_different ${DIR}/screenshots/study_view_lgg_ucsf_2014.png


### PR DESCRIPTION
Show version number in the footer inside span. During testing, do not display
version number to prevent having to update the screenshot with every version
change.

Signed-off-by: Marcin Stachniuk <marcin.stachniuk@contractors.roche.com>
Signed-off-by: Ino de Bruijn <ino@ino.pm>

## Screenshot
![screen shot 2016-04-18 at 6 52 57 pm](https://cloud.githubusercontent.com/assets/1334004/14622271/ce078dc8-0596-11e6-9d87-eaeabdca16f7.png)