### PR TITLE
Gene panel api expansion for oncoprint

### DIFF
--- a/model/src/main/java/org/cbioportal/model/GenePanelWithSamples.java
+++ b/model/src/main/java/org/cbioportal/model/GenePanelWithSamples.java
@@ -30,54 +30,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 package org.cbioportal.model;
+import java.util.List;
 
 /**
  *
  * @author heinsz
  */
+public class GenePanelWithSamples extends GenePanel {
+    private List<String> samples;
 
-import java.io.Serializable;
-import java.util.List;
-
-public class GenePanel  implements Serializable{
-    
-    private Integer internalId;
-    private String stableId;
-    private String description;
-    private List<Gene> genes;
-    
-    public GenePanel() {}
-    
-    public Integer getInternalId() {
-        return internalId;
+    public List<String> getSamples() {
+        return samples;
     }
-    
-    public void setInternalId(Integer internalId) {
-        this.internalId = internalId;
+    public void setSamples(List<String> samples) {
+        this.samples = samples;
     }
-    
-    public String getStableId() {
-        return stableId;
-    }
-    
-    public void setStableId(String stableId) {
-        this.stableId = stableId;
-    }
-    
-    public String getDescription() {
-        return description;
-    }
-    
-    public void setDescription(String description) {
-        this.description = description;
-    }
-    
-    public List<Gene> getGenes() {
-        return genes;
-    }
-    
-    public void setGenes(List<Gene> genes) {
-        this.genes = genes;
-    }
-    
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenePanelRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenePanelRepository.java
@@ -42,7 +42,7 @@ import java.util.*;
 
 public interface GenePanelRepository {
     
-        String getGenePanelBySampleIdAndProfileId(String sampleId, String profileId);
+        List<GenePanelWithSamples> getGenePanelsByProfile(String profileId);
         // TODO: All of the below methods are for importing purposes only. They should be
         // removed once a proper import solution is put in place.
         List<GenePanel> getGenePanelByStableId(String stableId);

--- a/persistence/persistence-mybatis-test/src/test/java/org/cbioportal/persistence/mybatis/GenePanelMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis-test/src/test/java/org/cbioportal/persistence/mybatis/GenePanelMyBatisRepositoryTest.java
@@ -58,9 +58,11 @@ public class GenePanelMyBatisRepositoryTest {
     private GenePanelMyBatisRepository genePanelMyBatisRepository;
     
     @Test
-    public void getGenePanelBySampleAndProfileId() {
-        String result = genePanelMyBatisRepository.getGenePanelBySampleIdAndProfileId("TCGA-A1-A0SB-01", "study_tcga_pub_gistic");
-        Assert.assertEquals("TESTPANEL1", result);
+    public void getGenePanelsByProfiles() {
+        List<String> genes = new ArrayList<>();
+        List<GenePanelWithSamples> result = genePanelMyBatisRepository.getGenePanelsByProfile("study_tcga_pub_gistic");
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals(3, result.get(0).getGenes().size());
     }
     
     @Test

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenePanelMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenePanelMapper.java
@@ -43,7 +43,7 @@ import org.cbioportal.model.*;
 
 public interface GenePanelMapper {
 
-    String getGenePanelBySampleIdAndProfileId(@Param("sampleId") String sampleId, @Param("profileId") String profileId);
+    List<GenePanelWithSamples> getGenePanelsByProfile(@Param("profileId") String profileId);
     // TODO: All of the below methods are for importing purposes only. They should be
     // removed once a proper import solution is put in place.
     List<GenePanel> getGenePanelByStableId(@Param("stableId") String stableId);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenePanelMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenePanelMyBatisRepository.java
@@ -50,8 +50,8 @@ public class GenePanelMyBatisRepository implements GenePanelRepository {
     GenePanelMapper genePanelMapper;
 
     @Override
-    public String getGenePanelBySampleIdAndProfileId(String sampleId, String profileId) {
-        return genePanelMapper.getGenePanelBySampleIdAndProfileId(sampleId, profileId);
+    public List<GenePanelWithSamples> getGenePanelsByProfile(String profileId) {       
+        return genePanelMapper.getGenePanelsByProfile(profileId);
     }
 
     // TODO: All of the below methods are for importing purposes only. They should be

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenePanelMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenePanelMapper.xml
@@ -21,6 +21,16 @@
         <result property="description" column="description"/>
     </resultMap>
     
+    <resultMap id="genePanelSampleResultMap" type="org.cbioportal.model.GenePanelWithSamples">
+        <result property="stableId" column="stableId" />
+        <result property="description" column="description"/>
+        <collection property = "genes" ofType="org.cbioportal.model.Gene">
+            <result property="hugoGeneSymbol" column="hugoGeneSymbol"/>
+        </collection>
+        <collection property="samples" ofType="String">
+            <result property="stableId" column="sampleId"/>
+        </collection>
+    </resultMap>
 
    <resultMap id="sampleResultMap" type="org.cbioportal.model.Sample">
         <result property="internalId" column="INTERNAL_ID"/>
@@ -103,17 +113,21 @@
         </association>
     </resultMap>
 
-    <select id="getGenePanelBySampleIdAndProfileId" resultType="String">
+    <select id="getGenePanelsByProfile" resultMap="genePanelSampleResultMap">
         select
-            gene_panel.STABLE_ID as stableId
-        from sample_profile
+            gene_panel.STABLE_ID as stableId,
+            gene_panel.DESCRIPTION as description,
+            gene.HUGO_GENE_SYMBOL as hugoGeneSymbol,
+            sample.STABLE_ID as sampleId
+        from genetic_profile
+            inner join sample_profile on genetic_profile.GENETIC_PROFILE_ID = sample_profile.GENETIC_PROFILE_ID
             inner join gene_panel on sample_profile.PANEL_ID = gene_panel.INTERNAL_ID
             inner join sample on sample_profile.SAMPLE_ID = sample.INTERNAL_ID
-            inner join genetic_profile on sample_profile.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
+            left join gene_panel_list on gene_panel.INTERNAL_ID = gene_panel_list.INTERNAL_ID
+            left join gene on gene_panel_list.GENE_ID = gene.ENTREZ_GENE_ID
         <where>
-            sample.STABLE_ID = #{sampleId}
-            and genetic_profile.STABLE_ID = #{profileId}
-        </where>
+            genetic_profile.STABLE_ID = #{profileId}
+        </where>        
     </select>
 
     <select id="getGenePanelByStableId" resultMap="genePanelResultMap">
@@ -138,7 +152,7 @@
             gene_panel.STABLE_ID as stableId,
             gene_panel.DESCRIPTION as description
         from gene_panel
-    </select>    
+    </select>
 
     <select id="getSampleByStableIdAndStudyId" resultMap="sampleResultMap">
         select

--- a/service/src/main/java/org/cbioportal/service/GenePanelService.java
+++ b/service/src/main/java/org/cbioportal/service/GenePanelService.java
@@ -11,10 +11,12 @@ package org.cbioportal.service;
  */
 
 import org.cbioportal.model.GenePanel;
+import org.cbioportal.model.GenePanelWithSamples;
 import java.util.List;
+import java.util.Map;
 
 public interface GenePanelService {
-    String getGenePanelBySampleIdAndProfileId(String sampleId, String profileId);
+    List<GenePanelWithSamples> getGenePanelDataByProfileAndGenes(String profileId, List<String> genes);
     List<GenePanel> getGenePanelByStableId(String panelId);
     List<GenePanel> getGenePanels();
 }

--- a/service/src/main/java/org/cbioportal/service/impl/GenePanelServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenePanelServiceImpl.java
@@ -11,9 +11,12 @@ package org.cbioportal.service.impl;
  */
 
 import org.cbioportal.model.GenePanel;
+import org.cbioportal.model.Gene;
+import org.cbioportal.model.GenePanelWithSamples;
 import org.cbioportal.persistence.GenePanelRepository;
 import org.cbioportal.service.GenePanelService;
 import java.util.List;
+import java.util.ArrayList;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -24,8 +27,19 @@ public class GenePanelServiceImpl implements GenePanelService {
     private GenePanelRepository genePanelRepository;
 
     @Override
-    public String getGenePanelBySampleIdAndProfileId(String sampleId, String profileId) {
-        return genePanelRepository.getGenePanelBySampleIdAndProfileId(sampleId, profileId);
+    public List<GenePanelWithSamples> getGenePanelDataByProfileAndGenes(String profileId, List<String> submittedGenes) {
+        List<GenePanelWithSamples> genePanels =  genePanelRepository.getGenePanelsByProfile(profileId);
+        for (GenePanelWithSamples genePanel : genePanels) {
+            List<Gene> genes = genePanel.getGenes();
+            List<Gene> genesToSet = new ArrayList<>();
+            for (Gene gene : genes) {
+                if (submittedGenes.contains(gene.getHugoGeneSymbol())) {
+                    genesToSet.add(gene);
+                }                
+            }
+            genePanel.setGenes(genesToSet);
+        }
+        return genePanels;
     }
     
     @Override

--- a/service/src/test/java/org/cbioportal/service/impl/GenePanelServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenePanelServiceImplTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.cbioportal.service.impl;
+
+import org.cbioportal.model.GenePanel;
+import org.cbioportal.model.Gene;
+import org.cbioportal.model.GenePanelWithSamples;
+import org.cbioportal.persistence.GenePanelRepository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+
+/**
+ *
+ * @author heinsz
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class GenePanelServiceImplTest {
+    
+    @InjectMocks
+    private GenePanelServiceImpl genePanelService;
+
+    @Mock
+    private GenePanelRepository genePanelRepository;
+    
+    private GenePanel genePanel1;
+    private GenePanel genePanel2;
+    private Gene egfr;
+    private Gene braf;
+    private Gene akt1;
+    
+    @Test
+    public void getGenePanelDataByProfileAndGenes() throws Exception {
+        genePanel1 = new GenePanel();
+        genePanel1.setStableId("GENEPANEL2");
+        genePanel1.setDescription("2 genes tested");
+        genePanel1.setInternalId(1);
+
+        genePanel2 = new GenePanel();
+        genePanel2.setStableId("GENEPANEL3");
+        genePanel2.setDescription("3 genes tested");
+        genePanel2.setInternalId(2);
+
+        List<Gene> genes = new ArrayList<>();
+        braf  = new Gene();
+        braf.setEntrezGeneId(673);
+        braf.setHugoGeneSymbol("BRAF");
+        braf.setType("protein-coding");
+        braf.setCytoband("7q34");
+        braf.setLength(4564);
+        egfr = new Gene();
+        egfr.setEntrezGeneId(1956);
+        egfr.setHugoGeneSymbol("EGFR");
+        egfr.setType("protein-coding");
+        egfr.setCytoband("7p12");
+        egfr.setLength(12961);
+        akt1 = new Gene();
+        akt1.setEntrezGeneId(207);
+        akt1.setHugoGeneSymbol("AKT1");
+        akt1.setType("protein-coding");
+        akt1.setCytoband("12q32.32");
+        akt1.setLength(10838);
+        genes.add(braf);
+        genes.add(egfr);
+        genes.add(akt1);
+
+        genePanel1.setGenes(genes);
+        
+        List<String> queryGenes = new ArrayList<>();
+        queryGenes.add("BRAF");
+        queryGenes.add("EGFR");
+        
+        List<GenePanelWithSamples> repositoryResponse = new ArrayList<>();
+        GenePanelWithSamples genePanelWithSamples = new GenePanelWithSamples();
+        genePanelWithSamples.setGenes(genes);
+        repositoryResponse.add(genePanelWithSamples);
+        
+        Mockito.when(genePanelRepository.getGenePanelsByProfile("PROFILE1")).thenReturn(repositoryResponse);
+        List<GenePanelWithSamples> serviceResponse = genePanelService.getGenePanelDataByProfileAndGenes("PROFILE1", queryGenes);
+        Assert.assertTrue(serviceResponse.get(0).getGenes().size() == 2);
+    }
+}

--- a/web/src/main/java/org/cbioportal/weblegacy/GenePanelController.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/GenePanelController.java
@@ -35,8 +35,10 @@ package org.cbioportal.weblegacy;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.GenePanel;
+import org.cbioportal.model.GenePanelWithSamples;
 import org.cbioportal.service.GenePanelService;
 import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
@@ -69,15 +71,15 @@ public class GenePanelController {
         }
     }
 
-    @ApiOperation(value = "Get gene panel information for a sample profile pair",
+    @ApiOperation(value = "Get gene panel information for a profile and set of genes. Will return a mapping of samples and genes from the query that are in profile",
             nickname = "getGenePanelData",
             notes = "")
     @Transactional
     @RequestMapping(method = RequestMethod.GET, value = "/genepanel/data",  produces="application/json")
-    public String getGenePanelData(@ApiParam(required = true, value = "sample id, such as those returned by /api/samples")
-            @RequestParam(required = true) String sample_id,
-            @ApiParam(required = true, value = "genetic profile id, such as those returned by /api/geneticprofiles")
-            @RequestParam(required = true) String profile_id) {
-        return genePanelService.getGenePanelBySampleIdAndProfileId(sample_id, profile_id);
+    public List<GenePanelWithSamples> getGenePanelData(@ApiParam(required = true, value = "genetic profile id, such as those returned by /api/geneticprofiles")
+            @RequestParam(required = true) String profile_id,
+            @ApiParam(required = true, value = "List of gene hugo symbols")
+            @RequestParam(required = true) List<String> genes) {
+        return genePanelService.getGenePanelDataByProfileAndGenes(profile_id, genes);
     }
 }


### PR DESCRIPTION
# What? Why?
Adds functionality to the gene panel api for the oncoprint.

Changes proposed in this pull request:
- Gene panel api can be queried with a profile and list of genes
- Returns sample that have gene panel data and the genes from the genes queried which are part of that panel.
- If no data provided for sample that is in a profile queried, it should be assumed that whole exome was done for that genetic profile.

Behavior:

- Endpoint is `genepanel/data`
- Takes a genomic profile and a gene list
- Returns a list of gene panels, each of which contains the genes from the query which are in the gene panel and the samples to which the gene panel applies
- If no gene panels exist for the profile queried, empty list returned.
- If some samples in the profile have no gene panel data associated with them (the sample is not in one of the sample lists inside the gene panel response objects) they are assumed to be whole exome.
- Example query: api-legacy/genepanel/data?profile_id=<PROFILE_STABLE_ID>&genes=TP53,AKT1,...

-Example output:
`[
  {
    "internalId": null,
    "stableId": "IMPACT341",
    "description": "Targeted (341 cancer genes) sequencing of various tumor types via MSK-IMPACT on Illumina HiSeq sequencers.",
    "genes": [
      {
        "entrezGeneId": null,
        "hugoGeneSymbol": "TP53",
        "type": null,
        "cytoband": null,
        "length": null,
        "aliases": null,
        "chromosome": null
      },
      {
        "entrezGeneId": null,
        "hugoGeneSymbol": "AKT1",
        "type": null,
        "cytoband": null,
        "length": null,
        "aliases": null,
        "chromosome": null
      }
    ],
    "samples": [
      "SampleId1",
      "SampleId2",
      "SampleId3"
    ]
  }
]`

@adamabeshouse does this sound ok to you?

# Checks
- [ ] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@adamabeshouse @sheridancbio 