### PR TITLE
Fix exception for swissprot_identifier: name

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportProfileData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportProfileData.java
@@ -83,7 +83,7 @@ public class ImportProfileData extends ConsoleRunnable {
 	                importer.setSwissprotIsAccession(true);
 	            } else if (
 	                    swissprotIdType != null &&
-	                    swissprotIdType != "name") {
+	                    !swissprotIdType.equals("name")) {
 	                throw new RuntimeException(
 	                        "Unrecognized swissprot_identifier " +
 	                        "specification, must be 'name' or 'accession'.");


### PR DESCRIPTION
Due to an error in the code, `ImportProfileData` would crash when loading
mutation data files of which the metadata file explicitly specifies that
the SWISSPROT column contains names (which is how this column is parsed
by default if unspecified). This commit fixes the bug.

# Suggested reviewers
@jjgao