### PR TITLE
Added new persistence and service modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,10 @@ core/target/*
 annotator/target/*
 importer/target/*
 business/target/*
+model/target/*
+persistence/persistence-api/target/*
+persistence/persistence-mybatis/target/*
+service/target/*
 web/target/*
 mutation-assessor/target/*
 cbioportal-client/target/*

--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -25,7 +25,7 @@
 
         <!-- scan for mappers and let them be autowired -->
         <bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
-            <property name="basePackage" value="org.mskcc.cbio.portal.persistence" />
+            <property name="basePackage" value="org.mskcc.cbio.portal.persistence,org.cbioportal.persistence.mybatis" />
         </bean>
 
         <!-- these are required to get properly autowired mappers into our service classes -->
@@ -45,8 +45,10 @@
             <property name="entityAttributeMapper" ref="entityAttributeMapper" />
         </bean>
 
-        <!-- enable component scanning (beware that this does not enable mapper scanning!) -->    
+        <!-- enable component scanning (beware that this does not enable mapper scanning!) -->
         <context:component-scan base-package="org.mskcc.cbio.portal.service" />
+         <context:component-scan base-package="org.cbioportal.persistence" />
+         <context:component-scan base-package="org.cbioportal.service" />
 
         <!-- enable autowire -->
         <context:annotation-config />

--- a/model/src/main/java/org/cbioportal/model/CancerStudy.java
+++ b/model/src/main/java/org/cbioportal/model/CancerStudy.java
@@ -1,8 +1,9 @@
 package org.cbioportal.model;
 
+import java.io.Serializable;
 import java.util.Date;
 
-public class CancerStudy {
+public class CancerStudy implements Serializable {
     private Integer cancerStudyId;
 
     private String cancerStudyIdentifier;

--- a/model/src/main/java/org/cbioportal/model/Gene.java
+++ b/model/src/main/java/org/cbioportal/model/Gene.java
@@ -1,6 +1,8 @@
 package org.cbioportal.model;
 
-public class Gene {
+import java.io.Serializable;
+
+public class Gene implements Serializable {
     private Integer entrezGeneId;
 
     private String hugoGeneSymbol;

--- a/model/src/main/java/org/cbioportal/model/GeneticProfile.java
+++ b/model/src/main/java/org/cbioportal/model/GeneticProfile.java
@@ -1,6 +1,8 @@
 package org.cbioportal.model;
 
-public class GeneticProfile {
+import java.io.Serializable;
+
+public class GeneticProfile implements Serializable {
     private Integer geneticProfileId;
 
     private String stableId;

--- a/model/src/main/java/org/cbioportal/model/Mutation.java
+++ b/model/src/main/java/org/cbioportal/model/Mutation.java
@@ -1,6 +1,8 @@
 package org.cbioportal.model;
 
-public class Mutation {
+import java.io.Serializable;
+
+public class Mutation implements Serializable {
     private MutationEvent mutationEvent;
 
     private GeneticProfile geneticProfile;

--- a/model/src/main/java/org/cbioportal/model/MutationCount.java
+++ b/model/src/main/java/org/cbioportal/model/MutationCount.java
@@ -1,6 +1,8 @@
 package org.cbioportal.model;
 
-public class MutationCount {
+import java.io.Serializable;
+
+public class MutationCount implements Serializable {
     private GeneticProfile geneticProfile;
 
     private Sample sample;

--- a/model/src/main/java/org/cbioportal/model/MutationEvent.java
+++ b/model/src/main/java/org/cbioportal/model/MutationEvent.java
@@ -1,6 +1,8 @@
 package org.cbioportal.model;
 
-public class MutationEvent {
+import java.io.Serializable;
+
+public class MutationEvent implements Serializable {
     private Integer mutationEventId;
 
     private Gene gene;

--- a/model/src/main/java/org/cbioportal/model/Patient.java
+++ b/model/src/main/java/org/cbioportal/model/Patient.java
@@ -1,6 +1,8 @@
 package org.cbioportal.model;
 
-public class Patient {
+import java.io.Serializable;
+
+public class Patient implements Serializable {
     private Integer internalId;
 
     private String stableId;

--- a/model/src/main/java/org/cbioportal/model/Sample.java
+++ b/model/src/main/java/org/cbioportal/model/Sample.java
@@ -1,6 +1,8 @@
 package org.cbioportal.model;
 
-public class Sample {
+import java.io.Serializable;
+
+public class Sample implements Serializable {
     private Integer internalId;
 
     private String stableId;

--- a/model/src/main/java/org/cbioportal/model/TypeOfCancer.java
+++ b/model/src/main/java/org/cbioportal/model/TypeOfCancer.java
@@ -1,6 +1,8 @@
 package org.cbioportal.model;
 
-public class TypeOfCancer {
+import java.io.Serializable;
+
+public class TypeOfCancer implements Serializable {
     private String typeOfCancerId;
 
     private String name;

--- a/persistence/persistence-api/pom.xml
+++ b/persistence/persistence-api/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>persistence</artifactId>
+        <groupId>org.mskcc.cbio</groupId>
+        <version>1.1.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>persistence-api</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mskcc.cbio</groupId>
+            <artifactId>model</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
@@ -1,0 +1,11 @@
+package org.cbioportal.persistence;
+
+import org.cbioportal.model.Mutation;
+
+import java.util.List;
+
+public interface MutationRepository {
+
+    List<Mutation> getMutations(List<String> geneticProfileStableIds, List<String> hugoGeneSymbols,
+                                List<String> sampleStableIds, String sampleListStableId);
+}

--- a/persistence/persistence-mybatis/pom.xml
+++ b/persistence/persistence-mybatis/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>persistence</artifactId>
+        <groupId>org.mskcc.cbio</groupId>
+        <version>1.1.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>persistence-mybatis</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mskcc.cbio</groupId>
+            <artifactId>persistence-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
@@ -1,0 +1,14 @@
+package org.cbioportal.persistence.mybatis;
+
+import org.apache.ibatis.annotations.Param;
+import org.cbioportal.model.Mutation;
+
+import java.util.List;
+
+public interface MutationMapper {
+
+    List<Mutation> getMutations(@Param("geneticProfileStableIds") List<String> geneticProfileStableIds,
+                                @Param("hugoGeneSymbols") List<String> hugoGeneSymbols,
+                                @Param("sampleStableIds") List<String> sampleStableIds,
+                                @Param("sampleListStableId") String sampleListStableId);
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
@@ -1,0 +1,22 @@
+package org.cbioportal.persistence.mybatis;
+
+import org.cbioportal.model.Mutation;
+import org.cbioportal.persistence.MutationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class MutationMyBatisRepository implements MutationRepository {
+
+    @Autowired
+    MutationMapper mutationMapper;
+
+    public List<Mutation> getMutations(List<String> geneticProfileStableIds, List<String> hugoGeneSymbols,
+                                       List<String> sampleStableIds, String sampleListStableId) {
+
+        return mutationMapper.getMutations(geneticProfileStableIds, hugoGeneSymbols, sampleStableIds,
+                sampleListStableId);
+    }
+}

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.cbioportal.persistence.mybatis.MutationMapper">
+    <cache/>
+
+    <select id="getMutations" resultType="org.cbioportal.model.Mutation">
+        select
+
+        mutation.CENTER as center,
+        mutation.MUTATION_STATUS as mutationStatus,
+        mutation.TUMOR_REF_COUNT as tumorRefCount,
+        mutation.NORMAL_REF_COUNT as normalRefCount,
+        mutation.TUMOR_ALT_COUNT as tumorAltCount,
+        mutation.NORMAL_ALT_COUNT as normalAltCount,
+        mutation.VALIDATION_STATUS as validationStatus,
+
+        mutation_event.MUTATION_TYPE as "mutationEvent.mutationType",
+        mutation_event.PROTEIN_CHANGE as "mutationEvent.proteinChange",
+        mutation_event.FUNCTIONAL_IMPACT_SCORE as "mutationEvent.functionalImpactScore",
+        mutation_event.LINK_XVAR as "mutationEvent.linkXvar",
+        mutation_event.LINK_PDB as "mutationEvent.linkPdb",
+        mutation_event.LINK_MSA as "mutationEvent.linkMsa",
+        mutation_event.CHR as "mutationEvent.chr",
+        mutation_event.START_POSITION as "mutationEvent.startPosition",
+        mutation_event.END_POSITION as "mutationEvent.endPosition",
+        mutation_event.ONCOTATOR_PROTEIN_POS_START as "mutationEvent.oncotatorProteinPosStart",
+        mutation_event.ONCOTATOR_PROTEIN_POS_END as "mutationEvent.oncotatorProteinPosEnd",
+        mutation_event.REFERENCE_ALLELE as "mutationEvent.referenceAllele",
+        mutation_event.TUMOR_SEQ_ALLELE as "mutationEvent.tumorSeqAllele",
+
+        gene.HUGO_GENE_SYMBOL as "gene.hugoGeneSymbol",
+        gene.ENTREZ_GENE_ID as "gene.entrezGeneId",
+
+        sample.STABLE_ID as "sample.stableId",
+
+        cancer_study.CANCER_STUDY_IDENTIFIER as "geneticProfile.cancerStudy.cancerStudyIdentifier",
+
+        genetic_profile.STABLE_ID as "geneticProfile.stableId"
+
+        from mutation
+        inner join mutation_event on mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID
+        inner join sample on mutation.SAMPLE_ID = sample.INTERNAL_ID
+        inner join gene on mutation.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
+        inner join genetic_profile on genetic_profile.GENETIC_PROFILE_ID = mutation.GENETIC_PROFILE_ID
+        inner join cancer_study on genetic_profile.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
+        <if test="sampleListStableId != null">
+            inner join sample_list_list on sample_list_list.SAMPLE_ID=sample.INTERNAL_ID
+            inner join sample_list on sample_list.LIST_ID=sample_list_list.LIST_ID
+        </if>
+        <where>
+            <if test="geneticProfileStableIds != null and !geneticProfileStableIds.isEmpty()">
+                genetic_profile.STABLE_ID in
+                <foreach item="item" collection="geneticProfileStableIds" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+            </if>
+            <if test="hugoGeneSymbols != null and !hugoGeneSymbols.isEmpty()">
+                and gene.HUGO_GENE_SYMBOL in
+                <foreach item="item" collection="hugoGeneSymbols" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+            </if>
+            <if test="sampleStableIds != null and !sampleStableIds.isEmpty()">
+                and sample.STABLE_ID in
+                <foreach item="item" collection="sampleStableIds" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+            </if>
+            <if test="sampleListStableId != null">
+                and sample_list.STABLE_ID = #{sampleListStableId}
+            </if>
+        </where>
+    </select>
+
+</mapper>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>master</artifactId>
+        <groupId>org.mskcc.cbio</groupId>
+        <version>1.1.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>persistence</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>persistence-api</module>
+        <module>persistence-mybatis</module>
+    </modules>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,8 @@
     <module>business</module>
     <module>web</module>
     <module>model</module>
+    <module>persistence</module>
+    <module>service</module>
   </modules>
 
   <dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>master</artifactId>
+        <groupId>org.mskcc.cbio</groupId>
+        <version>1.1.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>service</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mskcc.cbio</groupId>
+            <artifactId>persistence-mybatis</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/service/src/main/java/org/cbioportal/service/MutationService.java
+++ b/service/src/main/java/org/cbioportal/service/MutationService.java
@@ -1,0 +1,11 @@
+package org.cbioportal.service;
+
+import org.cbioportal.model.Mutation;
+
+import java.util.List;
+
+public interface MutationService {
+
+    List<Mutation> getMutations(List<String> geneticProfileStableIds, List<String> hugoGeneSymbols,
+                                List<String> sampleStableIds, String sampleListStableId);
+}

--- a/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
@@ -1,0 +1,23 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.model.Mutation;
+import org.cbioportal.persistence.MutationRepository;
+import org.cbioportal.service.MutationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MutationServiceImpl implements MutationService {
+
+    @Autowired
+    private MutationRepository mutationRepository;
+
+    public List<Mutation> getMutations(List<String> geneticProfileStableIds, List<String> hugoGeneSymbols,
+                                       List<String> sampleStableIds, String sampleListStableId) {
+
+        return mutationRepository.getMutations(geneticProfileStableIds, hugoGeneSymbols, sampleStableIds,
+                sampleListStableId);
+    }
+}


### PR DESCRIPTION
This module is using the new model module. Converted ProfileDataMapper.getMutationData to the new
modules as an example (didn't delete the original one in business module).
Didn't add the new model package to typeAliasesPackage because there are classes that has the same name in
org.mskcc.cbio.portal.model package, so we need to use explicit model class names in mapper xmls.
Wanted to turn mapUnderscoreToCamelCase setting on but it breaks the current code. We can make those changes
after we delete old models/modules.