### PR TITLE
Short-term return to underscore fields in API I/O

### DIFF
--- a/core/src/main/resources/db/cgds.sql
+++ b/core/src/main/resources/db/cgds.sql
@@ -2,8 +2,6 @@
 -- Database: `cgds`
 --
 
-drop table IF EXISTS gene_panel_list;
-drop table IF EXISTS gene_panel;
 drop table IF EXISTS clinical_event_data;
 drop table IF EXISTS clinical_event;
 drop table IF EXISTS pdb_uniprot_residue_mapping;
@@ -35,6 +33,8 @@ drop table if EXISTS mutation_count;
 drop table IF EXISTS mutation;
 drop table IF EXISTS mutation_event;
 drop table IF EXISTS sample_profile;
+drop table IF EXISTS gene_panel_list;
+drop table IF EXISTS gene_panel;
 drop table IF EXISTS genetic_profile_samples;
 drop table IF EXISTS genetic_alteration;
 drop table IF EXISTS genetic_profile;

--- a/web/src/main/java/org/cbioportal/web/config/CustomObjectMapper.java
+++ b/web/src/main/java/org/cbioportal/web/config/CustomObjectMapper.java
@@ -1,20 +1,18 @@
 package org.cbioportal.web.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import org.cbioportal.model.*;
-import org.cbioportal.web.mixin.*;
-
 import java.util.HashMap;
 import java.util.Map;
+import org.cbioportal.model.*;
+import org.cbioportal.web.mixin.*;
 
 public class CustomObjectMapper extends ObjectMapper {
 
     public CustomObjectMapper() {
+        super.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
         super.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-
         Map<Class<?>, Class<?>> mixinMap = new HashMap<>();
         mixinMap.put(CancerStudy.class, CancerStudyMixin.class);
         mixinMap.put(Gene.class, GeneMixin.class);

--- a/web/src/main/java/org/cbioportal/weblegacy/GenePanelController.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/GenePanelController.java
@@ -51,7 +51,7 @@ public class GenePanelController {
 
     @Autowired
     private GenePanelService genePanelService;
-    
+
     @ApiOperation(value = "Get gene panel information",
             nickname = "getGenePanel",
             notes = "")
@@ -60,14 +60,14 @@ public class GenePanelController {
     public List<GenePanel> getGenePanel(@ApiParam(required = false, value = "gene panel id. If provided, the list of /"
             + "genes associated with the gene panel will be presented. Otherwise, only the stable id and description will /"
             + "be shown for all gene panels in the database.")
-            @RequestParam(required = false) String panelId) {
-        if (panelId != null) {
-            return genePanelService.getGenePanelByStableId(panelId);
+            @RequestParam(required = false) String panel_id) {
+        if (panel_id != null) {
+            return genePanelService.getGenePanelByStableId(panel_id);
         }
         else {
             return genePanelService.getGenePanels();
         }
-    }        
+    }
 
     @ApiOperation(value = "Get gene panel information for a sample profile pair",
             nickname = "getGenePanelData",
@@ -75,9 +75,9 @@ public class GenePanelController {
     @Transactional
     @RequestMapping(method = RequestMethod.GET, value = "/genepanel/data",  produces="application/json")
     public String getGenePanelData(@ApiParam(required = true, value = "sample id, such as those returned by /api/samples")
-            @RequestParam(required = true) String sampleId,
+            @RequestParam(required = true) String sample_id,
             @ApiParam(required = true, value = "genetic profile id, such as those returned by /api/geneticprofiles")
-            @RequestParam(required = true) String profileId) {
-        return genePanelService.getGenePanelBySampleIdAndProfileId(sampleId, profileId);
+            @RequestParam(required = true) String profile_id) {
+        return genePanelService.getGenePanelBySampleIdAndProfileId(sample_id, profile_id);
     }
 }

--- a/web/src/test/java/org/cbioportal/weblegacy/CNSegmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/weblegacy/CNSegmentControllerTest.java
@@ -29,6 +29,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.cbioportal.weblegacy;
 
 import java.util.ArrayList;
@@ -67,28 +68,32 @@ public class CNSegmentControllerTest {
         Mockito.reset(cnSegmentServiceMock);
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
     }
-    
+
     @Test
     public void getCNSegmentTest() throws Exception {
         List<CNSegmentData> mockResponse = new ArrayList<>();
-        CNSegmentData cnSegmentData1 = new CNSegmentData(); 
+        CNSegmentData cnSegmentData1 = new CNSegmentData();
         cnSegmentData1.setStart(148350479);
         cnSegmentData1.setEnd(158385118);
         cnSegmentData1.setChr("7");
         cnSegmentData1.setNumProbes(4901);
         cnSegmentData1.setValue((float) 0.1315);
         cnSegmentData1.setSample("TCGA-AG-3732-01");
-        CNSegmentData cnSegmentData2 = new CNSegmentData(); 
+        CNSegmentData cnSegmentData2 = new CNSegmentData();
         cnSegmentData2.setStart(148347132);
         cnSegmentData2.setEnd(148348416);
         cnSegmentData2.setChr("7");
         cnSegmentData2.setNumProbes(3);
         cnSegmentData2.setValue((float) -1.5009);
         cnSegmentData2.setSample("TCGA-AG-3732-01");
-       
-      	mockResponse.add(cnSegmentData1);
+        mockResponse.add(cnSegmentData1);
         mockResponse.add(cnSegmentData2);
-        Mockito.when(cnSegmentServiceMock.getCNSegmentData(org.mockito.Matchers.anyString(), org.mockito.Matchers.anyListOf(String.class), org.mockito.Matchers.anyListOf(String.class))).thenReturn(mockResponse);
+        Mockito.when(
+                cnSegmentServiceMock.getCNSegmentData(org.mockito.Matchers.anyString(),
+                                                        org.mockito.Matchers.anyListOf(String.class),
+                                                        org.mockito.Matchers.anyListOf(String.class)))
+                .thenReturn(mockResponse)
+                ;
         this.mockMvc.perform(
                 MockMvcRequestBuilders.get("/copynumbersegments")
                 .accept(MediaType.parseMediaType("application/json;charset=UTF-8"))
@@ -102,15 +107,14 @@ public class CNSegmentControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].chr").value("7"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].start").value(148350479))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].end").value(158385118))
-                .andExpect(MockMvcResultMatchers.jsonPath("$[0].numProbes").value(4901))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].num_probes").value(4901))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].value").value(0.1315))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].sample").value("TCGA-AG-3732-01"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].chr").value("7"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].start").value(148347132))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].end").value(148348416))
-                .andExpect(MockMvcResultMatchers.jsonPath("$[1].numProbes").value(3))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].num_probes").value(3))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].value").value(-1.5009))
                 ;
     }
 }
-

--- a/web/src/test/java/org/cbioportal/weblegacy/GeneControllerTest.java
+++ b/web/src/test/java/org/cbioportal/weblegacy/GeneControllerTest.java
@@ -67,23 +67,23 @@ public class GeneControllerTest {
         Mockito.reset(geneServiceMock);
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
     }
-    
+
     @Test
     public void genesByHugoSymbolsDataTest() throws Exception {
         List<Gene> mockResponse = new ArrayList<>();
-        Gene gene1 = new Gene(); 
+        Gene gene1 = new Gene();
         gene1.setEntrezGeneId(673);
         gene1.setHugoGeneSymbol("BRAF");
         gene1.setType("protein-coding");
-        gene1.setCytoband("7q34");    
+        gene1.setCytoband("7q34");
         gene1.setLength(4564);
         Gene gene2 = new Gene();
         gene2.setEntrezGeneId(1956);
         gene2.setHugoGeneSymbol("EGFR");
         gene2.setType("protein-coding");
-        gene2.setCytoband("7p12");    
+        gene2.setCytoband("7p12");
         gene2.setLength(12961);
-      	mockResponse.add(gene1);
+        mockResponse.add(gene1);
         mockResponse.add(gene2);
         Mockito.when(geneServiceMock.getGeneListByHugoSymbols(org.mockito.Matchers.anyListOf(String.class))).thenReturn(mockResponse);
         this.mockMvc.perform(
@@ -93,17 +93,16 @@ public class GeneControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json;charset=UTF-8"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
-                .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneId").value(673))
-                .andExpect(MockMvcResultMatchers.jsonPath("$[0].hugoGeneSymbol").value("BRAF"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrez_gene_id").value(673))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].hugo_gene_symbol").value("BRAF"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].type").value("protein-coding"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].cytoband").value("7q34"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].length").value(4564))
-                .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneId").value(1956))
-                .andExpect(MockMvcResultMatchers.jsonPath("$[1].hugoGeneSymbol").value("EGFR"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrez_gene_id").value(1956))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].hugo_gene_symbol").value("EGFR"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].type").value("protein-coding"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].cytoband").value("7p12"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].length").value(12961))
                 ;
     }
-
 }

--- a/web/src/test/java/org/cbioportal/weblegacy/GenePanelControllerTest.java
+++ b/web/src/test/java/org/cbioportal/weblegacy/GenePanelControllerTest.java
@@ -68,8 +68,8 @@ public class GenePanelControllerTest {
     private GenePanelService genePanelServiceMock;
     private MockMvc mockMvc;
     private GenePanel genePanel1;
-        private GenePanel genePanel2;
-    
+    private GenePanel genePanel2;
+
     @Before
     public void setup() {
         Mockito.reset(genePanelServiceMock);
@@ -78,29 +78,29 @@ public class GenePanelControllerTest {
         genePanel1.setStableId("GENEPANEL2");
         genePanel1.setDescription("2 genes tested");
         genePanel1.setInternalId(1);
-        
+
         genePanel2 = new GenePanel();
         genePanel2.setStableId("GENEPANEL3");
         genePanel2.setDescription("3 genes tested");
         genePanel2.setInternalId(2);
-        
+
         List<Gene> genes = new ArrayList<>();
-        Gene gene1 = new Gene(); 
+        Gene gene1 = new Gene();
         gene1.setEntrezGeneId(673);
         gene1.setHugoGeneSymbol("BRAF");
         gene1.setType("protein-coding");
-        gene1.setCytoband("7q34");    
+        gene1.setCytoband("7q34");
         gene1.setLength(4564);
         Gene gene2 = new Gene();
         gene2.setEntrezGeneId(1956);
         gene2.setHugoGeneSymbol("EGFR");
         gene2.setType("protein-coding");
-        gene2.setCytoband("7p12");    
+        gene2.setCytoband("7p12");
         gene2.setLength(12961);
         genes.add(gene1);
         genes.add(gene2);
-        
-        genePanel1.setGenes(genes);        
+
+        genePanel1.setGenes(genes);
     }
 
     @Test
@@ -111,15 +111,15 @@ public class GenePanelControllerTest {
         this.mockMvc.perform(
         MockMvcRequestBuilders.get("/genepanel")
         .accept(MediaType.parseMediaType("application/json;charset=UTF-8"))
-        .param("panelId", "GENEPANEL2"))
+        .param("panel_id", "GENEPANEL2"))
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(MockMvcResultMatchers.content().contentType("application/json;charset=UTF-8"))
         .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(1)))
-        .andExpect(MockMvcResultMatchers.jsonPath("$[0].stableId").value("GENEPANEL2"))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].stable_id").value("GENEPANEL2"))
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].description").value("2 genes tested"))
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].genes", Matchers.hasSize(2)));
     }
-    
+
     @Test
     public void genePanelBySampleIdAndProfileIdTest() throws Exception {
         String mockResponse = "GENEPANEL2";
@@ -127,12 +127,12 @@ public class GenePanelControllerTest {
         this.mockMvc.perform(
         MockMvcRequestBuilders.get("/genepanel/data")
         .accept(MediaType.parseMediaType("application/json;charset=UTF-8"))
-        .param("sampleId", "SAMPLE1").param("profileId", "PROFILE1"))
+        .param("sample_id", "SAMPLE1").param("profile_id", "PROFILE1"))
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(MockMvcResultMatchers.content().contentType("application/json;charset=UTF-8"))
         .andExpect(MockMvcResultMatchers.jsonPath("$").value("GENEPANEL2"));
-    }    
-    
+    }
+
     @Test
     public void genePanel() throws Exception {
         List<GenePanel> mockResponse = new ArrayList<>();
@@ -145,9 +145,9 @@ public class GenePanelControllerTest {
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(MockMvcResultMatchers.content().contentType("application/json;charset=UTF-8"))
         .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
-        .andExpect(MockMvcResultMatchers.jsonPath("$[0].stableId").value("GENEPANEL2"))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].stable_id").value("GENEPANEL2"))
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].description").value("2 genes tested"))
-        .andExpect(MockMvcResultMatchers.jsonPath("$[1].stableId").value("GENEPANEL3"))
-        .andExpect(MockMvcResultMatchers.jsonPath("$[1].description").value("3 genes tested"));         
-    }    
+        .andExpect(MockMvcResultMatchers.jsonPath("$[1].stable_id").value("GENEPANEL3"))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[1].description").value("3 genes tested"));
+    }
 }


### PR DESCRIPTION
# What? Why?
This corrects a current problem on branch rc where the oncoprint is not showing mutations
A better / more uniform style of naming parameters and JSON field names is needed after this short term fix.

Changes proposed in this pull request:
- replace the jackson conversion of JSON output fields to underscore separation
- change parameters of the weblegacy apis to use underscore separation 

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/backend
