### PR TITLE
Fix bug in datamanager.js getMutationProfileIds

### DIFF
--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -1453,9 +1453,11 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	'getMutationProfileIds': makeCachedPromiseFunction(
 		function(self, fetch_promise) {
 		    self.getGeneticProfiles().then(function (profiles) {
-			fetch_promise.resolve(profiles.map(function (p) {
-			    return p.id;
-			}));
+			fetch_promise.resolve(
+                            profiles
+                            .filter(function (p) {return p.genetic_alteration_type === "MUTATION_EXTENDED";})
+                            .map(function (p) {return p.id;})
+                        );
 		    }).fail(function () {
 			fetch_promise.reject();
 		    });


### PR DESCRIPTION
datamanager.js has a function 'getMutationProfileIds' which was returning all retrieved profile ids rather than just the ids of mutation profiles. This was causing mutationmapper.js to not get mutation events if the first profile id returned was a copy number alternation profile (for example)

Changes proposed in this pull request:
- return list is now filtered to only return mutation profiles

note: we still need to add logic in the handler which starts mutationmapper to choose the "correct" mutation profile if there are more than one.
# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@onursumer @adamabeshouse @jjgao 

- instead of returning all profile ids, add filter to only return mutation profiles