### PR TITLE
Fix for timeline data #1227 (but pointing to rc-dfci branch)

### DIFF
--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -176,6 +176,7 @@ META_FIELD_MAP = {
     MetaFileTypes.TIMELINE: {
         'cancer_study_identifier': True,
         'genetic_alteration_type': True,
+        'datatype': True,
         'data_filename': True
     },
     MetaFileTypes.CASE_LIST: {

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1818,6 +1818,7 @@ class TimelineValidator(Validator):
         'STOP_DATE',
         'EVENT_TYPE']
     REQUIRE_COLUMN_ORDER = True
+    ALLOW_BLANKS = True
 
     def checkLine(self, data):
         super(TimelineValidator, self).checkLine(data)

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -781,8 +781,8 @@ Each event type requires its own data file, which contains all the events that e
 
 1. **PATIENT_ID**: the patient ID from the dataset
 2. **START_DATE**: the start point of any event, calculated in **_days_* from the date of diagnosis (which will act as point zero on the timeline scale)
-3. **EVENT_TYPE**: the category of the event. You are free to define any type of event here. For several event types cBioPortal has column naming suggestions and for several events there are column names which have special effects. See [event types](#event-types) for more information.
-4. **STOP_DATE**: The end date of the event is calculated in days from the date of diagnosis (which will act as point zero on the timeline scale). If the event occurs over time (e.g. a Treatment, ...) the STOP_DATE column should have values. If the event occurs at a time point (e.g. a Lab_test, Imaging, ...) the STOP_DATE is still mandatory, but the values should be blanks. 
+3. **STOP_DATE**: The end date of the event is calculated in days from the date of diagnosis (which will act as point zero on the timeline scale). If the event occurs over time (e.g. a Treatment, ...) the STOP_DATE column should have values. If the event occurs at a time point (e.g. a Lab_test, Imaging, ...) the STOP_DATE is still mandatory, but the values should be blanks.
+4. **EVENT_TYPE**: the category of the event. You are free to define any type of event here. For several event types cBioPortal has column naming suggestions and for several events there are column names which have special effects. See [event types](#event-types) for more information. 
 
 And one optional columns with a special effect:
 

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -763,7 +763,7 @@ This type data is not yet being validated. It can, however, be uploaded.
 Each event type requires its own meta file. A timeline meta file should contain the following fields:
 
 1. **cancer_study_identifier**: same value as specified in [study meta file](#cancer-study)
-2. **genetic_alteration_type**: TIMELINE
+2. **genetic_alteration_type**: CLINICAL
 3. **datatype**: TIMELINE
 4. **data_filename**: &lt;your datafile&gt;
 
@@ -782,10 +782,7 @@ Each event type requires its own data file, which contains all the events that e
 1. **PATIENT_ID**: the patient ID from the dataset
 2. **START_DATE**: the start point of any event, calculated in **_days_* from the date of diagnosis (which will act as point zero on the timeline scale)
 3. **EVENT_TYPE**: the category of the event. You are free to define any type of event here. For several event types cBioPortal has column naming suggestions and for several events there are column names which have special effects. See [event types](#event-types) for more information.
-
-There is one conditionally required column:
-
-1. **STOP_DATE**: The end date of the event is calculated in days from the date of diagnosis (which will act as point zero on the timeline scale). If the event occurs over time (e.g. a Treatment, ...) STOP_DATE should be used. If the event occurs at a time point (e.g. a Lab_test, Imaging, ...) STOP_DATE should not be used. 
+4. **STOP_DATE**: The end date of the event is calculated in days from the date of diagnosis (which will act as point zero on the timeline scale). If the event occurs over time (e.g. a Treatment, ...) the STOP_DATE column should have values. If the event occurs at a time point (e.g. a Lab_test, Imaging, ...) the STOP_DATE is still mandatory, but the values should be blanks. 
 
 And one optional columns with a special effect:
 


### PR DESCRIPTION
Fix for timeline data #1227  (same as #1230, but pointing to rc-dfci branch)

The following needs to be changed in timeline files:
* change genetic_alteration_type to CLINICAL
* STOP_DATE is now a mandatory column (third column). The values should be blank when STOP_DATE is not used. 