### PR TITLE
Make {portal,log4j}.properties.EXAMPLE default fallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,13 +69,6 @@ script:
             mkdir -p ~/.m2 && \
             cp .travis/settings.xml ~/.m2
         fi
-    # use EXAMPLE properties files
-    - |
-        if [[ "${TEST}" == core || "${TEST}" == end-to-end ]]
-        then
-            cp $PORTAL_HOME/src/main/resources/portal.properties.EXAMPLE $PORTAL_HOME/src/main/resources/portal.properties && \
-            cp $PORTAL_HOME/src/main/resources/log4j.properties.EXAMPLE $PORTAL_HOME/src/main/resources/log4j.properties
-        fi
     # make sure mysql container is running
     - |
         if [[ "${TEST}" == core ]]

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,68 @@
       <properties>
         <importer-main-class>org.mskcc.cbio.importer.Admin</importer-main-class>
       </properties>
+    <build>
+    <plugins>
+          <!-- copy portal.properties.EXAMPLE and log4j.properties.EXAMPLE if they don't exist -->
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.8</version>
+            <!-- only needs to be executed for parent pom -->
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <phase>validate</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <taskdef resource="net/sf/antcontrib/antlib.xml" classpathref="maven.dependency.classpath" />
+                    <if>
+                      <not>
+                        <available file="${basedir}/src/main/resources/portal.properties" />
+                      </not>
+                      <then>
+                        <copy
+                          file="${basedir}/src/main/resources/portal.properties.EXAMPLE"
+                          tofile="${basedir}/src/main/resources/portal.properties" />
+                      </then>
+                    </if>
+                    <if>
+                      <not>
+                        <available file="${basedir}/src/main/resources/log4j.properties" />
+                      </not>
+                      <then>
+                        <copy
+                          file="${basedir}/src/main/resources/log4j.properties.EXAMPLE"
+                          tofile="${basedir}/src/main/resources/log4j.properties" />
+                      </then>
+                    </if>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                <groupId>ant-contrib</groupId>
+                <artifactId>ant-contrib</artifactId>
+                <version>1.0b3</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>ant</groupId>
+                        <artifactId>ant</artifactId>
+                    </exclusion>
+                </exclusions>
+              </dependency>
+              <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant-nodeps</artifactId>
+                <version>1.8.1</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+    </plugins>
+    </build>
     </profile>
     <profile>
       <id>external</id>
@@ -79,30 +141,6 @@
               </execution>
             </executions>
           </plugin>
-          <!-- copy portal.properties.EXAMPLE and log4j.properties.EXAMPLE -->
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <!-- only needs to be executed for parent pom -->
-            <inherited>false</inherited>
-            <executions>
-              <execution>
-                <phase>validate</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <tasks>
-                    <copy
-                    file="${basedir}/src/main/resources/portal.properties.EXAMPLE"
-                    tofile="${basedir}/src/main/resources/portal.properties" />
-                    <copy
-                    file="${basedir}/src/main/resources/log4j.properties.EXAMPLE"
-                    tofile="${basedir}/src/main/resources/log4j.properties" />
-                  </tasks>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -131,9 +169,9 @@
 
     <final.war.name>cbioportal-${project.version}</final.war.name>
 
-	<db.test.driver>com.mysql.jdbc.Driver</db.test.driver>
+  <db.test.driver>com.mysql.jdbc.Driver</db.test.driver>
     <!-- For MySQL < 5.5 change 'default_storage_engine' to 'storage_engine' -->
-	<db.test.url>jdbc:mysql://127.0.0.1:3306/cgds_test?sessionVariables=default_storage_engine=InnoDB</db.test.url>
+  <db.test.url>jdbc:mysql://127.0.0.1:3306/cgds_test?sessionVariables=default_storage_engine=InnoDB</db.test.url>
     <db.test.username>cbio_user</db.test.username>
     <db.test.password>somepassword</db.test.password>
 


### PR DESCRIPTION
Copy the .EXAMPLE property files to their non-EXAMPLE postfixed counterparts (log4j.properties and portal.properties) if they don't exist.

This change allows one to serve the artifacts through [jitpack](https://jitpack.io/) (jitpack runs with default profile), thereby solving #873. See an example with @morungos war overlays here: https://github.com/pughlab/cbioportal-octane-overlay/pull/1/files. 

It also simplifies Travis & heroku specific build process.

Another option would have been to update all references to `portal.properties` to refer to `portal.properties.EXAMPLE` if it did not exist, but this seemed easier.

Also as @pieterlukasse pointed out you can get the artifacts like this (the scripts jar in this case):
https://jitpack.io/com/github/inodb/cbioportal/scripts/v1.3.0-test-jitpack/scripts-v1.3.0-test-jitpack.jar

or using mvn

```
# this points to the latest version of my branch use-env-vars and gets the war artifact
mvn dependency:get -DremoteRepositories=https://jitpack.io -Dartifact=com.github.inodb.cbioportal:cbioportal:use-env-vars-SNAPSHOT:war -Ddest=cbioportal.war
```
 or you can specify it as a dependency in your pom file, as shown in the mvn overlay example further up ☝️ .

## Reviewers
@cBioPortal/devops @n1zea144 @jjgao @pieterlukasse @angelicaochoa 