### PR TITLE
Add html viewer for image compare

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,37 +62,32 @@ some screenshots and compares them to the ones stored in the repository.
 
 ### What to do if the screenshot test fails
 When the screenshot test fails, it means that the screenshot taken from your
-instance of the portal differs from the screenshot stored in the repo. First
-download the image from Travis CI to your local repo. The Travis CI log will
-show you where the image was uploaded on [clbin.com](https://clbin.com).
-Download the image and replace the screenshot in the repo. For instance run in
-the root dir:
+instance of the portal differs from the screenshot stored in the repo.
+Copy+Paste the URL in the Travis CI log to view the image diff online. Further
+instructions are outlined on that page.
+
+If you prefer to compare the images locally, you need to first download the
+failing screenshot. The Travis CI log will show you where the image was
+uploaded on [clbin.com](https://clbin.com). First, download the image and
+replace the screenshot in the repo. For instance run in the root dir of
+cBioPortal:
 
 ```bash
 curl 'https://clbin.com/[replace-with-clbin-image-from-log].png' > test/end-to-end/screenshots/[replace-with-image-from-repo].png
-```
+``` 
 
-Then there are two ways to do an image diff:
+Then follow the steps outlined in [this blog post](http://www.akikoskinen.info/image-diffs-with-git/) to compare the 
+images locally. Run `git diff` from your repo to see the ImageMagick diff.
 
-1. Follow the steps outlined in [this blog
-post](http://www.akikoskinen.info/image-diffs-with-git/) to compare the images
-locally. Then run `git diff` from your repo to see the ImageMagick diff.
-2. Add the screenshot downloaded from [clbin.com](https://clbin.com) to your repo
-and push it to your PR. You can then compare the images in the 'Files changed'
-tab of the PR.
-
-Now that you can compare the images, you'll have to decide whether the change
-is desired or not and handle the failing test accordingly:
+Once you downloaded the images you do the following for each screenshot:
 
 - If the change in the screenshot is **undesired**, i.e. there is regression, you
   should fix your PR.
 - If the change in the screenshot is **desired**, add the screenshot to the
-  repo, commit it and push it to your PR's branch if you haven't already in the
-previous step.
+  repo, commit it and push it to your PR's branch.
 
 ## Additional Resources
 
 * [cBioPortal Issue Tracker](https://github.com/cBioPortal/cbioportal/issues)
 * [General GitHub documentation](http://help.github.com/)
 * [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
-

--- a/test/end-to-end/image-compare/index.html
+++ b/test/end-to-end/image-compare/index.html
@@ -1,0 +1,34 @@
+<html>
+    <head>
+    </head>
+    <body>
+        <script src="http://code.jquery.com/jquery-latest.min.js"></script>
+        <h1>Visual Regression Test Failed</h1>
+        <h2 class="screenshot-name"></h1>
+        <div class="juxtapose">
+            <img id="img1"  data-label="master" />
+            <img id="img2" data-label="PR" />
+        </div>
+        <p id="help-text">
+        When the screenshot test fails, it means that the screenshot taken from
+        your instance of the portal differs from the screenshot stored in the
+        repo.<br />
+        <br />
+        1. If the change in the screenshot is <b>undesired</b>, i.e. there is
+        regression, you should fix your PR.<br />
+        <br />
+        2. If the change in the screenshot is <b>desired</b>, add the screenshot
+        to the repo, commit it and push it to your PR's branch, that is:
+        <br />
+        <br /> curl > <span class="screenshot-name"></span><br />
+        git add <span class="screenshot-name"></span><br />
+        <br />
+        Then preferably use git commit --amend and change your commit message
+        to explain how the commit changed the screenshot. Subsequently force
+        push to your <b>own branch</b>.
+        </p>
+        <script src="js/main.js"></script>
+        <script src="https://cdn.knightlab.com/libs/juxtapose/latest/js/juxtapose.min.js"></script>
+        <link rel="stylesheet" href="https://cdn.knightlab.com/libs/juxtapose/latest/css/juxtapose.css" />
+    </body>
+</html>

--- a/test/end-to-end/image-compare/js/main.js
+++ b/test/end-to-end/image-compare/js/main.js
@@ -1,0 +1,27 @@
+function getURLParameterByName(name) {
+    name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+    var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+    results = regex.exec(location.search);
+    return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+}
+
+var img1 = getURLParameterByName("img1");
+var img2 = getURLParameterByName("img2");
+var label1 = getURLParameterByName("label1");
+var label2 = getURLParameterByName("label2");
+var screenshotName = getURLParameterByName("screenshot_name");
+
+if (img1 !== "" && img2 !== "") {
+    $("#img1").attr("src", img1);
+    $("#img2").attr("src", img2);
+
+    if (label1 !== "" && label2 !== "") {
+        $("#img1").attr("data-label", label1);
+        $("#img2").attr("data-label", label2);
+    }
+    if (screenshotName !== "") {
+        $(".screenshot-name").html(text);
+    }
+} else {
+    $("#help-text").text("Set images to compare in URL e.g. ?img1=http://image1.com&img2=http://image2.com&label1=before&label2=after&screenshot_name=test_screenshot");
+}


### PR DESCRIPTION
# What? Why?
Comparing changes in the screenshots still takes quite a lot of time, because one has to download the image locally and upload it to github or install a local image diff tool. This PR outputs a URL where one can compare the images online. The image compare viewer is in `test/end-to-end/image-compare`. The image URLs can be supplied as arguments to the URL allowing one to compare any combination of images.

Changes proposed in this pull request:
- Output a URL to compare image diff online when a screenshot test fails.
- Add image compare HTML page that uses juxtaposejs to compare images
- Update CONTRIBUTING.md to reflect those changes

# Checks
- [x] Runs on Heroku.
- [x] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Example
http://rawgit.com/cBioPortal/cbioportal/c0722d6483b103b7ac157903ee21b7d2a5db6499/test/end-to-end/image-compare/index.html?img1=https://raw.githubusercontent.com/cBioPortal/cbioportal/c0722d6483b103b7ac157903ee21b7d2a5db6499/test/end-to-end/screenshots/firefox/patient_view_lgg_ucsf_2014_case_id_P04.png&img2=https://clbin.com/SPPjt1.png&label1=hotfix&label2=c0722d6&screenshot_name=test/end-to-end/screenshots/firefox/patient_view_lgg_ucsf_2014_case_id_P04.png

# Notify reviewers
@zhx828 