### PR TITLE
make oncoprint linkouts open in new window/tab

### DIFF
--- a/portal/src/main/webapp/js/src/oncoprint/webgl/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/setup.js
@@ -59,11 +59,11 @@ var utils = {
 var tooltip_utils = {
     'sampleViewAnchorTag': function (sample_id) {
 	var href = cbio.util.getLinkToSampleView(QuerySession.getCancerStudyIds()[0], sample_id);
-	return '<a href="' + href + '">' + sample_id + '</a>';
+	return '<a href="' + href + '" target="_blank">' + sample_id + '</a>';
     },
     'patientViewAnchorTag': function(patient_id) {
 	var href = cbio.util.getLinkToPatientView(QuerySession.getCancerStudyIds()[0], patient_id);
-	return '<a href="' + href + '">' + patient_id + '</a>';
+	return '<a href="' + href + '" target="_blank">' + patient_id + '</a>';
     },
     'makeGeneticTrackTooltip':function(data_type, link_id) {
 	return function (d) {


### PR DESCRIPTION
Previously, clicking on a patient or sample id in a tooltip in the oncoprint opened the patient/sample view in the same page. Now, it will open in a new tab/window.

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@cBioPortal/frontend 

