### PR TITLE
Using LinkedHashMap for correct insert order

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/MySQLbulkLoader.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/MySQLbulkLoader.java
@@ -51,7 +51,7 @@ public class MySQLbulkLoader {
    private static boolean bulkLoad = false;
    private static boolean relaxedMode = false;
    
-   private static final Map<String,MySQLbulkLoader> mySQLbulkLoaders = new HashMap<String,MySQLbulkLoader>();
+   private static final Map<String,MySQLbulkLoader> mySQLbulkLoaders = new LinkedHashMap<String,MySQLbulkLoader>();
    /**
     * Get a MySQLbulkLoader
     * @param dbName database name

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1262,14 +1262,16 @@ class MutationsExtendedValidator(Validator):
             if not re.match(
                         r'^[A-Z0-9]{1,5}_[A-Z0-9]{1,5}$',
                         value):
-                cause = value
                 # if there is a ',' then give a more detailed message:
                 if ',' in value:
-                    cause = 'Expecting a single value, but found multiple separated by a `,`:' + value
-                # return this as an warning
-                self.logger.warning('SWISSPROT value is not a (single) UniProtKB/Swiss-Prot name. '
-                                    'Loader will try to find UniProt accesion using Entrez/HUGO',
-                                    extra={'line_number': self.line_number, 'cause': cause})
+                    self.logger.warning('SWISSPROT value is not a single UniProtKB/Swiss-Prot name. '
+                                        'Found multiple separated by a `,`. '
+                                        'Loader will try to find UniProt accession using Entrez/HUGO.',
+                                        extra={'line_number': self.line_number, 'cause': value})
+                else:
+                    self.logger.warning('SWISSPROT value is not a (single) UniProtKB/Swiss-Prot name. '
+                                        'Loader will try to find UniProt accession using Entrez/HUGO',
+                                        extra={'line_number': self.line_number, 'cause': value})
                 return True
         # if no reasons to return with a message were found, return valid
         return True


### PR DESCRIPTION
# What? Why?
Fixes MySQLBulkLoader issue in #1858 .

Changes proposed in this pull request:
- Using LinkedHashMap. This will ensure the `mutation_event` table gets updated before `mutation` table.

# Checks
- Successfully loaded `acc_tcga` study as a test

# Notify reviewers
@n1zea144 @sheridancbio @jjgao 