### PR TITLE
Optimize mutation count fetching

### DIFF
--- a/business/src/main/java/org/mskcc/cbio/portal/service/ApiService.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/service/ApiService.java
@@ -48,6 +48,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.cbioportal.service.CosmicCountService;
 import org.cbioportal.model.MutationSignature;
 import org.cbioportal.model.CosmicCount;
+import org.cbioportal.persistence.dto.PositionMutationCount;
 
 /**
  *
@@ -137,6 +138,11 @@ public class ApiService {
 		}
 		// TODO: implement other contexts
 		return signatures;
+	}
+
+	@Transactional
+	public List<PositionMutationCount> getPositionMutationCounts(Map<String, List<Integer>> hugoGeneSymbolToPositions) {
+		return mutationService.getPositionMutationCounts(hugoGeneSymbolToPositions);
 	}
 
         @Transactional

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
@@ -8,6 +8,8 @@ import org.cbioportal.persistence.dto.MutatedGeneSampleCount;
 import org.cbioportal.persistence.dto.SignificantlyMutatedGene;
 
 import java.util.List;
+import java.util.Map;
+import org.cbioportal.persistence.dto.PositionMutationCount;
 
 public interface MutationRepository {
 
@@ -43,4 +45,7 @@ public interface MutationRepository {
 
     List<AltCount> getMutationsCounts(String type, String hugoGeneSymbol, Integer start, Integer end,
                                       List<String> cancerStudyIdentifiers, Boolean perStudy);
+    
+    List<PositionMutationCount> getPositionMutationCounts(String hugoGeneSymbol, List<Integer> positions);
+    
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/dto/PositionMutationCount.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/dto/PositionMutationCount.java
@@ -1,0 +1,34 @@
+package org.cbioportal.persistence.dto;
+
+import java.io.Serializable;
+
+public class PositionMutationCount implements Serializable {
+
+	private String hugoGeneSymbol;
+	private Integer position;
+	private Integer count;
+
+	public Integer getCount() {
+		return count;
+	}
+
+	public void setCount(Integer count) {
+		this.count = count;
+	}
+
+	public String getHugoGeneSymbol() {
+		return hugoGeneSymbol;
+	}
+
+	public void setHugoGeneSymbol(String hugoGeneSymbol) {
+		this.hugoGeneSymbol = hugoGeneSymbol;
+	}
+
+	public Integer getPosition() {
+		return position;
+	}
+
+	public void setPosition(Integer position) {
+		this.position = position;
+	}
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
@@ -9,6 +9,7 @@ import org.cbioportal.persistence.dto.MutatedGeneSampleCount;
 import org.cbioportal.persistence.dto.SignificantlyMutatedGene;
 
 import java.util.List;
+import org.cbioportal.persistence.dto.PositionMutationCount;
 
 public interface MutationMapper {
 
@@ -50,4 +51,7 @@ public interface MutationMapper {
     List<Integer> getGenesOfMutations(@Param("mutationEventIds") List<Integer> mutationEventIds);
 
     List<String> getKeywordsOfMutations(@Param("mutationEventIds") List<Integer> mutationEventIds);
+    
+    List<PositionMutationCount> getPositionMutationCounts(@Param("hugoGeneSymbol") String hugoGeneSymbol, 
+							@Param("positions") List<Integer> positions);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Arrays;
 import java.util.List;
+import org.cbioportal.persistence.dto.PositionMutationCount;
 
 @Repository
 public class MutationMyBatisRepository implements MutationRepository {
@@ -108,5 +109,9 @@ public class MutationMyBatisRepository implements MutationRepository {
                                              List<String> cancerStudyIdentifiers, Boolean perStudy) {
 
         return mutationMapper.getMutationsCounts(type, hugoGeneSymbol, start, end, cancerStudyIdentifiers, perStudy);
+    }
+    
+    public List<PositionMutationCount> getPositionMutationCounts(String hugoGeneSymbol, List<Integer> positions) {
+	    return mutationMapper.getPositionMutationCounts(hugoGeneSymbol, positions);
     }
 }

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
@@ -362,5 +362,31 @@
         </if>
 
     </select>
-
+    
+    <select id="getPositionMutationCounts" resultType="org.cbioportal.persistence.dto.PositionMutationCount">
+        select
+            gene.HUGO_GENE_SYMBOL as hugoGeneSymbol,
+            mutation_event.ONCOTATOR_PROTEIN_POS_START as position,
+            count(*) as count
+        from gene,sample,mutation,mutation_event
+        where
+            <!-- Match arguments -->
+            gene.HUGO_GENE_SYMBOL = #{hugoGeneSymbol} and
+            mutation_event.ONCOTATOR_PROTEIN_POS_START in 
+                <foreach item="item" collection="positions" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+                
+                and
+            <!-- Join -->
+            sample.INTERNAL_ID = mutation.SAMPLE_ID and
+            gene.ENTREZ_GENE_ID = mutation.ENTREZ_GENE_ID and
+            mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID and
+            
+            <!-- Looking for mutation at single position -->
+            mutation_event.ONCOTATOR_PROTEIN_POS_START = mutation_event.ONCOTATOR_PROTEIN_POS_END
+            
+        group by gene.HUGO_GENE_SYMBOL, mutation_event.ONCOTATOR_PROTEIN_POS_START
+    </select>
+    
 </mapper>

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -172,7 +172,6 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	/* In: - webservice_data, a list of data obtained from the webservice API
 	 * Out: Promise which resolves with map from gene+","+start_pos+","+end_pos to cbioportal mutation count for that position range and gene
 	 */
-	var counts_map = {};
 	var def = new $.Deferred();
 	var to_query = {};
 	for (var i = 0; i < webservice_data.length; i++) {
@@ -182,12 +181,14 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	    }
 	    var gene = datum.hugo_gene_symbol;
 	    var start_pos = datum.protein_start_position;
-	    var end_pos = datum.protein_end_position;
-	    if (gene && start_pos && end_pos && !isNaN(start_pos) && !isNaN(end_pos)) {
-		to_query[gene + ',' + parseInt(start_pos, 10) + ',' + parseInt(end_pos, 10)] = true;
+	    //var end_pos = datum.protein_end_position;
+	    //if (gene && start_pos && end_pos && !isNaN(start_pos) && !isNaN(end_pos)) {
+	    if (gene && start_pos && !isNaN(start_pos)) {
+		to_query[gene] = to_query[gene] || {};
+		to_query[gene][parseInt(start_pos, 10)] = true;
 	    }
 	}
-	var queries = Object.keys(to_query).map(function (x) {
+	/*var queries = Object.keys(to_query).map(function (x) {
 	    var splitx = x.split(',');
 	    return {
 		gene: splitx[0],
@@ -203,26 +204,29 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	});
 	var ends = queries.map(function (q) {
 	    return q.end_pos;
-	});
-
-	if (queries.length > 0) {
-	    window.cbioportal_client.getMutationCounts({
-		'type': 'count',
-		'per_study': false,
-		'gene': genes,
-		'start': starts,
-		'end': ends,
-		'echo': ['gene', 'start', 'end']
-	    }).then(function (counts) {
-		for (var i = 0; i < counts.length; i++) {
-		    var gene = counts[i].gene;
-		    var start = parseInt(counts[i].start, 10);
-		    var end = parseInt(counts[i].end, 10);
-		    counts_map[gene + ',' + start + ',' + end] = parseInt(counts[i].count, 10);
-		}
-		def.resolve(counts_map);
-	    }).fail(function () {
+	});*/
+	if (Object.keys(to_query).length > 0) {
+	    var query_map = {};
+	    var query_genes = Object.keys(to_query);
+	    for (var i=0; i<query_genes.length; i++) {
+		query_map[query_genes[i]] = Object.keys(to_query[query_genes[i]]).map(function(x) { return parseInt(x,10); });
+	    }
+	    $.ajax({
+		type: "POST",
+		url: "api-legacy/mutation_count/position",
+		data: "hugoGeneSymbolToPositions=" + JSON.stringify(query_map),
+	    }).fail(function() {
 		def.reject();
+	    }).then(function(position_mutation_counts) {
+		var gene_to_position_to_count = {};
+		for (var i=0; i<position_mutation_counts.length; i++) {
+		    var gene = position_mutation_counts[i].hugoGeneSymbol;
+		    var position = position_mutation_counts[i].position;
+		    var count = position_mutation_counts[i].count;
+		    gene_to_position_to_count[gene] = gene_to_position_to_count[gene] || {};
+		    gene_to_position_to_count[gene][position] = count;
+		}
+		def.resolve(gene_to_position_to_count);
 	    });
 	} else {
 	    def.resolve({});
@@ -327,18 +331,19 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	 */
 	var def = new $.Deferred();
 	var attribute_name = 'cbioportal_mutation_count';
-	getCBioPortalMutationCounts(webservice_data).then(function (counts_map) {
+	getCBioPortalMutationCounts(webservice_data).then(function (gene_to_position_to_count) {
 	    for (var i = 0; i < webservice_data.length; i++) {
 		var datum = webservice_data[i];
-		if (datum.genetic_alteration_type !== "MUTATION_EXTENDED") {
+		if (datum.genetic_alteration_type !== "MUTATION_EXTENDED" || datum.simplified_mutation_type !== "missense") {
 		    continue;
 		}
 		var gene = datum.hugo_gene_symbol;
 		gene && (gene = gene.toUpperCase());
 		var start_pos = datum.protein_start_position;
-		var end_pos = datum.protein_end_position;
-		if (gene && start_pos && end_pos && !isNaN(start_pos) && !isNaN(end_pos)) {
-		    datum[attribute_name] = counts_map[gene + ',' + parseInt(start_pos, 10) + ',' + parseInt(end_pos, 10)];
+		//var end_pos = datum.protein_end_position;
+		//if (gene && start_pos && end_pos && !isNaN(start_pos) && !isNaN(end_pos)) {
+		if (gene && start_pos && !isNaN(start_pos)) {
+		    datum[attribute_name] = gene_to_position_to_count[gene][start_pos];
 		}
 	    }
 	    def.resolve(webservice_data);

--- a/service/src/main/java/org/cbioportal/service/MutationService.java
+++ b/service/src/main/java/org/cbioportal/service/MutationService.java
@@ -4,6 +4,8 @@ import org.cbioportal.model.Mutation;
 import org.cbioportal.persistence.dto.AltCount;
 
 import java.util.List;
+import java.util.Map;
+import org.cbioportal.persistence.dto.PositionMutationCount;
 
 public interface MutationService {
 
@@ -12,4 +14,7 @@ public interface MutationService {
 
     List<AltCount> getMutationsCounts(String type, String hugoGeneSymbol, Integer start, Integer end,
                                       List<String> cancerStudyIdentifiers, Boolean perStudy);
+    
+    List<PositionMutationCount> getPositionMutationCounts(Map<String, List<Integer>> hugoGeneSymbolToPositions);
+    
 }

--- a/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
@@ -1,5 +1,6 @@
 package org.cbioportal.service.impl;
 
+import java.util.LinkedList;
 import org.cbioportal.model.Mutation;
 import org.cbioportal.persistence.MutationRepository;
 import org.cbioportal.persistence.dto.AltCount;
@@ -8,6 +9,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.cbioportal.persistence.dto.PositionMutationCount;
 
 @Service
 public class MutationServiceImpl implements MutationService {
@@ -27,5 +31,13 @@ public class MutationServiceImpl implements MutationService {
 
         return mutationRepository.getMutationsCounts(type, hugoGeneSymbol, start, end, cancerStudyIdentifiers,
                 perStudy);
+    }
+    
+    public List<PositionMutationCount> getPositionMutationCounts(Map<String, List<Integer>> hugoGeneSymbolToPositions) {
+	    List<PositionMutationCount> ret = new LinkedList<PositionMutationCount>();
+	    for (Entry<String,List<Integer>> entry: hugoGeneSymbolToPositions.entrySet()) {
+		    ret.addAll(mutationRepository.getPositionMutationCounts(entry.getKey(), entry.getValue()));
+	    }
+	    return ret;
     }
 }

--- a/web/src/main/java/org/cbioportal/weblegacy/ApiController.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/ApiController.java
@@ -5,7 +5,8 @@
  */
 package org.cbioportal.weblegacy;
 
-import java.io.Serializable;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.ArrayList;
 import java.util.List;
 import org.mskcc.cbio.portal.service.ApiService;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.transaction.annotation.Transactional;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -34,6 +36,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import org.cbioportal.model.CosmicCount;
 import org.cbioportal.model.MutationSignature;
+import org.cbioportal.persistence.dto.PositionMutationCount;
 
 /**
  *
@@ -106,6 +109,22 @@ public class ApiController {
         }
         return service.getMutationsCounts(customizedAttrs, type, per_study, studyId, gene, start, end, echo);
                 
+    }
+    
+    @ApiOperation(value = "Get mutation count for certain gene at specified positions.",
+            nickname = "getPositionMutationCount",
+            notes = "")
+    @Transactional
+    @RequestMapping(value = "/mutation_count/position", method = {RequestMethod.GET, RequestMethod.POST})
+    public @ResponseBody List<PositionMutationCount> getPositionMutationCounts(
+        HttpServletRequest request,
+        @RequestParam(required = true) String hugoGeneSymbolToPositions) {
+	    try {
+		Map<String, List<Integer>> hugoGeneSymbolToPositionsDecodedMap = (new ObjectMapper()).readValue(hugoGeneSymbolToPositions, new TypeReference<Map<String, List<Integer>>>(){});
+		return service.getPositionMutationCounts(hugoGeneSymbolToPositionsDecodedMap);
+	    } catch (IOException e) {
+		    return new ArrayList<>();
+	    }
     }
 
 


### PR DESCRIPTION
# What? Why?

Fix https://github.com/cBioPortal/cbioportal/issues/1788

Changes proposed in this pull request:

Implemented new (legacy) API endpoint for getting mutation counts from single positions,
which is faster to do than with position inequalities.

Use this in data manager instead of old mutation count endpoint.
# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.
# Notify reviewers

@cBioPortal/frontend
@jjgao 
