### PR TITLE
Fix #1623 Timeline missing SAMPLE_ID in Specimen

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/patient_view/clinical_timeline.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/patient_view/clinical_timeline.jsp
@@ -134,10 +134,11 @@
                         if (specRefNum) {
                             if (specRefNum.length > 1) {
                                 console.warn("More than 1 specimen reference number found in tooltip table");
-                            }
-                            sortOrder = caseIds.indexOf(specRefNum[0][1]);
-                            if (sortOrder === -1) {
-                                sortOrder = Infinity;
+                            } else if (specRefNum.length === 1) {
+                                sortOrder = caseIds.indexOf(specRefNum[0][1]);
+                                if (sortOrder === -1) {
+                                    sortOrder = Infinity;
+                                }
                             }
                         }
                         return sortOrder;


### PR DESCRIPTION
Fix #1623. Fix timeline data not displaying when there is a Specimen track but it does not
contain a SAMPLE_ID, SPECIMEN_REFERENCE_NUMBER or a SpecimenReferenceNumber.

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.
