### PR TITLE
Fix #855 Show CNA if no mutation data is present

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/patient_view/cna.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/patient_view/cna.jsp
@@ -34,7 +34,6 @@
 <%@ page import="org.mskcc.cbio.portal.servlet.CnaJSON" %>
 
 <script type="text/javascript">
-    
     var cnaTableIndices = cbio.util.arrayToAssociatedArrayIndices(["id","case_ids","gene","alteration", "annotation","cytoband","mrna","altrate","drug"]);
     function buildCnaDataTable(cnas, cnaEventIds, table_id, sDom, iDisplayLength, sEmptyInfo) {
         var data = [];

--- a/portal/src/main/webapp/WEB-INF/jsp/patient_view/mutations.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/patient_view/mutations.jsp
@@ -40,13 +40,6 @@
 <link href="css/mutationMapper.min.css?<%=GlobalProperties.getAppVersion()%>" type="text/css" rel="stylesheet"/>
 
 <script type="text/javascript">
-    var mutTableIndices =
-            ["id","case_ids","gene","aa", "annotation", "chr","start","end","ref","_var","validation","type",
-             "tumor_freq","tumor_var_reads","tumor_ref_reads","norm_freq","norm_var_reads",
-             "norm_ref_reads","bam","cna","mrna","altrate","pancan_mutations", "cosmic","ma","drug"];
-
-    mutTableIndices = cbio.util.arrayToAssociatedArrayIndices(mutTableIndices);
-
     _.templateSettings = {
         interpolate : /\{\{(.+?)\}\}/g
     };

--- a/portal/src/main/webapp/WEB-INF/jsp/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/patient_view/patient_view.jsp
@@ -418,6 +418,13 @@ var caseMetaData = {
 var oncokbGeneStatus = <%=oncokbGeneStatus%>;
 var showHotspot = <%=showHotspot%>;
 var userName = '<%=userName%>';
+// TODO: hack for including mutation table indices in both cna.jsp and
+// mutations.jsp
+var mutTableIndices =
+		["id","case_ids","gene","aa", "annotation", "chr","start","end","ref","_var","validation","type",
+		 "tumor_freq","tumor_var_reads","tumor_ref_reads","norm_freq","norm_var_reads",
+		 "norm_ref_reads","bam","cna","mrna","altrate","pancan_mutations", "cosmic","ma","drug"];
+mutTableIndices = cbio.util.arrayToAssociatedArrayIndices(mutTableIndices);
 
 $(document).ready(function(){
     OncoKB.setUrl('<%=oncokbUrl%>');


### PR DESCRIPTION
Fix #855. Move `var mutTableIndices` to `patient_view.jsp`, such that both `cna.jsp` and
`mutations.jsp` can access it. Previously `mutations.jsp` defined it, which is
a problem when there is not mutation profile, because in that case `cna.jsp`
can't access it.

Signed-off-by: Ino de Bruijn <ino@ino.pm>

## Notify reviewers
@aderidder, @pieterlukasse, @zhx828, @jjgao 