### PR TITLE
Fix bugs when installing cBioPortal in Windows

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/MySQLbulkLoader.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/MySQLbulkLoader.java
@@ -177,7 +177,7 @@ public class MySQLbulkLoader {
             tempFileWriter.write( "\t" );
             tempFileWriter.write( escapeValue(fieldValues[i]) );
          }
-         tempFileWriter.newLine();
+         tempFileWriter.write("\n");;
 
          if( rows++ < numDebuggingRowsToPrint ){
             StringBuffer sb = new StringBuffer( escapeValue(fieldValues[0]) );
@@ -230,7 +230,7 @@ public class MySQLbulkLoader {
          con = JdbcUtil.getDbConnection(MySQLbulkLoader.class);
          stmt = con.createStatement();
          
-         String command = "LOAD DATA LOCAL INFILE '" + tempFileName + "'" + " INTO TABLE " + tableName;
+         String command = "LOAD DATA LOCAL INFILE '" + tempFileName.replace("\\", "\\\\") + "'" + " INTO TABLE " + tableName;
          stmt.execute( command );
          
          int updateCount = stmt.getUpdateCount();


### PR DESCRIPTION
Two Windows-specific bugs that appear when installing cBioPortal have been solved:
1- The `\\` were not correctly interpreted (apparently, Java was escaping and then, MySQL did it too).
2- `newLine()` was not correctly interpreted, so it has been replaced with `.write("\n")`