### PR TITLE
Making AD authentication work with rc branch

### DIFF
--- a/portal/src/main/resources/applicationContext-security.xml
+++ b/portal/src/main/resources/applicationContext-security.xml
@@ -40,6 +40,18 @@
     <!-- this bean needs to come after context:annotation-config so that annotations are recognized -->
     <b:bean id="accessControl" class="org.mskcc.cbio.portal.util.internal.AccessControlImpl"/>
 
+    <!-- set accessControl into SpringUtil -->
+    <b:bean
+        class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <b:property name="staticMethod"
+            value="org.mskcc.cbio.portal.util.SpringUtil.setAccessControl" />
+        <b:property name="arguments">
+            <b:list>
+                <b:ref bean="accessControl" />
+            </b:list>
+        </b:property>
+    </b:bean>
+
     <!-- beans used to access portal user db tables -->
     <b:bean id="portalUserDAO" class="org.mskcc.cbio.portal.dao.internal.PortalUserJDBCDAO">
         <b:constructor-arg ref="dataSource"/>
@@ -63,15 +75,6 @@
 
     <!-- googleplus beans -->
     <b:beans profile="googleplus">
-
-	<b:bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
-	    <b:property name="staticMethod" value="org.mskcc.cbio.portal.util.SpringUtil.setAccessControl"/>
-	    <b:property name="arguments">
-	        <b:list>
-	            <b:ref bean="accessControl"/>
-	        </b:list>
-	   </b:property>
-	</b:bean>
 
     <http entry-point-ref="authenticationEntryPoint" use-expressions="true"> 
 <intercept-url pattern="/auth/*" access="permitAll"/><intercept-url pattern="/favicon.ico" access="permitAll"/><intercept-url pattern="/login.jsp*" access="permitAll"/><intercept-url pattern="/webservice.do*" access="isAuthenticated() or hasIpAddress('127.0.0.1')"/><intercept-url pattern="/**" access="isAuthenticated()"/>
@@ -154,15 +157,6 @@
     <!-- openid beans -->
     <b:beans profile="openid">
 
-	<b:bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
-	    <b:property name="staticMethod" value="org.mskcc.cbio.portal.util.SpringUtil.setAccessControl"/>
-	    <b:property name="arguments">
-	        <b:list>
-	            <b:ref bean="accessControl"/>
-	        </b:list>
-	   </b:property>
-	</b:bean>
-
     <http use-expressions="true"> 
 
         <openid-login login-page="/login.jsp" default-target-url="/index.do" user-service-ref="customUserService" authentication-failure-url="/login.jsp?login_error=true">
@@ -198,15 +192,6 @@
 
     <!-- saml beans -->
     <b:beans profile="saml">
-
-	<b:bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
-	    <b:property name="staticMethod" value="org.mskcc.cbio.portal.util.SpringUtil.setAccessControl"/>
-	    <b:property name="arguments">
-	        <b:list>
-	            <b:ref bean="accessControl"/>
-	        </b:list>
-	   </b:property>
-	</b:bean>
 
     <http entry-point-ref="samlEntryPoint" use-expressions="true">
 <intercept-url pattern="/auth/*" access="permitAll"/><intercept-url pattern="/favicon.ico" access="permitAll"/><intercept-url pattern="/login.jsp*" access="permitAll"/><intercept-url pattern="/webservice.do*" access="isAuthenticated() or hasIpAddress('127.0.0.1')"/><intercept-url pattern="/**" access="isAuthenticated()"/>

--- a/portal/src/main/resources/applicationContext-security.xml
+++ b/portal/src/main/resources/applicationContext-security.xml
@@ -31,15 +31,6 @@
         <expression-handler ref="expressionHandler"/>
     </global-method-security>
 
-
-    <!-- support for general annotations within class definitions (used in AccessControl) -->
-    <context:annotation-config/>
-
-    <!-- we do post filtering within AccessControl -->
-    <global-method-security pre-post-annotations="enabled">
-        <expression-handler ref="expressionHandler"/>
-    </global-method-security>
-
     <!-- custom expression handler -->
     <b:bean id="expressionHandler" class="org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler">
         <b:property name="permissionEvaluator" ref="customPermissionEvaluator"/>


### PR DESCRIPTION
As asked for in #1072, the isolated changes that make authentication work with AD.

However, *authorization* is not working with this patch as - for some reason - the authorities come from the AD server. Further, the email address is not part of the `UserPasswordAuthenticationToken` that is passed around internally. The object of this type contains the user name and also the full LDAP distinguished name but no email address that could be used to access the email table.

Further, I could not find any mention of a user mapper in #117 that @ juleskers mentioned in the discussion in #102.

Thus, so far the only working solution that makes authentication with AD work for me and also offers the possibility to use the cBioPortal authorization via the users and authorities table goes through LDAP.