### PR TITLE
Implemented 5 endpoints in Cancer Type API and Genetic Profile API

### DIFF
--- a/business/src/main/java/org/mskcc/cbio/portal/persistence/GeneticProfileMapperLegacy.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/persistence/GeneticProfileMapperLegacy.java
@@ -12,7 +12,7 @@ import org.mskcc.cbio.portal.model.DBGeneticProfile;
  *
  * @author abeshoua
  */
-public interface GeneticProfileMapper {
+public interface GeneticProfileMapperLegacy {
     List<DBGeneticProfile> getGeneticProfiles(@Param("genetic_profile_ids") List<String> genetic_profile_ids);
     List<DBGeneticProfile> getGeneticProfilesByStudy(@Param("study_id") String study_id);
     List<DBGeneticProfile> getAllGeneticProfiles();

--- a/business/src/main/java/org/mskcc/cbio/portal/service/ApiService.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/service/ApiService.java
@@ -36,7 +36,7 @@ import org.mskcc.cbio.portal.persistence.ClinicalDataMapperLegacy;
 import org.mskcc.cbio.portal.persistence.ClinicalFieldMapper;
 import org.mskcc.cbio.portal.persistence.GeneAliasMapper;
 import org.mskcc.cbio.portal.persistence.GeneMapperLegacy;
-import org.mskcc.cbio.portal.persistence.GeneticProfileMapper;
+import org.mskcc.cbio.portal.persistence.GeneticProfileMapperLegacy;
 import org.mskcc.cbio.portal.persistence.PatientMapperLegacy;
 import org.mskcc.cbio.portal.persistence.ProfileDataMapper;
 import org.mskcc.cbio.portal.persistence.SampleListMapper;
@@ -67,7 +67,7 @@ public class ApiService {
 	@Autowired
 	private GeneAliasMapper geneAliasMapper;
 	@Autowired
-	private GeneticProfileMapper geneticProfileMapper;
+	private GeneticProfileMapperLegacy geneticProfileMapperLegacy;
 	@Autowired
 	private SampleListMapper sampleListMapper;
 	@Autowired
@@ -348,17 +348,17 @@ public class ApiService {
 	
 	@Transactional
 	public List<DBGeneticProfile> getGeneticProfiles() {
-		return geneticProfileMapper.getAllGeneticProfiles();
+		return geneticProfileMapperLegacy.getAllGeneticProfiles();
 	}
 
 	@Transactional
 	public List<DBGeneticProfile> getGeneticProfiles(String study_id) {
-		return geneticProfileMapper.getGeneticProfilesByStudy(study_id);
+		return geneticProfileMapperLegacy.getGeneticProfilesByStudy(study_id);
 	}
 
 	@Transactional
 	public List<DBGeneticProfile> getGeneticProfiles(List<String> genetic_profile_ids) {
-		return geneticProfileMapper.getGeneticProfiles(genetic_profile_ids);
+		return geneticProfileMapperLegacy.getGeneticProfiles(genetic_profile_ids);
 	}
 
 	@Transactional

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/GeneticProfileMapperLegacy.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/GeneticProfileMapperLegacy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="org.mskcc.cbio.portal.persistence.GeneticProfileMapper">
+<mapper namespace="org.mskcc.cbio.portal.persistence.GeneticProfileMapperLegacy">
 
 <resultMap id="GeneticProfileResult" type="DBGeneticProfile">
     <id property="internal_id" column="GENETIC_PROFILE_ID"/>

--- a/model/src/main/java/org/cbioportal/model/CancerStudy.java
+++ b/model/src/main/java/org/cbioportal/model/CancerStudy.java
@@ -8,6 +8,7 @@ import java.util.Date;
 public class CancerStudy extends CancerStudySummary {
 
     private TypeOfCancer typeOfCancer;
+    private Integer sampleCount;
 
     public TypeOfCancer getTypeOfCancer() {
         return typeOfCancer;
@@ -15,5 +16,13 @@ public class CancerStudy extends CancerStudySummary {
 
     public void setTypeOfCancer(TypeOfCancer typeOfCancer) {
         this.typeOfCancer = typeOfCancer;
+    }
+
+    public Integer getSampleCount() {
+        return sampleCount;
+    }
+
+    public void setSampleCount(Integer sampleCount) {
+        this.sampleCount = sampleCount;
     }
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CancerTypeRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CancerTypeRepository.java
@@ -1,0 +1,16 @@
+package org.cbioportal.persistence;
+
+import org.cbioportal.model.TypeOfCancer;
+import org.cbioportal.model.meta.BaseMeta;
+
+import java.util.List;
+
+public interface CancerTypeRepository {
+
+    List<TypeOfCancer> getAllCancerTypes(String projection, Integer pageSize, Integer pageNumber, String sortBy,
+                                         String direction);
+
+    BaseMeta getMetaCancerTypes();
+
+    TypeOfCancer getCancerType(String cancerTypeId);
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GeneticProfileRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GeneticProfileRepository.java
@@ -1,0 +1,21 @@
+package org.cbioportal.persistence;
+
+import org.cbioportal.model.GeneticProfile;
+import org.cbioportal.model.meta.BaseMeta;
+
+import java.util.List;
+
+public interface GeneticProfileRepository {
+
+    List<GeneticProfile> getAllGeneticProfiles(String projection, Integer pageSize, Integer pageNumber, String sortBy,
+                                               String direction);
+
+    BaseMeta getMetaGeneticProfiles();
+
+    GeneticProfile getGeneticProfile(String geneticProfileId);
+
+    List<GeneticProfile> getAllGeneticProfilesInStudy(String studyId, String projection, Integer pageSize,
+                                                      Integer pageNumber, String sortBy, String direction);
+
+    BaseMeta getMetaGeneticProfilesInStudy(String studyId);
+}

--- a/persistence/persistence-mybatis-test/src/test/java/org/cbioportal/persistence/mybatis/CancerTypeMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis-test/src/test/java/org/cbioportal/persistence/mybatis/CancerTypeMyBatisRepositoryTest.java
@@ -1,0 +1,111 @@
+package org.cbioportal.persistence.mybatis;
+
+import org.cbioportal.model.TypeOfCancer;
+import org.cbioportal.model.meta.BaseMeta;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/testContextDatabase.xml")
+@Configurable
+public class CancerTypeMyBatisRepositoryTest {
+
+    @Autowired
+    private CancerTypeMyBatisRepository cancerTypeMyBatisRepository;
+
+    @Test
+    public void getAllCancerTypesIdProjection() throws Exception {
+
+        List<TypeOfCancer> result = cancerTypeMyBatisRepository.getAllCancerTypes("ID", null, null, null, null);
+
+        Assert.assertEquals(2, result.size());
+        TypeOfCancer typeOfCancer = result.get(0);
+        Assert.assertEquals("acc", typeOfCancer.getTypeOfCancerId());
+    }
+
+    @Test
+    public void getAllCancerTypesSummaryProjection() throws Exception {
+
+        List<TypeOfCancer> result = cancerTypeMyBatisRepository.getAllCancerTypes("SUMMARY", null, null, null, null);
+
+        Assert.assertEquals(2, result.size());
+        TypeOfCancer typeOfCancer = result.get(0);
+        Assert.assertEquals("brca", typeOfCancer.getTypeOfCancerId());
+        Assert.assertEquals("Breast Invasive Carcinoma", typeOfCancer.getName());
+        Assert.assertEquals("breast,breast invasive", typeOfCancer.getClinicalTrialKeywords());
+        Assert.assertEquals("HotPink", typeOfCancer.getDedicatedColor());
+        Assert.assertEquals("Breast", typeOfCancer.getShortName());
+        Assert.assertEquals("tissue", typeOfCancer.getParent());
+    }
+
+    @Test
+    public void getAllCancerTypesDetailedProjection() throws Exception {
+
+        List<TypeOfCancer> result = cancerTypeMyBatisRepository.getAllCancerTypes("DETAILED", null, null, null, null);
+
+        Assert.assertEquals(2, result.size());
+        TypeOfCancer typeOfCancer = result.get(0);
+        Assert.assertEquals("brca", typeOfCancer.getTypeOfCancerId());
+        Assert.assertEquals("Breast Invasive Carcinoma", typeOfCancer.getName());
+        Assert.assertEquals("breast,breast invasive", typeOfCancer.getClinicalTrialKeywords());
+        Assert.assertEquals("HotPink", typeOfCancer.getDedicatedColor());
+        Assert.assertEquals("Breast", typeOfCancer.getShortName());
+        Assert.assertEquals("tissue", typeOfCancer.getParent());
+    }
+
+    @Test
+    public void getAllCancerTypesSummaryProjection1PageSize() throws Exception {
+
+        List<TypeOfCancer> result = cancerTypeMyBatisRepository.getAllCancerTypes("SUMMARY", 1, 0, null, null);
+
+        Assert.assertEquals(1, result.size());
+    }
+
+    @Test
+    public void getAllCancerTypesSummaryProjectionNameSort() throws Exception {
+
+        List<TypeOfCancer> result = cancerTypeMyBatisRepository.getAllCancerTypes("SUMMARY", null, null, "name", "ASC");
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("Adrenocortical Carcinoma", result.get(0).getName());
+        Assert.assertEquals("Breast Invasive Carcinoma", result.get(1).getName());
+    }
+
+    @Test
+    public void getMetaCancerTypes() throws Exception {
+
+        BaseMeta result = cancerTypeMyBatisRepository.getMetaCancerTypes();
+
+        Assert.assertEquals((Integer)2, result.getTotalCount());
+    }
+
+    @Test
+    public void getCancerTypeNullResult() throws Exception {
+
+        TypeOfCancer result = cancerTypeMyBatisRepository.getCancerType("invalid_cancer_type");
+
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void getCancerType() throws Exception {
+
+        TypeOfCancer result = cancerTypeMyBatisRepository.getCancerType("acc");
+
+        Assert.assertEquals("acc", result.getTypeOfCancerId());
+        Assert.assertEquals("Adrenocortical Carcinoma", result.getName());
+        Assert.assertEquals("adrenocortical carcinoma", result.getClinicalTrialKeywords());
+        Assert.assertEquals("Purple", result.getDedicatedColor());
+        Assert.assertEquals("ACC", result.getShortName());
+        Assert.assertEquals("adrenal_gland", result.getParent());
+    }
+}

--- a/persistence/persistence-mybatis-test/src/test/java/org/cbioportal/persistence/mybatis/GeneticProfileMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis-test/src/test/java/org/cbioportal/persistence/mybatis/GeneticProfileMyBatisRepositoryTest.java
@@ -1,0 +1,196 @@
+package org.cbioportal.persistence.mybatis;
+
+import org.cbioportal.model.CancerStudy;
+import org.cbioportal.model.GeneticProfile;
+import org.cbioportal.model.meta.BaseMeta;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/testContextDatabase.xml")
+@Configurable
+public class GeneticProfileMyBatisRepositoryTest {
+
+    @Autowired
+    private GeneticProfileMyBatisRepository geneticProfileMyBatisRepository;
+
+    @Test
+    public void getAllGeneticProfilesIdProjection() throws Exception {
+
+        List<GeneticProfile> result = geneticProfileMyBatisRepository.getAllGeneticProfiles("ID", null, null, null,
+                null);
+
+        Assert.assertEquals(6, result.size());
+        GeneticProfile geneticProfile = result.get(0);
+        Assert.assertEquals((Integer) 2, geneticProfile.getGeneticProfileId());
+        Assert.assertEquals("study_tcga_pub_gistic", geneticProfile.getStableId());
+        Assert.assertNull(geneticProfile.getCancerStudy());
+    }
+
+    @Test
+    public void getAllGeneticProfilesSummaryProjection() throws Exception {
+
+        List<GeneticProfile> result = geneticProfileMyBatisRepository.getAllGeneticProfiles("SUMMARY", null, null, null,
+                null);
+
+        Assert.assertEquals(6, result.size());
+        GeneticProfile geneticProfile = result.get(0);
+        Assert.assertEquals((Integer) 2, geneticProfile.getGeneticProfileId());
+        Assert.assertEquals("study_tcga_pub_gistic", geneticProfile.getStableId());
+        Assert.assertEquals((Integer) 1, geneticProfile.getCancerStudyId());
+        Assert.assertEquals("study_tcga_pub", geneticProfile.getCancerStudyIdentifier());
+        Assert.assertEquals("COPY_NUMBER_ALTERATION", geneticProfile.getGeneticAlterationType());
+        Assert.assertEquals("DISCRETE", geneticProfile.getDatatype());
+        Assert.assertEquals("Putative copy-number alterations from GISTIC", geneticProfile.getName());
+        Assert.assertEquals("Putative copy-number from GISTIC 2.0. Values: -2 = homozygous deletion; -1 = hemizygous " +
+                "deletion; 0 = neutral / no change; 1 = gain; 2 = high level amplification.",
+                geneticProfile.getDescription());
+        Assert.assertEquals(true, geneticProfile.getShowProfileInAnalysisTab());
+        Assert.assertNull(geneticProfile.getCancerStudy());
+    }
+
+    @Test
+    public void getAllGeneticProfilesDetailedProjection() throws Exception {
+
+        List<GeneticProfile> result = geneticProfileMyBatisRepository.getAllGeneticProfiles("DETAILED", null, null,
+                null, null);
+
+        Assert.assertEquals(6, result.size());
+        GeneticProfile geneticProfile = result.get(0);
+        Assert.assertEquals((Integer) 2, geneticProfile.getGeneticProfileId());
+        Assert.assertEquals("study_tcga_pub_gistic", geneticProfile.getStableId());
+        Assert.assertEquals((Integer) 1, geneticProfile.getCancerStudyId());
+        Assert.assertEquals("study_tcga_pub", geneticProfile.getCancerStudyIdentifier());
+        Assert.assertEquals("COPY_NUMBER_ALTERATION", geneticProfile.getGeneticAlterationType());
+        Assert.assertEquals("DISCRETE", geneticProfile.getDatatype());
+        Assert.assertEquals("Putative copy-number alterations from GISTIC", geneticProfile.getName());
+        Assert.assertEquals("Putative copy-number from GISTIC 2.0. Values: -2 = homozygous deletion; -1 = hemizygous " +
+                        "deletion; 0 = neutral / no change; 1 = gain; 2 = high level amplification.",
+                geneticProfile.getDescription());
+        Assert.assertEquals(true, geneticProfile.getShowProfileInAnalysisTab());
+        CancerStudy cancerStudy = geneticProfile.getCancerStudy();
+        Assert.assertEquals((Integer) 1, cancerStudy.getCancerStudyId());
+        Assert.assertEquals("study_tcga_pub", cancerStudy.getCancerStudyIdentifier());
+        Assert.assertEquals("brca", cancerStudy.getTypeOfCancerId());
+        Assert.assertEquals("Breast Invasive Carcinoma (TCGA, Nature 2012)", cancerStudy.getName());
+        Assert.assertEquals("BRCA (TCGA)", cancerStudy.getShortName());
+        Assert.assertEquals("<a href=\\\"http://cancergenome.nih.gov/\\\">The Cancer Genome Atlas (TCGA)</a> Breast" +
+                " Invasive Carcinoma project. 825 cases.<br><i>Nature 2012.</i> <a href=\\\"http://tcga-data.nci." +
+                "nih.gov/tcga/\\\">Raw data via the TCGA Data Portal</a>.", cancerStudy.getDescription());
+        Assert.assertEquals(true, cancerStudy.getPublicStudy());
+        Assert.assertEquals("23000897", cancerStudy.getPmid());
+        Assert.assertEquals("TCGA, Nature 2012", cancerStudy.getCitation());
+        Assert.assertEquals("SU2C-PI3K;PUBLIC;GDAC", cancerStudy.getGroups());
+        Assert.assertEquals((Integer)0 , cancerStudy.getStatus());
+    }
+
+    @Test
+    public void getAllGeneticProfilesSummaryProjection1PageSize() throws Exception {
+
+        List<GeneticProfile> result = geneticProfileMyBatisRepository.getAllGeneticProfiles("SUMMARY", 1, 0, null, null);
+
+        Assert.assertEquals(1, result.size());
+    }
+
+    @Test
+    public void getAllGeneticProfilesSummaryProjectionStableIdSort() throws Exception {
+
+        List<GeneticProfile> result = geneticProfileMyBatisRepository.getAllGeneticProfiles("SUMMARY", null, null,
+                "stableId", "ASC");
+
+        Assert.assertEquals(6, result.size());
+        Assert.assertEquals("study_tcga_pub_gistic", result.get(0).getStableId());
+        Assert.assertEquals("study_tcga_pub_log2CNA", result.get(1).getStableId());
+        Assert.assertEquals("study_tcga_pub_methylation_hm27", result.get(2).getStableId());
+        Assert.assertEquals("study_tcga_pub_mrna", result.get(3).getStableId());
+        Assert.assertEquals("study_tcga_pub_mutations", result.get(4).getStableId());
+        Assert.assertEquals("study_tcga_pub_sv", result.get(5).getStableId());
+    }
+
+    @Test
+    public void getMetaGeneticProfiles() throws Exception {
+
+        BaseMeta result = geneticProfileMyBatisRepository.getMetaGeneticProfiles();
+
+        Assert.assertEquals((Integer) 6, result.getTotalCount());
+    }
+
+    @Test
+    public void getGeneticProfileNullResult() throws Exception {
+
+        GeneticProfile result = geneticProfileMyBatisRepository.getGeneticProfile("invalid_genetic_profile");
+
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void getGeneticProfile() throws Exception {
+
+        GeneticProfile geneticProfile = geneticProfileMyBatisRepository.getGeneticProfile("study_tcga_pub_gistic");
+
+        Assert.assertEquals((Integer) 2, geneticProfile.getGeneticProfileId());
+        Assert.assertEquals("study_tcga_pub_gistic", geneticProfile.getStableId());
+        Assert.assertEquals((Integer) 1, geneticProfile.getCancerStudyId());
+        Assert.assertEquals("study_tcga_pub", geneticProfile.getCancerStudyIdentifier());
+        Assert.assertEquals("COPY_NUMBER_ALTERATION", geneticProfile.getGeneticAlterationType());
+        Assert.assertEquals("DISCRETE", geneticProfile.getDatatype());
+        Assert.assertEquals("Putative copy-number alterations from GISTIC", geneticProfile.getName());
+        Assert.assertEquals("Putative copy-number from GISTIC 2.0. Values: -2 = homozygous deletion; -1 = hemizygous " +
+                        "deletion; 0 = neutral / no change; 1 = gain; 2 = high level amplification.",
+                geneticProfile.getDescription());
+        Assert.assertEquals(true, geneticProfile.getShowProfileInAnalysisTab());
+        CancerStudy cancerStudy = geneticProfile.getCancerStudy();
+        Assert.assertEquals((Integer) 1, cancerStudy.getCancerStudyId());
+        Assert.assertEquals("study_tcga_pub", cancerStudy.getCancerStudyIdentifier());
+        Assert.assertEquals("brca", cancerStudy.getTypeOfCancerId());
+        Assert.assertEquals("Breast Invasive Carcinoma (TCGA, Nature 2012)", cancerStudy.getName());
+        Assert.assertEquals("BRCA (TCGA)", cancerStudy.getShortName());
+        Assert.assertEquals("<a href=\\\"http://cancergenome.nih.gov/\\\">The Cancer Genome Atlas (TCGA)</a> Breast" +
+                " Invasive Carcinoma project. 825 cases.<br><i>Nature 2012.</i> <a href=\\\"http://tcga-data.nci." +
+                "nih.gov/tcga/\\\">Raw data via the TCGA Data Portal</a>.", cancerStudy.getDescription());
+        Assert.assertEquals(true, cancerStudy.getPublicStudy());
+        Assert.assertEquals("23000897", cancerStudy.getPmid());
+        Assert.assertEquals("TCGA, Nature 2012", cancerStudy.getCitation());
+        Assert.assertEquals("SU2C-PI3K;PUBLIC;GDAC", cancerStudy.getGroups());
+        Assert.assertEquals((Integer)0 , cancerStudy.getStatus());
+    }
+
+    @Test
+    public void getAllGeneticProfilesInStudySummaryProjection() throws Exception {
+
+        List<GeneticProfile> result = geneticProfileMyBatisRepository.getAllGeneticProfilesInStudy("study_tcga_pub",
+                "SUMMARY", null, null, null, null);
+
+        Assert.assertEquals(6, result.size());
+        GeneticProfile geneticProfile = result.get(0);
+        Assert.assertEquals((Integer) 2, geneticProfile.getGeneticProfileId());
+        Assert.assertEquals("study_tcga_pub_gistic", geneticProfile.getStableId());
+        Assert.assertEquals((Integer) 1, geneticProfile.getCancerStudyId());
+        Assert.assertEquals("study_tcga_pub", geneticProfile.getCancerStudyIdentifier());
+        Assert.assertEquals("COPY_NUMBER_ALTERATION", geneticProfile.getGeneticAlterationType());
+        Assert.assertEquals("DISCRETE", geneticProfile.getDatatype());
+        Assert.assertEquals("Putative copy-number alterations from GISTIC", geneticProfile.getName());
+        Assert.assertEquals("Putative copy-number from GISTIC 2.0. Values: -2 = homozygous deletion; -1 = hemizygous " +
+                        "deletion; 0 = neutral / no change; 1 = gain; 2 = high level amplification.",
+                geneticProfile.getDescription());
+        Assert.assertEquals(true, geneticProfile.getShowProfileInAnalysisTab());
+        Assert.assertNull(geneticProfile.getCancerStudy());
+    }
+
+    @Test
+    public void getMetaGeneticProfilesInStudy() throws Exception {
+
+        BaseMeta result = geneticProfileMyBatisRepository.getMetaGeneticProfilesInStudy("study_tcga_pub");
+
+        Assert.assertEquals((Integer) 6, result.getTotalCount());
+    }
+}

--- a/persistence/persistence-mybatis-test/src/test/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis-test/src/test/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepositoryTest.java
@@ -60,7 +60,7 @@ public class StudyMyBatisRepositoryTest {
         Assert.assertEquals("23000897", cancerStudy.getPmid());
         Assert.assertEquals("TCGA, Nature 2012", cancerStudy.getCitation());
         Assert.assertEquals("SU2C-PI3K;PUBLIC;GDAC", cancerStudy.getGroups());
-        Assert.assertEquals((Integer)0 , cancerStudy.getStatus());
+        Assert.assertEquals((Integer) 0 , cancerStudy.getStatus());
         Assert.assertEquals(simpleDateFormat.parse("2011-12-18 13:17:17"), cancerStudy.getImportDate());
         Assert.assertNull(cancerStudy.getTypeOfCancer());
     }
@@ -87,7 +87,7 @@ public class StudyMyBatisRepositoryTest {
         Assert.assertEquals("23000897", cancerStudy.getPmid());
         Assert.assertEquals("TCGA, Nature 2012", cancerStudy.getCitation());
         Assert.assertEquals("SU2C-PI3K;PUBLIC;GDAC", cancerStudy.getGroups());
-        Assert.assertEquals((Integer)0 , cancerStudy.getStatus());
+        Assert.assertEquals((Integer) 0 , cancerStudy.getStatus());
         Assert.assertEquals(simpleDateFormat.parse("2011-12-18 13:17:17"), cancerStudy.getImportDate());
         TypeOfCancer typeOfCancer = cancerStudy.getTypeOfCancer();
         Assert.assertEquals("brca", typeOfCancer.getTypeOfCancerId());
@@ -122,7 +122,7 @@ public class StudyMyBatisRepositoryTest {
 
         BaseMeta result = studyMyBatisRepository.getMetaStudies();
 
-        Assert.assertEquals((Integer)2, result.getTotalCount());
+        Assert.assertEquals((Integer) 2, result.getTotalCount());
     }
 
     @Test
@@ -153,7 +153,7 @@ public class StudyMyBatisRepositoryTest {
         Assert.assertEquals("23000897", result.getPmid());
         Assert.assertEquals("TCGA, Nature 2012", result.getCitation());
         Assert.assertEquals("SU2C-PI3K;PUBLIC;GDAC", result.getGroups());
-        Assert.assertEquals((Integer)0 , result.getStatus());
+        Assert.assertEquals((Integer) 0 , result.getStatus());
         Assert.assertEquals(simpleDateFormat.parse("2011-12-18 13:17:17"), result.getImportDate());
         TypeOfCancer typeOfCancer = result.getTypeOfCancer();
         Assert.assertEquals("brca", typeOfCancer.getTypeOfCancerId());

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/CancerTypeMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/CancerTypeMapper.java
@@ -1,4 +1,21 @@
 package org.cbioportal.persistence.mybatis;
 
+import org.apache.ibatis.annotations.Param;
+import org.cbioportal.model.TypeOfCancer;
+import org.cbioportal.model.meta.BaseMeta;
+
+import java.util.List;
+
 public interface CancerTypeMapper {
+
+    List<TypeOfCancer> getAllCancerTypes(@Param("projection") String projection,
+                                         @Param("limit") Integer limit,
+                                         @Param("offset") Integer offset,
+                                         @Param("sortBy") String sortBy,
+                                         @Param("direction") String direction);
+
+    BaseMeta getMetaCancerTypes();
+
+    TypeOfCancer getCancerType(@Param("cancerTypeId") String cancerTypeId,
+                               @Param("projection") String projection);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/CancerTypeMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/CancerTypeMyBatisRepository.java
@@ -1,0 +1,38 @@
+package org.cbioportal.persistence.mybatis;
+
+import org.cbioportal.model.TypeOfCancer;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.persistence.CancerTypeRepository;
+import org.cbioportal.persistence.mybatis.tool.Constants;
+import org.cbioportal.persistence.mybatis.tool.OffsetCalculator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class CancerTypeMyBatisRepository implements CancerTypeRepository {
+
+    @Autowired
+    private CancerTypeMapper cancerTypeMapper;
+    @Autowired
+    private OffsetCalculator offsetCalculator;
+
+    @Override
+    public List<TypeOfCancer> getAllCancerTypes(String projection, Integer pageSize, Integer pageNumber, String sortBy,
+                                                String direction) {
+
+        return cancerTypeMapper.getAllCancerTypes(projection, pageSize,
+                offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction);
+    }
+
+    @Override
+    public BaseMeta getMetaCancerTypes() {
+        return cancerTypeMapper.getMetaCancerTypes();
+    }
+
+    @Override
+    public TypeOfCancer getCancerType(String cancerTypeId) {
+        return cancerTypeMapper.getCancerType(cancerTypeId, Constants.DETAILED_PROJECTION);
+    }
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticProfileMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticProfileMapper.java
@@ -1,0 +1,22 @@
+package org.cbioportal.persistence.mybatis;
+
+import org.apache.ibatis.annotations.Param;
+import org.cbioportal.model.GeneticProfile;
+import org.cbioportal.model.meta.BaseMeta;
+
+import java.util.List;
+
+public interface GeneticProfileMapper {
+
+    List<GeneticProfile> getAllGeneticProfiles(@Param("studyId") String studyId,
+                                               @Param("projection") String projection,
+                                               @Param("limit") Integer limit,
+                                               @Param("offset") Integer offset,
+                                               @Param("sortBy") String sortBy,
+                                               @Param("direction") String direction);
+
+    BaseMeta getMetaGeneticProfiles(@Param("studyId") String studyId);
+
+    GeneticProfile getGeneticProfile(@Param("geneticProfileId") String geneticProfileId,
+                                     @Param("projection") String projection);
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticProfileMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticProfileMyBatisRepository.java
@@ -1,0 +1,53 @@
+package org.cbioportal.persistence.mybatis;
+
+import org.cbioportal.model.GeneticProfile;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.persistence.GeneticProfileRepository;
+import org.cbioportal.persistence.mybatis.tool.Constants;
+import org.cbioportal.persistence.mybatis.tool.OffsetCalculator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class GeneticProfileMyBatisRepository implements GeneticProfileRepository {
+
+    @Autowired
+    private GeneticProfileMapper geneticProfileMapper;
+    @Autowired
+    private OffsetCalculator offsetCalculator;
+
+    @Override
+    public List<GeneticProfile> getAllGeneticProfiles(String projection, Integer pageSize, Integer pageNumber,
+                                                      String sortBy, String direction) {
+
+        return geneticProfileMapper.getAllGeneticProfiles(null, projection, pageSize,
+                offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction);
+    }
+
+    @Override
+    public BaseMeta getMetaGeneticProfiles() {
+
+        return geneticProfileMapper.getMetaGeneticProfiles(null);
+    }
+
+    @Override
+    public GeneticProfile getGeneticProfile(String geneticProfileId) {
+        return geneticProfileMapper.getGeneticProfile(geneticProfileId, Constants.DETAILED_PROJECTION);
+    }
+
+    @Override
+    public List<GeneticProfile> getAllGeneticProfilesInStudy(String studyId, String projection, Integer pageSize,
+                                                             Integer pageNumber, String sortBy, String direction) {
+
+        return geneticProfileMapper.getAllGeneticProfiles(studyId, projection, pageSize,
+                offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction);
+    }
+
+    @Override
+    public BaseMeta getMetaGeneticProfilesInStudy(String studyId) {
+
+        return geneticProfileMapper.getMetaGeneticProfiles(studyId);
+    }
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepository.java
@@ -3,6 +3,7 @@ package org.cbioportal.persistence.mybatis;
 import org.cbioportal.model.CancerStudy;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.StudyRepository;
+import org.cbioportal.persistence.mybatis.tool.Constants;
 import org.cbioportal.persistence.mybatis.tool.OffsetCalculator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -12,9 +13,8 @@ import java.util.List;
 @Repository
 public class StudyMyBatisRepository implements StudyRepository {
 
-    public static final String PUBLIC_STUDY = "publicStudy";
-    public static final String PUBLIC = "public";
-    public static final String DETAILED_PROJECTION = "DETAILED";
+    private static final String PUBLIC_STUDY = "publicStudy";
+    private static final String PUBLIC = "public";
 
     @Autowired
     private StudyMapper studyMapper;
@@ -40,6 +40,6 @@ public class StudyMyBatisRepository implements StudyRepository {
 
     @Override
     public CancerStudy getStudy(String studyId) {
-        return studyMapper.getStudy(studyId, DETAILED_PROJECTION);
+        return studyMapper.getStudy(studyId, Constants.DETAILED_PROJECTION);
     }
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/tool/Constants.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/tool/Constants.java
@@ -1,0 +1,6 @@
+package org.cbioportal.persistence.mybatis.tool;
+
+public class Constants {
+
+    public static final String DETAILED_PROJECTION = "DETAILED";
+}

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CancerTypeMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CancerTypeMapper.xml
@@ -16,4 +16,33 @@
         </if>
     </sql>
 
+    <select id="getAllCancerTypes" resultType="org.cbioportal.model.TypeOfCancer">
+        SELECT
+        <include refid="select">
+            <property name="prefix" value=""/>
+        </include>
+        FROM type_of_cancer
+        <if test="sortBy != null and projection != 'ID'">
+            ORDER BY ${sortBy} ${direction}
+        </if>
+        <if test="limit != null and limit != 0">
+            LIMIT #{limit} OFFSET #{offset}
+        </if>
+    </select>
+
+    <select id="getMetaCancerTypes" resultType="org.cbioportal.model.meta.BaseMeta">
+        SELECT
+        COUNT(*) AS totalCount
+        FROM type_of_cancer
+    </select>
+
+    <select id="getCancerType" resultType="org.cbioportal.model.TypeOfCancer">
+        SELECT
+        <include refid="select">
+            <property name="prefix" value=""/>
+        </include>
+        FROM type_of_cancer
+        WHERE type_of_cancer.TYPE_OF_CANCER_ID = #{cancerTypeId}
+    </select>
+
 </mapper>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalDataMapper.xml
@@ -91,7 +91,7 @@
             INNER JOIN type_of_cancer ON cancer_study.TYPE_OF_CANCER_ID = type_of_cancer.TYPE_OF_CANCER_ID
         </if>
         <include refid="whereSample"/>
-        <if test="sortBy != null">
+        <if test="sortBy != null and projection != 'ID'">
             ORDER BY ${sortBy} ${direction}
         </if>
         <if test="limit != null and limit != 0">
@@ -118,7 +118,7 @@
             INNER JOIN type_of_cancer ON cancer_study.TYPE_OF_CANCER_ID = type_of_cancer.TYPE_OF_CANCER_ID
         </if>
         <include refid="wherePatient"/>
-        <if test="sortBy != null">
+        <if test="sortBy != null and projection != 'ID'">
             ORDER BY ${sortBy} ${direction}
         </if>
         <if test="limit != null and limit != 0">

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GeneticProfileMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GeneticProfileMapper.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.cbioportal.persistence.mybatis.GeneticProfileMapper">
+    <cache/>
+
+    <sql id="select">
+        genetic_profile.GENETIC_PROFILE_ID AS "${prefix}geneticProfileId",
+        genetic_profile.STABLE_ID AS "${prefix}stableId"
+        <if test="projection == 'SUMMARY' || projection == 'DETAILED'">
+            ,
+            genetic_profile.CANCER_STUDY_ID AS "${prefix}cancerStudyId",
+            cancer_study.CANCER_STUDY_IDENTIFIER AS "${prefix}cancerStudyIdentifier",
+            genetic_profile.GENETIC_ALTERATION_TYPE AS "${prefix}geneticAlterationType",
+            genetic_profile.DATATYPE AS "${prefix}datatype",
+            genetic_profile.NAME AS "${prefix}name",
+            genetic_profile.DESCRIPTION AS "${prefix}description",
+            genetic_profile.SHOW_PROFILE_IN_ANALYSIS_TAB AS "${prefix}showProfileInAnalysisTab"
+        </if>
+        <if test="projection == 'DETAILED'">
+            ,
+            <include refid="org.cbioportal.persistence.mybatis.StudyMapper.select">
+                <property name="prefix" value="${prefix}cancerStudy."/>
+            </include>
+        </if>
+    </sql>
+
+    <select id="getAllGeneticProfiles" resultType="org.cbioportal.model.GeneticProfile">
+        SELECT
+        <include refid="select">
+            <property name="prefix" value=""/>
+        </include>
+        FROM genetic_profile
+        INNER JOIN cancer_study ON genetic_profile.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
+        <if test="studyId != null">
+            WHERE cancer_study.CANCER_STUDY_IDENTIFIER = #{studyId}
+        </if>
+        <if test="sortBy != null and projection != 'ID'">
+            ORDER BY ${sortBy} ${direction}
+        </if>
+        <if test="limit != null and limit != 0">
+            LIMIT #{limit} OFFSET #{offset}
+        </if>
+    </select>
+
+    <select id="getMetaGeneticProfiles" resultType="org.cbioportal.model.meta.BaseMeta">
+        SELECT
+        COUNT(*) AS totalCount
+        FROM genetic_profile
+        <if test="studyId != null">
+            INNER JOIN cancer_study ON genetic_profile.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
+            WHERE cancer_study.CANCER_STUDY_IDENTIFIER = #{studyId}
+        </if>
+    </select>
+    
+    <select id="getGeneticProfile" resultType="org.cbioportal.model.GeneticProfile">
+        SELECT
+        <include refid="select">
+            <property name="prefix" value=""/>
+        </include>
+        FROM genetic_profile
+        INNER JOIN cancer_study ON genetic_profile.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
+        WHERE genetic_profile.STABLE_ID = #{geneticProfileId}
+    </select>
+</mapper>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
@@ -20,11 +20,14 @@
             cancer_study.STATUS AS "${prefix}status",
             cancer_study.IMPORT_DATE AS "${prefix}importDate"
         </if>
+    </sql>
+
+    <sql id="from">
+        FROM cancer_study
         <if test="projection == 'DETAILED'">
-            ,
-            <include refid="org.cbioportal.persistence.mybatis.CancerTypeMapper.select">
-                <property name="prefix" value="${prefix}typeOfCancer."/>
-            </include>
+            INNER JOIN type_of_cancer ON cancer_study.TYPE_OF_CANCER_ID = type_of_cancer.TYPE_OF_CANCER_ID
+            INNER JOIN patient ON cancer_study.CANCER_STUDY_ID = patient.CANCER_STUDY_ID
+            INNER JOIN sample ON patient.INTERNAL_ID = sample.PATIENT_ID
         </if>
     </sql>
 
@@ -33,11 +36,18 @@
         <include refid="select">
             <property name="prefix" value=""/>
         </include>
-        FROM cancer_study
         <if test="projection == 'DETAILED'">
-            INNER JOIN type_of_cancer ON cancer_study.TYPE_OF_CANCER_ID = type_of_cancer.TYPE_OF_CANCER_ID
+            ,
+            COUNT(*) AS "sampleCount",
+            <include refid="org.cbioportal.persistence.mybatis.CancerTypeMapper.select">
+                <property name="prefix" value="typeOfCancer."/>
+            </include>
         </if>
-        <if test="sortBy != null">
+        <include refid="from"/>
+        <if test="projection == 'DETAILED'">
+            GROUP BY cancer_study.CANCER_STUDY_ID
+        </if>
+        <if test="sortBy != null and projection != 'ID'">
             ORDER BY ${sortBy} ${direction}
         </if>
         <if test="limit != null and limit != 0">
@@ -56,11 +66,18 @@
         <include refid="select">
             <property name="prefix" value=""/>
         </include>
-        FROM cancer_study
         <if test="projection == 'DETAILED'">
-            INNER JOIN type_of_cancer ON cancer_study.TYPE_OF_CANCER_ID = type_of_cancer.TYPE_OF_CANCER_ID
+            ,
+            COUNT(*) AS "sampleCount",
+            <include refid="org.cbioportal.persistence.mybatis.CancerTypeMapper.select">
+                <property name="prefix" value="typeOfCancer."/>
+            </include>
         </if>
+        <include refid="from"/>
         WHERE cancer_study.CANCER_STUDY_IDENTIFIER = #{studyId}
+        <if test="projection == 'DETAILED'">
+            GROUP BY cancer_study.CANCER_STUDY_ID
+        </if>
     </select>
 
 </mapper>

--- a/service/src/main/java/org/cbioportal/service/CancerTypeService.java
+++ b/service/src/main/java/org/cbioportal/service/CancerTypeService.java
@@ -1,0 +1,17 @@
+package org.cbioportal.service;
+
+import org.cbioportal.model.TypeOfCancer;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.service.exception.CancerTypeNotFoundException;
+
+import java.util.List;
+
+public interface CancerTypeService {
+
+    List<TypeOfCancer> getAllCancerTypes(String projection, Integer pageSize, Integer pageNumber, String sortBy,
+                                                String direction);
+
+    BaseMeta getMetaCancerTypes();
+
+    TypeOfCancer getCancerType(String cancerTypeId) throws CancerTypeNotFoundException;
+}

--- a/service/src/main/java/org/cbioportal/service/GeneticProfileService.java
+++ b/service/src/main/java/org/cbioportal/service/GeneticProfileService.java
@@ -1,0 +1,23 @@
+package org.cbioportal.service;
+
+import org.cbioportal.model.GeneticProfile;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.service.exception.GeneticProfileNotFoundException;
+
+import java.util.List;
+
+public interface GeneticProfileService {
+
+    List<GeneticProfile> getAllGeneticProfiles(String projection, Integer pageSize, Integer pageNumber, String sortBy,
+                                               String direction);
+
+
+    BaseMeta getMetaGeneticProfiles();
+
+    GeneticProfile getGeneticProfile(String geneticProfileId) throws GeneticProfileNotFoundException;
+
+    List<GeneticProfile> getAllGeneticProfilesInStudy(String studyId, String projection, Integer pageSize,
+                                                      Integer pageNumber, String sortBy, String direction);
+
+    BaseMeta getMetaGeneticProfilesInStudy(String studyId);
+}

--- a/service/src/main/java/org/cbioportal/service/StudyService.java
+++ b/service/src/main/java/org/cbioportal/service/StudyService.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 public interface StudyService {
 
-    List<CancerStudy> getAllStudies(String projection, Integer pageSize, Integer pageNumber,
-                                    String sortBy, String direction);
+    List<CancerStudy> getAllStudies(String projection, Integer pageSize, Integer pageNumber, String sortBy,
+                                    String direction);
 
     BaseMeta getMetaStudies();
 

--- a/service/src/main/java/org/cbioportal/service/exception/CancerTypeNotFoundException.java
+++ b/service/src/main/java/org/cbioportal/service/exception/CancerTypeNotFoundException.java
@@ -1,0 +1,19 @@
+package org.cbioportal.service.exception;
+
+public class CancerTypeNotFoundException extends Exception {
+
+    private String cancerTypeId;
+
+    public CancerTypeNotFoundException(String cancerTypeId) {
+        super();
+        this.cancerTypeId = cancerTypeId;
+    }
+
+    public String getCancerTypeId() {
+        return cancerTypeId;
+    }
+
+    public void setCancerTypeId(String cancerTypeId) {
+        this.cancerTypeId = cancerTypeId;
+    }
+}

--- a/service/src/main/java/org/cbioportal/service/exception/GeneticProfileNotFoundException.java
+++ b/service/src/main/java/org/cbioportal/service/exception/GeneticProfileNotFoundException.java
@@ -1,0 +1,19 @@
+package org.cbioportal.service.exception;
+
+public class GeneticProfileNotFoundException extends Exception {
+
+    private String geneticProfileId;
+
+    public GeneticProfileNotFoundException(String geneticProfileId) {
+        super();
+        this.geneticProfileId = geneticProfileId;
+    }
+
+    public String getGeneticProfileId() {
+        return geneticProfileId;
+    }
+
+    public void setGeneticProfileId(String geneticProfileId) {
+        this.geneticProfileId = geneticProfileId;
+    }
+}

--- a/service/src/main/java/org/cbioportal/service/impl/CancerTypeServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CancerTypeServiceImpl.java
@@ -1,0 +1,41 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.model.TypeOfCancer;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.persistence.CancerTypeRepository;
+import org.cbioportal.service.CancerTypeService;
+import org.cbioportal.service.exception.CancerTypeNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CancerTypeServiceImpl implements CancerTypeService {
+
+    @Autowired
+    private CancerTypeRepository cancerTypeRepository;
+
+    @Override
+    public List<TypeOfCancer> getAllCancerTypes(String projection, Integer pageSize, Integer pageNumber, String sortBy,
+                                                String direction) {
+
+        return cancerTypeRepository.getAllCancerTypes(projection, pageSize, pageNumber, sortBy, direction);
+    }
+
+    @Override
+    public BaseMeta getMetaCancerTypes() {
+        return cancerTypeRepository.getMetaCancerTypes();
+    }
+
+    @Override
+    public TypeOfCancer getCancerType(String cancerTypeId) throws CancerTypeNotFoundException {
+
+        TypeOfCancer typeOfCancer = cancerTypeRepository.getCancerType(cancerTypeId);
+        if (typeOfCancer == null) {
+            throw new CancerTypeNotFoundException(cancerTypeId);
+        }
+
+        return typeOfCancer;
+    }
+}

--- a/service/src/main/java/org/cbioportal/service/impl/GeneticProfileServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GeneticProfileServiceImpl.java
@@ -1,0 +1,55 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.model.GeneticProfile;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.persistence.GeneticProfileRepository;
+import org.cbioportal.service.GeneticProfileService;
+import org.cbioportal.service.exception.GeneticProfileNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class GeneticProfileServiceImpl implements GeneticProfileService {
+
+    @Autowired
+    private GeneticProfileRepository geneticProfileRepository;
+
+    @Override
+    public List<GeneticProfile> getAllGeneticProfiles(String projection, Integer pageSize, Integer pageNumber,
+                                                      String sortBy, String direction) {
+
+        return geneticProfileRepository.getAllGeneticProfiles(projection, pageSize, pageNumber, sortBy, direction);
+    }
+
+    @Override
+    public BaseMeta getMetaGeneticProfiles() {
+
+        return geneticProfileRepository.getMetaGeneticProfiles();
+    }
+
+    @Override
+    public GeneticProfile getGeneticProfile(String geneticProfileId) throws GeneticProfileNotFoundException {
+
+        GeneticProfile geneticProfile = geneticProfileRepository.getGeneticProfile(geneticProfileId);
+        if (geneticProfile == null) {
+            throw new GeneticProfileNotFoundException(geneticProfileId);
+        }
+
+        return geneticProfile;
+    }
+
+    @Override
+    public List<GeneticProfile> getAllGeneticProfilesInStudy(String studyId, String projection, Integer pageSize,
+                                                             Integer pageNumber, String sortBy, String direction) {
+
+        return geneticProfileRepository.getAllGeneticProfilesInStudy(studyId, projection, pageSize, pageNumber, sortBy,
+                direction);
+    }
+
+    @Override
+    public BaseMeta getMetaGeneticProfilesInStudy(String studyId) {
+        return geneticProfileRepository.getMetaGeneticProfilesInStudy(studyId);
+    }
+}

--- a/service/src/test/java/org/cbioportal/service/impl/BaseServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/BaseServiceImplTest.java
@@ -1,0 +1,17 @@
+package org.cbioportal.service.impl;
+
+public class BaseServiceImplTest {
+
+    public static final String PROJECTION = "projection";
+    public static final Integer PAGE_SIZE = 1000;
+    public static final Integer PAGE_NUMBER = 0;
+    public static final String SORT = "sort";
+    public static final String DIRECTION = "direction";
+    public static final String STUDY_ID = "study_id";
+    public static final String GENETIC_PROFILE_ID = "genetic_profile_id";
+    public static final String SAMPLE_ID = "sample_id";
+    public static final String PATIENT_ID = "patient_id";
+    public static final String ATTRIBUTE_ID = "attributeId";
+    public static final String PATIENT_CLINICAL_DATA_TYPE = "PATIENT";
+    public static final String CANCER_TYPE_ID = "cancer_type_id";
+}

--- a/service/src/test/java/org/cbioportal/service/impl/CancerTypeServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/CancerTypeServiceImplTest.java
@@ -1,0 +1,74 @@
+package org.cbioportal.service.impl;
+
+import junit.framework.Assert;
+import org.cbioportal.model.TypeOfCancer;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.persistence.CancerTypeRepository;
+import org.cbioportal.service.exception.CancerTypeNotFoundException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CancerTypeServiceImplTest extends BaseServiceImplTest {
+
+    @InjectMocks
+    private CancerTypeServiceImpl cancerTypeService;
+
+    @Mock
+    private CancerTypeRepository cancerTypeRepository;
+
+    @Test
+    public void getAllCancerTypes() throws Exception {
+
+        List<TypeOfCancer> expectedTypeOfCancerList = new ArrayList<>();
+        TypeOfCancer typeOfCancer = new TypeOfCancer();
+        expectedTypeOfCancerList.add(typeOfCancer);
+
+        Mockito.when(cancerTypeRepository.getAllCancerTypes(PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION))
+                .thenReturn(expectedTypeOfCancerList);
+
+        List<TypeOfCancer> result = cancerTypeService.getAllCancerTypes(PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT,
+                DIRECTION);
+
+        Assert.assertEquals(expectedTypeOfCancerList, result);
+    }
+
+    @Test
+    public void getMetaCancerTypes() throws Exception {
+
+        BaseMeta expectedBaseMeta = new BaseMeta();
+
+        Mockito.when(cancerTypeRepository.getMetaCancerTypes()).thenReturn(expectedBaseMeta);
+
+        BaseMeta result = cancerTypeService.getMetaCancerTypes();
+
+        Assert.assertEquals(expectedBaseMeta, result);
+    }
+
+    @Test(expected = CancerTypeNotFoundException.class)
+    public void getCancerTypeNotFound() throws Exception {
+
+        Mockito.when(cancerTypeRepository.getCancerType(CANCER_TYPE_ID)).thenReturn(null);
+
+        cancerTypeService.getCancerType(CANCER_TYPE_ID);
+    }
+
+    @Test
+    public void getCancerType() throws Exception {
+
+        TypeOfCancer expectedTypeOfCancer = new TypeOfCancer();
+
+        Mockito.when(cancerTypeRepository.getCancerType(CANCER_TYPE_ID)).thenReturn(expectedTypeOfCancer);
+
+        TypeOfCancer result = cancerTypeService.getCancerType(CANCER_TYPE_ID);
+
+        Assert.assertEquals(expectedTypeOfCancer, result);
+    }
+}

--- a/service/src/test/java/org/cbioportal/service/impl/ClinicalDataServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ClinicalDataServiceImplTest.java
@@ -17,21 +17,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
-
 @RunWith(MockitoJUnitRunner.class)
-public class ClinicalDataServiceImplTest {
-
-    public static final String STUDY_ID = "study_id";
-    public static final String SAMPLE_ID = "sample_id";
-    public static final String PATIENT_ID = "patient_id";
-    public static final String ATTRIBUTE_ID = "attributeId";
-    public static final String PROJECTION = "projection";
-    public static final Integer PAGE_SIZE = 1000;
-    public static final Integer PAGE_NUMBER = 0;
-    public static final String SORT = "sort";
-    public static final String DIRECTION = "direction";
-    public static final String PATIENT_CLINICAL_DATA_TYPE = "PATIENT";
+public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
 
     @InjectMocks
     private ClinicalDataServiceImpl clinicalDataService;

--- a/service/src/test/java/org/cbioportal/service/impl/GeneticProfileServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GeneticProfileServiceImplTest.java
@@ -1,0 +1,103 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.model.GeneticProfile;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.persistence.GeneticProfileRepository;
+import org.cbioportal.service.exception.GeneticProfileNotFoundException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GeneticProfileServiceImplTest extends BaseServiceImplTest {
+
+    @InjectMocks
+    private GeneticProfileServiceImpl geneticProfileService;
+
+    @Mock
+    private GeneticProfileRepository geneticProfileRepository;
+
+    @Test
+    public void getAllGeneticProfiles() throws Exception {
+
+        List<GeneticProfile> expectedGeneticProfileList = new ArrayList<>();
+        GeneticProfile geneticProfile = new GeneticProfile();
+        expectedGeneticProfileList.add(geneticProfile);
+
+        Mockito.when(geneticProfileRepository.getAllGeneticProfiles(PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT,
+                DIRECTION)).thenReturn(expectedGeneticProfileList);
+
+        List<GeneticProfile> result = geneticProfileService.getAllGeneticProfiles(PROJECTION, PAGE_SIZE, PAGE_NUMBER,
+                SORT, DIRECTION);
+
+        Assert.assertEquals(expectedGeneticProfileList, result);
+    }
+
+    @Test
+    public void getMetaGeneticProfiles() throws Exception {
+
+        BaseMeta expectedBaseMeta = new BaseMeta();
+
+        Mockito.when(geneticProfileRepository.getMetaGeneticProfiles()).thenReturn(expectedBaseMeta);
+
+        BaseMeta result = geneticProfileService.getMetaGeneticProfiles();
+
+        Assert.assertEquals(expectedBaseMeta, result);
+
+    }
+
+    @Test(expected = GeneticProfileNotFoundException.class)
+    public void getGeneticProfileNotFound() throws Exception {
+
+        Mockito.when(geneticProfileRepository.getGeneticProfile(GENETIC_PROFILE_ID)).thenReturn(null);
+
+        geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID);
+    }
+
+    @Test
+    public void getGeneticProfile() throws Exception {
+
+        GeneticProfile expectedGeneticProfile = new GeneticProfile();
+
+        Mockito.when(geneticProfileRepository.getGeneticProfile(GENETIC_PROFILE_ID)).thenReturn(expectedGeneticProfile);
+
+        GeneticProfile result = geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID);
+
+        Assert.assertEquals(expectedGeneticProfile, result);
+    }
+
+    @Test
+    public void getAllGeneticProfilesInStudy() throws Exception {
+
+        List<GeneticProfile> expectedGeneticProfileList = new ArrayList<>();
+        GeneticProfile geneticProfile = new GeneticProfile();
+        expectedGeneticProfileList.add(geneticProfile);
+
+        Mockito.when(geneticProfileRepository.getAllGeneticProfilesInStudy(STUDY_ID, PROJECTION, PAGE_SIZE, PAGE_NUMBER,
+                SORT, DIRECTION)).thenReturn(expectedGeneticProfileList);
+
+        List<GeneticProfile> result = geneticProfileService.getAllGeneticProfilesInStudy(STUDY_ID, PROJECTION,
+                PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+
+        Assert.assertEquals(expectedGeneticProfileList, result);
+    }
+
+    @Test
+    public void getMetaGeneticProfilesInStudy() throws Exception {
+
+        BaseMeta expectedBaseMeta = new BaseMeta();
+
+        Mockito.when(geneticProfileRepository.getMetaGeneticProfilesInStudy(STUDY_ID)).thenReturn(expectedBaseMeta);
+
+        BaseMeta result = geneticProfileService.getMetaGeneticProfilesInStudy(STUDY_ID);
+
+        Assert.assertEquals(expectedBaseMeta, result);
+    }
+}

--- a/service/src/test/java/org/cbioportal/service/impl/StudyServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/StudyServiceImplTest.java
@@ -15,17 +15,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
-
 @RunWith(MockitoJUnitRunner.class)
-public class StudyServiceImplTest {
-
-    public static final String STUDY_ID = "study_id";
-    public static final String PROJECTION = "projection";
-    public static final Integer PAGE_SIZE = 1000;
-    public static final Integer PAGE_NUMBER = 0;
-    public static final String SORT = "sort";
-    public static final String DIRECTION = "direction";
+public class StudyServiceImplTest extends BaseServiceImplTest {
 
     @InjectMocks
     private StudyServiceImpl studyService;

--- a/web/src/main/java/org/cbioportal/web/CancerTypeController.java
+++ b/web/src/main/java/org/cbioportal/web/CancerTypeController.java
@@ -2,9 +2,19 @@ package org.cbioportal.web;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.TypeOfCancer;
+import org.cbioportal.service.CancerTypeService;
+import org.cbioportal.service.exception.CancerTypeNotFoundException;
+import org.cbioportal.web.parameter.Direction;
+import org.cbioportal.web.parameter.HeaderKeyConstants;
 import org.cbioportal.web.parameter.PagingConstants;
 import org.cbioportal.web.parameter.Projection;
+import org.cbioportal.web.parameter.sort.CancerTypeSortBy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,19 +28,42 @@ import java.util.List;
 @Api(tags = "Cancer Types", description = " ")
 public class CancerTypeController {
 
-    @RequestMapping(value = "/cancer-types", method = RequestMethod.GET)
-    @ApiOperation("Get all cancer types")
-    public ResponseEntity<List<TypeOfCancer>> getAllCancerTypes(@RequestParam(defaultValue = "SUMMARY") Projection projection,
-                                                                @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
-                                                                @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber) {
+    @Autowired
+    private CancerTypeService cancerTypeService;
 
-        throw new UnsupportedOperationException();
+    @RequestMapping(value = "/cancer-types", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Get all cancer types")
+    public ResponseEntity<List<TypeOfCancer>> getAllCancerTypes(
+            @ApiParam("Level of detail of the response")
+            @RequestParam(defaultValue = "SUMMARY") Projection projection,
+            @ApiParam("Page size of the result list")
+            @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
+            @ApiParam("Page number of the result list")
+            @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber,
+            @ApiParam("Name of the property that the result list is sorted by")
+            @RequestParam(required = false) CancerTypeSortBy sortBy,
+            @ApiParam("Direction of the sort")
+            @RequestParam(defaultValue = "ASC") Direction direction) {
+
+        if (projection == Projection.META) {
+            HttpHeaders responseHeaders = new HttpHeaders();
+            responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, cancerTypeService.getMetaCancerTypes().getTotalCount()
+                    .toString());
+            return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(
+                    cancerTypeService.getAllCancerTypes(projection.name(), pageSize, pageNumber,
+                            sortBy == null ? null : sortBy.name(), direction.name()), HttpStatus.OK);
+        }
     }
 
-    @RequestMapping(value = "/cancer-types/{cancerTypeId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/cancer-types/{cancerTypeId}", method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get a cancer type")
-    public ResponseEntity<TypeOfCancer> getCancerType(@PathVariable String cancerTypeId) {
+    public ResponseEntity<TypeOfCancer> getCancerType(
+            @ApiParam(required = true, value = "Cancer Type ID e.g. acc")
+            @PathVariable String cancerTypeId) throws CancerTypeNotFoundException {
 
-        throw new UnsupportedOperationException();
+        return new ResponseEntity<>(cancerTypeService.getCancerType(cancerTypeId), HttpStatus.OK);
     }
 }

--- a/web/src/main/java/org/cbioportal/web/GeneticProfileController.java
+++ b/web/src/main/java/org/cbioportal/web/GeneticProfileController.java
@@ -2,9 +2,20 @@ package org.cbioportal.web;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.cbioportal.model.GeneticProfile;
 import org.cbioportal.model.summary.GeneticProfileSummary;
+import org.cbioportal.service.GeneticProfileService;
+import org.cbioportal.service.exception.GeneticProfileNotFoundException;
+import org.cbioportal.web.parameter.Direction;
+import org.cbioportal.web.parameter.HeaderKeyConstants;
 import org.cbioportal.web.parameter.PagingConstants;
 import org.cbioportal.web.parameter.Projection;
+import org.cbioportal.web.parameter.sort.GeneticProfileSortBy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,29 +29,72 @@ import java.util.List;
 @Api(tags = "Genetic Profiles", description = " ")
 public class GeneticProfileController {
 
-    @RequestMapping(value = "/genetic-profiles", method = RequestMethod.GET)
+    @Autowired
+    private GeneticProfileService geneticProfileService;
+
+    @RequestMapping(value = "/genetic-profiles", method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all genetic profiles")
-    public ResponseEntity<List<? extends GeneticProfileSummary>> getAllGeneticProfiles(@RequestParam(defaultValue = "SUMMARY") Projection projection,
-                                                                                       @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
-                                                                                       @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber) {
+    public ResponseEntity<List<? extends GeneticProfileSummary>> getAllGeneticProfiles(
+            @ApiParam("Level of detail of the response")
+            @RequestParam(defaultValue = "SUMMARY") Projection projection,
+            @ApiParam("Page size of the result list")
+            @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
+            @ApiParam("Page number of the result list")
+            @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber,
+            @ApiParam("Name of the property that the result list is sorted by")
+            @RequestParam(required = false) GeneticProfileSortBy sortBy,
+            @ApiParam("Direction of the sort")
+            @RequestParam(defaultValue = "ASC") Direction direction) {
 
-        throw new UnsupportedOperationException();
+        if (projection == Projection.META) {
+            HttpHeaders responseHeaders = new HttpHeaders();
+            responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, geneticProfileService.getMetaGeneticProfiles()
+                    .getTotalCount().toString());
+            return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
+        } else {
+            return new ResponseEntity<List<? extends GeneticProfileSummary>>(
+                    geneticProfileService.getAllGeneticProfiles(projection.name(), pageSize, pageNumber,
+                            sortBy == null ? null : sortBy.name(), direction.name()), HttpStatus.OK);
+        }
     }
 
-    @RequestMapping(value = "/genetic-profiles/{geneticProfileId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/genetic-profiles/{geneticProfileId}", method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get genetic profile")
-    public ResponseEntity<GeneticProfileSummary> getGeneticProfile(@PathVariable String geneticProfileId) {
+    public ResponseEntity<GeneticProfile> getGeneticProfile(
+            @ApiParam(required = true, value = "Genetic Profile ID e.g. acc_tcga_mutations")
+            @PathVariable String geneticProfileId) throws GeneticProfileNotFoundException {
 
-        throw new UnsupportedOperationException();
+        return new ResponseEntity<>(geneticProfileService.getGeneticProfile(geneticProfileId), HttpStatus.OK);
     }
 
-    @RequestMapping(value = "/studies/{studyId}/genetic-profiles", method = RequestMethod.GET)
+    @RequestMapping(value = "/studies/{studyId}/genetic-profiles", method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all genetic profiles in a study")
-    public ResponseEntity<List<? extends GeneticProfileSummary>> getAllGeneticProfilesInStudy(@PathVariable String studyId,
-                                                                                              @RequestParam(defaultValue = "SUMMARY") Projection projection,
-                                                                                              @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
-                                                                                              @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber) {
+    public ResponseEntity<List<? extends GeneticProfileSummary>> getAllGeneticProfilesInStudy(
+            @ApiParam(required = true, value = "Study ID e.g. acc_tcga")
+            @PathVariable String studyId,
+            @ApiParam("Level of detail of the response")
+            @RequestParam(defaultValue = "SUMMARY") Projection projection,
+            @ApiParam("Page size of the result list")
+            @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
+            @ApiParam("Page number of the result list")
+            @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber,
+            @ApiParam("Name of the property that the result list is sorted by")
+            @RequestParam(required = false) GeneticProfileSortBy sortBy,
+            @ApiParam("Direction of the sort")
+            @RequestParam(defaultValue = "ASC") Direction direction) {
 
-        throw new UnsupportedOperationException();
+        if (projection == Projection.META) {
+            HttpHeaders responseHeaders = new HttpHeaders();
+            responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, geneticProfileService
+                    .getMetaGeneticProfilesInStudy(studyId).getTotalCount().toString());
+            return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
+        } else {
+            return new ResponseEntity<List<? extends GeneticProfileSummary>>(
+                    geneticProfileService.getAllGeneticProfilesInStudy(studyId, projection.name(), pageSize, pageNumber,
+                            sortBy == null ? null : sortBy.name(), direction.name()), HttpStatus.OK);
+        }
     }
 }

--- a/web/src/main/java/org/cbioportal/web/error/GlobalExceptionHandler.java
+++ b/web/src/main/java/org/cbioportal/web/error/GlobalExceptionHandler.java
@@ -1,8 +1,6 @@
 package org.cbioportal.web.error;
 
-import org.cbioportal.service.exception.PatientNotFoundException;
-import org.cbioportal.service.exception.SampleNotFoundException;
-import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.service.exception.*;
 import org.cbioportal.web.exception.*;
 import org.cbioportal.web.parameter.PagingConstants;
 import org.springframework.beans.TypeMismatchException;
@@ -34,6 +32,20 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handlePatientNotFound(PatientNotFoundException ex) {
 
         return new ResponseEntity<>(new ErrorResponse("Patient not found: " + ex.getPatientId()),
+                HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(CancerTypeNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleCancerTypeNotFound(CancerTypeNotFoundException ex) {
+
+        return new ResponseEntity<>(new ErrorResponse("Cancer type not found: " + ex.getCancerTypeId()),
+                HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(GeneticProfileNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleGeneticProfileNotFound(GeneticProfileNotFoundException ex) {
+
+        return new ResponseEntity<>(new ErrorResponse("Genetic profile not found: " + ex.getGeneticProfileId()),
                 HttpStatus.NOT_FOUND);
     }
 

--- a/web/src/main/java/org/cbioportal/web/mixin/CancerStudyMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/CancerStudyMixin.java
@@ -6,4 +6,5 @@ import org.cbioportal.web.mixin.summary.CancerStudySummaryMixin;
 public class CancerStudyMixin extends CancerStudySummaryMixin {
 
     private TypeOfCancer typeOfCancer;
+    private Integer sampleCount;
 }

--- a/web/src/main/java/org/cbioportal/web/mixin/ClinicalAttributeMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/ClinicalAttributeMixin.java
@@ -1,11 +1,9 @@
 package org.cbioportal.web.mixin;
 
-public class ClinicalAttributeMixin {
+import org.cbioportal.model.CancerStudy;
+import org.cbioportal.web.mixin.summary.ClinicalAttributeSummaryMixin;
 
-    private String attrId;
-    private String displayName;
-    private String description;
-    private String datatype;
-    private Boolean patientAttribute;
-    private String priority;
+public class ClinicalAttributeMixin extends ClinicalAttributeSummaryMixin {
+
+    private CancerStudy cancerStudy;
 }

--- a/web/src/main/java/org/cbioportal/web/mixin/summary/ClinicalAttributeSummaryMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/summary/ClinicalAttributeSummaryMixin.java
@@ -1,0 +1,15 @@
+package org.cbioportal.web.mixin.summary;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class ClinicalAttributeSummaryMixin {
+
+    private String attrId;
+    private String displayName;
+    private String description;
+    private String datatype;
+    private Boolean patientAttribute;
+    private String priority;
+    @JsonIgnore
+    private Integer cancerStudyId;
+}

--- a/web/src/main/java/org/cbioportal/web/parameter/sort/CancerTypeSortBy.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/sort/CancerTypeSortBy.java
@@ -1,0 +1,11 @@
+package org.cbioportal.web.parameter.sort;
+
+public enum CancerTypeSortBy {
+
+    typeOfCancerId,
+    name,
+    clinicalTrialKeywords,
+    dedicatedColor,
+    shortName,
+    parent
+}

--- a/web/src/main/java/org/cbioportal/web/parameter/sort/GeneticProfileSortBy.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/sort/GeneticProfileSortBy.java
@@ -1,0 +1,11 @@
+package org.cbioportal.web.parameter.sort;
+
+public enum GeneticProfileSortBy {
+
+    stableId,
+    geneticAlterationType,
+    datatype,
+    name,
+    description,
+    showProfileInAnalysisTab
+}

--- a/web/src/main/java/org/cbioportal/weblegacy/StructuralVariantController.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/StructuralVariantController.java
@@ -30,7 +30,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package org.cbioportal.web.legacy;
+package org.cbioportal.weblegacy;
 
 import java.util.List;
 import org.cbioportal.model.StructuralVariant;

--- a/web/src/test/java/org/cbioportal/web/CancerTypeControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CancerTypeControllerTest.java
@@ -1,0 +1,163 @@
+package org.cbioportal.web;
+
+import org.cbioportal.model.TypeOfCancer;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.service.CancerTypeService;
+import org.cbioportal.service.exception.CancerTypeNotFoundException;
+import org.cbioportal.web.parameter.HeaderKeyConstants;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration("/applicationContext-web.xml")
+@Configuration
+public class CancerTypeControllerTest {
+
+    private static final String TEST_TYPE_OF_CANCER_ID_1 = "test_type_of_cancer_id_1";
+    private static final String TEST_NAME_1 = "test_type_of_cancer_name_1";
+    private static final String TEST_CLINICAL_TRIAL_KEYWORDS_1 = "test_clinical_trial_keywords_1";
+    private static final String TEST_DEDICATED_COLOR_1 = "test_dedicated_color_1";
+    private static final String TEST_SHORT_NAME_1 = "test_type_of_cancer_short_name_1";
+    private static final String TEST_PARENT_1 = "test_parent_1";
+    private static final String TEST_TYPE_OF_CANCER_ID_2 = "test_type_of_cancer_id_2";
+    private static final String TEST_NAME_2 = "test_type_of_cancer_name_2";
+    private static final String TEST_CLINICAL_TRIAL_KEYWORDS_2 = "test_clinical_trial_keywords_2";
+    private static final String TEST_DEDICATED_COLOR_2 = "test_dedicated_color_2";
+    private static final String TEST_SHORT_NAME_2 = "test_type_of_cancer_short_name_2";
+    private static final String TEST_PARENT_2 = "test_parent_2";
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Autowired
+    private CancerTypeService cancerTypeService;
+    private MockMvc mockMvc;
+
+    @Bean
+    public CancerTypeService cancerTypeService() {
+        return Mockito.mock(CancerTypeService.class);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+
+        Mockito.reset(cancerTypeService);
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+    }
+
+    @Test
+    public void getAllCancerTypesDefaultProjection() throws Exception {
+
+        List<TypeOfCancer> typeOfCancerList = new ArrayList<>();
+        TypeOfCancer typeOfCancer1 = new TypeOfCancer();
+        typeOfCancer1.setTypeOfCancerId(TEST_TYPE_OF_CANCER_ID_1);
+        typeOfCancer1.setName(TEST_NAME_1);
+        typeOfCancer1.setClinicalTrialKeywords(TEST_CLINICAL_TRIAL_KEYWORDS_1);
+        typeOfCancer1.setDedicatedColor(TEST_DEDICATED_COLOR_1);
+        typeOfCancer1.setShortName(TEST_SHORT_NAME_1);
+        typeOfCancer1.setParent(TEST_PARENT_1);
+        typeOfCancerList.add(typeOfCancer1);
+        TypeOfCancer typeOfCancer2 = new TypeOfCancer();
+        typeOfCancer2.setTypeOfCancerId(TEST_TYPE_OF_CANCER_ID_2);
+        typeOfCancer2.setName(TEST_NAME_2);
+        typeOfCancer2.setClinicalTrialKeywords(TEST_CLINICAL_TRIAL_KEYWORDS_2);
+        typeOfCancer2.setDedicatedColor(TEST_DEDICATED_COLOR_2);
+        typeOfCancer2.setShortName(TEST_SHORT_NAME_2);
+        typeOfCancer2.setParent(TEST_PARENT_2);
+        typeOfCancerList.add(typeOfCancer2);
+
+        Mockito.when(cancerTypeService.getAllCancerTypes(Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(),
+                Mockito.anyString(), Mockito.anyString())).thenReturn(typeOfCancerList);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/cancer-types")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].typeOfCancerId").value(TEST_TYPE_OF_CANCER_ID_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].name").value(TEST_NAME_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].clinicalTrialKeywords")
+                        .value(TEST_CLINICAL_TRIAL_KEYWORDS_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].dedicatedColor").value(TEST_DEDICATED_COLOR_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].shortName").value(TEST_SHORT_NAME_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].parent").value(TEST_PARENT_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].typeOfCancerId").value(TEST_TYPE_OF_CANCER_ID_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].name").value(TEST_NAME_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].clinicalTrialKeywords")
+                        .value(TEST_CLINICAL_TRIAL_KEYWORDS_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].dedicatedColor").value(TEST_DEDICATED_COLOR_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].shortName").value(TEST_SHORT_NAME_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].parent").value(TEST_PARENT_2));
+    }
+
+    @Test
+    public void getAllCancerTypesMetaProjection() throws Exception {
+
+        BaseMeta baseMeta = new BaseMeta();
+        baseMeta.setTotalCount(2);
+
+        Mockito.when(cancerTypeService.getMetaCancerTypes()).thenReturn(baseMeta);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/cancer-types")
+                .param("projection", "META"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.header().string(HeaderKeyConstants.TOTAL_COUNT, "2"));
+    }
+
+    @Test
+    public void getCancerTypeNotFound() throws Exception {
+
+        Mockito.when(cancerTypeService.getCancerType(Mockito.anyString()))
+                .thenThrow(new CancerTypeNotFoundException("cancer_type_id"));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/cancer-types/cancer_type_id")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("Cancer type not found: cancer_type_id"));
+    }
+
+    @Test
+    public void getCancerType() throws Exception {
+
+        TypeOfCancer typeOfCancer = new TypeOfCancer();
+        typeOfCancer.setTypeOfCancerId(TEST_TYPE_OF_CANCER_ID_1);
+        typeOfCancer.setName(TEST_NAME_1);
+        typeOfCancer.setClinicalTrialKeywords(TEST_CLINICAL_TRIAL_KEYWORDS_1);
+        typeOfCancer.setDedicatedColor(TEST_DEDICATED_COLOR_1);
+        typeOfCancer.setShortName(TEST_SHORT_NAME_1);
+        typeOfCancer.setParent(TEST_PARENT_1);
+
+        Mockito.when(cancerTypeService.getCancerType(Mockito.anyString())).thenReturn(typeOfCancer);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/cancer-types/cancer_type_id")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.typeOfCancerId").value(TEST_TYPE_OF_CANCER_ID_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.name").value(TEST_NAME_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.clinicalTrialKeywords")
+                        .value(TEST_CLINICAL_TRIAL_KEYWORDS_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.dedicatedColor").value(TEST_DEDICATED_COLOR_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.shortName").value(TEST_SHORT_NAME_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.parent").value(TEST_PARENT_1));
+    }
+}

--- a/web/src/test/java/org/cbioportal/web/GeneticProfileControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GeneticProfileControllerTest.java
@@ -1,0 +1,268 @@
+package org.cbioportal.web;
+
+import org.cbioportal.model.CancerStudy;
+import org.cbioportal.model.GeneticProfile;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.service.GeneticProfileService;
+import org.cbioportal.service.exception.GeneticProfileNotFoundException;
+import org.cbioportal.web.parameter.HeaderKeyConstants;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration("/applicationContext-web.xml")
+@Configuration
+public class GeneticProfileControllerTest {
+
+    public static final int TEST_GENETIC_PROFILE_ID_1 = 1;
+    public static final String TEST_STABLE_ID_1 = "test_stable_id_1";
+    public static final int TEST_CANCER_STUDY_ID_1 = 1;
+    public static final String TEST_STUDY_IDENTIFIER_1 = "test_study_identifier_1";
+    public static final String TEST_GENETIC_ALTERATION_TYPE_1 = "test_genetic_alteration_type_1";
+    public static final String TEST_DATATYPE_1 = "test_datatype_1";
+    public static final String TEST_NAME_1 = "test_name_1";
+    public static final String TEST_DESCRIPTION_1 = "test_description_1";
+    public static final boolean TEST_SHOW_PROFILE_IN_ANALYSIS_TAB_1 = true;
+    private static final String TEST_CANCER_STUDY_IDENTIFIER_1 = "test_study_1";
+    private static final String TEST_TYPE_OF_CANCER_ID_1 = "test_type_of_cancer_id_1";
+    private static final String TEST_STUDY_NAME_1 = "test_study_name_1";
+    private static final String TEST_SHORT_NAME_1 = "test_short_name_1";
+    private static final String TEST_STUDY_DESCRIPTION_1 = "test_study_description_1";
+    public static final int TEST_GENETIC_PROFILE_ID_2 = 2;
+    public static final String TEST_STABLE_ID_2 = "test_stable_id_2";
+    public static final int TEST_CANCER_STUDY_ID_2 = 2;
+    public static final String TEST_STUDY_IDENTIFIER_2 = "test_study_identifier_2";
+    public static final String TEST_GENETIC_ALTERATION_TYPE_2 = "test_genetic_alteration_type_2";
+    public static final String TEST_DATATYPE_2 = "test_datatype_2";
+    public static final String TEST_NAME_2 = "test_name_2";
+    public static final String TEST_DESCRIPTION_2 = "test_description_2";
+    public static final boolean TEST_SHOW_PROFILE_IN_ANALYSIS_TAB_2 = false;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Autowired
+    private GeneticProfileService geneticProfileService;
+    private MockMvc mockMvc;
+
+    @Bean
+    public GeneticProfileService geneticProfileService() {
+        return Mockito.mock(GeneticProfileService.class);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+
+        Mockito.reset(geneticProfileService);
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+    }
+
+    @Test
+    public void getAllGeneticProfilesDefaultProjection() throws Exception {
+
+        List<GeneticProfile> geneticProfileList = createExampleGeneticProfiles();
+
+        Mockito.when(geneticProfileService.getAllGeneticProfiles(Mockito.anyString(), Mockito.anyInt(),
+                Mockito.anyInt(), Mockito.anyString(), Mockito.anyString())).thenReturn(geneticProfileList);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/genetic-profiles")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].geneticProfileId").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].stableId").value(TEST_STABLE_ID_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].cancerStudyId").value(TEST_STUDY_IDENTIFIER_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].geneticAlterationType")
+                        .value(TEST_GENETIC_ALTERATION_TYPE_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].datatype").value(TEST_DATATYPE_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].name").value(TEST_NAME_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].description").value(TEST_DESCRIPTION_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].showProfileInAnalysisTab")
+                        .value(TEST_SHOW_PROFILE_IN_ANALYSIS_TAB_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].geneticProfileId").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].stableId").value(TEST_STABLE_ID_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].cancerStudyId").value(TEST_STUDY_IDENTIFIER_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].geneticAlterationType")
+                        .value(TEST_GENETIC_ALTERATION_TYPE_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].datatype").value(TEST_DATATYPE_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].name").value(TEST_NAME_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].description").value(TEST_DESCRIPTION_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].showProfileInAnalysisTab")
+                        .value(TEST_SHOW_PROFILE_IN_ANALYSIS_TAB_2));
+
+
+
+    }
+
+    @Test
+    public void getAllGeneticProfilesMetaProjection() throws Exception {
+
+        BaseMeta baseMeta = new BaseMeta();
+        baseMeta.setTotalCount(2);
+
+        Mockito.when(geneticProfileService.getMetaGeneticProfiles()).thenReturn(baseMeta);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/genetic-profiles")
+                .param("projection", "META"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.header().string(HeaderKeyConstants.TOTAL_COUNT, "2"));
+    }
+
+    @Test
+    public void getGeneticProfileNotFound() throws Exception {
+
+        Mockito.when(geneticProfileService.getGeneticProfile(Mockito.anyString())).thenThrow(
+                new GeneticProfileNotFoundException("test_genetic_profile_id"));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/genetic-profiles/test_genetic_profile_id")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message")
+                        .value("Genetic profile not found: test_genetic_profile_id"));
+    }
+
+    @Test
+    public void getGeneticProfile() throws Exception {
+
+        GeneticProfile geneticProfile = new GeneticProfile();
+        geneticProfile.setGeneticProfileId(TEST_GENETIC_PROFILE_ID_1);
+        geneticProfile.setStableId(TEST_STABLE_ID_1);
+        geneticProfile.setCancerStudyId(TEST_CANCER_STUDY_ID_1);
+        geneticProfile.setCancerStudyIdentifier(TEST_STUDY_IDENTIFIER_1);
+        geneticProfile.setGeneticAlterationType(TEST_GENETIC_ALTERATION_TYPE_1);
+        geneticProfile.setDatatype(TEST_DATATYPE_1);
+        geneticProfile.setName(TEST_NAME_1);
+        geneticProfile.setDescription(TEST_DESCRIPTION_1);
+        geneticProfile.setShowProfileInAnalysisTab(TEST_SHOW_PROFILE_IN_ANALYSIS_TAB_1);
+        CancerStudy cancerStudy = new CancerStudy();
+        cancerStudy.setCancerStudyId(TEST_CANCER_STUDY_ID_1);
+        cancerStudy.setCancerStudyIdentifier(TEST_CANCER_STUDY_IDENTIFIER_1);
+        cancerStudy.setTypeOfCancerId(TEST_TYPE_OF_CANCER_ID_1);
+        cancerStudy.setName(TEST_STUDY_NAME_1);
+        cancerStudy.setShortName(TEST_SHORT_NAME_1);
+        cancerStudy.setDescription(TEST_STUDY_DESCRIPTION_1);
+        geneticProfile.setCancerStudy(cancerStudy);
+
+        Mockito.when(geneticProfileService.getGeneticProfile(Mockito.anyString())).thenReturn(geneticProfile);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/genetic-profiles/test_genetic_profile_id")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.geneticProfileId").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.stableId").value(TEST_STABLE_ID_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.cancerStudyId").value(TEST_STUDY_IDENTIFIER_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.geneticAlterationType")
+                        .value(TEST_GENETIC_ALTERATION_TYPE_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.datatype").value(TEST_DATATYPE_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.name").value(TEST_NAME_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.description").value(TEST_DESCRIPTION_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.showProfileInAnalysisTab")
+                        .value(TEST_SHOW_PROFILE_IN_ANALYSIS_TAB_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.cancerStudy.cancerStudyId").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.cancerStudy.cancerStudyIdentifier")
+                        .value(TEST_CANCER_STUDY_IDENTIFIER_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.cancerStudy.description").value(TEST_STUDY_DESCRIPTION_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.cancerStudy.name").value(TEST_STUDY_NAME_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.cancerStudy.shortName").value(TEST_SHORT_NAME_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.cancerStudy.typeOfCancerId")
+                        .value(TEST_TYPE_OF_CANCER_ID_1));
+    }
+
+    @Test
+    public void getAllGeneticProfilesInStudyDefaultProjection() throws Exception {
+
+        List<GeneticProfile> geneticProfileList = createExampleGeneticProfiles();
+
+        Mockito.when(geneticProfileService.getAllGeneticProfilesInStudy(Mockito.anyString(), Mockito.anyString(),
+                Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(geneticProfileList);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/studies/test_study_id/genetic-profiles")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].geneticProfileId").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].stableId").value(TEST_STABLE_ID_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].cancerStudyId").value(TEST_STUDY_IDENTIFIER_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].geneticAlterationType")
+                        .value(TEST_GENETIC_ALTERATION_TYPE_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].datatype").value(TEST_DATATYPE_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].name").value(TEST_NAME_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].description").value(TEST_DESCRIPTION_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].showProfileInAnalysisTab")
+                        .value(TEST_SHOW_PROFILE_IN_ANALYSIS_TAB_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].geneticProfileId").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].stableId").value(TEST_STABLE_ID_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].cancerStudyId").value(TEST_STUDY_IDENTIFIER_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].geneticAlterationType")
+                        .value(TEST_GENETIC_ALTERATION_TYPE_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].datatype").value(TEST_DATATYPE_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].name").value(TEST_NAME_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].description").value(TEST_DESCRIPTION_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].showProfileInAnalysisTab")
+                        .value(TEST_SHOW_PROFILE_IN_ANALYSIS_TAB_2));
+    }
+
+    @Test
+    public void getAllGeneticProfilesInStudyMetaProjection() throws Exception {
+
+        BaseMeta baseMeta = new BaseMeta();
+        baseMeta.setTotalCount(2);
+
+        Mockito.when(geneticProfileService.getMetaGeneticProfilesInStudy(Mockito.anyString())).thenReturn(baseMeta);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/studies/test_study_id/genetic-profiles")
+                .param("projection", "META"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.header().string(HeaderKeyConstants.TOTAL_COUNT, "2"));
+    }
+
+        private List<GeneticProfile> createExampleGeneticProfiles() {
+        List<GeneticProfile> geneticProfileList = new ArrayList<>();
+        GeneticProfile geneticProfile1 = new GeneticProfile();
+        geneticProfile1.setGeneticProfileId(TEST_GENETIC_PROFILE_ID_1);
+        geneticProfile1.setStableId(TEST_STABLE_ID_1);
+        geneticProfile1.setCancerStudyId(TEST_CANCER_STUDY_ID_1);
+        geneticProfile1.setCancerStudyIdentifier(TEST_STUDY_IDENTIFIER_1);
+        geneticProfile1.setGeneticAlterationType(TEST_GENETIC_ALTERATION_TYPE_1);
+        geneticProfile1.setDatatype(TEST_DATATYPE_1);
+        geneticProfile1.setName(TEST_NAME_1);
+        geneticProfile1.setDescription(TEST_DESCRIPTION_1);
+        geneticProfile1.setShowProfileInAnalysisTab(TEST_SHOW_PROFILE_IN_ANALYSIS_TAB_1);
+        geneticProfileList.add(geneticProfile1);
+        GeneticProfile geneticProfile2 = new GeneticProfile();
+        geneticProfile2.setGeneticProfileId(TEST_GENETIC_PROFILE_ID_2);
+        geneticProfile2.setStableId(TEST_STABLE_ID_2);
+        geneticProfile2.setCancerStudyId(TEST_CANCER_STUDY_ID_2);
+        geneticProfile2.setCancerStudyIdentifier(TEST_STUDY_IDENTIFIER_2);
+        geneticProfile2.setGeneticAlterationType(TEST_GENETIC_ALTERATION_TYPE_2);
+        geneticProfile2.setDatatype(TEST_DATATYPE_2);
+        geneticProfile2.setName(TEST_NAME_2);
+        geneticProfile2.setDescription(TEST_DESCRIPTION_2);
+        geneticProfile2.setShowProfileInAnalysisTab(TEST_SHOW_PROFILE_IN_ANALYSIS_TAB_2);
+        geneticProfileList.add(geneticProfile2);
+        return geneticProfileList;
+    }
+}

--- a/web/src/test/java/org/cbioportal/web/StudyControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StudyControllerTest.java
@@ -35,35 +35,36 @@ import java.util.TimeZone;
 @Configuration
 public class StudyControllerTest {
 
-    public static final int TEST_CANCER_STUDY_ID_1 = 1;
-    public static final String TEST_CANCER_STUDY_IDENTIFIER_1 = "test_study_1";
-    public static final String TEST_TYPE_OF_CANCER_ID_1 = "test_type_of_cancer_id_1";
-    public static final String TEST_NAME_1 = "test_name_1";
-    public static final String TEST_SHORT_NAME_1 = "test_short_name_1";
-    public static final String TEST_DESCRIPTION_1 = "test_description_1";
-    public static final boolean TEST_PUBLIC_STUDY_1 = true;
-    public static final String TEST_PMID_1 = "test_pmid_1";
-    public static final String TEST_CITATION_1 = "test_citation_1";
-    public static final String TEST_GROUPS_1 = "test_groups_1";
-    public static final int TEST_STATUS_1 = 0;
-    public static final String TEST_DATE_1 = "2011-12-18 13:17:17";
-    public static final int TEST_CANCER_STUDY_ID_2 = 2;
-    public static final String TEST_CANCER_STUDY_IDENTIFIER_2 = "test_study_2";
-    public static final String TEST_TYPE_OF_CANCER_ID_2 = "test_type_of_cancer_id_2";
-    public static final String TEST_NAME_2 = "test_name_2";
-    public static final String TEST_SHORT_NAME_2 = "test_short_name_2";
-    public static final String TEST_DESCRIPTION_2 = "test_description_2";
-    public static final boolean TEST_PUBLIC_STUDY_2 = true;
-    public static final String TEST_PMID_2 = "test_pmid_2";
-    public static final String TEST_CITATION_2 = "test_citation_2";
-    public static final String TEST_GROUPS_2 = "test_groups_2";
-    public static final int TEST_STATUS_2 = 0;
-    public static final String TEST_DATE_2 = "2013-10-12 11:11:15";
-    public static final String TEST_TYPE_OF_CANCER_NAME = "test_type_of_cancer_name";
-    public static final String TEST_CLINICAL_TRIAL_KEYWORDS = "test_clinical_trial_keywords";
-    public static final String TEST_DEDICATED_COLOR = "test_dedicated_color";
-    public static final String TEST_TYPE_OF_CANCER_SHORT_NAME = "test_type_of_cancer_short_name";
-    public static final String TEST_PARENT = "test_parent";
+    private static final int TEST_CANCER_STUDY_ID_1 = 1;
+    private static final String TEST_CANCER_STUDY_IDENTIFIER_1 = "test_study_1";
+    private static final String TEST_TYPE_OF_CANCER_ID_1 = "test_type_of_cancer_id_1";
+    private static final String TEST_NAME_1 = "test_name_1";
+    private static final String TEST_SHORT_NAME_1 = "test_short_name_1";
+    private static final String TEST_DESCRIPTION_1 = "test_description_1";
+    private static final boolean TEST_PUBLIC_STUDY_1 = true;
+    private static final String TEST_PMID_1 = "test_pmid_1";
+    private static final String TEST_CITATION_1 = "test_citation_1";
+    private static final String TEST_GROUPS_1 = "test_groups_1";
+    private static final int TEST_STATUS_1 = 0;
+    private static final String TEST_DATE_1 = "2011-12-18 13:17:17";
+    private static final int TEST_CANCER_STUDY_ID_2 = 2;
+    private static final String TEST_CANCER_STUDY_IDENTIFIER_2 = "test_study_2";
+    private static final String TEST_TYPE_OF_CANCER_ID_2 = "test_type_of_cancer_id_2";
+    private static final String TEST_NAME_2 = "test_name_2";
+    private static final String TEST_SHORT_NAME_2 = "test_short_name_2";
+    private static final String TEST_DESCRIPTION_2 = "test_description_2";
+    private static final boolean TEST_PUBLIC_STUDY_2 = true;
+    private static final String TEST_PMID_2 = "test_pmid_2";
+    private static final String TEST_CITATION_2 = "test_citation_2";
+    private static final String TEST_GROUPS_2 = "test_groups_2";
+    private static final int TEST_STATUS_2 = 0;
+    private static final String TEST_DATE_2 = "2013-10-12 11:11:15";
+    private static final String TEST_TYPE_OF_CANCER_NAME = "test_type_of_cancer_name";
+    private static final String TEST_CLINICAL_TRIAL_KEYWORDS = "test_clinical_trial_keywords";
+    private static final String TEST_DEDICATED_COLOR = "test_dedicated_color";
+    private static final String TEST_TYPE_OF_CANCER_SHORT_NAME = "test_type_of_cancer_short_name";
+    private static final String TEST_PARENT = "test_parent";
+
     @Autowired
     private WebApplicationContext wac;
 
@@ -214,6 +215,7 @@ public class StudyControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.get("/studies/test_study_id")
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.cancerStudyId").doesNotExist())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.cancerStudyIdentifier")
                         .value(TEST_CANCER_STUDY_IDENTIFIER_1))

--- a/web/src/test/java/org/cbioportal/weblegacy/ApiControllerConfig.java
+++ b/web/src/test/java/org/cbioportal/weblegacy/ApiControllerConfig.java
@@ -43,7 +43,7 @@ import org.mskcc.cbio.portal.persistence.ClinicalDataMapperLegacy;
 import org.mskcc.cbio.portal.persistence.ClinicalFieldMapper;
 import org.mskcc.cbio.portal.persistence.GeneAliasMapper;
 import org.mskcc.cbio.portal.persistence.GeneMapperLegacy;
-import org.mskcc.cbio.portal.persistence.GeneticProfileMapper;
+import org.mskcc.cbio.portal.persistence.GeneticProfileMapperLegacy;
 import org.mskcc.cbio.portal.persistence.PatientMapperLegacy;
 import org.mskcc.cbio.portal.persistence.ProfileDataMapper;
 import org.mskcc.cbio.portal.persistence.SampleListMapper;
@@ -104,8 +104,8 @@ public class ApiControllerConfig extends WebMvcConfigurerAdapter {
         return Mockito.mock(GeneMapperLegacy.class);
     }
     @Bean
-    public GeneticProfileMapper geneticProfileMapper() {
-        return Mockito.mock(GeneticProfileMapper.class);
+    public GeneticProfileMapperLegacy geneticProfileMapper() {
+        return Mockito.mock(GeneticProfileMapperLegacy.class);
     }
     @Bean
     public PatientMapperLegacy patientMapper() {

--- a/web/src/test/java/org/cbioportal/weblegacy/ApiControllerTest.java
+++ b/web/src/test/java/org/cbioportal/weblegacy/ApiControllerTest.java
@@ -55,7 +55,7 @@ import org.mockito.Mockito;
 import org.mskcc.cbio.portal.model.DBCancerType;
 import org.mskcc.cbio.portal.model.DBGeneticProfile;
 import org.mskcc.cbio.portal.persistence.CancerTypeMapperLegacy;
-import org.mskcc.cbio.portal.persistence.GeneticProfileMapper;
+import org.mskcc.cbio.portal.persistence.GeneticProfileMapperLegacy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
@@ -75,7 +75,7 @@ public class ApiControllerTest {
     @Autowired
     private CancerTypeMapperLegacy cancerTypeMapperLegacyMock;
     @Autowired
-    private GeneticProfileMapper geneticProfileMapperMock;
+    private GeneticProfileMapperLegacy geneticProfileMapperLegacyMock;
     @Autowired
     private MutationService mutationServiceMock;
     @Autowired
@@ -88,7 +88,7 @@ public class ApiControllerTest {
     @Before
     public void setup() {
         Mockito.reset(cancerTypeMapperLegacyMock);
-        Mockito.reset(geneticProfileMapperMock);
+        Mockito.reset(geneticProfileMapperLegacyMock);
         Mockito.reset(mutationServiceMock);
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
     }
@@ -164,7 +164,7 @@ public class ApiControllerTest {
     public void geneticProfileDataTest1() throws Exception {
         List<Mutation> mockResponse = getGeneticprofiledataQuery1ServiceMock();
         List<DBGeneticProfile> ctMockResponse = getGeneticProfileQuery1ServiceMock();
-        Mockito.when(geneticProfileMapperMock.getGeneticProfiles(
+        Mockito.when(geneticProfileMapperLegacyMock.getGeneticProfiles(
                         org.mockito.Matchers.anyListOf(String.class)
 )).thenReturn(ctMockResponse);
         Mockito.when(mutationServiceMock.getMutationsDetailed(
@@ -354,7 +354,7 @@ public class ApiControllerTest {
     public void geneticProfileDataTest2() throws Exception {
         List<Mutation> mockResponse = getGeneticprofiledataQuery1ServiceMock().subList(0,2);
         List<DBGeneticProfile> ctMockResponse = getGeneticProfileQuery1ServiceMock();
-        Mockito.when(geneticProfileMapperMock.getGeneticProfiles(
+        Mockito.when(geneticProfileMapperLegacyMock.getGeneticProfiles(
                         org.mockito.Matchers.anyListOf(String.class)
 )).thenReturn(ctMockResponse);
         Mockito.when(mutationServiceMock.getMutationsDetailed(
@@ -436,7 +436,7 @@ public class ApiControllerTest {
     public void geneticProfileDataTest3() throws Exception {
         List<Mutation> mockResponse = getGeneticprofiledataQuery1ServiceMock().subList(0,0);
         List<DBGeneticProfile> ctMockResponse = getGeneticProfileQuery1ServiceMock();
-        Mockito.when(geneticProfileMapperMock.getGeneticProfiles(
+        Mockito.when(geneticProfileMapperLegacyMock.getGeneticProfiles(
                         org.mockito.Matchers.anyListOf(String.class)
 )).thenReturn(ctMockResponse);
         Mockito.when(mutationServiceMock.getMutationsDetailed(
@@ -464,7 +464,7 @@ public class ApiControllerTest {
     public void geneticProfileDataTest4() throws Exception {
         List<Mutation> mockResponse = getGeneticprofiledataQuery1ServiceMock().subList(0,2);
         List<DBGeneticProfile> ctMockResponse = getGeneticProfileQuery1ServiceMock();
-        Mockito.when(geneticProfileMapperMock.getGeneticProfiles(
+        Mockito.when(geneticProfileMapperLegacyMock.getGeneticProfiles(
                         org.mockito.Matchers.anyListOf(String.class)
 )).thenReturn(ctMockResponse);
         Mockito.when(mutationServiceMock.getMutationsDetailed(

--- a/web/src/test/java/org/cbioportal/weblegacy/StructuralVariantControllerTest.java
+++ b/web/src/test/java/org/cbioportal/weblegacy/StructuralVariantControllerTest.java
@@ -30,7 +30,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package org.cbioportal.web.legacy;
+package org.cbioportal.weblegacy;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/web/src/test/java/org/cbioportal/weblegacy/StructuralVariantControllerTestConfig.java
+++ b/web/src/test/java/org/cbioportal/weblegacy/StructuralVariantControllerTestConfig.java
@@ -30,7 +30,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package org.cbioportal.web.legacy;
+package org.cbioportal.weblegacy;
 
 import java.util.List;
 import org.cbioportal.persistence.mybatis.StructuralVariantMapper;
@@ -47,7 +47,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
 @Configuration
 @EnableWebMvc
-@ComponentScan(basePackages = {"org.cbioportal.web"})
+@ComponentScan(basePackages = {"org.cbioportal.weblegacy"})
 public class StructuralVariantControllerTestConfig extends WebMvcConfigurerAdapter {
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {


### PR DESCRIPTION
Implemented 5 endpoints in Cancer Type API and Genetic Profile API with persistence, service and web tests

GET /cancer-types
GET /cancer-types/{cancerTypeId}
GET /genetic-profiles
GET /genetic-profiles/{geneticProfileId}
GET /studies/{studyId}/genetic-profiles

Also added sampleCount to the Study APIs `DETAILED` projection.