### PR TITLE
Add tab for MDACC Heatmap viewer on study page

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -124,6 +124,12 @@ public class GlobalProperties {
     public static final String PATIENT_VIEW_DIGITAL_SLIDE_META_URL = "digitalslidearchive.meta.url";
     public static final String PATIENT_VIEW_TCGA_PATH_REPORT_URL = "tcga_path_report.url";
     public static final String ONCOKB_URL = "oncokb.url";
+    public static final String PATIENT_VIEW_MDACC_HEATMAP_META_URL = "mdacc.heatmap.meta.url";
+    public static final String PATIENT_VIEW_MDACC_HEATMAP_URL = "mdacc.heatmap.patient.url";
+
+    public static final String STUDY_VIEW_MDACC_HEATMAP_URL = "mdacc.heatmap.study.url";
+    public static final String STUDY_VIEW_MDACC_HEATMAP_META_URL = "mdacc.heatmap.study.meta.url";
+
 
     // properties for showing the right logo in the header_bar and default logo
     public static final String SKIN_RIGHT_LOGO = "skin.right_logo";
@@ -629,6 +635,32 @@ public class GlobalProperties {
     {
         String url = properties.getProperty(PATIENT_VIEW_DIGITAL_SLIDE_META_URL);
         return url+caseId;
+    }
+
+    public static String getStudyHeatmapMetaUrl()
+    {
+        String url = properties.getProperty(STUDY_VIEW_MDACC_HEATMAP_META_URL);
+        return url;
+    }
+
+    public static String getStudyHeatmapViewerUrl()
+    {
+        String url = properties.getProperty(STUDY_VIEW_MDACC_HEATMAP_URL);
+        return url;
+    }
+
+    public static String getPatientHeatmapMetaUrl(String caseId)
+    {
+        String url = properties.getProperty(PATIENT_VIEW_MDACC_HEATMAP_META_URL);
+        if (url == null || url.length() == 0) return null;
+        return url + caseId;
+    }
+
+    public static String getPatientHeatmapViewerUrl(String caseId)
+    {
+        String url = properties.getProperty(PATIENT_VIEW_MDACC_HEATMAP_URL);
+        if (url == null || url.length() == 0) return null;
+        return url + caseId;
     }
 
     public static String getTCGAPathReportUrl()

--- a/portal/src/main/webapp/WEB-INF/jsp/study_view/cancer_study_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/study_view/cancer_study_view.jsp
@@ -119,9 +119,12 @@ if (cancerStudyViewError!=null) {
     <%if(showCNATab){%>
     <li><a href='#cna' id='study-tab-cna-a' class='study-tab' title='Copy Number Alterations'>Copy Number Alterations</a></li>
     <%}%>
-    
+
+    <%-- Always start with tab.  JS in browser will remove if not needed. --%>
+    <li id="study-tab-heatmap-li"><a href="#heatmap" id="study-tab-heatmap-a" class="study-tab">Heatmap</a></li>
+
     </ul>
-    
+
     <div class="study-section" id="summary">
         <%@ include file="dcplots.jsp" %>
     </div>
@@ -141,6 +144,12 @@ if (cancerStudyViewError!=null) {
         <%@ include file="cna.jsp" %>
     </div>
     <%}%>
+
+    <%-- Always start with this.  JS in browser will remove if not needed. --%>
+    <div class="study-section" id="heatmap">
+        <%@ include file="mdacc_heatmap_viewer.jsp" %>
+    </div>
+
 
 </div>
 <%  

--- a/portal/src/main/webapp/WEB-INF/jsp/study_view/mdacc_heatmap_viewer.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/study_view/mdacc_heatmap_viewer.jsp
@@ -1,0 +1,125 @@
+<%--
+ - Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ -
+ - This library is distributed in the hope that it will be useful, but WITHOUT
+ - ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ - FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ - is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ - obligations to provide maintenance, support, updates, enhancements or
+ - modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ - liable to any party for direct, indirect, special, incidental or
+ - consequential damages, including lost profits, arising out of the use of this
+ - software and its documentation, even if Memorial Sloan-Kettering Cancer
+ - Center has been advised of the possibility of such damage.
+ --%>
+
+<%--
+ - This file is part of cBioPortal.
+ -
+ - cBioPortal is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+--%>
+
+
+<%--  For the STUDY view  --%>
+
+<%@ page import="org.mskcc.cbio.portal.util.GlobalProperties" %>
+<%@ page import="org.mskcc.cbio.portal.servlet.QueryBuilder" %>
+
+
+<script type="text/javascript">
+
+
+    $(function () {
+
+        /* This function is probably redundant. It shouldn't need to be here. */
+        function getRequests() {
+            var s1 = location.search.substring(1, location.search.length).split('&'),
+                r = {}, s2, i;
+            for (i = 0 ; i < s1.length ; i += 1) {
+                s2 = s1[i].split('=');
+                r[decodeURIComponent(s2[0]).toLowerCase()] = decodeURIComponent(s2[1]);
+            }
+            return r;
+        }
+
+        var tabLI = $('#study-tab-heatmap-li'),             // the <li> for the tab
+            heatmapDiv = $('div#heatmap'),
+            enabled = false;
+
+        tabLI.attr('style', 'display:none');
+        //heatmapDiv.attr('style', 'display:none');     // display is already none
+
+        var metaUrl = '<%=GlobalProperties.getStudyHeatmapMetaUrl()%>';
+        if (metaUrl === 'null') return;                 // not configured in properties
+
+        var queryString = getRequests();
+
+        // Next line no longer works -- QueryBuilder hasn't kept up with change to study page
+        //var studyId = '"' + queryString['<%=QueryBuilder.CANCER_STUDY_ID%>'] + '"';
+
+        var studyId = queryString['id'];
+        // ### Next line for testing ###  To be removed...
+        if (studyId === 'study_es_0') studyId = 'brca_tcga_pub';
+
+        metaUrl += studyId;
+
+        /*
+         * <li><a href="#heatmap" id="study-tab-heatmap-a" class="study-tab">Heatmap</a></li>
+         * _and_
+         * <div class="study-section" id="heatmap">
+         *     etc etc
+         * </div>
+         */
+
+        // AJAX call to DyCE (index service), then test if result is empty.
+        $.getJSON(metaUrl, function(data){
+
+            // Check if there were any heatmaps for this study
+            if (data.jobStatus === "completed" && data.fileContent != undefined) {
+                enabled = !( data.fileContent.startsWith('[]') );   // array not empty
+                // ### Just for testing
+                //enabled = true;
+            }
+
+            if (enabled) {  // Only enable tab if there are heatmaps to show
+                data.fileContent = JSON.parse(data.fileContent);
+                var viewerUrl = '<%=GlobalProperties.getStudyHeatmapViewerUrl()%>';
+                if (viewerUrl === 'null') return;          // not configured in properties
+
+                viewerUrl += data.fileContent[0];
+
+                // So we display the tab
+                tabLI.attr('style', 'display:list-item');
+                heatmapDiv.attr('style', 'display:block');
+
+                // And give it a click handler to insert the iframe
+                $("#study-tab-heatmap-a").click(function() {
+                    if (!$(this).parent().hasClass('ui-state-disabled') && !$(this).hasClass("tab-clicked")) {
+
+                        $(this).addClass("tab-clicked");
+
+                        heatmapDiv.html('<iframe id="frame" src="'+viewerUrl+'" width="100%" height="700px"></iframe>');
+                    }
+                    window.location.hash = '#heatmap';
+                });
+            }
+        })
+        .fail(function (jqXHR, textStatus, errorThrown) {
+            // Unsure what else to do for errors.  Tab just won't be displayed.
+            console.log ('AJAX Error: ' + textStatus);
+        });
+    });
+</script>
+
+<div id="chm-viewer-div"><img src="images/ajax-loader.gif"/></div>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -106,8 +106,11 @@ ldap.attributes.last_name=sn
 ldap.attributes.given_name=givenName
 ldap.attributes.email=mail
 
+# study view settings
 # always show studies with this group
 always_show_study_group=
+mdacc.heatmap.study.meta.url=http://bioinformatics.mdanderson.org/study2url?studyid=
+mdacc.heatmap.study.url=http://bioinformatics.mdanderson.org/TCGA/NGCHMPortal/?
 
 # patient view settings
 patient_view_placeholder=false
@@ -116,6 +119,8 @@ digitalslidearchive.iframe.url=http://cancer.digitalslidearchive.net/index_mskcc
 digitalslidearchive.meta.url=http://cancer.digitalslidearchive.net/local_php/get_slide_list_from_db_groupid_not_needed.php?slide_name_filter=
 tumor_image.url=http://cbio.mskcc.org/cancergenomics/tcga-tumor-images/
 tcga_path_report.url=https://github.com/cbioportal/datahub/raw/master/tcga/pathology_reports/pathology_reports.txt
+mdacc.heatmap.patient.url=http://bioinformatics.mdanderson.org/TCGA/NGCHMPortal/?participant=
+mdacc.heatmap.meta.url=http://bioinformatics.mdanderson.org/participant2maps?participant=
 
 # various url's
 segfile.url=http://cbio.mskcc.org/cancergenomics/gdac-portal/seg/


### PR DESCRIPTION
# What?
Add tab for MDACC Heatmap viewer on study page, as an embedded iframe

# Why?
Integrates MD Anderson's pregenerated heatmap compendiums to many of the same studies that are loaded into cBioPortal.  This PR is the feature to show the compendium of heatmaps for a particular study, while the next PR will show patient/sample related heatmaps.

Changes proposed in this pull request:
- cancer_study_view.jsp : add tab HTML elements and include feature-specific javascript file
- mdacc_heatmap_viewer.jsp : the javascript file
- GlobalProperties.java : new functions to return meta service url and url for page
- portal.properties.EXAMPLE : additions for new properties for URLs

# Checks
- [ ] Runs on Heroku.  (Did not test, but runs within Docker.)
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). 
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
No. This has the new visual feature of the added tab, but properties must be configured and the study must be selected to see the tab.  I don't know how to automate that complete scenario.

# Notify reviewers
@zhx828
@cBioPortal/frontend

This adds a new tab to the study view page.  Clicking on the tab
displays an embedded "MDACC Clustered Heatmap Compendium" page, that
shows only heatmaps that were indexed as belonging with the study being
viewed.  If the user clicks on a heatmap, The NG-CHM viewer is displayed
within that embedded iframe.  The approach used (the embedded iframe)
follows the approach for the existing embedded Digital Slide Archive
viewer.

This is based on the 7/5/16 phone discussion with Niki Schultz, Ethan
Cerami, John Weinstein, and myself, when we demoed a patient view
version of the same.

The heatmap index mentioned above is queried via a web service running
at MD Anderson, whose URL is set in the property
mdacc.heatmap.study.meta.url in portal.properties.EXAMPLE.  A blank or
missing url property causes the query to be skipped and disables the
entire functionality.  For development purposes, the test study in the
"Seed Database" with id 'study_es_0' is mapped to the same heatmaps
that we have for study id 'brca_tcga_pub' that contains similar
samples.

Signed-off-by: Chris Wakefield <cwakefield@mdanderson.org>