### PR TITLE
Comment out ClinicalFreeForm.json servlet call in dynamicQuery.js

### DIFF
--- a/portal/src/main/webapp/js/src/dynamicQuery.js
+++ b/portal/src/main/webapp/js/src/dynamicQuery.js
@@ -698,7 +698,7 @@ function updateCancerStudyInformation() {
     // check if cancer study has a clinical_free_form data to filter,
     // if there is data to filter, then enable "build custom case set" link,
     // otherwise disable the button
-    jQuery.getJSON("ClinicalFreeForm.json",
+    /*jQuery.getJSON("ClinicalFreeForm.json",
 		{studyId: $("#select_single_study").val()},
 		function(json){
 			var noDataToFilter = false;
@@ -728,9 +728,9 @@ function updateCancerStudyInformation() {
 			if (noDataToFilter)
 			{
 				// no clinical_free_form data to filter for the current
-				// cancer study, so disable the button
+	*/			// cancer study, so disable the button
 				$("#build_custom_case_set").hide();
-			}
+	/*		}
 			else
 			{
 				$("#build_custom_case_set").tipTip({defaultPosition: "right",
@@ -740,7 +740,7 @@ function updateCancerStudyInformation() {
 				
 				$("#build_custom_case_set").hide();//.show(); temporarily disabled build case list
 			}
-		});
+		});*/
 }
 //  Triggered when a cancer study has been selected, either by the user
 //  or programatically.


### PR DESCRIPTION
# What? Why?
Fix # . This small change disables the javascript call to ClinicalFreeForm.json servlet in (dynamicQuery.js) : the custom case set feature of the querybuilder is no longer in use, and the overhead of this call was computationally heavy. A future PR should remove all functionality related to this feature. By fixing this now, we can get a better comparison of load balancing (this fix previously was only in the deployed pancanatlas tomcat web application)

Changes proposed in this pull request:
- comment out call to ClinicalFreeForm.json

# Checks
- [ ] Runs on Heroku.
- [ ] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
If your pull request involves changes to an existing file, one or more of the
people that edited before you might be good candidates to review it. Please use
`git blame <filename>` to determine that and notify them here. Otherwise notify
everybody in the core team:
@zheins @n1zea144 
