### PR TITLE
Potential solution to force increase groupConcatMaxLen

### DIFF
--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
@@ -30,7 +30,7 @@ public interface MutationMapper {
     Boolean hasAlleleFrequencyData(@Param("geneticProfileId") Integer geneticProfileId,
                                    @Param("sampleId") Integer sampleId);
 
-    void groupConcatMaxLenSet();
+    Integer groupConcatMaxLenSet();
 
     List<SignificantlyMutatedGene> getSignificantlyMutatedGenes(@Param("geneticProfileId") Integer geneticProfileId,
                                                                 @Param("entrezGeneIds") List<Integer> entrezGeneIds,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
@@ -74,7 +74,7 @@ public class MutationMyBatisRepository implements MutationRepository {
                                                                        boolean setGroupConcatMaxLen) {
 
         if (setGroupConcatMaxLen) {
-            mutationMapper.groupConcatMaxLenSet();
+            Integer returnVal = mutationMapper.groupConcatMaxLenSet();
         }
         return mutationMapper.getSignificantlyMutatedGenes(geneticProfileId, entrezGeneIds, sampleIds,
                 thresholdRecurrence, thresholdNumGenes);


### PR DESCRIPTION
# What? Why?
Fix #1880 and https://github.com/cBioPortal/iViz/issues/293 .

Changes proposed in this pull request:
Make function ```groupConcatMaxLenSet``` in ```MutationMapper``` returns Integer.
We think the reason we randomly have the issue like #1880 is because the script to increase ```group_concat_max_len``` is not executed before the database query sometimes. By doing the fixes in the pull request, the database query will wait until groupConcatMaxLenSet returns the value.
 
# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@ersinciftci @jjgao 
@cBioPortal/backend 
