### PR TITLE
group_concat_max_len fix

### DIFF
--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
@@ -29,6 +29,8 @@ public interface MutationMapper {
     Boolean hasAlleleFrequencyData(@Param("geneticProfileId") Integer geneticProfileId,
                                    @Param("sampleId") Integer sampleId);
 
+    void groupConcatMaxLenSet();
+
     List<SignificantlyMutatedGene> getSignificantlyMutatedGenes(@Param("geneticProfileId") Integer geneticProfileId,
                                                                 @Param("entrezGeneIds") List<Integer> entrezGeneIds,
                                                                 @Param("sampleIds") List<Integer> sampleIds,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
@@ -61,6 +61,7 @@ public class MutationMyBatisRepository implements MutationRepository {
                                                                        Integer thresholdRecurrence,
                                                                        Integer thresholdNumGenes) {
 
+        mutationMapper.groupConcatMaxLenSet();
         return mutationMapper.getSignificantlyMutatedGenes(geneticProfileId, entrezGeneIds, sampleIds,
                 thresholdRecurrence, thresholdNumGenes);
     }

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
@@ -181,6 +181,10 @@
         )
     </select>
 
+    <insert  id = "groupConcatMaxLenSet">
+        SET SESSION group_concat_max_len = 1000000;
+    </insert>
+
     <select id="getSignificantlyMutatedGenes" resultType="org.cbioportal.persistence.dto.SignificantlyMutatedGene">
         select
 


### PR DESCRIPTION
# What? Why?
Default group_concat_max_len is 1024, we set it to 1000000 in JDBC but forgot in MyBatis.

# Checks
- [ ] Runs on Heroku.
- [ ] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.
