### PR TITLE
Enable validation of required case list `_all`

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -314,7 +314,12 @@ class Validator(object):
 
         self.logger.debug('Starting validation of file')
 
-        with open(self.filename, 'rU') as data_file:
+        try:
+            opened_file = open(self.filename, 'rU')
+        except IOError:
+            self.logger.error('File could not be opened')
+            return
+        with opened_file as data_file:
 
             # parse any block of start-of-file comment lines and the tsv header
             top_comments = []

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1,9 +1,32 @@
 #!/usr/bin/env python2.7
 
-# ------------------------------------------------------------------------------
-# Data validation script - validates files before import into portal.
-# ------------------------------------------------------------------------------
+#
+# Copyright (c) 2016 The Hyve B.V.
+# This code is licensed under the GNU Affero General Public License (AGPL),
+# version 3, or (at your option) any later version.
+#
 
+#
+# This file is part of cBioPortal.
+#
+# cBioPortal is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Data validation script - validate files before import into portal.
+
+Run with the command line option --help for usage information.
+"""
 
 # imports
 import sys

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -2370,28 +2370,28 @@ def process_metadata_files(directory, portal_instance, logger):
 
 
 def processCaseListDirectory(caseListDir, cancerStudyId, logger,
-                             stableid_files=None):
-    """Validate the case lists in a directory and log findings.
+                             prev_stableid_files=None):
+    """Validate the case lists in a directory and return an id/file mapping.
 
     Args:
         caseListDir (str): path to the case list directory.
         cancerStudyId (str): cancer_study_identifier expected in the files.
         logger: logging.Logger instance through which to send output.
-        stableid_files (Optional): dict mapping the stable ids of any case
+        prev_stableid_files (Optional): dict mapping the stable IDs of any case
             lists already defined to the files they were defined in.
+
+    Returns:
+        Dict[str, str]: dict mapping the stable IDs of all valid defined case
+            lists to the files they were defined in, including the
+            prev_stableid_files argument
     """
 
     logger.debug('Validating case lists')
 
-    # start with an empty dictionary if none was given
-    # (using mutable objects as default arguments directly is confusing)
-    if stableid_files == None:
-        stableid_files = {}
-
-    # TODO: include ids based on the defined profiles here
-    required_id_suffixes = ('all', )
-    required_stable_ids = [cancerStudyId + '_' + suffix for suffix in
-                           required_id_suffixes]
+    stableid_files = {}
+    # include the previously defined stable IDs
+    if prev_stableid_files is not None:
+        stableid_files.update(prev_stableid_files)
 
     case_list_fns = [os.path.join(caseListDir, fn) for
                      fn in os.listdir(caseListDir) if
@@ -2437,21 +2437,30 @@ def processCaseListDirectory(caseListDir, cancerStudyId, logger,
                     'White space in sample id is not supported',
                     extra={'filename_': case,
                            'cause': value})
-                
 
-    for required_id in required_stable_ids:
-        if required_id not in stableid_files:
-            if required_id == cancerStudyId + '_all':
-                suggestion = ("Consider adding 'add_global_case_list: true' "
-                              "to the study metadata file")
-            else:
-                suggestion = "Please define it in the 'case_lists' folder"
-            logger.error("No  case list found for stable_id '%s'. %s",
-                         required_id,
-                         suggestion)
+    logger.info('Validation of case list folder complete')
 
-    logger.info('Validation of case lists complete')
+    return stableid_files
 
+
+def validate_defined_caselists(cancer_study_id, case_list_fns, file_types, logger):
+
+    """Validate the set of case lists defined in a study.
+
+    Args:
+        cancer_study_id (str): the study ID to be expected in the stable IDs
+        case_list_fns (Iterable[str]): stable ids of defined case lists
+        file_types (Dict[str, str]): listing of the MetaFileTypes with high-
+            dimensional data in this study--these may imply certain case lists
+        logger: logging.Logger instance to log output to
+    """
+
+    if cancer_study_id + '_all' not in case_list_fns:
+        logger.error(
+                "No case list found for stable_id '%s', consider adding "
+                    "'add_global_case_list: true' to the study metadata file",
+                cancer_study_id + '_all')
+    # TODO: check for required suffixes based on the defined profiles
 
 def request_from_portal_api(server_url, api_name, logger):
     """Send a request to the portal API and return the decoded JSON object."""
@@ -2767,8 +2776,14 @@ def validate_study(study_dir, portal_instance, logger):
     if not os.path.isdir(case_list_dirname):
         logger.info("No directory named 'case_lists' found, so assuming no custom case lists.")
     else:
-        processCaseListDirectory(case_list_dirname, study_id, logger,
-                                 stableid_files=defined_case_list_fns)
+        defined_case_list_fns = processCaseListDirectory(
+                case_list_dirname, study_id, logger,
+                prev_stableid_files=defined_case_list_fns)
+
+    validate_defined_caselists(
+        study_id, defined_case_list_fns,
+        file_types=validators_by_meta_type.keys(),
+        logger=logger)
 
     logger.info('Validation complete')
 

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -2443,19 +2443,19 @@ def processCaseListDirectory(caseListDir, cancerStudyId, logger,
     return stableid_files
 
 
-def validate_defined_caselists(cancer_study_id, case_list_fns, file_types, logger):
+def validate_defined_caselists(cancer_study_id, case_list_ids, file_types, logger):
 
     """Validate the set of case lists defined in a study.
 
     Args:
         cancer_study_id (str): the study ID to be expected in the stable IDs
-        case_list_fns (Iterable[str]): stable ids of defined case lists
+        case_list_ids (Iterable[str]): stable ids of defined case lists
         file_types (Dict[str, str]): listing of the MetaFileTypes with high-
             dimensional data in this study--these may imply certain case lists
         logger: logging.Logger instance to log output to
     """
 
-    if cancer_study_id + '_all' not in case_list_fns:
+    if cancer_study_id + '_all' not in case_list_ids:
         logger.error(
                 "No case list found for stable_id '%s', consider adding "
                     "'add_global_case_list: true' to the study metadata file",
@@ -2771,17 +2771,18 @@ def validate_study(study_dir, portal_instance, logger):
                 continue
             validator.validate()
 
-    # finally validate case lists if present
+    # finally validate the case list directory if present
     case_list_dirname = os.path.join(study_dir, 'case_lists')
     if not os.path.isdir(case_list_dirname):
         logger.info("No directory named 'case_lists' found, so assuming no custom case lists.")
     else:
+        # add case lists IDs defined in the directory to any previous ones
         defined_case_list_fns = processCaseListDirectory(
                 case_list_dirname, study_id, logger,
                 prev_stableid_files=defined_case_list_fns)
 
     validate_defined_caselists(
-        study_id, defined_case_list_fns,
+        study_id, defined_case_list_fns.keys(),
         file_types=validators_by_meta_type.keys(),
         logger=logger)
 

--- a/core/src/test/scripts/test_data/study_es_0/result_report.html
+++ b/core/src/test/scripts/test_data/study_es_0/result_report.html
@@ -170,7 +170,7 @@
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
                 <td>&ndash;</td>
                 <td>&ndash;</td>
-                <td>Validation of case lists complete</td>
+                <td>Validation of case list folder complete</td>
                 <td>&ndash;</td>
               </tr>
               <tr class="success">

--- a/core/src/test/scripts/test_data/study_maf_test/result_report.html
+++ b/core/src/test/scripts/test_data/study_maf_test/result_report.html
@@ -159,18 +159,18 @@
                 <td>Validating case lists</td>
                 <td>&ndash;</td>
               </tr>
-              <tr class="danger">
-                <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
-                <td>&ndash;</td>
-                <td>&ndash;</td>
-                <td>No  case list found for stable_id &#39;brca_tcga_pub_all&#39;. Consider adding &#39;add_global_case_list: true&#39; to the study metadata file</td>
-                <td>&ndash;</td>
-              </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
                 <td>&ndash;</td>
                 <td>&ndash;</td>
-                <td>Validation of case lists complete</td>
+                <td>Validation of case list folder complete</td>
+                <td>&ndash;</td>
+              </tr>
+              <tr class="danger">
+                <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
+                <td>&ndash;</td>
+                <td>&ndash;</td>
+                <td>No case list found for stable_id &#39;brca_tcga_pub_all&#39;, consider adding &#39;add_global_case_list: true&#39; to the study metadata file</td>
                 <td>&ndash;</td>
               </tr>
               <tr class="success">

--- a/core/src/test/scripts/test_data/study_missing_caselists/data_samples.txt
+++ b/core/src/test/scripts/test_data/study_missing_caselists/data_samples.txt
@@ -1,0 +1,13 @@
+#Patient Identifier	Sample Identifier	Subtype	Cancer Type	Cancer Type Detailed
+#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.	Disease type.	Cancer Type Detailed.
+#STRING	STRING	STRING	STRING	STRING
+#1	1	1	1	1
+PATIENT_ID	SAMPLE_ID	SUBTYPE	CANCER_TYPE	CANCER_TYPE_DETAILED
+TEST-PAT1	TEST-PAT1-SAMPLE1	Luminal A	Cancer_type20	Cancer_type20_Sub16
+TEST-PAT1	TEST-PAT1-SAMPLE2	Luminal B	Cancer_type27	Cancer_type27_Sub16
+TEST-PAT1	TEST-PAT1-SAMPLE3	basal-like	Cancer_type8	Cancer_type8_Sub13
+TEST-PAT1	TEST-PAT1-SAMPLE4	basal-like	Cancer_type17	Cancer_type17_Sub10
+TEST-PAT1	TEST-PAT1-SAMPLE5	Her2 enriched	Cancer_type27	Cancer_type27_Sub18
+TEST-PAT1	TEST-PAT1-SAMPLE6	Luminal A	Cancer_type7	Cancer_type7_Sub13
+TEST-PAT2	TEST-PAT2-SAMPLE1	Luminal A	Cancer_type23	Cancer_type23_Sub3
+TEST-PAT2	TEST-PAT2-SAMPLE2	basal-like	Cancer_type7	Cancer_type7_Sub5

--- a/core/src/test/scripts/test_data/study_missing_caselists/meta_samples.txt
+++ b/core/src/test/scripts/test_data/study_missing_caselists/meta_samples.txt
@@ -1,0 +1,4 @@
+cancer_study_identifier: spam
+genetic_alteration_type: CLINICAL
+datatype: SAMPLE_ATTRIBUTES
+data_filename: data_samples.txt

--- a/core/src/test/scripts/test_data/study_missing_caselists/meta_study.txt
+++ b/core/src/test/scripts/test_data/study_missing_caselists/meta_study.txt
@@ -1,6 +1,5 @@
 cancer_study_identifier: spam
-type_of_cancer: luad
+type_of_cancer: brca
 name: Spam (spam)
 description: Baked beans
 short_name: Spam
-add_global_case_list: true

--- a/core/src/test/scripts/test_data/study_quotes/result_report.html
+++ b/core/src/test/scripts/test_data/study_quotes/result_report.html
@@ -163,7 +163,7 @@
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
                 <td>&ndash;</td>
                 <td>&ndash;</td>
-                <td>Validation of case lists complete</td>
+                <td>Validation of case list folder complete</td>
                 <td>&ndash;</td>
               </tr>
               <tr class="success">

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -1229,5 +1229,19 @@ class StableIdValidationTestCase(LogBufferTestCase):
         self.assertEqual(warning.cause, 'stable_id')
 
 
+class DataFileIOTestCase(PostClinicalDataFileTestCase):
+    """Test if the right behavior occurs if study files cannot be read."""
+
+    def test_missing_datafile(self):
+        """Test the error if files referenced from meta files do not exist."""
+        self.logger.setLevel(logging.ERROR)
+        record_list = self.validate('filename-that-does-not-exist.txt',
+                                    validateData.ContinuousValuesValidator)
+        self.assertEqual(len(record_list), 1)
+        record = record_list.pop()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertIn('file', record.getMessage().lower())
+
+
 if __name__ == '__main__':
     unittest.main(buffer=True)

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -1181,6 +1181,21 @@ class CaseListDirTestCase(PostClinicalDataFileTestCase):
         self.assertTrue(record.cause.startswith('brca_tcga_pub_all'),
                         "Error is not about the id 'brca_tcga_pub_all'")
 
+    def test_missing_caselists(self):
+        """Test if errors are issued if certain case lists are not defined."""
+        self.logger.setLevel(logging.ERROR)
+        validateData.validate_study(
+                'test_data/study_missing_caselists',
+                PORTAL_INSTANCE,
+                self.logger)
+        record_list = self.get_log_records()
+        self.assertEqual(len(record_list), 1)
+        # <study ID>_all
+        record = record_list.pop()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertIn('spam_all', record.getMessage())
+        self.assertIn('add_global_case_list', record.getMessage())
+
 
 class StableIdValidationTestCase(LogBufferTestCase):
 


### PR DESCRIPTION
A bug led to the validator sometimes failing to emit an error if this
case list is missing in a study, resulting in a server-side exception
(HTTP Status 500) when loading the OncoPrint. See issue #1214.
This commit fixes the bug and adds a unit test to prevent further
regressions.

In addition, fix the exception that occurs if a referenced data file cannot be found, and add a licence notice to the top of the file.

### Reviewers ###
@cBioPortal/core-developers

