### PR TITLE
For heroku profile, copy log4j.properties.EXAMPLE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
               </execution>
             </executions>
           </plugin>
-          <!-- copy portal.properties.EXAMPLE -->
+          <!-- copy portal.properties.EXAMPLE and log4j.properties.EXAMPLE -->
           <plugin>
             <artifactId>maven-antrun-plugin</artifactId>
             <!-- only needs to be executed for parent pom -->
@@ -179,6 +179,9 @@
                     <copy
                     file="${basedir}/src/main/resources/portal.properties.EXAMPLE"
                     tofile="${basedir}/src/main/resources/portal.properties" />
+                    <copy
+                    file="${basedir}/src/main/resources/log4j.properties.EXAMPLE"
+                    tofile="${basedir}/src/main/resources/log4j.properties" />
                   </tasks>
                 </configuration>
               </execution>


### PR DESCRIPTION
# What? Why?
Heroku review app log shows there is a problem with not being able to locate the log4j.properties file. This copies the example file to the appropriate location when the heroku profile is activated. This makes heroku work again. Only problem is that we still get a few `Error R14 (Memory quota exceeded) Process running mem=593M(114.7%)`. It's mostly the first time you load the page. There's not much to do about that other than either

1. improving memory efficiency
2. paying for bigger dynos (as the workers are called in heroku) or
3. Using a smaller test database

Changes proposed in this pull request:
- copy `log4j.properties.EXAMPLE` to `src/main/resources/` when `heroku` profile is active

# Checks
- [x] Runs on Heroku.
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@jjgao 