### PR TITLE
Fix Travis core tests to work with docker services enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,34 @@ script:
     - ~/maven/$MAVEN_VERSION/bin/mvn -e -DPORTAL_HOME=$PORTAL_HOME -Ppublic clean test
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
-    - ~/maven/$MAVEN_VERSION/bin/mvn -e -DPORTAL_HOME=$PORTAL_HOME -Ppublic -DskipTests -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test -Ddb.connection_string=jdbc:mysql://cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com:3306/ -Ddb.host=cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com clean install
+    # make sure mysql docker is running
+    - |
+        while [ 1 != $(docker exec core-tests-mysql /bin/bash -c \
+                       "echo 'select 1;' | \
+                        mysql --user cbio_user  -P 3306 --password=somepassword cbioportal | head -1") ]
+        do 
+            sleep 5s
+        done
+    - |
+        docker exec core-test-mysql /bin/bash -c \
+            "echo 'show tables;' | \
+             mysql --user cbio_user -P 3306 --password=somepassword cbioportal"
+    - |
+        ~/maven/$MAVEN_VERSION/bin/mvn \
+            -e -DPORTAL_HOME=$PORTAL_HOME \
+            -Ppublic \
+            clean test
+    # end-to-end tests
+    - |
+        ~/maven/$MAVEN_VERSION/bin/mvn \
+            -e -DPORTAL_HOME=$PORTAL_HOME \
+            -Ppublic -DskipTests \
+            -Ddb.user=cbio_user \
+            -Ddb.password=cbio_pass \
+            -Ddb.portal_db_name=public_test \
+            -Ddb.connection_string=jdbc:mysql://cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com:3306/ \
+            -Ddb.host=cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com \
+            clean install
     - java -Ddbconnector=dbcp -jar portal/target/dependency/webapp-runner.jar --expand-war portal/target/cbioportal.war &
     - sleep 20s
     - bash test/end-to-end/test_make_screenshots.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ install:
     - sudo apt-get update
     - sudo apt-get install -y mysql-server
     - sudo mysql_install_db
-    - sudo /usr/bin/mysqld_safe
     - |
         mysql -u root -e "CREATE DATABASE cbioportal; \
                           CREATE DATABASE cgds_test; \

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ services:
     - mysql
 
 sudo: required
+language: java
+jdk: openjdk7
+
+env:
+    - MAVEN_VERSION=3.3.3
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,14 @@ before_script:
                  -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
                  -e MYSQL_PASSWORD=somepassword \
                  -e MYSQL_DATABASE=cbioportal \
-                 -d mysql:latest
+                 -d mysql:5.7.12
 
 script:
     - export PORTAL_HOME=$(pwd)
     # core tests
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
+    - echo 'show tables;' | mysql --user cbio_user --host=docker -P 3306 --password=somepassword cgds_test
     - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
-sudo: true
+sudo: false
 language: java
 jdk: openjdk7
 
 services:
-    - mysql
     - docker
-
 
 cache:
     directories:
@@ -25,16 +23,24 @@ install:
                 tar -C ~/maven/$MAVEN_VERSION --strip-components=1 -xzf -; }
 
 before_script:
+    # copy settings for core database
     - mkdir -p ~/.m2
     - cp .travis/settings.xml ~/.m2
-    - sudo apt-get install mysql
-    - mysql --user travis --password= <<< 'CREATE DATABASE cgds_test'
+    - docker run --name core-tests-mysql \
+                 -p 3306:3306 \
+                 -e MYSQL_USER=travis \
+                 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+                 -e MYSQL_PASSWORD=mypassword \
+                 -e MYSQL_DATABASE=cgds_test \
+                 -d mysql:latest
 
 script:
     - export PORTAL_HOME=$(pwd)
+    # core tests
     - cp .travis/src/main/resources/portal.properties $PORTAL_HOME/src/main/resources/portal.properties
     - cp .travis/src/main/resources/log4j.properties $PORTAL_HOME/src/main/resources/log4j.properties
     - ~/maven/$MAVEN_VERSION/bin/mvn -e -DPORTAL_HOME=$PORTAL_HOME -Ppublic clean test
+    # end-to-end tests
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
     - ~/maven/$MAVEN_VERSION/bin/mvn -e -DPORTAL_HOME=$PORTAL_HOME -Ppublic -DskipTests -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test -Ddb.connection_string=jdbc:mysql://cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com:3306/ -Ddb.host=cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
     - |
         docker run \
             --privileged \
-            -v $PWD \
+            -v $PWD:/cbioportal \
             -e PORTAL_HOME=/cbioportal \
             maven:3.3-jdk-7 \
                 /bin/bash -c \

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ script:
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
     - chmod -R 777 .
+    - sudo service docker restart
     - |
         docker run \
             -v $PWD:/cbioportal \

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,20 @@ script:
                 -Ddb.connection_string=jdbc:mysql://localhost:3306/ \
                 clean test'
     - |
+        docker run \
+            --privileged \
+            -v $PWD:/cbioportal \
+            -e PORTAL_HOME=/cbioportal \
+            maven:3.3.3-jdk-9 \
+                /bin/bash -c \
+                'cd $PORTAL_HOME &&
+                mvn -e \
+                -DPORTAL_HOME=$PORTAL_HOME \
+                -Ppublic \
+                -Ddb.host=localhost \
+                -Ddb.connection_string=jdbc:mysql://localhost:3306/ \
+                clean test'
+    - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \
             -Ddb.host=localhost \

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
             --privileged \
             -v $PWD:/cbioportal \
             -e PORTAL_HOME=/cbioportal \
-            maven:3.3-jdk-7 \
+            maven:3.3-jdk-8 \
                 /bin/bash -c \
                 'cd $PORTAL_HOME &&
                 mvn -e \

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,18 @@ script:
                  -e MYSQL_USER=cbio_user \
                  -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
                  -e MYSQL_PASSWORD=somepassword \
-                 -e MYSQL_DATABASE=cbioportal \
+                 -e MYSQL_DATABASE=cgds_test \
                  -d mysql:5.7.12
     # core tests
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
     - echo 'show tables;' | mysql --user cbio_user -h 127.0.0.1 -P 3306 --password=somepassword cgds_test
+    - |
+        docker run --rm --link=core-tests-mysql:db \
+            -e PORTAL_HOME=/cbioportal \
+            -v $PWD:/cbioportal \
+            mysql:5.7.12 \
+                /bin/bash -c 'echo "show tables;" | mysql --user cbio_user --host=db -P 3306 --password=somepassword cgds_test'
     - docker ps
     - docker inspect core-tests-mysql
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,27 @@ services:
 
 sudo: required
 
-before_script:
-    # copy settings for core database
-    - mkdir -p ~/.m2
-    - cp .travis/settings.xml ~/.m2
+cache:
+    directories:
+        - $HOME/.m2
+        - $HOME/maven
 
 install:
+    # install mysql
     - sudo apt-get update
     - sudo apt-get install -y mysql-server
     - sudo mysql_install_db
+    # installl maven
+    - mkdir -p ~/maven
+    - |
+        test -d ~/maven/$MAVEN_VERSION/bin || { \
+            find ~/maven -mindepth 1 -delete && \
+            mkdir -p ~/maven/$MAVEN_VERSION && \
+            wget -O - http://www.eu.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | \
+                tar -C ~/maven/$MAVEN_VERSION --strip-components=1 -xzf -; }
+
+before_script:
+    # create mysql db for core test
     - |
         mysql -u root -e "CREATE DATABASE cbioportal; \
                           CREATE DATABASE cgds_test; \
@@ -20,31 +32,17 @@ install:
                           GRANT ALL ON cbioportal.* TO 'cbio_user'@'localhost'; \
                           GRANT ALL ON cgds_test.* TO 'cbio_user'@'localhost'; \
                           flush privileges; " 
+    # copy settings for core database
+    - mkdir -p ~/.m2
+    - cp .travis/settings.xml ~/.m2
 
 script:
     - export PORTAL_HOME=$(pwd)
     # run mysql db for core tests
     - echo 'show tables;' | mysql --user cbio_user -h localhost -P 3306 --password=somepassword cgds_test
-    - |
-        docker run --name core-tests-mysql \
-                 -e MYSQL_USER=cbio_user \
-                 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
-                 -e MYSQL_PASSWORD=somepassword \
-                 -e MYSQL_DATABASE=cgds_test \
-                 -d mysql:5.7.12
-    #expose port to host -p 3306:3306
     # core tests
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
-    - echo 'show tables;' | mysql --user cbio_user -h 127.0.0.1 -P 3306 --password=somepassword cgds_test
-    - |
-        docker run --rm --link=core-tests-mysql:db \
-            -e PORTAL_HOME=/cbioportal \
-            -v $PWD:/cbioportal \
-            mysql:5.7.12 \
-                /bin/bash -c 'echo "show tables;" | mysql --user cbio_user --host=db -P 3306 --password=somepassword cgds_test'
-    - docker ps
-    - docker inspect core-tests-mysql
     - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ jdk: openjdk7
 env:
     - MAVEN_VERSION=3.3.3
 
+addons:
+    # fix https://github.com/travis-ci/travis-ci/issues/5227
+    hostname: short-hostname
+
 cache:
     directories:
         - $HOME/.m2
@@ -66,9 +70,11 @@ script:
             -Ddb.connection_string=jdbc:mysql://cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com:3306/ \
             -Ddb.host=cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com \
             clean install
-    - java -Ddbconnector=dbcp -jar portal/target/dependency/webapp-runner.jar --expand-war portal/target/cbioportal.war &
-    - sleep 20s
-    - bash test/end-to-end/test_make_screenshots.sh
+    - cd test/end-to-end
+    - docker-compose up -d
+    - sleep 30s
+    - cd ../..
+    - bash test/end-to-end/test_make_screenshots.sh test/end-to-end/screenshots.yml
 
 notifications:
   slack: cbioportal:S2qVTFTFMtizONhCOe8BYxS6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+# currently running maven on host node, but could use docker container instead
 language: java
 jdk: openjdk7
 
@@ -14,24 +15,28 @@ env:
     - MAVEN_VERSION=3.3.3
 
 install:
+    # download and install maven
     - mkdir -p ~/maven
     - |
         test -d ~/maven/$MAVEN_VERSION/bin || { \
             find ~/maven -mindepth 1 -delete && \
             mkdir -p ~/maven/$MAVEN_VERSION && \
-            wget -O - http://www.eu.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | \
+            wget -O - \
+                http://www.eu.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | \
                 tar -C ~/maven/$MAVEN_VERSION --strip-components=1 -xzf -; }
 
 before_script:
     # copy settings for core database
     - mkdir -p ~/.m2
     - cp .travis/settings.xml ~/.m2
-    - docker run --name core-tests-mysql \
+    # run mysql db for core tests
+    - |
+        docker run --name core-tests-mysql \
                  -p 3306:3306 \
-                 -e MYSQL_USER=travis \
+                 -e MYSQL_USER=cbio_user \
                  -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
-                 -e MYSQL_PASSWORD=mypassword \
-                 -e MYSQL_DATABASE=cgds_test \
+                 -e MYSQL_PASSWORD=somepassword \
+                 -e MYSQL_DATABASE=cbioportal \
                  -d mysql:latest
 
 script:
@@ -39,15 +44,27 @@ script:
     # core tests
     - cp .travis/src/main/resources/portal.properties $PORTAL_HOME/src/main/resources/portal.properties
     - cp .travis/src/main/resources/log4j.properties $PORTAL_HOME/src/main/resources/log4j.properties
-    - ~/maven/$MAVEN_VERSION/bin/mvn -e -DPORTAL_HOME=$PORTAL_HOME -Ppublic clean test
+    - |
+        ~/maven/$MAVEN_VERSION/bin/mvn \
+            -e -DPORTAL_HOME=$PORTAL_HOME \
+            -Ppublic \
+            clean test
     # end-to-end tests
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
-    - ~/maven/$MAVEN_VERSION/bin/mvn -e -DPORTAL_HOME=$PORTAL_HOME -Ppublic -DskipTests -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test -Ddb.connection_string=jdbc:mysql://cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com:3306/ -Ddb.host=cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com clean install
+    - |
+        ~/maven/$MAVEN_VERSION/bin/mvn \
+            -e -DPORTAL_HOME=$PORTAL_HOME \
+            -Ppublic -DskipTests \
+            -Ddb.user=cbio_user \
+            -Ddb.password=cbio_pass \
+            -Ddb.portal_db_name=public_test \
+            -Ddb.connection_string=jdbc:mysql://cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com:3306/ \
+            -Ddb.host=cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com \
+            clean install
     - java -Ddbconnector=dbcp -jar portal/target/dependency/webapp-runner.jar --expand-war portal/target/cbioportal.war &
     - sleep 20s
     - bash test/end-to-end/test_make_screenshots.sh
 
 notifications:
   slack: cbioportal:S2qVTFTFMtizONhCOe8BYxS6
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,11 @@ script:
     - |
         docker run \
             -v $PWD:/cbioportal \
-            -e PORTAL_HOME=/cbioportal
+            -e PORTAL_HOME=/cbioportal \
             maven:3.3-jdk-7 \
                 mvn -e \
-                -DPORTAL_HOME=$PORTAL_HOME
-                -Ppublic
+                -DPORTAL_HOME=$PORTAL_HOME \
+                -Ppublic \
                 -Ddb.host=localhost \
                 -Ddb.connection_string=jdbc:mysql://localhost:3306/ \
                 clean test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ sudo: required
 language: java
 jdk:
     - openjdk7
-    - openjdk6
-    - oraclejdk7
-    - oraclejdk8
 
 env:
     - MAVEN_VERSION=3.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_script:
 install:
     - sudo apt-get update
     - sudo apt-get install -y mysql-server
-    - mysql_install_db
-    - /usr/bin/mysqld_safe
+    - sudo mysql_install_db
+    - sudo /usr/bin/mysqld_safe
     - |
         mysql -u root -e "CREATE DATABASE cbioportal; \
                           CREATE DATABASE cgds_test; \

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
-sudo: false
+sudo: true
 language: java
 jdk: openjdk7
+
+services:
+    - mysql
+    - docker
+
 
 cache:
     directories:
@@ -22,6 +27,7 @@ install:
 before_script:
     - mkdir -p ~/.m2
     - cp .travis/settings.xml ~/.m2
+    - sudo apt-get install mysql
     - mysql --user travis --password= <<< 'CREATE DATABASE cgds_test'
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,16 +42,14 @@ before_script:
 script:
     - export PORTAL_HOME=$(pwd)
     # core tests
-    - cp .travis/src/main/resources/portal.properties $PORTAL_HOME/src/main/resources/portal.properties
-    - cp .travis/src/main/resources/log4j.properties $PORTAL_HOME/src/main/resources/log4j.properties
+    - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
+    - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
     - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \
             -Ppublic \
             clean test
     # end-to-end tests
-    - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
-    - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
     - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ script:
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
     - echo 'show tables;' | mysql --user cbio_user -h 127.0.0.1 -P 3306 --password=somepassword cgds_test
+    - docker ps
+    - docker inspect core-tests-mysql
     - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,12 @@ script:
     # core tests
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
-    - echo 'show tables;' | mysql --user cbio_user -P 3306 --password=somepassword cgds_test
+    - echo 'show tables;' | mysql --user cbio_user -h 127.0.0.1 -P 3306 --password=somepassword cgds_test
     - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \
+            -Ddb.host=127.0.0.1 \
+            -Ddb.connection_string=jdbc:mysql://127.0.0.1:3306/ \
             -Ppublic \
             clean test
     # end-to-end tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
             --privileged \
             -v $PWD:/cbioportal \
             -e PORTAL_HOME=/cbioportal \
-            maven:3.3-jdk-8 \
+            maven:3.3.3-jdk-8 \
                 /bin/bash -c \
                 'cd $PORTAL_HOME &&
                 mvn -e \

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,5 @@
-sudo: false
-# currently running maven on host node, but could use docker container instead
-language: java
-jdk: openjdk7
-
 services:
     - docker
-
-cache:
-    directories:
-        - $HOME/.m2
-        - $HOME/maven
-
-env:
-    - MAVEN_VERSION=3.3.3
-
-install:
-    # download and install maven
-    - mkdir -p ~/maven
-    - |
-        test -d ~/maven/$MAVEN_VERSION/bin || { \
-            find ~/maven -mindepth 1 -delete && \
-            mkdir -p ~/maven/$MAVEN_VERSION && \
-            wget -O - \
-                http://www.eu.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | \
-                tar -C ~/maven/$MAVEN_VERSION --strip-components=1 -xzf -; }
 
 before_script:
     # copy settings for core database

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ script:
                 mvn -e \
                 -DPORTAL_HOME=$PORTAL_HOME \
                 -Ppublic \
+                -Ddb.user=cbio_user \
+                -Ddb.pass=somepassword \
                 -Ddb.host=localhost \
                 -Ddb.connection_string=jdbc:mysql://localhost:3306/ \
                 clean test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,17 @@ script:
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
     - |
+        docker run \
+            -v $PWD:/cbioportal \
+            -e PORTAL_HOME=/cbioportal
+            maven:3.3-jdk-7 \
+                mvn -e \
+                -DPORTAL_HOME=$PORTAL_HOME
+                -Ppublic
+                -Ddb.host=localhost \
+                -Ddb.connection_string=jdbc:mysql://localhost:3306/ \
+                clean test
+    - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \
             -Ddb.host=localhost \

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ before_script:
     - cp .travis/settings.xml ~/.m2
 
 install:
-    - sudo apt-get install mysql-server
+    - sudo apt-get update
+    - sudo apt-get install -y mysql-server
     - mysql_install_db
     - /usr/bin/mysqld_safe
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ services:
 
 sudo: required
 language: java
-jdk: openjdk7
+jdk:
+    - openjdk7
+    - openjdk6
+    - oraclejdk7
+    - oraclejdk8
 
 env:
     - MAVEN_VERSION=3.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ script:
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
     - chmod -R 777 .
     - sudo service docker restart
+    - sleep 10s
     - |
         docker run \
             --net=host \

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ script:
     - sudo service docker restart
     - |
         docker run \
-            -v $PWD:/cbioportal \
+            --privileged \
+            -v $PWD \
             -e PORTAL_HOME=/cbioportal \
             maven:3.3-jdk-7 \
                 /bin/bash -c \

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: required
 language: java
 jdk: openjdk7
 
+services:
+    - docker
+
 cache:
     directories:
         - $HOME/.m2
@@ -22,10 +25,17 @@ install:
 before_script:
     - mkdir -p ~/.m2
     - cp .travis/settings.xml ~/.m2
-    - mysql --user travis --password= <<< 'CREATE DATABASE cgds_test'
+	- # run mysql db for core tests
+    - |
+        docker run --name core-tests-mysql \
+                 -p 3306:3306 \
+                 -e MYSQL_USER=cbio_user \
+                 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+                 -e MYSQL_PASSWORD=somepassword \
+                 -e MYSQL_DATABASE=cgds_test \
+                 -d mysql:5.7.12
 
 script:
-    - sudo service docker start
     - export PORTAL_HOME=$(pwd)
     - cp .travis/src/main/resources/portal.properties $PORTAL_HOME/src/main/resources/portal.properties
     - cp .travis/src/main/resources/log4j.properties $PORTAL_HOME/src/main/resources/log4j.properties
@@ -36,14 +46,14 @@ script:
     - |
         while [ 1 != $(docker exec core-tests-mysql /bin/bash -c \
                        "echo 'select 1;' | \
-                        mysql --user cbio_user  -P 3306 --password=somepassword cbioportal | head -1") ]
+                        mysql --user cbio_user  -P 3306 --password=somepassword cgds_test | head -1") ]
         do 
             sleep 5s
         done
     - |
         docker exec core-test-mysql /bin/bash -c \
             "echo 'show tables;' | \
-             mysql --user cbio_user -P 3306 --password=somepassword cbioportal"
+             mysql --user cbio_user -P 3306 --password=somepassword cgds_test"
     - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,16 @@
-services:
-    - docker
-    - mysql
-
 sudo: required
 language: java
-jdk:
-    - openjdk7
-
-env:
-    - MAVEN_VERSION=3.3.3
+jdk: openjdk7
 
 cache:
     directories:
         - $HOME/.m2
         - $HOME/maven
 
+env:
+    - MAVEN_VERSION=3.3.3
+
 install:
-    # install mysql
-    - sudo apt-get update
-    - sudo apt-get install -y mysql-server
-    - sudo mysql_install_db
-    # installl maven
     - mkdir -p ~/maven
     - |
         test -d ~/maven/$MAVEN_VERSION/bin || { \
@@ -30,81 +20,23 @@ install:
                 tar -C ~/maven/$MAVEN_VERSION --strip-components=1 -xzf -; }
 
 before_script:
-    # create mysql db for core test
-    - |
-        mysql -u root -e "CREATE DATABASE cbioportal; \
-                          CREATE DATABASE cgds_test; \
-                          CREATE USER 'cbio_user'@'localhost' IDENTIFIED BY 'somepassword'; \
-                          GRANT ALL ON cbioportal.* TO 'cbio_user'@'localhost'; \
-                          GRANT ALL ON cgds_test.* TO 'cbio_user'@'localhost'; \
-                          flush privileges; " 
-    # copy settings for core database
     - mkdir -p ~/.m2
     - cp .travis/settings.xml ~/.m2
+    - mysql --user travis --password= <<< 'CREATE DATABASE cgds_test'
 
 script:
+    - sudo service docker start
     - export PORTAL_HOME=$(pwd)
-    # core tests
+    - cp .travis/src/main/resources/portal.properties $PORTAL_HOME/src/main/resources/portal.properties
+    - cp .travis/src/main/resources/log4j.properties $PORTAL_HOME/src/main/resources/log4j.properties
+    - ~/maven/$MAVEN_VERSION/bin/mvn -e -DPORTAL_HOME=$PORTAL_HOME -Ppublic clean test
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
-    - chmod -R 777 .
-    - sudo service docker restart
-    - sleep 10s
-    - |
-        docker run \
-            --net=host \
-            --privileged \
-            -v $PWD:/cbioportal \
-            -e PORTAL_HOME=/cbioportal \
-            maven:3.3.3-jdk-8 \
-                /bin/bash -c \
-                'cd $PORTAL_HOME &&
-                mvn -e \
-                -DPORTAL_HOME=$PORTAL_HOME \
-                -Ppublic \
-                -Ddb.user=cbio_user \
-                -Ddb.pass=somepassword \
-                -Ddb.host=localhost \
-                -Ddb.connection_string=jdbc:mysql://localhost:3306/ \
-                clean test'
-    - |
-        docker run \
-            --net=host \
-            --privileged \
-            -v $PWD:/cbioportal \
-            -e PORTAL_HOME=/cbioportal \
-            maven:3.3.3-jdk-9 \
-                /bin/bash -c \
-                'cd $PORTAL_HOME &&
-                mvn -e \
-                -DPORTAL_HOME=$PORTAL_HOME \
-                -Ppublic \
-                -Ddb.host=localhost \
-                -Ddb.connection_string=jdbc:mysql://localhost:3306/ \
-                clean test'
-    - |
-        ~/maven/$MAVEN_VERSION/bin/mvn \
-            -e -DPORTAL_HOME=$PORTAL_HOME \
-            -Ddb.host=localhost \
-            -Ddb.connection_string=jdbc:mysql://localhost:3306/ \
-            -Ppublic \
-            clean test
-    # end-to-end tests
-    - |
-        ~/maven/$MAVEN_VERSION/bin/mvn \
-            -e -DPORTAL_HOME=$PORTAL_HOME \
-            -Ppublic -DskipTests \
-            -Ddb.user=cbio_user \
-            -Ddb.password=cbio_pass \
-            -Ddb.portal_db_name=public_test \
-            -Ddb.connection_string=jdbc:mysql://cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com:3306/ \
-            -Ddb.host=cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com \
-            clean install
-    - cd test/end-to-end
-    - docker-compose up -d
-    - sleep 30s
-    - cd ../..
-    - bash test/end-to-end/test_make_screenshots.sh test/end-to-end/screenshots.yml
+    - ~/maven/$MAVEN_VERSION/bin/mvn -e -DPORTAL_HOME=$PORTAL_HOME -Ppublic -DskipTests -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test -Ddb.connection_string=jdbc:mysql://cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com:3306/ -Ddb.host=cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com clean install
+    - java -Ddbconnector=dbcp -jar portal/target/dependency/webapp-runner.jar --expand-war portal/target/cbioportal.war &
+    - sleep 20s
+    - bash test/end-to-end/test_make_screenshots.sh
 
 notifications:
   slack: cbioportal:S2qVTFTFMtizONhCOe8BYxS6
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,38 @@
 services:
     - docker
+    - mysql
+
+sudo: required
 
 before_script:
     # copy settings for core database
     - mkdir -p ~/.m2
     - cp .travis/settings.xml ~/.m2
 
+install:
+    - sudo apt-get install mysql-server
+    - mysql_install_db
+    - /usr/bin/mysqld_safe
+    - |
+        mysql -u root -e "CREATE DATABASE cbioportal; \
+                          CREATE DATABASE cgds_test; \
+                          CREATE USER 'cbio_user'@'localhost' IDENTIFIED BY 'somepassword'; \
+                          GRANT ALL ON cbioportal.* TO 'cbio_user'@'localhost'; \
+                          GRANT ALL ON cgds_test.* TO 'cbio_user'@'localhost'; \
+                          flush privileges; " 
+
 script:
     - export PORTAL_HOME=$(pwd)
     # run mysql db for core tests
+    - echo 'show tables;' | mysql --user cbio_user -h localhost -P 3306 --password=somepassword cgds_test
     - |
         docker run --name core-tests-mysql \
-                 -p 3306:3306 \
                  -e MYSQL_USER=cbio_user \
                  -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
                  -e MYSQL_PASSWORD=somepassword \
                  -e MYSQL_DATABASE=cgds_test \
                  -d mysql:5.7.12
+    #expose port to host -p 3306:3306
     # core tests
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ jdk:
 env:
     - MAVEN_VERSION=3.3.3
 
-addons:
-    # fix https://github.com/travis-ci/travis-ci/issues/5227
-    hostname: short-hostname
-
 cache:
     directories:
         - $HOME/.m2
@@ -51,16 +47,14 @@ before_script:
 
 script:
     - export PORTAL_HOME=$(pwd)
-    # run mysql db for core tests
-    - echo 'show tables;' | mysql --user cbio_user -h localhost -P 3306 --password=somepassword cgds_test
     # core tests
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
     - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \
-            -Ddb.host=127.0.0.1 \
-            -Ddb.connection_string=jdbc:mysql://127.0.0.1:3306/ \
+            -Ddb.host=localhost \
+            -Ddb.connection_string=jdbc:mysql://localhost:3306/ \
             -Ppublic \
             clean test
     # end-to-end tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ before_script:
     # copy settings for core database
     - mkdir -p ~/.m2
     - cp .travis/settings.xml ~/.m2
+
+script:
+    - export PORTAL_HOME=$(pwd)
     # run mysql db for core tests
     - |
         docker run --name core-tests-mysql \
@@ -38,9 +41,6 @@ before_script:
                  -e MYSQL_PASSWORD=somepassword \
                  -e MYSQL_DATABASE=cbioportal \
                  -d mysql:5.7.12
-
-script:
-    - export PORTAL_HOME=$(pwd)
     # core tests
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ script:
     # core tests
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
+    - chmod -R 777 .
     - |
         docker run \
             -v $PWD:/cbioportal \

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
     # core tests
     - cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
     - cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
-    - echo 'show tables;' | mysql --user cbio_user --host=docker -P 3306 --password=somepassword cgds_test
+    - echo 'show tables;' | mysql --user cbio_user -P 3306 --password=somepassword cgds_test
     - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,20 @@ install:
 before_script:
     - mkdir -p ~/.m2
     - cp .travis/settings.xml ~/.m2
+	- # create cbio network
+	- docker network create cbio-net
 	- # run mysql db for core tests
     - |
-        docker run --name core-tests-mysql \
+        docker run \
+				 --name core-tests-mysql \
+			     --net=cbio-net \
                  -p 3306:3306 \
                  -e MYSQL_USER=cbio_user \
                  -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
                  -e MYSQL_PASSWORD=somepassword \
                  -e MYSQL_DATABASE=cgds_test \
-                 -d mysql:5.7.12
+                 -d \
+				 mysql:5.7.12
 
 script:
     - export PORTAL_HOME=$(pwd)
@@ -46,14 +51,33 @@ script:
     - |
         while [ 1 != $(docker exec core-tests-mysql /bin/bash -c \
                        "echo 'select 1;' | \
-                        mysql --user cbio_user  -P 3306 --password=somepassword cgds_test | head -1") ]
+                        mysql --user cbio_user -P 3306 --password=somepassword cgds_test | head -1") ]
         do 
             sleep 5s
         done
     - |
-        docker exec core-test-mysql /bin/bash -c \
+        docker exec core-tests-mysql /bin/bash -c \
             "echo 'show tables;' | \
              mysql --user cbio_user -P 3306 --password=somepassword cgds_test"
+	# core tests
+	- |
+        docker run \
+			--name maven \
+			--net=cbio-net \
+            -v $PWD:/cbioportal \
+            -e PORTAL_HOME=/cbioportal \
+            maven:3.3-jdk-7 \
+                /bin/bash -c \
+                'cd $PORTAL_HOME &&
+                mvn -e \
+                -DPORTAL_HOME=$PORTAL_HOME \
+                -Ppublic \
+				-Ddb.user=cbio_user \
+				-Ddb.password=somepassword \
+                -Ddb.host=localhost \
+                -Ddb.connection_string=jdbc:mysql://localhost:3306/ \
+				-X \
+                clean test'
     - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,14 @@ script:
             -v $PWD:/cbioportal \
             -e PORTAL_HOME=/cbioportal \
             maven:3.3-jdk-7 \
+                /bin/bash -c \
+                'cd $PORTAL_HOME &&
                 mvn -e \
                 -DPORTAL_HOME=$PORTAL_HOME \
                 -Ppublic \
                 -Ddb.host=localhost \
                 -Ddb.connection_string=jdbc:mysql://localhost:3306/ \
-                clean test
+                clean test'
     - |
         ~/maven/$MAVEN_VERSION/bin/mvn \
             -e -DPORTAL_HOME=$PORTAL_HOME \

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ script:
     - sudo service docker restart
     - |
         docker run \
+            --net=host \
             --privileged \
             -v $PWD:/cbioportal \
             -e PORTAL_HOME=/cbioportal \
@@ -65,6 +66,7 @@ script:
                 clean test'
     - |
         docker run \
+            --net=host \
             --privileged \
             -v $PWD:/cbioportal \
             -e PORTAL_HOME=/cbioportal \

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -4,7 +4,7 @@
     <server>
       <id>settingsKey</id>
       <username>travis</username>
-      <password></password>
+      <password>mypassword</password>
    </server>
  </servers>
 </settings>

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -3,8 +3,8 @@
   <servers>
     <server>
       <id>settingsKey</id>
-      <username>travis</username>
-      <password>mypassword</password>
+      <username>cbio_user</username>
+      <password>somepassword</password>
    </server>
  </servers>
 </settings>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -356,7 +356,7 @@
             <!-- username & password gets put in .m2/settings.xml -->
               <settingsKey>settingsKey</settingsKey>
               <driver>com.mysql.jdbc.Driver</driver>
-              <url>jdbc:mysql://127.0.0.1:3306/cgds_test</url>
+              <url>jdbc:mysql://localhost:3306/cgds_test</url>
               <sqlCommand>SET storage_engine=INNODB</sqlCommand>
               <sqlCommand>SET SESSION sql_mode = 'ANSI_QUOTES'</sqlCommand>
               <srcFiles>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -356,7 +356,7 @@
             <!-- username & password gets put in .m2/settings.xml -->
               <settingsKey>settingsKey</settingsKey>
               <driver>com.mysql.jdbc.Driver</driver>
-              <url>jdbc:mysql://localhost:3306/cgds_test</url>
+              <url>jdbc:mysql://127.0.0.1:3306/cgds_test</url>
               <sqlCommand>SET storage_engine=INNODB</sqlCommand>
               <sqlCommand>SET SESSION sql_mode = 'ANSI_QUOTES'</sqlCommand>
               <srcFiles>

--- a/core/src/test/resources/applicationContext-dao.xml
+++ b/core/src/test/resources/applicationContext-dao.xml
@@ -46,7 +46,7 @@
 	<!-- Values are for testing only, so need to correspond to the cgds in the pom.xml -->
 	<bean id="dbcpDataSource" destroy-method="close" class="org.apache.commons.dbcp.BasicDataSource">
 		<property name="driverClassName" value="com.mysql.jdbc.Driver" />
-		<property name="url" value="jdbc:mysql://127.0.0.1:3306/cgds_test" />
+		<property name="url" value="jdbc:mysql://localhost:3306/cgds_test" />
 		<property name="username" value="${db.user}" />
 		<property name="password" value="${db.password}" />
 		<property name="minIdle" value="0" />

--- a/core/src/test/resources/applicationContext-dao.xml
+++ b/core/src/test/resources/applicationContext-dao.xml
@@ -46,7 +46,7 @@
 	<!-- Values are for testing only, so need to correspond to the cgds in the pom.xml -->
 	<bean id="dbcpDataSource" destroy-method="close" class="org.apache.commons.dbcp.BasicDataSource">
 		<property name="driverClassName" value="com.mysql.jdbc.Driver" />
-		<property name="url" value="jdbc:mysql://localhost:3306/cgds_test" />
+		<property name="url" value="jdbc:mysql://127.0.0.1:3306/cgds_test" />
 		<property name="username" value="${db.user}" />
 		<property name="password" value="${db.password}" />
 		<property name="minIdle" value="0" />


### PR DESCRIPTION
Currently the end-to-end tests are disabled, because the Travis core tests don't work with docker services enabled. This should fix the core tests to continue to work with docker services enabled.