### PR TITLE
Add max_retry for screenshots test

### DIFF
--- a/test/end-to-end/screenshots.yml
+++ b/test/end-to-end/screenshots.yml
@@ -12,6 +12,10 @@ screenshot:
   timeout:
     - 10
     - 10
+  # number of retries before failing
+  retry:
+    - 3
+    - 2
 browsers:
   - firefox
   - chrome


### PR DESCRIPTION
# What? Why?
Due to difference in load on Travis, the screenshot can sometimes fail. This
retries taking the screenshot with increasing number of waiting time.  All the
parameters can be set in `screenshots.yml`. Another option would be tor wait for some HTML element to appear instead of doing a sleep, but I haven't been able to find such an element on all pages. It also makes writing the tests harder. Therefore the retry option was chosen.

For example see:

https://travis-ci.org/cBioPortal/cbioportal/jobs/139524886#L1814-L1817

Changes proposed in this pull request:
- Add a retry parameter to `screenshots.yml`. On failure the screenshot is taken again with increased timout. The new timeout value is `nr_retry * timout`, thereby increasing the timeout on each retry.

# Checks
- [x] Runs on Heroku.
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
If your pull request involves changes to an existing file, one or more of the
people that edited before you might be good candidates to review it. Please use
`git blame <filename>` to determine that and notify them here. Otherwise notify
everybody in the core team:
@fedde-s @ersinciftci 

Signed-off-by: Ino de Bruijn <ino@ino.pm>