### PR TITLE
Added updating statistics after mutation import 

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
@@ -124,7 +124,24 @@ public final class DaoMutation {
         return 1;
     }
 
+    public static void updateStatistics () throws DaoException {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try {
+            con = JdbcUtil.getDbConnection(DaoMutation.class);
+            pstmt = con.prepareStatement(
+                "ANALYZE TABLE mutation;");
+            pstmt.execute();
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        } finally {
+            JdbcUtil.closeAll(DaoMutation.class, con, pstmt, rs);
+        }
+    }
+
     public static int calculateMutationCount (int profileId) throws DaoException {
+        updateStatistics();
         Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;


### PR DESCRIPTION
replaces #1229 
Table mutation can get pretty big and without statistics update I often see queries that use it take more than 30 seconds. Running ANALYZE TABLE fixes it.
