### PR TITLE
setting default value of empty string for property session service url

### DIFF
--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -159,8 +159,11 @@ genomespace=true
 # set this to true if you update cancer studies in your production database without shutting the web server
 recache_study_after_update=false
 
-# session-service URL 
-session.service.url=http://localhost:8080/session_service/api/sessions/msk_portal/
+# session-service url: http://[host]:[port]/[session_service_app]/api/sessions/[portal_instance]/ 
+# example session-service url: http://localhost:8080/session_service/api/sessions/public_portal/
+# see: https://github.com/cBioPortal/session-service
+# excluding this value or setting it to an empty string will revert to the previous bookmarking method
+session.service.url=
 
 # disabled tabs, | delimited
 # possible values: cancer_types_summary, mutual_exclusivity, plots, mutations, co_expression, enrichments, survival, network, download, bookmark, IGV

--- a/web/src/main/java/org/mskcc/cbio/portal/web/ProxyController.java
+++ b/web/src/main/java/org/mskcc/cbio/portal/web/ProxyController.java
@@ -54,7 +54,7 @@ public class ProxyController
   public void setBitlyURL(String property) { this.bitlyURL = property; }
 
   private String sessionServiceURL;
-  @Value("${session.service.url}")
+  @Value("${session.service.url:''}") // default is empty string
   public void setSessionServiceURL(String property) { this.sessionServiceURL = property; }
 
   private String pdbDatabaseURL;


### PR DESCRIPTION
This sets the default value for sessions.service.url to be an empty string to fix #1685 