### PR TITLE
Do not throw error on clin attr mismatch

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportClinicalData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportClinicalData.java
@@ -230,9 +230,7 @@ public class ImportClinicalData extends ConsoleRunnable {
                 DaoClinicalAttribute.addDatum(attr);
             }
             else if (attrInDb.isPatientAttribute() != attr.isPatientAttribute()) {
-            	throw new DaoException("Illegal change in attribute type[SAMPLE/PATIENT] for attribute " + attr.getAttrId() + 
-            			". An attribute cannot change from SAMPLE type to PATIENT type (or vice-versa) during import. This should " + 
-            			"be changed manually first in DB.");
+        		ProgressMonitor.logWarning("WARNING: Change in attribute type [SAMPLE/PATIENT] for attribute " + attr.getAttrId() + ".");
             }
         }
 


### PR DESCRIPTION
# What? Why?
We have lots of attributes from many sources which are extremely difficult to normalize across. If an attribute is set as a patient attribute in the db, but a study is trying to import it as a sample attribute, just log a warning instead of failing to impoort.

# Notify reviewers
@jjgao @n1zea144
