### PR TITLE
Close db connection in bulk loader flushAll

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
@@ -171,7 +171,7 @@ public class JdbcUtil {
      * @param rs  ResultSet Object.
      */
     public static void closeAll(ResultSet rs) {
-                JdbcUtil.closeAll((String)null, null, rs);
+                JdbcUtil.closeAll((String)null, null, null, rs);
         }
 
     /**
@@ -183,7 +183,7 @@ public class JdbcUtil {
      */
     public static void closeAll(Class clazz, Connection con, PreparedStatement ps,
             ResultSet rs) {
-        closeAll(clazz.getName(), con, rs);
+        closeAll(clazz.getName(), con, ps, rs);
     }
 
     /**
@@ -192,9 +192,8 @@ public class JdbcUtil {
      * @param con Connection Object.
      * @param rs  ResultSet Object.
      */
-    private static void closeAll(String requester, Connection con,
+    private static void closeAll(String requester, Connection con, PreparedStatement ps,
                                  ResultSet rs) {
-        closeConnection(requester, con);
         if (rs != null) {
             try {
                 rs.close();
@@ -202,6 +201,14 @@ public class JdbcUtil {
                 e.printStackTrace();
             }
         }
+        if (ps != null) {
+            try {
+                ps.close();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }
+        closeConnection(requester, con);        
     }
 
     /**

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/MySQLbulkLoader.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/MySQLbulkLoader.java
@@ -77,8 +77,9 @@ public class MySQLbulkLoader {
 	   int checks = 0;
        PreparedStatement stmt = null;
        boolean executedSetFKChecks = false;
+       Connection con = null;
        try {
-            Connection con = JdbcUtil.getDbConnection(MySQLbulkLoader.class);
+            con = JdbcUtil.getDbConnection(MySQLbulkLoader.class);
             stmt = con.prepareStatement("SELECT @@foreign_key_checks;");
             ResultSet result = stmt.executeQuery();
             
@@ -104,16 +105,17 @@ public class MySQLbulkLoader {
         	throw new DaoException(e);
         }
         finally {
-        	mySQLbulkLoaders.clear();
+            mySQLbulkLoaders.clear();
             if (executedSetFKChecks && stmt != null) {
-            	try {
-					stmt.setLong(1, checks);
-					stmt.execute();
-				} catch (SQLException e) {
-					throw new DaoException(e);
-				}
-            	
+                try {
+                    stmt.setLong(1, checks);
+                    stmt.execute();
+                }
+                catch (SQLException e) {
+                    throw new DaoException(e);
+                }            	
             }
+            JdbcUtil.closeAll(MySQLbulkLoader.class, con, stmt, null);
         }
     }
 


### PR DESCRIPTION
# What? Why?
Not closing the database connection in the flushAll method was causing db connections to not be returned to the pool after importing data. If importing multiple studies or large studies with many files, the import would hang waiting for a db connection.

Changes proposed in this pull request:
- Close db connection after import in flushAll

# Checks
- [ ] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):
@mandawilson 
@n1zea144 