### PR TITLE
Fixed bug with importing fusion data correctly.

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GeneticProfileReader.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GeneticProfileReader.java
@@ -80,10 +80,14 @@ public class GeneticProfileReader {
              throw new RuntimeException("Error: genetic_profile record found with same Stable ID as the one used in your data:  "
                   + existingGeneticProfile.getStableId() + ". Remove the existing genetic_profile record first.");
          }
-         else {
+         else if (geneticProfile.getDatatype().equals("FUSION")){
              // For mutation data only we can have multiple files with the same genetic_profile.
              // There is a constraint in the mutation database table to prevent duplicated data
              // If this constraint is hit (mistakenly importing the same maf twice) MySqlBulkLoader will throw an exception
+             geneticProfile.setGeneticProfileId(existingGeneticProfile.getGeneticProfileId());
+             return geneticProfile;
+         }
+         else {
              return existingGeneticProfile;
          }
       }


### PR DESCRIPTION
GeneticProfileReader was not returning the genetic profile meta data loaded from the meta_fusions file. Instead it overwrote the fusions genetic profile with the existing MAF genetic profile, thus overwriting the datatype from 'FUSION' to 'MAF' and causing ImportProfileData to run ImportExtendedMutationData instead of ImportFusionData.