### PR TITLE
Add screenshot test documentation for devs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ script:
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
     - ~/maven/$MAVEN_VERSION/bin/mvn -e -DPORTAL_HOME=$PORTAL_HOME -Ppublic -DskipTests -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test -Ddb.connection_string=jdbc:mysql://cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com:3306/ -Ddb.host=cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com clean install
     - java -Ddbconnector=dbcp -jar portal/target/dependency/webapp-runner.jar --expand-war portal/target/cbioportal.war &
-    - sleep 10s
-    - bash -x test/end-to-end/test_make_screenshots.sh
+    - sleep 20s
+    - bash test/end-to-end/test_make_screenshots.sh
 
 notifications:
   slack: cbioportal:S2qVTFTFMtizONhCOe8BYxS6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,45 @@ When you are ready to submit your pull-request:
 
 For instructions on submitting a pull-request, please see:  [Using Pull Requests ](https://help.github.com/articles/using-pull-requests/) and [Sending Pull Requests](http://help.github.com/send-pull-requests/).
 
+## Automated tests on Travis CI
+All Pull Requests are automatically tested on [Travis
+CI](https://travis-ci.org/cBioPortal/cbioportal/pull_requests). Currently there
+is a set of tests for the core module and a visual regression test that makes
+some screenshots and compares them to the ones stored in the repository.
+
+### What to do if the screenshot test fails
+When the screenshot test fails, it means that the screenshot taken from your
+instance of the portal differs from the screenshot stored in the repo. First
+download the image from Travis CI to your local repo. The Travis CI log will
+show you where the image was uploaded on [clbin.com](https://clbin.com).
+Download the image and replace the screenshot in the repo. For instance run in
+the root dir:
+
+```bash
+curl 'https://clbin.com/[replace-with-clbin-image-from-log].png' > test/end-to-end/screenshots/[replace-with-image-from-repo].png
+```
+
+Then there are two ways to do an image diff:
+
+1. Follow the steps outlined in [this blog
+post](http://www.akikoskinen.info/image-diffs-with-git/) to compare the images
+locally. Then run `git diff` from your repo to see the ImageMagick diff.
+2. Add the screenshot downloaded from [clbin.com](https://clbin.com) to your repo
+and push it to your PR. You can then compare the images in the 'Files changed'
+tab of the PR.
+
+Now that you can compare the images, you'll have to decide whether the change
+is desired or not and handle the failing test accordingly:
+
+- If the change in the screenshot is **undesired**, i.e. there is regression, you
+  should fix your PR.
+- If the change in the screenshot is **desired**, add the screenshot to the
+  repo, commit it and push it to your PR's branch if you haven't already in the
+previous step.
+
 ## Additional Resources
 
 * [cBioPortal Issue Tracker](https://github.com/cBioPortal/cbioportal/issues)
 * [General GitHub documentation](http://help.github.com/)
 * [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
+

--- a/test/end-to-end/test_make_screenshots.sh
+++ b/test/end-to-end/test_make_screenshots.sh
@@ -1,25 +1,64 @@
 #!/usr/bin/env bash
-# halt on error
-set -e
 
-# make sure screenshot is still the same as the one in the repo, if not upload
-# the image
-upload_screenshot_if_different() {
-    git diff --quiet -- $1 || \
-        (echo "screenshot differs see:" && curl -F "clbin=@$1" https://clbin.com && exit 1)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+compare_image() {
+    local url=${1}
+    local png=${2}
+    local TIMEOUT=10000
+
+    phantomjs --ignore-ssl-errors=true make_screenshot.js $url $png $TIMEOUT && \
+        git diff --quiet -- $png
+    return $?
 }
+
+upload_image() {
+    local png=${1}
+
+    curl -s -F "clbin=@$png" https://clbin.com
+}
+
+# screenshots and the urls where they were taken
+declare -A screenshot_urls=(
+    ["screenshots/patient_view_lgg_ucsf_2014_case_id_P04.png"]="http://localhost:8080/case.do?cancer_study_id=lgg_ucsf_2014&case_id=P04"
+    ["screenshots/study_view_lgg_ucsf_2014.png"]="http://localhost:8080/study.do?cancer_study_id=lgg_ucsf_2014"
+)
 
 # dir of bash script http://stackoverflow.com/questions/59895
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# move to test dir
+cd ${DIR}
 
-# patient view screenshot
-phantomjs --ignore-ssl-errors=true ${DIR}/make_screenshot.js 'http://localhost:8080/case.do?cancer_study_id=lgg_ucsf_2014&case_id=P04' \
-                              "${DIR}/screenshots/patient_view_lgg_ucsf_2014_case_id_P04.png" \
-                              5000
-upload_screenshot_if_different ${DIR}/screenshots/patient_view_lgg_ucsf_2014_case_id_P04.png
+# make screenshots and compare against image in repo
+screenshot_error_count=0
+screenshots_failed=()
+echo "Running screenshot tests"
+for png in "${!screenshot_urls[@]}"; do
+    url=${screenshot_urls[$png]}
+    echo -e "Checking ${DIR}/${png} at $url..."
+    compare_image $url $png
+    # check exit code
+    if [[ $? -gt 0 ]]; then
+        echo -e "$RED FAILED${NC}"
+        screenshot_error_count=$(($screenshot_error_count + 1))
+        screenshots_failed=( ${screenshots_failed[$@]} $png )
+    else
+        echo -e "$GREEN SUCCESS${NC}"
+    fi
+done
 
-# studie view screenshot
-phantomjs --ignore-ssl-errors=true --web-security=false ${DIR}/make_screenshot.js 'http://localhost:8080/study.do?cancer_study_id=lgg_ucsf_2014' \
-                              "${DIR}/screenshots/study_view_lgg_ucsf_2014.png" \
-                              5000
-upload_screenshot_if_different ${DIR}/screenshots/study_view_lgg_ucsf_2014.png
+# show dev how to download failing test screenshots
+if [[ $screenshot_error_count -gt 0 ]]; then
+    echo -e "${RED}${screenshot_error_count} SCREENSHOT TESTS FAILED!${NC}"
+    echo -e "FOR STEPS TO SEE IMAGE DIFF ${RED}READ CONTRIBUTING.md${NC}"
+    echo "TO DOWNLOAD FAILING SCREENSHOTS TO LOCAL REPO ROOT RUN:"
+    for png in "${screenshots_failed[$@]}"; do
+        echo "curl '"$(upload_image $png)"' > test/end-to-end/${png}"
+    done
+    exit 1
+else
+    echo -e "${GREEN}SCREENSHOT TESTS SUCCEEDED${NC}"
+    exit 0
+fi


### PR DESCRIPTION
Currently the screenshot test documentation is lacking.

This PR does the following:

- More verbose output of the screenshot test
- Add documentation to `CONTRIBUTING.md` about how to fix failing screenshot test

## Reviewers
@jjgao @pieterlukasse @fedde-s 

Signed-off-by: Ino de Bruijn <ino@ino.pm>