### PR TITLE
Travis add settings.xml for core tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ script:
     - export PORTAL_HOME=$(pwd)
     # run the python unit tests (for the dataset validation scripts)
     - |
-
         if [[ "${TEST}" == python-validator ]]
         then
             export PYTHONPATH=$PYTHONPATH:$PORTAL_HOME/core/src/main/scripts:/usr/local/lib/python2.7/dist-packages:/usr/lib/python2.7/dist-packages
@@ -62,6 +61,13 @@ script:
             $PORTAL_HOME/core/src/test/scripts/./unit_tests_validate_data.py
             $PORTAL_HOME/core/src/test/scripts/./system_tests_validate_data.py
             cd $PORTAL_HOME
+        fi
+    # use .travis/settings.xml for core tests
+    - |
+        if [[ "${TEST}" == core ]]
+        then
+            mkdir -p ~/.m2
+            cp .travis/settings.xml ~/.m2
         fi
     # use EXAMPLE properties files
     - |

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<settings>
+  <servers>
+    <server>
+      <id>settingsKey</id>
+      <username>cbio_user</username>
+      <password>somepassword</password>
+   </server>
+ </servers>
+</settings>


### PR DESCRIPTION
# What? Why?
Restore previously redundant settings.xml file. This is being used in the core
tests. It probably shouldn't be using both the settings from properties file and settings.xml, but this is a quickfix for the moment

Changes proposed in this pull request:
- Restore settings.xml on Travis
- Temporary fix

# Checks
- [ ] Runs on Heroku.
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
If your pull request involves changes to an existing file, one or more of the
people that edited before you might be good candidates to review it. Please use
`git blame <filename>` to determine that and notify them here. Otherwise notify
everybody in the core team:
@jjgao @ersinciftci 