### PR TITLE
Make study query suggestions configurable

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
@@ -243,6 +243,12 @@ public class QueryBuilder extends HttpServlet {
                 httpServletRequest.setAttribute(DB_ERROR, "Current DB Version: " + dbVersion + "<br/>" + "DB version expected by Portal: " + dbPortalVersion + "<br/>" + extraMessage);
             }
 
+            // Get the example study queries configured as a skin property
+            String[] exampleStudyQueries = GlobalProperties.getExampleStudyQueries().split("\n");
+            httpServletRequest.setAttribute(
+                    "exampleStudyQueries",
+                    exampleStudyQueries);
+
             boolean errorsExist = validateForm(action, profileList, geneticProfileIdSet,
                                                sampleSetId, sampleIds, httpServletRequest);
             if (action != null && action.equals(ACTION_SUBMIT) && (!errorsExist)) {

--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -98,6 +98,17 @@ public class GlobalProperties {
     public static final String SKIN_RIGHT_NAV_SHOW_TESTIMONIALS = "skin.right_nav.show_testimonials";
     public static final String SKIN_AUTHORIZATION_MESSAGE = "skin.authorization_message";
     public static final String DEFAULT_AUTHORIZATION_MESSAGE = "Access to this portal is only available to authorized users.";
+    public static final String SKIN_EXAMPLE_STUDY_QUERIES = "skin.example_study_queries";
+    public static final String DEFAULT_SKIN_EXAMPLE_STUDY_QUERIES =
+            "tcga\n" +
+            "tcga -provisional\n" +
+            "tcga -moratorium\n" +
+            "tcga OR icgc\n" +
+            "-\"cell line\"\n" +
+            "prostate mskcc\n" +
+            "esophageal OR stomach\n" +
+            "serous\n" +
+            "breast";
     public static final String SKIN_DATASETS_HEADER = "skin.data_sets_header";
     public static final String DEFAULT_SKIN_DATASETS_HEADER = "The portal currently contains data from the following " +
             "cancer genomics studies.  The table below lists the number of available samples per data type and tumor.";
@@ -556,6 +567,12 @@ public class GlobalProperties {
     {
         String authMessage = properties.getProperty(SKIN_AUTHORIZATION_MESSAGE);
         return authMessage == null ? DEFAULT_AUTHORIZATION_MESSAGE : authMessage;
+    }
+
+    public static String getExampleStudyQueries() {
+        return properties.getProperty(
+                SKIN_EXAMPLE_STUDY_QUERIES,
+                DEFAULT_SKIN_EXAMPLE_STUDY_QUERIES);
     }
 
     // added usage of default data sets header

--- a/docs/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/Customizing-your-instance-of-cBioPortal.md
@@ -37,6 +37,12 @@ Below you can find the complete list of all the available skin properties.
 			<td>comma separated text</td>
 		</tr>
 		<tr>
+			<td>skin.example_study_queries</td>
+			<td>\n-separated list of study query suggestions displayed when clicking the ‘select a cancer study' search box</td>
+			<td>tcga\ntcga -provisional\ntcga -moratorium\ntcga OR icgc\n-"cell line"\nprostate mskcc\nesophageal OR stomach\nserous\nbreast</td>
+			<td>text separated by the escape sequence \n</td>
+		</tr>
+		<tr>
 			<td>skin.data_sets_footer</td>
 			<td>sets the text that is shown below the number of samples, after clicking on the "DATA SETS" tab in the header.</td>
 			<td>The portal currently contains data from the following cancer genomics studies.  The table below lists the number of available samples per data type and tumor.</td>

--- a/portal/src/main/webapp/WEB-INF/jsp/step1_json.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/step1_json.jsp
@@ -30,6 +30,9 @@
  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --%>
 
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+
 <%
     String step1ErrorMsg = (String) request.getAttribute(QueryBuilder.STEP1_ERROR_MSG);
 %>
@@ -44,16 +47,10 @@
                   <span class="caret"></span>
                   <span class="sr-only">Toggle Dropdown</span>
                 </button>
-                <ul class="dropdown-menu dropdown-menu-right" role="menu" title="Select from dropdown">
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("tcga");$("#jstree_search_input").trigger("input");' >tcga</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("tcga -provisional");$("#jstree_search_input").trigger("input");' >tcga -provisional</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("tcga -moratorium");$("#jstree_search_input").trigger("input");' >tcga -moratorium</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("tcga OR icgc");$("#jstree_search_input").trigger("input");'>tcga OR icgc</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("-\"cell line\"");$("#jstree_search_input").trigger("input");'>-"cell line"</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("prostate mskcc");$("#jstree_search_input").trigger("input");'>prostate mskcc</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("esophageal OR stomach");$("#jstree_search_input").trigger("input");'>esophageal OR stomach</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("serous");$("#jstree_search_input").trigger("input");'>serous</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("breast");$("#jstree_search_input").trigger("input");'>breast</a></li>
+                <%-- loop over the configured query suggestions --%>
+                <ul class="dropdown-menu dropdown-menu-right" role="menu" title="Select from dropdown"><c:forEach var="query" items="${exampleStudyQueries}">
+                    <%-- escape \ to \\ and " to \" inside the JS string --%>
+                    <li role="presentation"><a role="menuitem" tabindex="-1" href='javascript:void(0)' onclick='$("#jstree_search_input").val("${fn:escapeXml(fn:replace(fn:replace(query, "\\", "\\\\"), "\"", "\\\""))}");$("#jstree_search_input").trigger("input");'><c:out value="${query}" /></a></li></c:forEach>
                 </ul>
             </div>
         </div>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -16,9 +16,8 @@ db.version=${db.version}
 # web page cosmetics
 skin.title=cBioPortal for Cancer Genomics
 skin.email_contact=cbioportal at googlegroups dot com
-skin.blurb=The cBioPortal for Cancer Genomics provides <b>visualization</b>, <b>analysis</b> and <b>download</b> of large-scale cancer genomics data sets.  <p>Please adhere to <u><a href=\"http://cancergenome.nih.gov/abouttcga/policies/publicationguidelines\"> the TCGA publication guidelines</a></u> when using TCGA data in your publications.</p> <p><b>Please cite</b> <a href=\"http://www.ncbi.nlm.nih.gov/pubmed/23550210\">Gao et al. <i>Sci. Signal.</i> 2013</a> &amp;  <a href=\"http://cancerdiscovery.aacrjournals.org/content/2/5/401.abstract\"> Cerami et al. <i>Cancer Discov.</i> 2012</a> when publishing results based on cBioPortal.</p>
 skin.authorization_message=Access to this portal is only available to authorized users at Memorial Sloan Kettering Cancer Center.  [<a href="http://bit.ly/ZevaHa">Request Access</a>].
-skin.right_nav.show_testimonials=true
+skin.example_study_queries=tcga\ntcga -provisional\ntcga -moratorium\ntcga OR icgc\n-"cell line"\nprostate mskcc\nesophageal OR stomach\nserous\nbreast
 skin.data_sets_header=The portal currently contains data from the following cancer genomics studies.  The table below lists the number of available samples per data type and tumor.
 skin.data_sets_footer=Data sets of TCGA studies were downloaded from Broad Firehose (http://gdac.broadinstitute.org) and updated monthly. In some studies, data sets were from the TCGA working groups directly.
 skin.examples_right_column=examples.html


### PR DESCRIPTION
Allow administrators of cBioPortal installations to configure the example queries listed in the dropdown menu of the study search box, as requested in issue #1380.

This can be useful in installations that do not contain the datasets used as examples by default. Administrators of such installations want to customise the default suggestions and replace them with ones that make sense for the data in their portal.

![screen shot 2016-06-29 at 16 18 57](https://cloud.githubusercontent.com/assets/4929431/16455629/504fbda8-3e15-11e6-9e25-62c7e477e715.png)

Changes proposed in this pull request:
- parse and document a portal property named `skin.example_study_queries`, a newline-separated list with the previously hard-coded values as the default value
- generate the list of query suggestions to filter studies in the query view based on the new portal property