### PR TITLE
Re-enabled the patient view darwin link

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/patient_view/patient_view.jsp
@@ -125,7 +125,7 @@ boolean showDrugs = GlobalProperties.showDrugsTab();
 boolean showSamplesTable = isPatientView;
 String userName = GlobalProperties.getAuthenticatedUserName();
 
-// String darwinAccessURL = CheckDarwinAccess.checkAccess(request);
+String darwinAccessURL = CheckDarwinAccess.checkAccess(request);
 
 double[] genomicOverviewCopyNumberCnaCutoff = GlobalProperties.getPatientViewGenomicOverviewCnaCutoff();
 
@@ -342,7 +342,7 @@ var oncokbGeneStatus = <%=oncokbGeneStatus%>;
 var showHotspot = <%=showHotspot%>;
 var userName = '<%=userName%>';
 
-var darwinAccessUrl = null;
+var darwinAccessUrl = '<%=darwinAccessURL%>';
 
 // TODO: hack for including mutation table indices in both cna.jsp and
 // mutations.jsp


### PR DESCRIPTION
# What? Why?
Darwin patient view link was disabled in #1015 - this PR re-enables the link

# Checks
- [x] Runs on Heroku.
- [ ] Single commit and [No merge commits](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
Shows a darwin link behind the patient's clinical attributes on the patient view. MSKCC internal.
![screen shot 2016-06-30 at 6 48 40 pm](https://cloud.githubusercontent.com/assets/1334004/16506847/50d82790-3ef3-11e6-8f4e-228bfb33cbd9.png)

# Notify reviewers
@inodb 

