### PR TITLE
Quick fix to use both new/old evidence structure of OncoKB

### DIFF
--- a/portal/src/main/webapp/js/src/OncoKBConnector.js
+++ b/portal/src/main/webapp/js/src/OncoKBConnector.js
@@ -510,7 +510,7 @@ var OncoKB = (function(_, $) {
                             //if evidence has level information, that means this is treatment evidence.
                             if (['LEVEL_0'].indexOf(evidence.levelOfEvidence) === -1) {
                                 var _treatment = {};
-                                _treatment.tumorType = evidence.tumorType.name;
+                                _treatment.tumorType = _.isObject(evidence.tumorType) ? evidence.tumorType.name : (evidence.subtype || evidence.cancerType);
                                 _treatment.level = evidence.levelOfEvidence;
                                 _treatment.content = evidence.treatments;
                                 _treatment.description = OncoKB.utils.findRegex(description) || 'No yet curated';


### PR DESCRIPTION
# What? Why?
OncoKB is going to have a new evidence model, this requires updating OncoKBConnector.js to adapt new and old structure

# Checks
- [ ] Runs on Heroku.
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
No

# Notify reviewers
@jjgao 
