### PR TITLE
Add validation for clinical attrs with set meanings

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -147,8 +147,9 @@ class Jinja2HtmlHandler(logging.handlers.BufferingHandler):
         self.output_filename = output_filename
         self.max_level = logging.NOTSET
         self.closed = False
-        # get the directory name of the currently running script
-        self.template_dir = os.path.dirname(__file__)
+        # get the directory name of the currently running script,
+        # resolving any symlinks
+        self.template_dir = os.path.dirname(os.path.realpath(__file__))
         super(Jinja2HtmlHandler, self).__init__(*args, **kwargs)
 
     def emit(self, record):

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1315,10 +1315,10 @@ class ClinicalValidator(Validator):
         'DRIVER_MUTATIONS': {
             'is_patient_attribute': '0'
         },
-        'ERG-FUSION_ACGH': {
+        'ERG_FUSION_ACGH': {
             'is_patient_attribute': '0'
         },
-        'ETS/RAF/SPINK1_STATUS': {
+        'ETS_RAF_SPINK1_STATUS': {
             'is_patient_attribute': '0'
         },
         'GENDER': {
@@ -1383,7 +1383,7 @@ class ClinicalValidator(Validator):
             'is_patient_attribute': '1',
             'datatype': 'STRING'
         },
-        'TMPRSS2-ERG_FUSION_STATUS': {
+        'TMPRSS2_ERG_FUSION_STATUS': {
             'is_patient_attribute': '0'
         },
         'TUMOR_GRADE': {

--- a/core/src/test/scripts/test_data/data_cancertype_invalid_color.txt
+++ b/core/src/test/scripts/test_data/data_cancertype_invalid_color.txt
@@ -1,0 +1,1 @@
+net	Neuroendocrine Tumour	endocrine,hormonal,neural,nervous	Zebra	tissue

--- a/core/src/test/scripts/test_data/data_cancertype_lung_twice.txt
+++ b/core/src/test/scripts/test_data/data_cancertype_lung_twice.txt
@@ -1,2 +1,2 @@
 luad	Lung Adenocarcinoma	lung,pulmonary,adenocarcinoma of the lung	Gainsboro	Lung
-luad	Lung Adenocarcinoma	lung,pulmonary,adenocarcinoma of the lung	Pearl	Lung
+luad	Lung Adenocarcinoma	lung,pulmonary,adenocarcinoma of the lung	AntiqueWhite	Lung

--- a/core/src/test/scripts/test_data/data_cancertype_undefined_parent.txt
+++ b/core/src/test/scripts/test_data/data_cancertype_undefined_parent.txt
@@ -1,2 +1,2 @@
 luad	Lung Adenocarcinoma	lung,pulmonary,adenocarcinoma of the lung	Gainsboro	Long
-new	new type	to test tissue special case	test	tissue
+new	new type	to test tissue special case	PaleGreen	tissue

--- a/core/src/test/scripts/test_data/data_clin_coldefs_hardcoded_attrs.txt
+++ b/core/src/test/scripts/test_data/data_clin_coldefs_hardcoded_attrs.txt
@@ -1,0 +1,13 @@
+#Patient Identifier	Overall Survival (Months)	Overall Survival Status	Disease Free (Months)	Disease Free Status	Other Sample ID
+#Identifier to uniquely specify a patient.	Overall survival in months since initial diagnosis.	Overall patient survival status.	Disease free (months) since initial treatment.	Disease free status since initial treatment.	Legacy DMP sample identifier (DMPnnnn)
+#STRING	STRING	STRING	NUMBER	STRING	STRING
+#1	1	1	1	1	1
+PATIENT_ID	OS_MONTHS	OS_STATUS	DFS_MONTHS	DFS_STATUS	OTHER_SAMPLE_ID
+TEST-PAT1	272	LIVING	272	Recurred/Progressed	NA
+TEST-PAT3	208	LIVING	208	Recurred/Progressed	NA
+TEST-PAT4	60	DECEASED	60	Recurred/Progressed	NA
+TEST-PAT6	151	LIVING	151	Recurred/Progressed	NA
+TEST-PAT5	290	LIVING	290	Recurred/Progressed	NA
+TEST-PAT7	88	LIVING	88	Recurred/Progressed	NA
+TEST-PAT9	72	LIVING	72	Recurred/Progressed	NA
+TEST-PAT2	161	DECEASED	161	NA	NA

--- a/core/src/test/scripts/test_data/data_clin_hardcoded_attr_vals.txt
+++ b/core/src/test/scripts/test_data/data_clin_hardcoded_attr_vals.txt
@@ -1,0 +1,13 @@
+#Patient Identifier	Overall Survival (Months)	Overall Survival Status	Disease Free (Months)	Disease Free Status
+#Identifier to uniquely specify a patient.	Overall survival in months since initial diagnosis.	Overall patient survival status.	Disease free (months) since initial treatment.	Disease free status since initial treatment.
+#STRING	NUMBER	STRING	NUMBER	STRING
+#1	1	1	1	1
+PATIENT_ID	OS_MONTHS	OS_STATUS	DFS_MONTHS	DFS_STATUS
+TEST-PAT1	272	ALIVE	272	Recurred/Progressed
+TEST-PAT3	208	LIVING	208	LIVING
+TEST-PAT4	60	DECEASED	60	Recurred/Progressed
+TEST-PAT6	151	living	151	Recurred/Progressed
+TEST-PAT5	290	LIVING	290	Progressed
+TEST-PAT7	88	LIVING	88	recurred/progressed
+TEST-PAT9	72	LIVING	72	Recurred/Progressed
+TEST-PAT2	NA	DECEASED	161	NA

--- a/core/src/test/scripts/test_data/study_es_0/data_patients.txt
+++ b/core/src/test/scripts/test_data/study_es_0/data_patients.txt
@@ -3,7 +3,7 @@
 #STRING	STRING	NUMBER	STRING	NUMBER
 #1	1	1	1	1
 PATIENT_ID	OS_STATUS	OS_MONTHS	DFS_STATUS	DFS_MONTHS
-TCGA-A2-A04P	DECEASED		Recurred/Progressed	[Not Available]
+TCGA-A2-A04P			Recurred/Progressed	[Not Available]
 TCGA-A1-A0SK	DECEASED	31.77		[Not Available]
 TCGA-A2-A0CM	DECEASED	24.77	Recurred/Progressed	[Not Available]
 TCGA-AR-A1AR	DECEASED	17.18	[Not Available]	[Not Available]

--- a/core/src/test/scripts/test_data/study_maf_test/result_report.html
+++ b/core/src/test/scripts/test_data/study_maf_test/result_report.html
@@ -309,7 +309,7 @@
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
               aria-controls="collapse_2670945268483421722" href="#collapse_2670945268483421722">
-            <span class="badge">7</span>
+            <span class="badge">8</span>
             <h4 class="panel-title">data_patients.txt</h4>
           </a>
         </div>
@@ -332,6 +332,13 @@
                 <td>&ndash;</td>
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
+                <td>&ndash;</td>
+              </tr>
+              <tr class="danger">
+                <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
+                <td>&ndash;</td>
+                <td>&ndash;</td>
+                <td>datatype definition for attribute &#39;DFS_MONTHS&#39; must be NUMBER</td>
                 <td>&ndash;</td>
               </tr>
               <tr class="warning">

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -312,6 +312,7 @@ class CancerTypeFileValidationTestCase(DataFileTestCase):
         record = record_list.pop()
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.column_number, 4)
+        self.assertIn('blank', record.getMessage().lower())
 
     def test_cancer_type_undefined_parent(self):
         """Test when a new cancer type's parent cancer type is not known."""
@@ -322,6 +323,16 @@ class CancerTypeFileValidationTestCase(DataFileTestCase):
         record = record_list.pop()
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.column_number, 5)
+
+    def test_cancer_type_invalid_color(self):
+        """Test error if a cancer type's color is not a web color name."""
+        self.logger.setLevel(logging.ERROR)
+        record_list = self.validate('data_cancertype_invalid_color.txt',
+                                    validateData.CancerTypeValidator)
+        self.assertEqual(len(record_list), 1)
+        record = record_list.pop()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.column_number, 4)
 
     def test_cancer_type_matching_portal(self):
         """Test when an existing cancer type is defined exactly as known."""

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -291,6 +291,43 @@ class PatientAttrFileTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(record.cause, 'TEST-PAT4')
         self.assertIn('missing', record.getMessage().lower())
 
+    def test_hardcoded_attr_values(self):
+        """Test if attributes with set meanings have recognized values."""
+        self.logger.setLevel(logging.ERROR)
+        record_list = self.validate('data_clin_hardcoded_attr_vals.txt',
+                                    validateData.PatientClinicalValidator)
+        self.assertEqual(len(record_list), 5)
+        record_iterator = iter(record_list)
+        # OS_STATUS not in controlled vocabulary
+        record = record_iterator.next()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.line_number, 6)
+        self.assertEqual(record.column_number, 3)
+        self.assertEqual(record.cause, 'ALIVE')
+        # DFS_STATUS having an OS_STATUS value
+        record = record_iterator.next()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.line_number, 7)
+        self.assertEqual(record.column_number, 5)
+        self.assertEqual(record.cause, 'LIVING')
+        # wrong casing for OS_STATUS
+        record = record_iterator.next()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.line_number, 9)
+        self.assertEqual(record.column_number, 3)
+        self.assertEqual(record.cause, 'living')
+        # DFS_STATUS not in controlled vocabulary (wrong casing)
+        record = record_iterator.next()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.line_number, 11)
+        self.assertEqual(record.column_number, 5)
+        self.assertEqual(record.cause, 'recurred/progressed')
+        # unspecified OS_MONTHS while OS_STATUS is DECEASED
+        record = record_iterator.next()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.line_number, 13)
+        self.assertIn('DECEASED', record.getMessage())
+
 
 # TODO: make tests in this testcase check the number of properly defined types
 class CancerTypeFileValidationTestCase(DataFileTestCase):

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -156,6 +156,11 @@ The following columns are used by the study view as well as the patient view. In
     - In the patient view, DiseaseFree creates a green label, Recurred/Progressed a red label.
 - **DFS_MONTHS**: Disease free (months) since initial treatment
 
+These columns, when provided, add additional information to the patient description in the header:
+- **PATIENT_DISPLAY_NAME**: Patient display name (string)
+- **GENDER** or **SEX**: Gender or sex of the patient (string)
+- **AGE**: Age at which the condition or disease was first diagnosed, in years (number)
+
 Optional attributes:
 - **Other Clinical Attribute Headers**: Clinical attribute headers are free-form. You can add any additional clinical attribute and cBioPortal will add them to the database. Be sure to provide the correct `'Datatype'`, as described above, for optimal search, sorting, filtering (in [clinical data tab](http://www.cbioportal.org/study?id=brca_tcga#clinical)) and display.
 
@@ -182,10 +187,15 @@ The following columns are required if you want the [pan-cancer summary statistic
 - **CANCER_TYPE**: Cancer Type
 - **CANCER_TYPE_DETAILED**: Cancer Type Detailed, a sub-type of the specified CANCER_TYPE
 
-The following columns affect the header of the patient view by adding text to the samples:
+The following columns affect the header of the patient view by adding text to the samples in the header:
+- **SAMPLE_DISPLAY_NAME**: displayed in addition to the ID
+- **TYPE_OF_CANCER**: Overrides CANCER_TYPE in the header
+- **DETAILED_CANCER_TYPE**: Overrides CANCER_TYPE_DETAILED in the header
 - **KNOWN_MOLECULAR_CLASSIFIER**
-- **GLEASON_SCORE**
-- **GLEASON_SCORE_1** and **GLEASON_SCORE_2**: if both are defined, overwrites GLEASON_SCORE
+- **TUMOR_SITE**
+- **METASTATIC_SITE** or **PRIMARY_SITE**: Override TUMOR_SITE depending on sample type
+- **SAMPLE_CLASS**
+- **GLEASON_SCORE**: Radical prostatectomy Gleason score for prostate cancer
 - **HISTOLOGY**
 - **TUMOR_STAGE_2009**
 - **TUMOR_GRADE**
@@ -195,12 +205,12 @@ The following columns affect the header of the patient view by adding text to th
 - **SERUM_PSA**
 - **DRIVER_MUTATIONS**
 
-The following columns affect the [Timeline data](#timeline-data) visualization:
+The following columns additionally affect the [Timeline data](#timeline-data) visualization:
 - **OTHER_SAMPLE_ID**: sometimes the timeline data (see the [timeline data section](#timeline-data)) will not have the SAMPLE_ID but instead an alias to the sample (in the field `SPECIMEN_REFERENCE_NUMBER`). To ensure that the timeline data field `SPECIMEN_REFERENCE_NUMBER` is correctly linked to this sample, be sure to add this column `OTHER_SAMPLE_ID` as an attribute to your sample attributes file.  
-- **SAMPLE_TYPE**: gives sample icon in the timeline a color. 
-    - If set to `recurrence`, `progressed`, `progression` or `recurred`: orange
+- **SAMPLE_TYPE**, **TUMOR_TISSUE_SITE** or **TUMOR_TYPE**: gives sample icon in the timeline a color.
+    - If set to `recurrence`, `recurred`, `progression` or `progressed`: orange
     - If set to `metastatic` or `metastasis`: red
-    - Otherwise: black
+    - If set to `primary` or otherwise: black
 
 Optional attributes
 - **Other Clinical Attribute Headers**: Clinical attribute headers are free-form. You can add any additional clinical attribute you have tracked and cBioPortal will add them to the database. Be sure to provide the correct `'Datatype'`, as described above (for the header lines), for optimal search, sorting, filtering (in [clinical data tab](http://www.cbioportal.org/study?id=brca_tcga#clinical)) and display.

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -199,9 +199,9 @@ The following columns affect the header of the patient view by adding text to th
 - **HISTOLOGY**
 - **TUMOR_STAGE_2009**
 - **TUMOR_GRADE**
-- **ETS/RAF/SPINK1_STATUS**
-- **TMPRSS2-ERG_FUSION_STATUS**
-- **ERG-FUSION_ACGH**
+- **ETS_RAF_SPINK1_STATUS**
+- **TMPRSS2_ERG_FUSION_STATUS**
+- **ERG_FUSION_ACGH**
 - **SERUM_PSA**
 - **DRIVER_MUTATIONS**
 

--- a/portal/src/main/webapp/css/patient-view/clinical-attributes.css
+++ b/portal/src/main/webapp/css/patient-view/clinical-attributes.css
@@ -18,9 +18,9 @@
 .clinical-attribute[attr-id="HISTOLOGY"],
 .clinical-attribute[attr-id="TUMOR_STAGE_2009"],
 .clinical-attribute[attr-id="TUMOR_GRADE"],
-.clinical-attribute[attr-id="ETS/RAF/SPINK1_STATUS"],
-.clinical-attribute[attr-id="TMPRSS2-ERG_FUSION_STATUS"],
-.clinical-attribute[attr-id="ERG-FUSION_ACGH"],
+.clinical-attribute[attr-id="ETS_RAF_SPINK1_STATUS"],
+.clinical-attribute[attr-id="TMPRSS2_ERG_FUSION_STATUS"],
+.clinical-attribute[attr-id="ERG_FUSION_ACGH"],
 .clinical-attribute[attr-id="SERUM_PSA"],
 .clinical-attribute[attr-id="DRIVER_MUTATIONS"],
 .clinical-attribute[attr-id="SAMPLE_CLASS"],
@@ -102,10 +102,10 @@
 .clinical-attribute[attr-id="SERUM_PSA"]:before {
     content: ", Serum PSA: ";
 }
-.clinical-attribute[attr-id="ERG-FUSION_ACGH"]:before {
+.clinical-attribute[attr-id="ERG_FUSION_ACGH"]:before {
     content: ", ERG-fusion aCGH: ";
 }
-.clinical-attribute[attr-id="TMPRSS2-ERG_FUSION_STATUS"]:before {
+.clinical-attribute[attr-id="TMPRSS2_ERG_FUSION_STATUS"]:before {
     content: ", TMPRSS2-ERG Fusion: ";
 }
 .clinical-attribute[attr-id="GLEASON"]:before {


### PR DESCRIPTION
Certain clinical attributes have meanings coded into the frontend, as documented on [the page on file formats](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#the-patient-file). This pull request adds the assumptions made in the code to the validator, so that loaded studies will not configure the database to contradict them (i.e. by defining sample-level attributes as patient-level ones or using unsupported values for `OS_STATUS` or `DFS_STATUS`, see also issue #1213)

In addition, it corrects the names of three of these attributes both in the validator and the frontend to match what has been seen in data, adds validation that colours defined for cancer types are colours that will be understood in CSS by web browsers, and makes it possible to run the validation script through a symbolic link (a practice relatively common on Unix-like systems) by resolving the link when locating the Jinja template in the same directory.

Changes proposed in this pull request:
- Validate that cancer type colors are web colors
- Resolve symlinks in the path to the script when locating the Jinja template for the validator’s output
- Add validation for correct definition of clinical attributes with set meanings in the frontend
- Replace punctuation in three of these attributes to match what is found in [the API output of the main public cBioPortal](http://www.cbioportal.org/api/clinicalattributes/samples)
- Add validation for correct values of clinical attributes with set meanings in the frontend

### Suggested reviewers ###
- @zheins 
- @inodb 
