### PR TITLE
Define Locale in NormalizeExpressionLevels.java

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/NormalizeExpressionLevels.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/NormalizeExpressionLevels.java
@@ -260,7 +260,7 @@ public class NormalizeExpressionLevels{
                       // Double.NaN indicates an invalid expression value
                       if(zscores[k] != Double.NaN){
                          // limit precision
-                         outputLine.add( String.format( "%.4f", zscores[k] ) );
+                         outputLine.add( String.format( Locale.US, "%.4f", zscores[k] ) ); 
                       }else{
                          outputLine.add( NOT_AVAILABLE );
                       }


### PR DESCRIPTION
NormalizeExpressionLevels.java calculates Z-scores from copy number and expression files. However, the values are shown using the default Locale from the computer. This can be a problem if the computer is configured in German, Spanish or other languages where they use commas instead of points as decimal separator. 