### PR TITLE
Fix for issue where mvn picks the wrong java version when none is specified

### DIFF
--- a/business/pom.xml
+++ b/business/pom.xml
@@ -26,16 +26,6 @@
 
   <build>
     <plugins>
-      <!-- java 1.7 support -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.0.2</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -282,16 +282,6 @@
 
   <build>
     <plugins>
-      <!-- java 1.7 support -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.0.2</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -474,6 +474,16 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.3</version>
       </plugin>
+      <!-- build with java 1.7 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.0.2</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -47,16 +47,6 @@
     <!-- final name of the app -->
     <finalName>${final-war-name}</finalName>
     <plugins>
-      <!-- java 1.7 support -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.0.2</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
       <!-- war plugin config -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -61,18 +61,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <!-- java 1.7 support -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.0.2</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
# What? Why?
Apparently the java version used by Maven for the compilation of the code depends on the local environment where the build is running. This fix forces maven to use a *specific* version, making the build process more stable. 

The issue was introduced by the new sub-modules recently added: `persistence` and `service`.

Changes proposed in this pull request:
- force maven to use `java 1.7`

@ersinciftci : can you review? 