### PR TITLE
Use the console runner for caises xml import script

### DIFF
--- a/core/src/test/java/org/mskcc/cbio/portal/scripts/TestImportCaisesClinicalXML.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/scripts/TestImportCaisesClinicalXML.java
@@ -96,7 +96,10 @@ public class TestImportCaisesClinicalXML {
      @Test
      public void test() throws Exception {
         File xmlFile = new File("target/test-classes/data_clinical_caises.xml");
-        ImportCaisesClinicalXML.importData(xmlFile, 1);
+        CancerStudy cancerStudy = new CancerStudy("prad","prad","prad","prad",true);
+        ImportCaisesClinicalXML importCaisesClinicalXML = new ImportCaisesClinicalXML(null);
+        importCaisesClinicalXML.setFile(xmlFile, cancerStudy);
+        importCaisesClinicalXML.importData();
      }
      
 //     @Test


### PR DESCRIPTION
# What? Why?
`ImportCaisesClinicalXML.java` was never updated to extend ConsoleRunnable.java, which would cause our import pipeline to crash when attempting to use it.

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@jjgao @pieterlukasse 