### PR TITLE
New seed DB

### DIFF
--- a/docs/Downloads.md
+++ b/docs/Downloads.md
@@ -8,10 +8,7 @@ This page describes the various files available for download.
 
 # [Seed Database](seed-database)
 
-The files are MySQL database dump for seeding a new instance of the cBioPortal.  They contain all the necessary background data for a properly functioning cBioPortal website, including cancer types, gene, uniprot-mappings, drug, pdb and network data.  The files are available for download here:
-
-- [cbioportal-seed SQL (.gz) file - part1 (no pdb_ tables)](https://storage.googleapis.com/cbiostorage-1/seedDB/v1/cbioportal-seed_no-pdb_hg19.sql.gz)
-- [cbioportal-seed SQL (.gz) file - part2 (only pdb_ tables)](https://storage.googleapis.com/cbiostorage-1/seedDB/v1/cbioportal-seed_only-pdb.sql.gz)
+The files are MySQL database dump for seeding a new instance of the cBioPortal. For instructions for downloading it [see our datahub page](https://github.com/cbioportal/datahub/blob/master/seedDB/README.md). 
 
 # [MAF Example](maf-example)
 

--- a/docs/Downloads.md
+++ b/docs/Downloads.md
@@ -10,7 +10,8 @@ This page describes the various files available for download.
 
 This file is a MySQL database dump for seeding a new instance of the cBioPortal.  It contains all the necessary background data for a properly functioning cBioPortal website, including cancer types, gene, uniprot-mappings, drug and network data.  The file is available for download here:
 
-[cbioportal-seed.sql.gz](https://storage.googleapis.com/cbiostorage-1/cbioportal-seed.sql.gz)
+[cbioportal-seed SQL (.gz) file - part1 (no pdb_ tables)](https://storage.googleapis.com/cbiostorage-1/seedDB/v1/cbioportal-seed_no-pdb_hg19.sql.gz)
+[cbioportal-seed SQL (.gz) file - part2 (only pdb_ tables)](https://storage.googleapis.com/cbiostorage-1/seedDB/v1/cbioportal-seed_only-pdb.sql.gz)
 
 # [MAF Example](maf-example)
 

--- a/docs/Downloads.md
+++ b/docs/Downloads.md
@@ -8,10 +8,10 @@ This page describes the various files available for download.
 
 # [Seed Database](seed-database)
 
-This file is a MySQL database dump for seeding a new instance of the cBioPortal.  It contains all the necessary background data for a properly functioning cBioPortal website, including cancer types, gene, uniprot-mappings, drug and network data.  The file is available for download here:
+The files are MySQL database dump for seeding a new instance of the cBioPortal.  They contain all the necessary background data for a properly functioning cBioPortal website, including cancer types, gene, uniprot-mappings, drug, pdb and network data.  The files are available for download here:
 
-[cbioportal-seed SQL (.gz) file - part1 (no pdb_ tables)](https://storage.googleapis.com/cbiostorage-1/seedDB/v1/cbioportal-seed_no-pdb_hg19.sql.gz)
-[cbioportal-seed SQL (.gz) file - part2 (only pdb_ tables)](https://storage.googleapis.com/cbiostorage-1/seedDB/v1/cbioportal-seed_only-pdb.sql.gz)
+- [cbioportal-seed SQL (.gz) file - part1 (no pdb_ tables)](https://storage.googleapis.com/cbiostorage-1/seedDB/v1/cbioportal-seed_no-pdb_hg19.sql.gz)
+- [cbioportal-seed SQL (.gz) file - part2 (only pdb_ tables)](https://storage.googleapis.com/cbiostorage-1/seedDB/v1/cbioportal-seed_only-pdb.sql.gz)
 
 # [MAF Example](maf-example)
 

--- a/docs/Import-the-Seed-Database.md
+++ b/docs/Import-the-Seed-Database.md
@@ -26,6 +26,8 @@ and (this command takes a bit longer to import PDB data that will enable the vis
 
     > mysql --user=cbio_user --password=somepassword cbioportal  < seed-cbioportal_only-pdb.sql
 
+:information_source: please be aware of the version of the seed DB. If it is different from what the cBioPortal system is expecting, the system will at some point ask you to run a migration step. The system will automatically give you a clear message about this (with instructions) if a migration is needed. 
+
 ## Drug-target and Clinical Trial Data
 
 Due to data provider specific restrictions on data re-distribution, the database setup, as outlined above, will lack some of the drug-gene relationships from specific data-resources and also all clinical trial information. If you would like to obtain the complete the data sets from these resources, we encourage you to take advantage of [PiHelper](http://bitbucket.org/armish/pihelper) for aggregating drug-target associations and [NCI's Data Dissemination Program](http://www.cancer.gov/publications/pdq), PDQ, for clinical trials data; and use the corresponding data importers, `importPiHelperData.sh` and `importClinicalTrialData.pl`, that are distributed as part of cBioPortal.

--- a/docs/Import-the-Seed-Database.md
+++ b/docs/Import-the-Seed-Database.md
@@ -16,11 +16,15 @@ After download, the files can be unzipped by entering the following command:
 
 Then import the seed database via the `mysql` commands:
 
-    > mysql --user=cbio_user --password=somepassword cbioportal  < cbioportal-seed_no-pdb_hg19.sql
+    > mysql --user=cbio_user --password=somepassword cbioportal  < cgds.sql
+
+and:
+
+    > mysql --user=cbio_user --password=somepassword cbioportal  < seed-cbioportal_no-pdb_hg19.sql
     
 and (this command takes a bit longer to import PDB data that will enable the visualization of PDB structures in the mutation tab): 
 
-    > mysql --user=cbio_user --password=somepassword cbioportal  < cbioportal-seed_only-pdb.sql
+    > mysql --user=cbio_user --password=somepassword cbioportal  < seed-cbioportal_only-pdb.sql
 
 ## Drug-target and Clinical Trial Data
 

--- a/docs/Import-the-Seed-Database.md
+++ b/docs/Import-the-Seed-Database.md
@@ -4,7 +4,7 @@ The next step is to populate your cBioPortal instance with all the required back
 
 ## Download the cBioPortal Database
 
-A cBioPortal seed database can be found on the [Downloads](Downloads.md#seed-database) page.
+A cBioPortal seed database can be found on [the datahub page](https://github.com/cbioportal/datahub/blob/master/seedDB/README.md).
 
 After download, the files can be unzipped by entering the following command:
 

--- a/docs/Import-the-Seed-Database.md
+++ b/docs/Import-the-Seed-Database.md
@@ -26,7 +26,7 @@ and (this command takes a bit longer to import PDB data that will enable the vis
 
     > mysql --user=cbio_user --password=somepassword cbioportal  < seed-cbioportal_only-pdb.sql
 
-:information_source: please be aware of the version of the seed DB. If it is different from what the cBioPortal system is expecting, the system will at some point ask you to run a migration step. The system will automatically give you a clear message about this (with instructions) if a migration is needed. 
+:information_source: please be aware of the version of the seed DB. If it is different from what the cBioPortal system is expecting, the system will at some point ask you to run a migration step. The system will automatically give you a clear message (with instructions) about this (during startup or during data loading process) if a migration is needed. 
 
 ## Drug-target and Clinical Trial Data
 

--- a/docs/Import-the-Seed-Database.md
+++ b/docs/Import-the-Seed-Database.md
@@ -6,17 +6,21 @@ The next step is to populate your cBioPortal instance with all the required back
 
 A cBioPortal seed database can be found on the [Downloads](Downloads.md#seed-database) page.
 
-After download, this file can be unzipped by entering the following command:
+After download, the files can be unzipped by entering the following command:
 
-    gunzip cbioportal-seed.sql.gz
+    gunzip *.sql.gz
 
 ## Import the cBioPortal Database
 
 *Important:*  Before importing, make sure that you have [followed the pre-build steps](Pre-Build-Steps.md#prepare_database) for creating the `cbioportal` database.  
 
-Then import the seed database via the `mysql` command:
+Then import the seed database via the `mysql` commands:
 
-    > mysql --user=cbio_user --password=somepassword cbioportal  < cbioportal-seed.sql
+    > mysql --user=cbio_user --password=somepassword cbioportal  < cbioportal-seed_no-pdb_hg19.sql
+    
+and (this command takes a bit longer to import PDB data that will enable the visualization of PDB structures in the mutation tab): 
+
+    > mysql --user=cbio_user --password=somepassword cbioportal  < cbioportal-seed_only-pdb.sql
 
 ## Drug-target and Clinical Trial Data
 


### PR DESCRIPTION
# What? Why?

This PR documents the location of the new seed DB and how to load it. 

Changes proposed in this pull request:

These files contain the updated seed database for cBioPortal. We included:
1. Updated genes (60072) and gene aliases according to latest NCBI file
2. Updated gene lengths in `gene` table according to latest GRCh37 data from Gencode, using the fix proposed in #1678
3. Updated `pfam_graphics` table with latest data, according to #1653

Compared to the previous seed database, the following number of values are removed from these tables because their associated Entrez Gene IDs do not exist anymore in the latest NCBI Gene info file:
- cosmic_mutation: 247
- uniprot_id_mapping: 1375
- interaction: 56
- drug_interaction: 6

These tables were dropped, since they were not found in cgds.sql anymore:
- micro_rna
- micro_rna_alteration
- mutation_frequency
- patient_list
- patient_list_list
# Notify reviewers

@cBioPortal/frontend
@cBioPortal/backend
@cBioPortal/devops

In particular: 
@aderidder @sheridancbio @ersinciftci @sandertan 
