### PR TITLE
fix for failing CNA data when there is 'new CNA event' in a new study (on dfci 'rc')

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCnaEvent.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCnaEvent.java
@@ -56,6 +56,8 @@ public final class DaoCnaEvent {
         	long eventId = cnaEvent.getEventId();
         	if (newCnaEvent) {
                 eventId = addCnaEventDirectly(cnaEvent);
+                // update object based on new DB id (since this object is locally cached after this):
+                cnaEvent.setEventId(eventId);
             }
             
             MySQLbulkLoader.getMySQLbulkLoader("sample_cna_event").insertRecord(


### PR DESCRIPTION
Fixes remaining issue in #844 (same as #1209, but for dfci 'rc' branch)