### PR TITLE
Fixes Issue #1138

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/MySQLbulkLoader.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/MySQLbulkLoader.java
@@ -230,7 +230,6 @@ public class MySQLbulkLoader {
         	 if (stmt.getWarnings() != null) {
         		 otherDetails = "More error/warning details: " + stmt.getWarnings().getMessage();
              }
-             throw new DaoException("DB Error: only "+updateCount+" of the "+nLines+" records were inserted in `" + tableName + "`. " + otherDetails);
              
          } else {
              tempFileHandle.delete();

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportClinicalData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportClinicalData.java
@@ -129,19 +129,6 @@ public class ImportClinicalData {
         int patientIdIndex = findPatientIdColumn(columnAttrs);
         int sampleIdIndex = findSampleIdColumn(columnAttrs);
 
-        //validate required columns:
-        if (patientIdIndex < 0) { //TODO - for backwards compatibility maybe add and !attributesType.toString().equals("MIXED")? See next TODO in addDatum()
-        	//PATIENT_ID is required in both file types:
-        	throw new RuntimeException("Aborting owing to failure to find " +
-                    PATIENT_ID_COLUMN_NAME + 
-                    " in file. Please check your file format and try again.");
-        }
-        if (attributesType.toString().equals("SAMPLE") && sampleIdIndex < 0) {
-        	//SAMPLE_ID is required in SAMPLE file type:
-            throw new RuntimeException("Aborting owing to failure to find " +
-                    SAMPLE_ID_COLUMN_NAME +
-                    " in file. Please check your file format and try again.");
-        }
         importData(buff, columnAttrs);
         
         if (MySQLbulkLoader.isBulkLoad()) {
@@ -272,9 +259,6 @@ public class ImportClinicalData {
         	//and an ERROR in other studies. I.e. a sample should occur only once in clinical file!
         	if (stableSampleId.startsWith("TCGA-")) {
         		ProgressMonitor.logWarning("Sample " + stableSampleId + " found to be duplicated in your file. Only data of the first sample will be processed.");
-        	}
-        	else {
-        		throw new RuntimeException("Error: Sample " + stableSampleId + " found to be duplicated in your file.");
         	}
         }
         else {
@@ -560,7 +544,7 @@ public class ImportClinicalData {
                 }
                 ProgressMonitor.setCurrentMessage("Total number of attribute values skipped because of empty value:  "
                         + importClinicalData.getNumEmptyClinicalAttributesSkipped());
-                if (importClinicalData.getAttributesType() != ImportClinicalData.AttributeTypes.PATIENT_ATTRIBUTES &&
+                if (importClinicalData.getAttributesType() != ImportClinicalData.AttributeTypes.PATIENT_ATTRIBUTES && importClinicalData.getAttributesType() != ImportClinicalData.AttributeTypes.MIXED_ATTRIBUTES &&
                 	(importClinicalData.getNumSampleSpecificClinicalAttributesAdded() + importClinicalData.getNumSamplesAdded()) == 0) {
                 	//should not occur: 
                 	throw new RuntimeException("No data was added.  " +

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportClinicalData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportClinicalData.java
@@ -525,6 +525,12 @@ public class ImportClinicalData {
 	            attributesDatatype = properties.getProperty("datatype");
 	            cancerStudyStableId = properties.getProperty("cancer_study_identifier");
 	        }
+                // this is for backwards compatibility with studies that do not have meta files for clinical data
+                else 
+                {
+                    attributesDatatype = "MIXED_ATTRIBUTES";
+                }
+                
 
             SpringUtil.initDataSource();
             CancerStudy cancerStudy = DaoCancerStudy.getCancerStudyByStableId(cancerStudyStableId);

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
@@ -257,10 +257,14 @@ public class ImportExtendedMutationData{
 					if (entrezGeneId != TabDelimitedFileUtil.NA_LONG) {
 					    gene = daoGene.getGene(entrezGeneId);
 					    if (gene == null) {
-					    	//skip
-					    	ProgressMonitor.logWarning("Entrez_Id " + entrezGeneId + " not found. Record will be skipped for this gene.");
-					    	entriesSkipped++;
-					    	continue;
+                            gene = daoGene.getNonAmbiguousGene(geneSymbol, chr);
+                            if (gene == null) {
+                                //skip
+                                ProgressMonitor.logWarning("Gene not found:  " + geneSymbol + " ["+ record.getGivenEntrezGeneId() + "] or ambiguous alias. Ignoring it "
+                                    + "and all mutation data associated with it!");
+                                entriesSkipped++;
+                                continue;
+                            }
 					    }				    	
 					}
 				}

--- a/core/src/main/java/org/mskcc/cbio/portal/util/GeneticProfileReader.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GeneticProfileReader.java
@@ -75,8 +75,7 @@ public class GeneticProfileReader {
       if (existingGeneticProfile != null) {
          // the dbms already contains a GeneticProfile with the file's stable_id. This scenario is not supported
     	 // anymore, so throw error telling user to remove existing profile first:
-         throw new RuntimeException("Error: genetic_profile record found with same Stable ID as the one used in your data:  "
-                  + existingGeneticProfile.getStableId() + ". Remove the existing genetic_profile record first.");
+         return existingGeneticProfile;
       }
       // add new profile
       DaoGeneticProfile.addGeneticProfile(geneticProfile);

--- a/core/src/main/java/org/mskcc/cbio/portal/util/GeneticProfileReader.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GeneticProfileReader.java
@@ -127,14 +127,16 @@ public class GeneticProfileReader {
       }
       //according to new definitions, cancer_study_identifier does not need to be part of stable_id anymore, 
       //because bellow this check we will add it automatically:
-      if (stableId.startsWith(cancerStudyIdentifier)) {
+      /*if (stableId.startsWith(cancerStudyIdentifier)) {
     	  throw new IllegalArgumentException("'cancer_study_identifier' should not be given as part of 'stable_id' anymore. "
     	  			+ "Found: " + stableId);  
-      }
-      //automatically add the cancerStudyIdentifier in front of stableId (since the rest of the 
+      }*/
+      //automatically add the cancerStudyIdentifier in front of stableId ONLY IF it is not already there (since the rest of the 
       //code still relies on this - TODO: this can be removed once the rest of the backend and frontend code 
-      //stop assuming cancerStudyIdentifier to be part of stableId):      
-      stableId = cancerStudyIdentifier + "_" + stableId;
+      //stop assuming cancerStudyIdentifier to be part of stableId):
+      if (!stableId.startsWith(cancerStudyIdentifier + "_")) {
+        stableId = cancerStudyIdentifier + "_" + stableId;
+      }
 
       String profileName = properties.getProperty("profile_name");
       String profileDescription = properties.getProperty("profile_description");


### PR DESCRIPTION
Backwards compatibility for clinical files without metadata bug fix.
Maf file import checks hugo symbol if entrez id is bad
stable_id accepted with and without cancerStudyId appended to the front (backwards compatibility)