### PR TITLE
Fix patient mixed data; fix for MySQLbulkLoader to fix related unit test

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportClinicalData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportClinicalData.java
@@ -487,7 +487,7 @@ public class ImportClinicalData {
     	return numEmptyClinicalAttributesSkipped;
     }
     
-    public int getNumSamplesAdded() {
+    public int getNumSamplesProcessed() {
     	return numSamplesProcessed;
     }
     
@@ -580,13 +580,13 @@ public class ImportClinicalData {
                 		importClinicalData.getAttributesType() == ImportClinicalData.AttributeTypes.MIXED_ATTRIBUTES) { 
                 	ProgressMonitor.setCurrentMessage("Total number of sample specific clinical attributes added:  "
                         + importClinicalData.getNumSampleSpecificClinicalAttributesAdded());
-                	ProgressMonitor.setCurrentMessage("Total number of samples added:  "
-                        + importClinicalData.getNumSamplesAdded());
+                	ProgressMonitor.setCurrentMessage("Total number of samples processed:  "
+                        + importClinicalData.getNumSamplesProcessed());
                 }
                 ProgressMonitor.setCurrentMessage("Total number of attribute values skipped because of empty value:  "
                         + importClinicalData.getNumEmptyClinicalAttributesSkipped());
-                if (importClinicalData.getAttributesType() != ImportClinicalData.AttributeTypes.PATIENT_ATTRIBUTES &&
-                	(importClinicalData.getNumSampleSpecificClinicalAttributesAdded() + importClinicalData.getNumSamplesAdded()) == 0) {
+                if (importClinicalData.getAttributesType() == ImportClinicalData.AttributeTypes.SAMPLE_ATTRIBUTES &&
+                	(importClinicalData.getNumSampleSpecificClinicalAttributesAdded() + importClinicalData.getNumSamplesProcessed()) == 0) {
                 	//should not occur: 
                 	throw new RuntimeException("No data was added.  " +
                             "Please check your file format and try again.");
@@ -597,6 +597,13 @@ public class ImportClinicalData {
                     throw new RuntimeException("No data was added.  " +
                             "Please check your file format and try again. If you only have sample clinical data, then a patients file with only PATIENT_ID column is not required.");
                 }
+                //backward compatible check (TODO - remove this later):
+                if (importClinicalData.getAttributesType() == ImportClinicalData.AttributeTypes.MIXED_ATTRIBUTES &&
+                    (importClinicalData.getNumPatientSpecificClinicalAttributesAdded() + importClinicalData.getNumSampleSpecificClinicalAttributesAdded()) == 0) {
+                    	//should not occur: 
+                    	throw new RuntimeException("No data was added.  " +
+                                "Please check your data and try again.");
+                    }
                 ProgressMonitor.setCurrentMessage("Done.");
 
             }

--- a/core/src/test/java/org/mskcc/cbio/portal/scripts/TestImportClinicalData.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/scripts/TestImportClinicalData.java
@@ -123,7 +123,7 @@ public class TestImportClinicalData {
         ImportClinicalData importClinicalData = new ImportClinicalData(
                 study, clinicalFile, "MIXED_ATTRIBUTES");
         
-        exception.expect(RuntimeException.class);
+        exception.expect(DaoException.class);
         importClinicalData.importData();
         ConsoleUtil.showWarnings();
 	}
@@ -146,7 +146,7 @@ public class TestImportClinicalData {
         ImportClinicalData importClinicalData = new ImportClinicalData(
                 study, clinicalFile, "PATIENT_ATTRIBUTES");
         
-        exception.expect(RuntimeException.class);
+        exception.expect(DaoException.class);
         importClinicalData.importData();
         ConsoleUtil.showWarnings();
 	}


### PR DESCRIPTION
Fix to make the code more tolerant for a previously existing sample (instead of giving an error) for MIXED data type. 

A MySQLbulkLoader fix (discussed in #844) was also necessary to fix the related unit tests in `TestImportClinicalData` 
