### PR TITLE
Fixes to avoid exceptions for malformed OMA links in mutation_events

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/MutationDataUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/MutationDataUtils.java
@@ -101,6 +101,7 @@ public class MutationDataUtils {
 	public static final String CNA_CONTEXT = "cna";
     public static final String MY_CANCER_GENOME = "myCancerGenome";
     public static final String IS_HOTSPOT = "isHotspot";
+    public static final String OMA_LINK_NOT_AVAILABLE_VALUE = "NA";
 
     /**
      * Generates an array (JSON array) of mutations for the given sample
@@ -385,40 +386,23 @@ public class MutationDataUtils {
 
         return counts;
     }
-
+ 
     /**
      * Returns the MSA (alignment) link for the given mutation.
      *
      * @param mutation  mutation instance
      * @return          corresponding MSA link
      */
-    protected String getMsaLink(ExtendedMutation mutation)
-    {
-        String urlMsa = "";
-
-        if (linkIsValid(mutation.getLinkMsa()))
-        {
-            try
-            {
-                if(mutation.getLinkMsa().length() == 0 ||
-                        mutation.getLinkMsa().equals("NA"))
-                {
-                    urlMsa = "NA";
-                }
-                else
-                {
-                    urlMsa = OmaLinkUtil.createOmaRedirectLink(mutation.getLinkMsa());
-                }
-            }
-            catch (MalformedURLException e)
-            {
-                logger.error("Could not parse OMA URL:  " + e.getMessage());
+    protected String getMsaLink(ExtendedMutation mutation) {
+        if (mutation != null && OmaLinkUtil.omaLinkIsValid(mutation.getLinkMsa())) {
+            try {
+                return OmaLinkUtil.createOmaRedirectLink(mutation.getLinkMsa());
+            } catch (MalformedURLException e) {
+                logger.error("Could not parse OMA URL " + mutation.getLinkMsa() + " : " + e.getMessage());
             }
         }
-
-        return urlMsa;
+        return OMA_LINK_NOT_AVAILABLE_VALUE;
     }
-
 
     /**
      * Returns the PDB (structure) link for the given mutation.
@@ -426,31 +410,15 @@ public class MutationDataUtils {
      * @param mutation  mutation instance
      * @return          corresponding PDB link
      */
-    protected String getPdbLink(ExtendedMutation mutation)
-    {
-        String urlPdb = "";
-
-        if (linkIsValid(mutation.getLinkPdb()))
-        {
-            try
-            {
-                if(mutation.getLinkPdb().length() == 0 ||
-                        mutation.getLinkPdb().equals("NA"))
-                {
-                    urlPdb = "NA";
-                }
-                else
-                {
-                    urlPdb = OmaLinkUtil.createOmaRedirectLink(mutation.getLinkPdb());
-                }
-            }
-            catch (MalformedURLException e)
-            {
-                logger.error("Could not parse OMA URL:  " + e.getMessage());
+    protected String getPdbLink(ExtendedMutation mutation) {
+        if (mutation != null && OmaLinkUtil.omaLinkIsValid(mutation.getLinkPdb())) {
+            try {
+                return OmaLinkUtil.createOmaRedirectLink(mutation.getLinkPdb());
+            } catch (MalformedURLException e) {
+                logger.error("Could not parse OMA URL " + mutation.getLinkPdb() + " : " + e.getMessage());
             }
         }
-
-        return urlPdb;
+        return OMA_LINK_NOT_AVAILABLE_VALUE;
     }
 
     /**
@@ -459,37 +427,16 @@ public class MutationDataUtils {
      * @param mutation  mutation instance
      * @return          corresponding xVar link
      */
-    protected String getXVarLink(ExtendedMutation mutation)
-    {
-        String xVarLink = "";
-
-        if (linkIsValid(mutation.getLinkXVar()))
-        {
-            try
-            {
-                xVarLink = OmaLinkUtil.createOmaRedirectLink(mutation.getLinkXVar());
-            }
-            catch (MalformedURLException e)
-            {
-                logger.error("Could not parse OMA URL:  " + e.getMessage());
+    protected String getXVarLink(ExtendedMutation mutation) {
+        if (mutation != null && OmaLinkUtil.omaLinkIsValid(mutation.getLinkXVar())) {
+            try {
+                return OmaLinkUtil.createOmaRedirectLink(mutation.getLinkXVar());
+            } catch (MalformedURLException e) {
+                logger.error("Could not parse OMA URL " + mutation.getLinkXVar() + " : " + e.getMessage());
                 //return HtmlUtil.createEmptySpacer();
             }
         }
-
-        return xVarLink;
-    }
-
-    /**
-     * Checks the validity of the given link.
-     *
-     * @param link  string representation of a URL
-     * @return      true if valid, false otherwise
-     */
-    protected boolean linkIsValid(String link)
-    {
-        return link != null &&
-                link.length() > 0 &&
-                !link.equalsIgnoreCase("NA");
+        return OMA_LINK_NOT_AVAILABLE_VALUE;
     }
 
     protected String getSequencingCenter(ExtendedMutation mutation)

--- a/core/src/main/java/org/mskcc/cbio/portal/util/OmaLinkUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/OmaLinkUtil.java
@@ -36,6 +36,7 @@ import java.net.URL;
 import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 
 /**
@@ -52,6 +53,7 @@ import java.util.Collections;
 public class OmaLinkUtil {
     private final static String OMA_REDIRECT_LINK = "omaRedirect.do?";
     private final static String SITE_PARAM = "site";
+    private final static ArrayList<String> EMPTY_FIELD_MARKERS= new ArrayList<String>(Arrays.asList("", "NA", "[Not Available]"));
 
     /**
      * Creates a Redirect Link from Portal to OMA.
@@ -67,6 +69,9 @@ public class OmaLinkUtil {
      * @throws MalformedURLException Malformed URL Error.
      */
     public static String createOmaRedirectLink(String omaUrl) throws MalformedURLException {
+        if (EMPTY_FIELD_MARKERS.contains(omaUrl)) {
+            throw new MalformedURLException("value is empty field marker: " + omaUrl);
+        }
         omaUrl = conditionallyPrependHttp(omaUrl);
         URL url = new URL (omaUrl);
         String site = url.getHost();
@@ -89,14 +94,20 @@ public class OmaLinkUtil {
      * @throws MalformedURLException Malformed URL Error.
      */
     public static String createOmaLink(String omaQueryString) throws MalformedURLException {
+        if (EMPTY_FIELD_MARKERS.contains(omaQueryString)) {
+            throw new MalformedURLException("value is empty field marker: " + omaQueryString);
+        }
         omaQueryString = removePath(omaQueryString);
         String params[] = omaQueryString.split("&");
         HashMap<String, String> paramMap = getParameterMap(params);
         String path = paramMap.get(SITE_PARAM);
         ArrayList<String> keyList = getKeyList(paramMap);
-
         String queryString = createQueryString(keyList, paramMap);
         return "http://" + path + "?" + queryString;
+    }
+
+    public static boolean omaLinkIsValid(String omaQueryString) {
+        return !(omaQueryString == null || omaQueryString.length() == 0 || EMPTY_FIELD_MARKERS.contains(omaQueryString));
     }
 
     private static String conditionallyPrependHttp(String omaUrl) {

--- a/core/src/test/java/org/mskcc/cbio/portal/util/TestOmaLinkUtil.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/util/TestOmaLinkUtil.java
@@ -32,10 +32,8 @@
 
 package org.mskcc.cbio.portal.util;
 
-
-
 import java.net.MalformedURLException;
-
+import org.junit.*;
 import static org.junit.Assert.*;
 
 /**
@@ -47,27 +45,27 @@ public class TestOmaLinkUtil {
     private String queryStringParams1 = "cm=var&fts=all&var=17,7517830,G,C";
     private String queryStringParams2 = "from=601&prot=EGFR_HUMAN&to=800&var=C620Y";
 
+    @Test
     public void testOmaLinkUtil1() throws MalformedURLException {
         String omaLinkIn = "http://mutationassessor.org/?" + queryStringParams1;
         String omaLinkOut = OmaLinkUtil.createOmaRedirectLink(omaLinkIn);
         assertEquals("omaRedirect.do?site=mutationassessor.org/&" + queryStringParams1, omaLinkOut);
-
         String omaLink = OmaLinkUtil.createOmaLink(omaLinkOut);
         assertEquals (omaLinkIn, omaLink);
-
         omaLink = OmaLinkUtil.createOmaLink("site=mutationassessor.org/&" + queryStringParams1);
         assertEquals (omaLinkIn, omaLink);
     }
 
+    @Test
     public void testOmaLinkUtil2() throws MalformedURLException {
         String omaLinkIn = "http://mutationassessor.org/pdb.php?" + queryStringParams2;
         String omaLinkOut = OmaLinkUtil.createOmaRedirectLink(omaLinkIn);
-        assertEquals("omaRedirect.do?site=mutationassessor.org/pdb.php&"
-                + queryStringParams2, omaLinkOut);
+        assertEquals("omaRedirect.do?site=mutationassessor.org/pdb.php&" + queryStringParams2, omaLinkOut);
         String omaLink = OmaLinkUtil.createOmaLink(omaLinkOut);
         assertEquals (omaLinkIn, omaLink);
     }
 
+    @Test
     public void testOmaLinkUtil3() throws MalformedURLException {
         String omaLinkIn = "http://xvar.org/pdb.php?" + queryStringParams2;
         String omaLinkOut = OmaLinkUtil.createOmaRedirectLink(omaLinkIn);
@@ -75,13 +73,28 @@ public class TestOmaLinkUtil {
         assertEquals (omaLinkIn, omaLink);
     }
 
+    @Test
     public void testOmaLinkUtil4() throws MalformedURLException {
         String omaLinkIn = "mutationassessor.org/?" + queryStringParams1;
         String omaLinkOut = OmaLinkUtil.createOmaRedirectLink(omaLinkIn);
         assertEquals("omaRedirect.do?site=mutationassessor.org/&" + queryStringParams1, omaLinkOut);
-
-        String omaLink = OmaLinkUtil.createOmaLink("site=mutationassessor.org/&"
-                + queryStringParams1);
+        String omaLink = OmaLinkUtil.createOmaLink("site=mutationassessor.org/&" + queryStringParams1);
         assertEquals ("http://" + omaLinkIn, omaLink);
+    }
+
+    private void testExpectedMalformedLink(String omaLinkIn) {
+        try {
+            String omaLinkOut = OmaLinkUtil.createOmaRedirectLink(omaLinkIn);
+            fail("call to OmaLinkUtil.createOmaRedirectLink(\"" + omaLinkIn + "\") was expected to generate an exception but returned: " + omaLinkOut);
+        } catch (MalformedURLException e) {
+            // expected .. no failure
+        }
+    }
+
+    @Test
+    public void testOmaLinkUtil5() {
+        testExpectedMalformedLink("NA");
+        testExpectedMalformedLink("[Not Available]");
+        testExpectedMalformedLink("");
     }
 }


### PR DESCRIPTION
# What? Why?
Problem described here: #1646 

Changes proposed in this pull request:
- In addition to "NA", check mutation_event link fields for the value [Not Available]
- also added additional error logging, a notification to user on failed redirect, and unit tests

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
@cBioPortal/backend

- MutationDataUtils now calls OmaLinkUtil function to see if link is valid
- three values are checked as empty field marker: "", "NA", "[Not Available]"
- invalid links (null, empty, empty field marker) automatically send "NA"
- redirect servlet now catches errors and logs .. also presents a fail message to user