### PR TITLE
Updating gene length method

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGene.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGene.java
@@ -104,9 +104,6 @@ final class DaoGene {
             if (rows != 1) {
                 ProgressMonitor.logWarning("No change for " + gene.getEntrezGeneId() + " " + gene.getHugoGeneSymbolAllCaps() + "? Code " + rows);
             }
-            else {
-                ProgressMonitor.logWarning("Updated gene"); //should be message, but warnings are nicely summarized. TODO - add message summary to ProgressMonitor
-            }
             //add the current set of aliases:
             rows += addGeneAliases(gene);
 

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGene.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGene.java
@@ -33,6 +33,7 @@
 package org.mskcc.cbio.portal.dao;
 
 import org.mskcc.cbio.portal.model.CanonicalGene;
+import org.mskcc.cbio.portal.util.ProgressMonitor;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -41,6 +42,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -70,6 +72,57 @@ final class DaoGene {
         return addGene(gene);
     }
 
+    /**
+     * Update Gene Record in the Database. It will also replace this 
+     * gene's aliases with the ones found in the given gene object.
+     */
+    public static int updateGene(CanonicalGene gene) throws DaoException {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        boolean setBulkLoadAtEnd = false;
+        try {
+            //this method only works well with bulk load off, especially 
+            //when it is called in a process that may update a gene more than once
+            //(e.g. the ImportGeneData updates some of the fields based on one 
+            // input file and other fields based on another input file):
+            setBulkLoadAtEnd = MySQLbulkLoader.isBulkLoad();
+            MySQLbulkLoader.bulkLoadOff();
+            //delete aliases first:
+            deleteGeneAlias(gene.getEntrezGeneId());
+            
+            int rows = 0;
+            con = JdbcUtil.getDbConnection(DaoGene.class);
+            pstmt = con.prepareStatement
+                    ("UPDATE gene SET `HUGO_GENE_SYMBOL`=?, `TYPE`=?,`CYTOBAND`=?,`LENGTH`=? WHERE `ENTREZ_GENE_ID`=?");
+            pstmt.setString(1, gene.getHugoGeneSymbolAllCaps());
+            pstmt.setString(2, gene.getType());
+            pstmt.setString(3, gene.getCytoband());
+            pstmt.setInt(4, gene.getLength());
+            pstmt.setLong(5, gene.getEntrezGeneId());
+            rows += pstmt.executeUpdate();
+            if (rows != 1) {
+                ProgressMonitor.logWarning("No change for " + gene.getEntrezGeneId() + " " + gene.getHugoGeneSymbolAllCaps() + "? Code " + rows);
+            }
+            else {
+                ProgressMonitor.logWarning("Updated gene"); //should be message, but warnings are nicely summarized. TODO - add message summary to ProgressMonitor
+            }
+            //add the current set of aliases:
+            rows += addGeneAliases(gene);
+
+            return rows;
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        } finally {
+            if (setBulkLoadAtEnd) {
+                //reset to original state:
+                MySQLbulkLoader.bulkLoadOn();
+            }   
+            JdbcUtil.closeAll(DaoGene.class, con, pstmt, rs);
+        }
+        
+}
+    
     /**
      * Adds a new Gene Record to the Database.
      *
@@ -246,7 +299,7 @@ final class DaoGene {
             JdbcUtil.closeAll(DaoGene.class, con, pstmt, rs);
         }
     }
-
+    
     /**
      * Gets all Genes in the Database.
      *
@@ -396,6 +449,8 @@ final class DaoGene {
      * Deletes all Gene Records in the Database.
      *
      * @throws DaoException Database Error.
+     * 
+     * @deprecated only used by deprecated code, so deprecating this as well.
      */
     public static void deleteAllRecords() throws DaoException {
         Connection con = null;
@@ -415,6 +470,12 @@ final class DaoGene {
         deleteAllAliasRecords();
     }
     
+    /**
+     * 
+     * @throws DaoException
+     * 
+     * @deprecated only used by deprecated code, so deprecating this as well.
+     */
     private static void deleteAllAliasRecords() throws DaoException {
         Connection con = null;
         PreparedStatement pstmt = null;

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGeneOptimized.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGeneOptimized.java
@@ -169,18 +169,13 @@ public class DaoGeneOptimized {
     }
     
     /**
-     * Update database with gene length
-     * @return number of records updated.
-     * @throws DaoException 
+     * Update Gene Record in the Database. It will also replace this 
+     * gene's aliases with the ones found in the given gene object.
      */
-    public int flushUpdateToDatabase() throws DaoException {
-        DaoGene.deleteAllRecords();
-        MySQLbulkLoader.bulkLoadOn();
-        int ret = 0;
-        for (CanonicalGene gene : getAllGenes()) {
-            ret += DaoGene.addGene(gene);
-        }
-        MySQLbulkLoader.flushAll();
+    public int updateGene(CanonicalGene gene)  throws DaoException {
+        int ret = DaoGene.updateGene(gene);
+        //recache:
+        cacheGene(gene);
         return ret;
     }
     
@@ -446,8 +441,11 @@ public class DaoGeneOptimized {
     /**
      * Deletes all Gene Records in the Database.
      * @throws DaoException Database Error.
+     * 
+     * @deprecated  only used by deprecated code, so deprecating this as well.
      */
     public void deleteAllRecords() throws DaoException {
         DaoGene.deleteAllRecords();
     }
+
 }

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGeneOptimized.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGeneOptimized.java
@@ -387,6 +387,10 @@ public class DaoGeneOptimized {
      * @return a gene that can be non-ambiguously determined, or null if cannot.
      */
     public CanonicalGene getNonAmbiguousGene(String geneId, String chr) {
+    	return getNonAmbiguousGene(geneId, chr, true);
+    }
+    
+    public CanonicalGene getNonAmbiguousGene(String geneId, String chr, boolean issueWarning) {
         List<CanonicalGene> genes = guessGene(geneId, chr);
         if (genes.isEmpty()) {
             return null;
@@ -399,17 +403,18 @@ public class DaoGeneOptimized {
         if (disambiguousGenes.containsKey(geneId)) {
             return disambiguousGenes.get(geneId);
         }
-        
-        StringBuilder sb = new StringBuilder("Ambiguous alias ");
-        sb.append(geneId);
-        sb.append(": corresponding entrez ids of ");
-        for (CanonicalGene gene : genes) {
-            sb.append(gene.getEntrezGeneId());
-            sb.append(",");
+        if (issueWarning) {
+	        StringBuilder sb = new StringBuilder("Ambiguous alias ");
+	        sb.append(geneId);
+	        sb.append(": corresponding entrez ids of ");
+	        for (CanonicalGene gene : genes) {
+	            sb.append(gene.getEntrezGeneId());
+	            sb.append(",");
+	        }
+	        sb.deleteCharAt(sb.length()-1);
+	        
+	        ProgressMonitor.logWarning(sb.toString());
         }
-        sb.deleteCharAt(sb.length()-1);
-        
-        ProgressMonitor.logWarning(sb.toString());
         return null;
         
     }

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGeneData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGeneData.java
@@ -42,11 +42,6 @@ import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 
 import java.io.*;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.*;
 
 /**
@@ -66,12 +61,7 @@ public class ImportGeneData extends ConsoleRunnable {
         try (FileReader reader = new FileReader(geneFile)) {
             BufferedReader buf = new BufferedReader(reader);
             String line;
-            DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
-            ArrayList<CanonicalGene> allGenes = daoGene.getAllGenes();
-            for(CanonicalGene geneName : allGenes) { //Loop through all genes
-            	if (geneName != null) {
-                throw new DaoException("Error: the table Gene is not empty.");
-                }
+            
             while ((line = buf.readLine()) != null) {
             	ProgressMonitor.incrementCurValue();
             	ConsoleUtil.showProgress();
@@ -79,73 +69,96 @@ public class ImportGeneData extends ConsoleRunnable {
                     continue;
                 }
                 
-                    String parts[] = line.split("\t");
-                    int taxonimy = Integer.parseInt(parts[0]);
-                    if (taxonimy!=9606) {
-                        // only import human genes
-                        continue;
+                String parts[] = line.split("\t");
+                int taxonimy = Integer.parseInt(parts[0]);
+                if (taxonimy!=9606) {
+                    // only import human genes
+                    continue;
+                }
+                
+                int entrezGeneId = Integer.parseInt(parts[1]);
+                String geneSymbol = parts[2];
+                String locusTag = parts[3];
+                String strAliases = parts[4];
+                //String strXrefs = parts[5];
+                String cytoband = parts[7];
+                //String desc = parts[8];
+                String type = parts[9];
+                String mainSymbol = parts[10]; // use 10 instead of 2 since column 2 may have duplication
+                Set<String> aliases = new HashSet<String>();
+                if (!locusTag.equals("-")) {
+                    aliases.add(locusTag);
+                }
+                if (!strAliases.equals("-")) {
+                    aliases.addAll(Arrays.asList(strAliases.split("\\|")));
+                }
+                
+                if (geneSymbol.startsWith("MIR") && type.equalsIgnoreCase("miscRNA")) {
+                    line = buf.readLine();
+                    continue; // ignore miRNA; process separately
+                }
+                
+                CanonicalGene gene = null;
+                if (!mainSymbol.equals("-")) {
+                    //try the main symbol:
+                    gene = new CanonicalGene(entrezGeneId, mainSymbol, aliases);
+                    Set<CanonicalGene> genes = genesWithSymbolFromNomenClatureAuthority.get(mainSymbol);
+                    if (genes==null) {
+                        genes = new HashSet<CanonicalGene>();
+                        genesWithSymbolFromNomenClatureAuthority.put(mainSymbol, genes);
                     }
-                    
-                    int entrezGeneId = Integer.parseInt(parts[1]);
-                    String geneSymbol = parts[2];
-                    String locusTag = parts[3];
-                    String strAliases = parts[4];
-                    String strXrefs = parts[5];
-                    String cytoband = parts[7];
-                    String desc = parts[8];
-                    String type = parts[9];
-                    String mainSymbol = parts[10]; // use 10 instead of 2 since column 2 may have duplication
-                    Set<String> aliases = new HashSet<String>();
-                    if (!locusTag.equals("-")) {
-                        aliases.add(locusTag);
+                    genes.add(gene);
+                } else if (!geneSymbol.equals("-")) {
+                    //there is no main symbol, so import using the temporary/unnoficial(?) symbol:
+                    gene = new CanonicalGene(entrezGeneId, geneSymbol, aliases);
+                    Set<CanonicalGene> genes = genesWithoutSymbolFromNomenClatureAuthority.get(geneSymbol);
+                    if (genes==null) {
+                        genes = new HashSet<CanonicalGene>();
+                        genesWithoutSymbolFromNomenClatureAuthority.put(geneSymbol, genes);
                     }
-                    if (!strAliases.equals("-")) {
-                        aliases.addAll(Arrays.asList(strAliases.split("\\|")));
+                    genes.add(gene);
+                }
+                
+                if (gene!=null) {
+                    if (!cytoband.equals("-")) {
+                        gene.setCytoband(cytoband);
                     }
-                    
-                    if (geneSymbol.startsWith("MIR") && type.equalsIgnoreCase("miscRNA")) {
-                        line = buf.readLine();
-                        continue; // ignore miRNA; process separately
-                    }
-                    
-                    CanonicalGene gene = null;
-                    if (!mainSymbol.equals("-")) {
-                        //try the main symbol:
-                        gene = new CanonicalGene(entrezGeneId, mainSymbol, aliases);
-                        Set<CanonicalGene> genes = genesWithSymbolFromNomenClatureAuthority.get(mainSymbol);
-                        if (genes==null) {
-                            genes = new HashSet<CanonicalGene>();
-                            genesWithSymbolFromNomenClatureAuthority.put(mainSymbol, genes);
-                        }
-                        genes.add(gene);
-                    } else if (!geneSymbol.equals("-")) {
-                        //there is no main symbol, so import using the temporary/unnoficial(?) symbol:
-                        gene = new CanonicalGene(entrezGeneId, geneSymbol, aliases);
-                        Set<CanonicalGene> genes = genesWithoutSymbolFromNomenClatureAuthority.get(geneSymbol);
-                        if (genes==null) {
-                            genes = new HashSet<CanonicalGene>();
-                            genesWithoutSymbolFromNomenClatureAuthority.put(geneSymbol, genes);
-                        }
-                        genes.add(gene);
-                    }
-                    
-                    if (gene!=null) {
-                        if (!cytoband.equals("-")) {
-                            gene.setCytoband(cytoband);
-                        }
-                        gene.setType(type);
-                    }
+                    gene.setType(type);
+                }
             }
+            addGenesToDB(genesWithSymbolFromNomenClatureAuthority, genesWithoutSymbolFromNomenClatureAuthority);
         }
-        
+    }
+         
+    
+    /**
+     * Iterate over the genes found in the given maps and try to add them to the DB. 
+     * 
+     * @param genesWithSymbolFromNomenClatureAuthority: genes with official hugo symbol
+     * @param genesWithoutSymbolFromNomenClatureAuthority: genes without official hugo symbol (can happen, some entrez genes 
+     * 				have no hugo symbol yet, but a temporary symbol)
+     * 
+     * @throws DaoException
+     */
+    private static void addGenesToDB(Map<String, Set<CanonicalGene>> genesWithSymbolFromNomenClatureAuthority,
+		Map<String, Set<CanonicalGene>> genesWithoutSymbolFromNomenClatureAuthority) throws DaoException {
+
+    	DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
+		int nrExisting = 0;
         // Add genes with symbol from nomenclature authority
         for (Map.Entry<String, Set<CanonicalGene>> entry : genesWithSymbolFromNomenClatureAuthority.entrySet()) {
             Set<CanonicalGene> genes = entry.getValue();
             if (genes.size()==1) {
                 CanonicalGene gene = genes.iterator().next();
-                daoGene.addGene(gene);
-                ProgressMonitor.logWarning("New gene added");
+                // first check if gene exists. If exists, give warning and skip record: 
+                if (daoGene.getGene(gene.getEntrezGeneId()) != null) {
+                	ProgressMonitor.logWarning("Gene is already in table. Updates are not allowed. If you need to update the `gene` table, please remove all studies first and empty the `gene` table.");
+                	nrExisting++;
+                	continue;
                 }
+                daoGene.addGene(gene);
+                ProgressMonitor.logWarning("New gene with official symbol added");
+            }
             else {
             	//TODO - is unexpected for official symbols...raise Exception instead?
                 logDuplicateGeneSymbolWarning(entry.getKey(), genes, true);
@@ -161,27 +174,37 @@ public class ImportGeneData extends ConsoleRunnable {
 	            String symbol = entry.getKey();
 	            if (genes.size()==1) {
 	                CanonicalGene gene = genes.iterator().next();
+	                //only add the gene if it does not conflict with an official symbol:
 	                if (!genesWithSymbolFromNomenClatureAuthority.containsKey(symbol)) {
-	                    CanonicalGene dbGene = daoGene.getGene(gene.getEntrezGeneId());
+	                    // first check if gene exists. If exists, give warning and skip record since we don't allow updates in this process: 
+	                    if (daoGene.getGene(gene.getEntrezGeneId()) != null) {
+	                    	ProgressMonitor.logWarning("Gene is already in table. Updates are not allowed. If you need to update the `gene` table, please remove all studies first and empty the `gene` table.");
+	                    	nrSkipped++;
+	                    	nrExisting++;
+	                    	continue;
+	                    }
 	                    daoGene.addGene(gene);
-	                    ProgressMonitor.logWarning("New gene with no official symbol added");
+	                    ProgressMonitor.logWarning("New gene with *no* official symbol added");
 	                    nrImported++;
 	                } else {
 	                    // ignore entries with a symbol that have the same value as stardard one
-	                    ProgressMonitor.logWarning("Ignored line with entrez gene id "+gene.getEntrezGeneId()
-	                            + " because symbol "+symbol+" is already an 'official symbol' of another gene");
+	                    ProgressMonitor.logWarning("Ignored line with entrez gene id "+gene.getEntrezGeneId() + " because its 'unnoficial' symbol " +
+	                            symbol+" is already an 'official symbol' of another gene");
 	                    nrSkipped++;
+	                    continue;
 	                }
 	            } else {
 	                logDuplicateGeneSymbolWarning(symbol, genes, false);
-	                nrSkipped =+ genes.size();
+	                nrSkipped++;
+	                continue;
 	            }
 	        }
 	        ProgressMonitor.logWarning("There were " +genesWithoutSymbolFromNomenClatureAuthority.keySet().size() + 
 	        		" genes names in this file without an official symbol from nomenclature authority. Imported: " + nrImported + 
-	        		", skipped (because of duplicate symbol entry or because symbol is an 'official symbol' of another gene): " + nrSkipped);
+	        		". Gene names skipped (because of duplicate symbol entry or because symbol is an 'official symbol' of another gene): " + nrSkipped);
         }
-       
+        if (nrExisting > 0) {
+        	ProgressMonitor.logWarning("Number of records skipped because the gene was already in the gene table (updates are not allowed - see specific warnings above): " + nrExisting);
         }
        
     }
@@ -216,23 +239,16 @@ public class ImportGeneData extends ConsoleRunnable {
         FileReader reader = new FileReader(geneFile);
         BufferedReader buf = new BufferedReader(reader);
         String line;
-        String genesNotFound = "";
-        int genesNotFoundCount = 0;
+        Set<String> genesNotFound = new HashSet<String>();
         HashMap<Long, List<long[]>> geneLociMap = new HashMap<Long, List<long[]>>();
         ProgressMonitor.setCurrentMessage("\n\nUpdating gene lengths: \n\n"); //Display a message in the console
         
         //Iterate over the file and fill the hash map with the max and min values of each gene (start and end position)
         while ((line=buf.readLine()) != null) {
         	String parts[] = line.split("\t");
-            CanonicalGene gene = daoGeneOptimized.getNonAmbiguousGene(parts[3], parts[0]); //Identify unambiguously the gene (with the symbol and the chromosome)
+            CanonicalGene gene = daoGeneOptimized.getNonAmbiguousGene(parts[3], parts[0], false); //Identify unambiguously the gene (with the symbol and the chromosome)
         	if (gene==null) { //Report the genes that have not been unambiguously identified
-        		genesNotFoundCount++;
-                if (genesNotFoundCount <= 3) { 
-                    genesNotFound += parts[3] + ", ";
-                }
-                else if (genesNotFoundCount == 4) {
-                    genesNotFound += "...";
-                }
+        		genesNotFound.add(parts[3]);
                 continue;
             }
         	else {
@@ -244,21 +260,34 @@ public class ImportGeneData extends ConsoleRunnable {
         		}
         		list.add(new long[]{Long.parseLong(parts[1]), Long.parseLong(parts[2])}); //Add the new positions
         	}
-        	//Report non ambiguous genes
-        	if (genesNotFound.length() > 0) {
-                ProgressMonitor.logWarning("Could not find non ambiguous gene(s): " + genesNotFound);
-        		}
         }
         
+    	//Report non ambiguous genes
+    	if (genesNotFound.size() > 0) {
+    		String genesString = genesNotFound.toString();
+    		// limit size:
+    		if (genesString.length() > 100)
+    			genesString = genesString.substring(0, 100) + "...";
+            ProgressMonitor.logWarning("Genes not found, or symbol found to be ambiguous ("+ genesNotFound.size() +" genes in total): " + genesString);
+    	}
+        
         //Calculate the length for each gene and update genes
+        int nrGenesUpdated = 0;
         for (Long key : geneLociMap.keySet()) { //Get the keys and iterate over them
         	List<long[]> exons = geneLociMap.get(key); //Get the values
         	int length = calculateGeneLength(exons);
         	CanonicalGene gene = daoGeneOptimized.getGene(key);
-        	gene.setLength(length);
-            daoGeneOptimized.updateGene(gene); 
-            }
-      }
+        	//only update if length is different:
+        	if (gene.getLength() != length) {
+	        	gene.setLength(length);
+	            daoGeneOptimized.updateGene(gene);
+	            nrGenesUpdated++;
+        	}
+        }
+        ProgressMonitor.setCurrentMessage("\n\nUpdated length info for " + nrGenesUpdated + " genes\n");
+
+        
+    }
     
 
     /**
@@ -347,20 +376,18 @@ public class ImportGeneData extends ConsoleRunnable {
 	        ProgressMonitor.setConsoleMode(true);
 	        
 	        File geneFile;
+	        int numLines;
 			if(options.has("genes")) {
 				geneFile = new File((String) options.valueOf("genes"));
+			
+		        System.out.println("Reading gene data from:  " + geneFile.getAbsolutePath());
+		        numLines = FileUtil.getNumLines(geneFile);
+		        System.out.println(" --> total number of lines:  " + numLines);
+		        ProgressMonitor.setMaxValue(numLines);
+		        MySQLbulkLoader.bulkLoadOn();
+		        ImportGeneData.importData(geneFile);
+		        MySQLbulkLoader.flushAll(); //Gene and gene_alias should be updated before calculating gene length (exon-loci)!
 			}
-			else {
-				throw new UsageException(progName, description, parser,
-				        "Error: 'genes' argument required.");
-			}
-	        System.out.println("Reading gene data from:  " + geneFile.getAbsolutePath());
-	        int numLines = FileUtil.getNumLines(geneFile);
-	        System.out.println(" --> total number of lines:  " + numLines);
-	        ProgressMonitor.setMaxValue(numLines);
-	        MySQLbulkLoader.bulkLoadOn();
-	        ImportGeneData.importData(geneFile);
-	        MySQLbulkLoader.flushAll(); //Gene and gene_alias should be updated before calculating gene length (exon-loci)!
 	        
 	        if(options.has("supp-genes")) {
 	            File suppGeneFile = new File((String) options.valueOf("genes"));


### PR DESCRIPTION
The current method to calculate gene length uses a bed file to obtain the length of the exons of a particular gene, and then adding the exon lengths in positions that are not overlapping to obtain the length of this particular gene (for example, if a gene have two exons, one that goes from position 1 to 4 and another from position 3 to 7, they will be counted as a single exon going from position 1 to 7). However, the current method has a problem since it only takes the exons of the same gene together if they are in consecutive lines in the bed file. This problem is solved here, using also new methods to update genes created by @pieterlukasse. 