### PR TITLE
Removed bulk load option from addGene() method

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGene.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGene.java
@@ -78,15 +78,8 @@ final class DaoGene {
      * @throws DaoException Database Error.
      */
     public static int addGene(CanonicalGene gene) throws DaoException {
-        if (MySQLbulkLoader.isBulkLoad()) {
-            //  write to the temp file maintained by the MySQLbulkLoader
-            MySQLbulkLoader.getMySQLbulkLoader("gene").insertRecord(Long.toString(gene.getEntrezGeneId()),
-                    gene.getHugoGeneSymbolAllCaps(),gene.getType(),gene.getCytoband(),gene.getLength()==0?null:Integer.toString(gene.getLength()));
-            addGeneAliases(gene);
-            // return 1 because normal insert will return 1 if no error occurs
-            return 1;
-        }
-        
+    	//because many tables depend on gene, we want to add gene directly to DB, and
+    	//never through MySQLbulkLoader to avoid any Foreign key constraint violations:
         Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;


### PR DESCRIPTION
# What? Why?
Removed bulk load option from addGene() method. This was resulting in a similar issue to #1858, but now for RPPA data (where "dummy" genes need to be added on the fly during import - see `ImportTabDelimData.java`, `parseRPPAGenes()` method). Because many tables depend on gene, we want to add gene directly to DB, and	never through MySQLbulkLoader to avoid any Foreign key constraint violations.

Changes proposed in this pull request:
- let DaoGene.addGene() insert any genes directly into DB instead of using a delayed MySQLbulkLoader process

# Checks
- [x] Successfully imported 2 studies from datahub after this fix.

# Notify reviewers
@n1zea144 @zheins 