### PR TITLE
Fix issues with zero for Entrez gene id in MAF import

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
@@ -254,7 +254,7 @@ public class ImportExtendedMutationData{
 		            	entriesSkipped++;
 				    	continue;
 					}	
-					if (entrezGeneId != TabDelimitedFileUtil.NA_LONG) {
+					if (entrezGeneId != 0) {
 					    gene = daoGene.getGene(entrezGeneId);
 					    if (gene == null) {
 					    	//skip


### PR DESCRIPTION
This resolves the issues in #1117, where a zero gene identifier in a MAF import file was breaking the import process, where previously the symbol would be used as a fallback. There's more dead code in this area, but this resolves the core problem. 