### PR TITLE
Fix #1542 Validator test not reporting error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,24 +56,24 @@ script:
     - |
         if [[ "${TEST}" == python-validator ]]
         then
-            export PYTHONPATH=$PYTHONPATH:$PORTAL_HOME/core/src/main/scripts:/usr/local/lib/python2.7/dist-packages:/usr/lib/python2.7/dist-packages
-            cd $PORTAL_HOME/core/src/test/scripts/
-            $PORTAL_HOME/core/src/test/scripts/./unit_tests_validate_data.py
-            $PORTAL_HOME/core/src/test/scripts/./system_tests_validate_data.py
+            export PYTHONPATH=$PYTHONPATH:$PORTAL_HOME/core/src/main/scripts:/usr/local/lib/python2.7/dist-packages:/usr/lib/python2.7/dist-packages && \
+            cd $PORTAL_HOME/core/src/test/scripts/ && \
+            $PORTAL_HOME/core/src/test/scripts/./unit_tests_validate_data.py && \
+            $PORTAL_HOME/core/src/test/scripts/./system_tests_validate_data.py && \
             cd $PORTAL_HOME
         fi
     # use .travis/settings.xml for core tests
     - |
         if [[ "${TEST}" == core ]]
         then
-            mkdir -p ~/.m2
+            mkdir -p ~/.m2 && \
             cp .travis/settings.xml ~/.m2
         fi
     # use EXAMPLE properties files
     - |
         if [[ "${TEST}" == core || "${TEST}" == end-to-end ]]
         then
-            cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties
+            cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties && \
             cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
         fi
     # make sure mysql container is running
@@ -119,10 +119,10 @@ script:
     - |
         if [[ "${TEST}" == end-to-end ]]
         then
-            cd test/end-to-end
-            docker-compose up -d
-            sleep 30s
-            cd ../..
+            cd test/end-to-end && \
+            docker-compose up -d && \
+            sleep 30s && \
+            cd ../.. && \
             # spot visual regression by comparing screenshots in the repo with
             # screenshots of this portal loaded with the data from the amazon db
             bash test/end-to-end/test_make_screenshots.sh test/end-to-end/screenshots.yml


### PR DESCRIPTION
# What? Why?
Fix #1542

Travis does not halt on errors in a code block. Only the exit command of the
last command is used to determine failure/success, which causes the python
validator to report success even on error. This appends ampersands to
statements in code blocks as a quickfix.

Changes proposed in this pull request:
- Append ampersands to statements in code blocks as a quickfix.

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@fedde-s 