### PR TITLE
Fix a test failing because of an earlier merge

### DIFF
--- a/core/src/test/scripts/test_data/study_maf_test/error_file.txt
+++ b/core/src/test/scripts/test_data/study_maf_test/error_file.txt
@@ -1,12 +1,10 @@
->data_patients.txt | ERROR: According to portal, attribute should be loaded as NUMBER. Value of attribute to be loaded as NUMBER is not a real number
-6,7,8,9,10,11,12,13,14,15,39,103,104,105,106,107,108,109,111,112,119,159,162,163,164,165,166,168,169,170,171,173,175,176,177,178,179,180,181,182,183,184,185,196,242,276,372,392,394,395,396,397,398,399,401,402,403,406,407,425,428,441,520,528,529,530,531,532,533,534,535,536,537,538,539,540,541,542,543,544,545,546,547,548,549,550,551,552,553,554,555,566,605,639,794,795,808,809,810,811,823,824,825,826,827,828,829
->brca_tcga_pub.maf | WARNING: Entrez gene id not known to the cBioPortal instance. This gene will not be loaded
-2,3,5,8,9,11,12,16
 >data_patients.txt | WARNING: datatype definition for attribute 'DFS_MONTHS' does not match the portal, and will be loaded as 'NUMBER'
 3
 >data_patients.txt | ERROR: Value of attribute to be loaded as NUMBER is not a real number (nb: even though 'datatype' definition in file is STRING, attribute is being validated as NUMBER according to the portal's definition - see also previous warning for this attribute)
 8,10
 >data_patients.txt | ERROR: Value of attribute to be loaded as NUMBER is not a real number
 536,540
+>brca_tcga_pub.maf | WARNING: Entrez gene id not known to the cBioPortal instance. This gene will not be loaded
+2,3,5,8,9,11,12,16
 >brca_tcga_pub.maf | ERROR: Normal sample id not in list of sample ids configured in corresponding metafile. Please check your metafile field 'normal_samples_list'.
 8,9,11,12

--- a/core/src/test/scripts/test_data/study_quotes/result_report.html
+++ b/core/src/test/scripts/test_data/study_quotes/result_report.html
@@ -47,7 +47,7 @@
       <div class="jumbotron">
         <h1>cBioPortal validation report</h1>
         <p>Study directory:<br />test_data/study_quotes/</p>
-        <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/wiki/File%20Formats'>the documentation on file formats supported by cBioPortal</a></p>
+        <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/blob/master/docs/File-Formats.md'>the documentation on file formats supported by cBioPortal</a></p>
       </div>
     </div>
 


### PR DESCRIPTION
When changes in the behaviour of the validator introduced in the hotfix branch were merged with changes introduced in the rc branch in commit 0901c50db8896721f584895a35125533be076397, a merge conflict resolution caused an end-to-end test of the validation script to fail, and a second one failed because of incompatible changes elsewhere. Travis failed to report [these failures](https://travis-ci.org/cBioPortal/cbioportal/jobs/146414643#L510) because of an unrelated bug in the Travis configuration. This fixes both tests.

Changes proposed in this pull request:
- Correctly resolve the merge conflict in the expected output file `core/src/test/scripts/test_data/study_maf_test/error_file.txt` to match what the script now generates
- Adjust the documentation link the newly added expected output file `core/src/test/scripts/test_data/study_quotes/result_report.html` to match what the script now generates

### Requested reviewers ###
@pieterlukasse @jjgao