### PR TITLE
set scope of tocmat-catalina lib to provided

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,7 +17,7 @@
     },
     "MAVEN_CUSTOM_OPTS": {
         "description":"set heroku profile for mvn",
-        "value":"-Pheroku,public -DskipTests -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test -Ddb.connection_string=jdbc:mysql://cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com:3306/ -Ddb.host=cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com"
+        "value":"-Pheroku,public -DskipTests -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test -Dtomcat.catalina.scope=runtime -Ddb.connection_string=jdbc:mysql://cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com:3306/ -Ddb.host=cbioportal-public.c1xhhbwn8izk.us-east-1.rds.amazonaws.com"
     }
   },
   "buildpacks": [

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
     </profile>
     <profile>
       <id>heroku</id>
+      <properties>
+          <!--Our heroku instance uses jetty and therefore needs to include the tomcat lib-->
+          <tomcat.catalina.scope>runetime</tomcat.catalina.scope>
+      </properties>
+
       <build>
         <plugins>
           <!-- copy files in heroku/ to root-->
@@ -134,6 +139,9 @@
 	<db.test.url>jdbc:mysql://127.0.0.1:3306/cgds_test</db.test.url>
     <db.test.username>cbio_user</db.test.username>
     <db.test.password>somepassword</db.test.password>
+    
+    <!--For tomcat instances, the scope to tomcat catalina lib should be provided. this prop is used in portal module.-->
+    <tomcat.catalina.scope>provided</tomcat.catalina.scope>
 
     <!-- THIS SHOULD BE KEPT IN SYNC TO VERSION IN CGDS.SQL -->
     <db.version>1.2.1</db.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,10 +43,6 @@
     </profile>
     <profile>
       <id>heroku</id>
-      <properties>
-          <!--Our heroku instance uses jetty and therefore needs to include the tomcat lib-->
-          <tomcat.catalina.scope>runetime</tomcat.catalina.scope>
-      </properties>
 
       <build>
         <plugins>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -45,7 +45,7 @@
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-catalina</artifactId>
       <version>7.0.68</version>
-      <scope>runtime</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -45,7 +45,10 @@
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-catalina</artifactId>
       <version>7.0.68</version>
-      <scope>provided</scope>
+      <scope>
+          <!--tomcat.catalina.scope is defined in master module-->
+          ${tomcat.catalina.scope}
+      </scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
# What? Why?
https://github.com/cBioPortal/cbioportal/pull/1517 included tomcat-catalina dependency which broke the deployment to tomcat.

http://stackoverflow.com/questions/14028476/java-web-api-conflict-using-maven

Setting the scope to `provided` solve the issue.

Changes proposed in this pull request:
- Setting the scope to `provided`

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
If your pull request involves changes to an existing file, one or more of the
people that edited before you might be good candidates to review it. Please use
`git blame <filename>` to determine that and notify them here. Otherwise notify
everybody in the core team:
@morungos 

