### PR TITLE
Ensure that exit code is set properly

### DIFF
--- a/core/src/main/scripts/importer/metaImport.py
+++ b/core/src/main/scripts/importer/metaImport.py
@@ -113,6 +113,7 @@ if __name__ == '__main__':
                 print >> sys.stderr, Color.BOLD + "Overriding Warnings. Importing study now" + Color.END
                 print >> sys.stderr, "#" * 71 + "\n"
                 cbioportalImporter.main(args)
+                exitcode = 0
             else:
                 print >> sys.stderr, Color.BOLD + "Warnings. Please fix your files or import with override warning option" + Color.END
                 print >> sys.stderr, "#" * 71
@@ -128,3 +129,4 @@ if __name__ == '__main__':
         print >> sys.stderr, "!" * 71
         print >> sys.stderr, Color.RED + "Error occurred during data loading step. Please fix the problem and run this again to make sure study is completely loaded." + Color.END
         raise
+    sys.exit(exitcode)

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -2898,3 +2898,4 @@ if __name__ == '__main__':
                 1: 'failed',
                 2: 'not performed as problems occurred',
                 3: 'succeeded with warnings'}.get(exit_status, 'unknown')))
+    sys.exit(exit_status)


### PR DESCRIPTION
Currently both tools return 0 if problems occur but they do not
ultimately have an uncaught exception. For example, if metaImport.py
calls main_validate() and gets return code != 0, it will exit with
success despite printing an error message. validateData.py does the same
when run standalone.

Without this PR, it is hard to programmatically verify success, as
mentioned in #848.