### PR TITLE
Fix bug in validator regarding scientific notation of int

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1897,11 +1897,13 @@ class SegValidator(Validator):
                     del parsed_coords[col_name]
             elif col_name == 'num.mark':
                 if not self.checkInt(value):
-                    self.logger.error(
-                        'Number of probes is not an integer',
-                        extra={'line_number': self.line_number,
-                               'column_number': col_index + 1,
-                               'cause': value})
+                    # also check if the value is an int in scientific notation (1e+05) 
+                    if not ("e+" in value and self.checkFloat(value)):
+                        self.logger.error(
+                            'Number of probes is not an integer',
+                            extra={'line_number': self.line_number,
+                                   'column_number': col_index + 1,
+                                   'cause': value})
             elif col_name == 'seg.mean':
                 if not self.checkFloat(value):
                     self.logger.error(


### PR DESCRIPTION
# What? Why?
Fix small bug in validator regarding values in scientific notation (1e+05) in the segment files. We checked the java code, and found it can correctly parse such values to a long. 