### PR TITLE
Update warning to fix unit-test

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1262,14 +1262,16 @@ class MutationsExtendedValidator(Validator):
             if not re.match(
                         r'^[A-Z0-9]{1,5}_[A-Z0-9]{1,5}$',
                         value):
-                cause = value
                 # if there is a ',' then give a more detailed message:
                 if ',' in value:
-                    cause = 'Expecting a single value, but found multiple separated by a `,`:' + value
-                # return this as an warning
-                self.logger.warning('SWISSPROT value is not a (single) UniProtKB/Swiss-Prot name. '
-                                    'Loader will try to find UniProt accesion using Entrez/HUGO',
-                                    extra={'line_number': self.line_number, 'cause': cause})
+                    self.logger.warning('SWISSPROT value is not a single UniProtKB/Swiss-Prot name. '
+                                        'Found multiple separated by a `,`. '
+                                        'Loader will try to find UniProt accession using Entrez/HUGO.',
+                                        extra={'line_number': self.line_number, 'cause': value})
+                else:
+                    self.logger.warning('SWISSPROT value is not a (single) UniProtKB/Swiss-Prot name. '
+                                        'Loader will try to find UniProt accession using Entrez/HUGO',
+                                        extra={'line_number': self.line_number, 'cause': value})
                 return True
         # if no reasons to return with a message were found, return valid
         return True


### PR DESCRIPTION
# What? Why?
PR1729 included a last minute change to the warning, which caused the unit-test to fail. This PR modifies the warning message so that the unit-test succeeds, and also moved the warning message from `cause`-field to `message`-field.