### PR TITLE
Fix more unit tests

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
@@ -69,7 +69,7 @@ public final class DaoCancerStudy {
         reCacheAll();
     }
 
-    private static synchronized void reCacheAll() {
+    public static synchronized void reCacheAll() {
         
         System.out.println("Recaching... ");
         DaoCancerStudy.reCache();

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
@@ -425,6 +425,8 @@ public final class DaoCancerStudy {
     /**
      * Deletes all Cancer Studies.
      * @throws DaoException Database Error.
+     * 
+     * @deprecated this should not be used. Use deleteCancerStudy(cancerStudyStableId) instead
      */
     public static void deleteAllRecords() throws DaoException {
         cacheDateByStableId.clear();

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGeneOptimized.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGeneOptimized.java
@@ -58,6 +58,7 @@ public class DaoGeneOptimized {
     private static final String GENE_SYMBOL_DISAMBIGUATION_FILE = "/gene_symbol_disambiguation.txt";
         
     private static final DaoGeneOptimized daoGeneOptimized = new DaoGeneOptimized();
+    //nb: make sure any map is also cleared in clearCache() method below:
     private final HashMap<String, CanonicalGene> geneSymbolMap = new HashMap <String, CanonicalGene>();
     private final HashMap<Long, CanonicalGene> entrezIdMap = new HashMap <Long, CanonicalGene>();
     private final HashMap<String, List<CanonicalGene>> geneAliasMap = new HashMap<String, List<CanonicalGene>>();
@@ -70,6 +71,10 @@ public class DaoGeneOptimized {
      * @throws DaoException Database Error.
      */
     private DaoGeneOptimized () {
+        fillCache();
+    }
+    
+    private synchronized void fillCache() {
         try {
             //  Automatically populate hashmap upon init
             ArrayList<CanonicalGene> globalGeneList = DaoGene.getAllGenes();
@@ -125,6 +130,26 @@ public class DaoGeneOptimized {
         }
     }
 
+    private void clearCache()
+    {
+        geneSymbolMap.clear();
+        entrezIdMap.clear();
+        geneAliasMap.clear();
+        cbioCancerGenes.clear();
+        disambiguousGenes.clear();
+    }
+
+    /**
+     * Clear and fill cache again. Useful for unit tests and 
+     * for the Import procedure to update the genes table, clearing the
+     * cache without the need to restart the webserver.
+     */
+    public synchronized void reCache()
+    {
+        clearCache();
+        fillCache();
+    }
+    
     /**
      * Adds a new Gene Record to the Database. If the Entrez Gene ID is negative,
      * a fake Entrez Gene ID will be assigned.

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoTypeOfCancer.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoTypeOfCancer.java
@@ -131,6 +131,13 @@ public class DaoTypeOfCancer {
       }
    }
 
+    /**
+     * Deletes all records from DB using TRUNCATE statement!
+     * 
+     * @throws DaoException
+     * 
+     * @deprecated do not use this! Use deleteAllTypesOfCancer instead
+     */
     public static void deleteAllRecords() throws DaoException {
         Connection con = null;
         PreparedStatement pstmt = null;
@@ -145,6 +152,18 @@ public class DaoTypeOfCancer {
             throw new DaoException(e);
         } finally {
             JdbcUtil.closeAll(DaoTypeOfCancer.class, con, pstmt, rs);
+        }
+    }
+    
+    /**
+     * Deletes all records from DB using DELETE statement.
+     * 
+     * @param typeOfCancerId
+     * @throws DaoException
+     */
+    public static void deleteAllTypesOfCancer() throws DaoException {
+        for (TypeOfCancer typeOfCancer : getAllTypesOfCancer()) {
+            deleteTypeOfCancer(typeOfCancer.getTypeOfCancerId());
         }
     }
 

--- a/core/src/test/java/org/mskcc/cbio/portal/pancancer/TestPanCancerStudySummaryImport.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/pancancer/TestPanCancerStudySummaryImport.java
@@ -1,5 +1,7 @@
 package org.mskcc.cbio.portal.pancancer;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mskcc.cbio.portal.dao.*;
@@ -27,6 +29,26 @@ import static org.junit.Assert.assertEquals;
 @Transactional
 public class TestPanCancerStudySummaryImport {
 
+    @Before
+    public void setUp() throws DaoException {
+        //clear cache to ensure this test is not affected by other tests (i.e. some tests add the same
+        //samples to the DB and these remain in the cache after tests are done...if tests don't implement
+        //teardown properly).
+        DaoPatient.reCache();
+        DaoSample.reCache();
+        DaoGeneticProfile.reCache();
+        DaoGeneOptimized.getInstance().reCache();
+    }
+    
+    @After
+    public void tearDown() {
+        //clear any cached data:
+        DaoPatient.reCache();
+        DaoSample.reCache();
+        DaoGeneticProfile.reCache();
+        DaoGeneOptimized.getInstance().reCache();
+    }
+    
     @Test
     public void testPanCancerImport() throws Exception {
         ProgressMonitor.setConsoleMode(true);

--- a/core/src/test/java/org/mskcc/cbio/portal/util/TestImportUtil.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/util/TestImportUtil.java
@@ -38,9 +38,18 @@ import org.mskcc.cbio.portal.scripts.ResetDatabase;
 
 /**
  * JUnit tests utility class.
+ * 
+ * @deprecated
  */
 public class TestImportUtil {
 
+    /**
+     * 
+     * @param resetDatabase
+     * @throws DaoException
+     * 
+     * @deprecated let's not do this...the new testing framework does this in another way (via seed_mini.sql)
+     */
     public static void createSmallDbms(boolean resetDatabase) throws DaoException
     {
       if (resetDatabase){


### PR DESCRIPTION
Fixed a couple of tests, making sure cache is cleared correctly before and after test execution. One of the tests was also calling a TRUNCATE table SQL execution, which cannot be rolled back and affects other tests depending on the order of execution of the tests. 

