### PR TITLE
Validator: fix requirement for OS_MONTHS

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1798,15 +1798,6 @@ class PatientClinicalValidator(ClinicalValidator):
             elif col_name == 'OS_MONTHS':
                 osmonths_value = value
 
-        if osstatus_is_deceased and (
-                    osmonths_value is None or
-                    osmonths_value.lower() in self.NULL_VALUES):
-            if osmonths_value is None or osmonths_value == '':
-                osmonths_value = '<none>'
-            self.logger.error(
-                "OS_STATUS is 'DECEASED', but OS_MONTHS is not specified",
-                extra={'line_number': self.line_number,
-                       'cause': osmonths_value})
 
     def onComplete(self):
         """Perform final validations based on the data parsed."""

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1798,6 +1798,17 @@ class PatientClinicalValidator(ClinicalValidator):
             elif col_name == 'OS_MONTHS':
                 osmonths_value = value
 
+        if osstatus_is_deceased and (
+                    osmonths_value is None or
+                    osmonths_value.lower() in self.NULL_VALUES):
+            if osmonths_value is None or osmonths_value == '':
+                osmonths_value = '<none>'
+            self.logger.warning(
+                'OS_MONTHS is not specified for deceased patient. Patient '
+                'will be excluded from survival curve and month of death '
+                'will not be shown on patient view timeline.',
+                extra={'line_number': self.line_number,
+                       'cause': osmonths_value})
 
     def onComplete(self):
         """Perform final validations based on the data parsed."""

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -278,10 +278,10 @@ class PatientAttrFileTestCase(PostClinicalDataFileTestCase):
 
     def test_hardcoded_attr_values(self):
         """Test if attributes with set meanings have recognized values."""
-        self.logger.setLevel(logging.ERROR)
+        self.logger.setLevel(logging.WARNING)
         record_list = self.validate('data_clin_hardcoded_attr_vals.txt',
                                     validateData.PatientClinicalValidator)
-        self.assertEqual(len(record_list), 4)
+        self.assertEqual(len(record_list), 5)
         record_iterator = iter(record_list)
         # OS_STATUS not in controlled vocabulary
         record = record_iterator.next()
@@ -307,6 +307,14 @@ class PatientAttrFileTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(record.line_number, 11)
         self.assertEqual(record.column_number, 5)
         self.assertEqual(record.cause, 'recurred/progressed')
+        # unspecified OS_MONTHS while OS_STATUS is DECEASED
+        record = record_iterator.next()
+        self.assertEqual(record.levelno, logging.WARNING)
+        self.assertEqual(record.line_number, 13)
+        self.assertIn('OS_MONTHS is not specified for deceased patient. Patient '
+                      'will be excluded from survival curve and month of death '
+                      'will not be shown on patient view timeline.',
+                      record.getMessage())
 
 
 # TODO: make tests in this testcase check the number of properly defined types

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -281,7 +281,7 @@ class PatientAttrFileTestCase(PostClinicalDataFileTestCase):
         self.logger.setLevel(logging.ERROR)
         record_list = self.validate('data_clin_hardcoded_attr_vals.txt',
                                     validateData.PatientClinicalValidator)
-        self.assertEqual(len(record_list), 5)
+        self.assertEqual(len(record_list), 4)
         record_iterator = iter(record_list)
         # OS_STATUS not in controlled vocabulary
         record = record_iterator.next()
@@ -307,11 +307,6 @@ class PatientAttrFileTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(record.line_number, 11)
         self.assertEqual(record.column_number, 5)
         self.assertEqual(record.cause, 'recurred/progressed')
-        # unspecified OS_MONTHS while OS_STATUS is DECEASED
-        record = record_iterator.next()
-        self.assertEqual(record.levelno, logging.ERROR)
-        self.assertEqual(record.line_number, 13)
-        self.assertIn('DECEASED', record.getMessage())
 
 
 # TODO: make tests in this testcase check the number of properly defined types

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -150,7 +150,7 @@ The following columns are used by the study view as well as the patient view. In
     - Possible values: DECEASED, LIVING
     - In the patient view, LIVING creates a green label, DECEASED a red label.
     - In visualisation of [Timeline data](#timeline-data), DECEASED will result in a new event of type STATUS
-- **OS_MONTHS (required if OS_STATUS is DECEASED)**:  Overall survival in months since initial diagnosis
+- **OS_MONTHS**:  Overall survival in months since initial diagnosis
 - **DFS_STATUS**: Disease free status since initial treatment
     - Possible values: DiseaseFree, Recurred/Progressed
     - In the patient view, DiseaseFree creates a green label, Recurred/Progressed a red label.


### PR DESCRIPTION
Changes proposed in this pull request:
Remove the requirement: `OS_MONTHS has to be specified when OS_STATUS is DECEASED` in validateData.py

The requirement was added in 1.3.1 in commit aa9a48cb1d5601a840267aabc86f5bc6482edd5a . It was added because @aderidder noticed in early 2016 that the front end could not handle a missing value for OS_MONTHS when OS_STATUS was deceased, which caused issues with the patient information page.

We cannot reproduce this error anymore, but this requirement does lead to failed verifications of studies that are presumed to be good:

TCGA studies from datahub (such as lgg_tcga) that could be loaded prior to 1.3.1, now fail to load, because studies can contain [Not Available] in the OS_MONTHS column of `data_bcr_clinical_data_patient.txt`. We loaded this data in prior versions (1.2.5) of cBioPortal, and did not find any issues with the patient information page. 

We also loaded time-line data which contained [Not Available] in OS_MONTHS for a patient and this also seems to work fine. The timeline cannot show months in this case, but everything else on the page functions correctly.
