### PR TITLE
Fix label positioning in old oncoprint

### DIFF
--- a/portal/src/main/webapp/js/src/oncoprint/new/OncoprintSVGRenderer.js
+++ b/portal/src/main/webapp/js/src/oncoprint/new/OncoprintSVGRenderer.js
@@ -720,8 +720,7 @@
 				var pos = $(text_elt.node()).offset();
 				var text = text_elt.text();
 				svg.append('text').style('font-family', font).style('font-weight', weight).style('font-size', size)
-						.attr('transform', utils.translate(pos.left - root.left,pos.top - root.top))
-						.style('alignment-baseline', 'text-before-edge')
+						.attr('transform', utils.translate(pos.left - root.left,pos.top - root.top + parseInt(size)))
 						.text(text);	
 			});
 		})();
@@ -762,8 +761,7 @@
 							var pos = $(text_elt.node()).offset();
 							svg.append('text').style('font-family', font).style('font-weight', weight)
 								.style('font-size', size)
-								.attr('transform', utils.translate(pos.left - root.left, pos.top - root.top))
-								.style('alignment-baseline', 'hanging')
+								.attr('transform', utils.translate(pos.left - root.left, pos.top - root.top + parseInt(size)))
 								.text(text);
 						} else if (this.tagName.toLowerCase() === 'svg') {
 							var elt = d3.select(this);


### PR DESCRIPTION
The svg property alignment-baseline was not available to our server-side svg to pdf engine, Batik, so this functionality has been replaced by a y-coordinate adjustment for the labels.