### PR TITLE
correct comment syntax in mysql scripts

### DIFF
--- a/core/src/main/resources/db/cgds.sql
+++ b/core/src/main/resources/db/cgds.sql
@@ -25,7 +25,7 @@
 --
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
--------------------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
 --
 -- Database: `cgds`
 --

--- a/core/src/main/resources/db/migration.sql
+++ b/core/src/main/resources/db/migration.sql
@@ -25,7 +25,7 @@
 --
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
--------------------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
 ##version: 1.0.0
 CREATE TABLE info (DB_SCHEMA_VERSION VARCHAR(8));
 INSERT INTO info VALUES ("1.0.0");


### PR DESCRIPTION
cgds.sql and migration.sql have incorrect comment format for two lines

issue: #1821

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@cBioPortal/backend
