### PR TITLE
Simplify JSP EL code quoting in study query list

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/step1_json.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/step1_json.jsp
@@ -31,7 +31,7 @@
 --%>
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@taglib prefix="s" uri="http://www.springframework.org/tags" %>
 
 <%
     String step1ErrorMsg = (String) request.getAttribute(QueryBuilder.STEP1_ERROR_MSG);
@@ -50,7 +50,8 @@
                 <%-- loop over the configured query suggestions --%>
                 <ul class="dropdown-menu dropdown-menu-right" role="menu" title="Select from dropdown"><c:forEach var="query" items="${exampleStudyQueries}">
                     <%-- escape \ to \\ and " to \" inside the JS string --%>
-                    <li role="presentation"><a role="menuitem" tabindex="-1" href='javascript:void(0)' onclick='$("#jstree_search_input").val("${fn:escapeXml(fn:replace(fn:replace(query, "\\", "\\\\"), "\"", "\\\""))}");$("#jstree_search_input").trigger("input");'><c:out value="${query}" /></a></li></c:forEach>
+                    <c:set var="escapedJsString"><s:escapeBody javaScriptEscape="true"><c:out value="${query}" escapeXml="false" /></s:escapeBody></c:set>
+                    <li role="presentation"><a role="menuitem" tabindex="-1" href='javascript:void(0)' onclick='$("#jstree_search_input").val("${escapedJsString}");$("#jstree_search_input").trigger("input");'><c:out value="${query}" /></a></li></c:forEach>
                 </ul>
             </div>
         </div>

--- a/portal/src/main/webapp/WEB-INF/jsp/step1_json.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/step1_json.jsp
@@ -48,16 +48,9 @@
                   <span class="sr-only">Toggle Dropdown</span>
                 </button>
                 <%-- loop over the configured query suggestions --%>
-               <ul class="dropdown-menu dropdown-menu-right" role="menu" title="Select from dropdown">
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("tcga");$("#jstree_search_input").trigger("input");' >tcga</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("tcga -provisional");$("#jstree_search_input").trigger("input");' >tcga -provisional</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("tcga -moratorium");$("#jstree_search_input").trigger("input");' >tcga -moratorium</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("tcga OR icgc");$("#jstree_search_input").trigger("input");'>tcga OR icgc</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("-\"cell line\"");$("#jstree_search_input").trigger("input");'>-"cell line"</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("prostate mskcc");$("#jstree_search_input").trigger("input");'>prostate mskcc</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("esophageal OR stomach");$("#jstree_search_input").trigger("input");'>esophageal OR stomach</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("serous");$("#jstree_search_input").trigger("input");'>serous</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1"  href='javascript:void(0)' onclick='$("#jstree_search_input").val("breast");$("#jstree_search_input").trigger("input");'>breast</a></li>
+                <ul class="dropdown-menu dropdown-menu-right" role="menu" title="Select from dropdown"><c:forEach var="query" items="${exampleStudyQueries}">
+                    <%-- escape \ to \\ and " to \" inside the JS string --%>
+                    <li role="presentation"><a role="menuitem" tabindex="-1" href='javascript:void(0)' onclick='$("#jstree_search_input").val("${fn:escapeXml(fn:replace(fn:replace(query, "\\", "\\\\"), "\"", "\\\""))}");$("#jstree_search_input").trigger("input");'><c:out value="${query}" /></a></li></c:forEach>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
The template implementation of the feature introduced in commit 172e1a170fdd086af48a1b853c59a06cb7c84eb6 resulted in exceptions on certain server-side installations and was disabled. This patch reintroduces the feature and cleans up the quoting of JavaScript strings in the new code, which is the likely cause of the issues, by using a tag from the Spring library.