### PR TITLE
 	Solved bugs when installing cBioPortal in Windows.

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/MySQLbulkLoader.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/MySQLbulkLoader.java
@@ -177,7 +177,7 @@ public class MySQLbulkLoader {
             tempFileWriter.write( "\t" );
             tempFileWriter.write( escapeValue(fieldValues[i]) );
          }
-         tempFileWriter.newLine();
+         tempFileWriter.write("\n");//newLine();
 
          if( rows++ < numDebuggingRowsToPrint ){
             StringBuffer sb = new StringBuffer( escapeValue(fieldValues[0]) );
@@ -230,7 +230,7 @@ public class MySQLbulkLoader {
          con = JdbcUtil.getDbConnection(MySQLbulkLoader.class);
          stmt = con.createStatement();
          
-         String command = "LOAD DATA LOCAL INFILE '" + tempFileName + "'" + " INTO TABLE " + tableName;
+         String command = "LOAD DATA LOCAL INFILE '" + tempFileName.replace("\\", "\\\\") + "'" + " INTO TABLE " + tableName;
          stmt.execute( command );
          
          int updateCount = stmt.getUpdateCount();

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -2298,6 +2298,10 @@ def process_metadata_files(directory, portal_instance, logger):
                 if ('add_global_case_list' in meta and
                         meta['add_global_case_list'].lower() == 'true'):
                     case_list_suffix_fns['all'] = filename
+            # raise a warning if pmid is existing, but no citation is available. 
+            if 'pmid' in meta and not 'citation' in meta:
+                logger.warning(
+                'Citation is required when giving a pubmed id (pmid).')
 
         # create a list for the file type in the dict
         if meta_file_type not in validators_by_type:
@@ -2310,6 +2314,7 @@ def process_metadata_files(directory, portal_instance, logger):
             validators_by_type[meta_file_type].append(validator)
         else:
             validators_by_type[meta_file_type].append(None)
+        
 
     if study_cancer_type is None:
         logger.error(


### PR DESCRIPTION
Two Windows-specific bugs that appear when installing cBioPortal have been solved:
1- The `\\` were not correctly interpreted (apparently, Java was escaping and then, MySQL did it too).
2- `newLine()` was not correctly interpreted, so it has been replaced with `.write("\n")`