### PR TITLE
DB schema version fixes

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoInfo.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoInfo.java
@@ -54,6 +54,7 @@ public class DaoInfo {
             rs = pstmt.executeQuery();
             if (rs.next()) {
                 version = rs.getString("DB_SCHEMA_VERSION");
+                System.out.println("Found DB schema version: " + version);
             }
         } catch (SQLException e) {
             e.printStackTrace();
@@ -68,6 +69,7 @@ public class DaoInfo {
 
     public static boolean checkVersion() {
         setVersion();
+        System.out.println("Expected DB schema version: " + GlobalProperties.getDbVersion());
         if (GlobalProperties.getDbVersion().equals(getVersion())) {
             return true;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <tomcat.catalina.scope>provided</tomcat.catalina.scope>
 
     <!-- THIS SHOULD BE KEPT IN SYNC TO VERSION IN CGDS.SQL -->
-    <db.version>1.2.1</db.version>
+    <db.version>1.2.2</db.version>
 
   </properties>
 


### PR DESCRIPTION
# What? Why?
The PR #1618 changed `migration.sql` but forgot to update pom.xml `db.version`. Here we fix this and also add some extra info to the console that helps troubleshooting db schema version mismatches. 

Changes proposed in this pull request:
- correct db schema version in pom.xml
- better reporting on what the schema version check found (specially useful when running data loading from the command line)


# Notify reviewers
@zheins @sheridancbio 