### PR TITLE
Add datasets related counts to Study API's DETAILED projection

### DIFF
--- a/model/src/main/java/org/cbioportal/model/CancerStudy.java
+++ b/model/src/main/java/org/cbioportal/model/CancerStudy.java
@@ -18,7 +18,15 @@ public class CancerStudy implements Serializable {
     private Integer status;
     private Date importDate;
     private TypeOfCancer typeOfCancer;
-    private Integer sampleCount;
+    private Integer allSampleCount;
+    private Integer sequencedSampleCount;
+    private Integer cnaSampleCount;
+    private Integer mrnaRnaSeqV2SampleCount;
+    private Integer mrnaMicroarraySampleCount;
+    private Integer miRnaSampleCount;
+    private Integer methylationHm27SampleCount;
+    private Integer rppaSampleCount;
+    private Integer completeSampleCount;
 
     public Integer getCancerStudyId() {
         return cancerStudyId;
@@ -124,11 +132,75 @@ public class CancerStudy implements Serializable {
         this.typeOfCancer = typeOfCancer;
     }
 
-    public Integer getSampleCount() {
-        return sampleCount;
+    public Integer getAllSampleCount() {
+        return allSampleCount;
     }
 
-    public void setSampleCount(Integer sampleCount) {
-        this.sampleCount = sampleCount;
+    public void setAllSampleCount(Integer allSampleCount) {
+        this.allSampleCount = allSampleCount;
+    }
+
+    public Integer getSequencedSampleCount() {
+        return sequencedSampleCount;
+    }
+
+    public void setSequencedSampleCount(Integer sequencedSampleCount) {
+        this.sequencedSampleCount = sequencedSampleCount;
+    }
+
+    public Integer getCnaSampleCount() {
+        return cnaSampleCount;
+    }
+
+    public void setCnaSampleCount(Integer cnaSampleCount) {
+        this.cnaSampleCount = cnaSampleCount;
+    }
+
+    public Integer getMrnaRnaSeqV2SampleCount() {
+        return mrnaRnaSeqV2SampleCount;
+    }
+
+    public void setMrnaRnaSeqV2SampleCount(Integer mrnaRnaSeqV2SampleCount) {
+        this.mrnaRnaSeqV2SampleCount = mrnaRnaSeqV2SampleCount;
+    }
+
+    public Integer getMrnaMicroarraySampleCount() {
+        return mrnaMicroarraySampleCount;
+    }
+
+    public void setMrnaMicroarraySampleCount(Integer mrnaMicroarraySampleCount) {
+        this.mrnaMicroarraySampleCount = mrnaMicroarraySampleCount;
+    }
+
+    public Integer getMiRnaSampleCount() {
+        return miRnaSampleCount;
+    }
+
+    public void setMiRnaSampleCount(Integer miRnaSampleCount) {
+        this.miRnaSampleCount = miRnaSampleCount;
+    }
+
+    public Integer getMethylationHm27SampleCount() {
+        return methylationHm27SampleCount;
+    }
+
+    public void setMethylationHm27SampleCount(Integer methylationHm27SampleCount) {
+        this.methylationHm27SampleCount = methylationHm27SampleCount;
+    }
+
+    public Integer getRppaSampleCount() {
+        return rppaSampleCount;
+    }
+
+    public void setRppaSampleCount(Integer rppaSampleCount) {
+        this.rppaSampleCount = rppaSampleCount;
+    }
+
+    public Integer getCompleteSampleCount() {
+        return completeSampleCount;
+    }
+
+    public void setCompleteSampleCount(Integer completeSampleCount) {
+        this.completeSampleCount = completeSampleCount;
     }
 }

--- a/persistence/persistence-mybatis-test/src/test/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis-test/src/test/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepositoryTest.java
@@ -62,6 +62,7 @@ public class StudyMyBatisRepositoryTest {
         Assert.assertEquals("SU2C-PI3K;PUBLIC;GDAC", cancerStudy.getGroups());
         Assert.assertEquals((Integer) 0 , cancerStudy.getStatus());
         Assert.assertEquals(simpleDateFormat.parse("2011-12-18 13:17:17"), cancerStudy.getImportDate());
+        Assert.assertEquals((Integer) 14, cancerStudy.getAllSampleCount());
         Assert.assertNull(cancerStudy.getTypeOfCancer());
     }
 
@@ -89,6 +90,15 @@ public class StudyMyBatisRepositoryTest {
         Assert.assertEquals("SU2C-PI3K;PUBLIC;GDAC", cancerStudy.getGroups());
         Assert.assertEquals((Integer) 0 , cancerStudy.getStatus());
         Assert.assertEquals(simpleDateFormat.parse("2011-12-18 13:17:17"), cancerStudy.getImportDate());
+        Assert.assertEquals((Integer) 14, cancerStudy.getAllSampleCount());
+        Assert.assertEquals((Integer) 7, cancerStudy.getCnaSampleCount());
+        Assert.assertEquals((Integer) 7, cancerStudy.getCompleteSampleCount());
+        Assert.assertEquals((Integer) 1, cancerStudy.getMethylationHm27SampleCount());
+        Assert.assertEquals((Integer) 8, cancerStudy.getMiRnaSampleCount());
+        Assert.assertEquals((Integer) 0, cancerStudy.getMrnaMicroarraySampleCount());
+        Assert.assertEquals((Integer) 7, cancerStudy.getMrnaRnaSeqV2SampleCount());
+        Assert.assertEquals((Integer) 0, cancerStudy.getRppaSampleCount());
+        Assert.assertEquals((Integer) 7, cancerStudy.getSequencedSampleCount());
         TypeOfCancer typeOfCancer = cancerStudy.getTypeOfCancer();
         Assert.assertEquals("brca", typeOfCancer.getTypeOfCancerId());
         Assert.assertEquals("Breast Invasive Carcinoma", typeOfCancer.getName());
@@ -155,6 +165,15 @@ public class StudyMyBatisRepositoryTest {
         Assert.assertEquals("SU2C-PI3K;PUBLIC;GDAC", result.getGroups());
         Assert.assertEquals((Integer) 0 , result.getStatus());
         Assert.assertEquals(simpleDateFormat.parse("2011-12-18 13:17:17"), result.getImportDate());
+        Assert.assertEquals((Integer) 14, result.getAllSampleCount());
+        Assert.assertEquals((Integer) 7, result.getCnaSampleCount());
+        Assert.assertEquals((Integer) 7, result.getCompleteSampleCount());
+        Assert.assertEquals((Integer) 1, result.getMethylationHm27SampleCount());
+        Assert.assertEquals((Integer) 8, result.getMiRnaSampleCount());
+        Assert.assertEquals((Integer) 0, result.getMrnaMicroarraySampleCount());
+        Assert.assertEquals((Integer) 7, result.getMrnaRnaSeqV2SampleCount());
+        Assert.assertEquals((Integer) 0, result.getRppaSampleCount());
+        Assert.assertEquals((Integer) 7, result.getSequencedSampleCount());
         TypeOfCancer typeOfCancer = result.getTypeOfCancer();
         Assert.assertEquals("brca", typeOfCancer.getTypeOfCancerId());
         Assert.assertEquals("Breast Invasive Carcinoma", typeOfCancer.getName());

--- a/persistence/persistence-mybatis-test/src/test/resources/testSql.sql
+++ b/persistence/persistence-mybatis-test/src/test/resources/testSql.sql
@@ -523,14 +523,20 @@ INSERT INTO "sample_profile" ("SAMPLE_ID","GENETIC_PROFILE_ID","PANEL_ID") VALUE
 INSERT INTO "sample_profile" ("SAMPLE_ID","GENETIC_PROFILE_ID","PANEL_ID") VALUES (14,4,NULL);
 
 -- sample_list
-INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (1,'study_tcga_pub_all','other',1,'All Tumors','All tumor samples (14 samples)');
-INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (2,'study_tcga_pub_acgh','other',1,'Tumors aCGH','All tumors with aCGH data (778 samples)');
-INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (3,'study_tcga_pub_cnaseq','other',1,'Tumors with sequencing and aCGH data','All tumor samples that have CNA and sequencing data (482 samples)');
-INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (4,'study_tcga_pub_complete','other',1,'Complete samples (mutations, copy-number, expression)','Samples with complete data (463 samples)');
-INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (5,'study_tcga_pub_log2CNA','other',1,'Tumors log2 copy-number','All tumors with log2 copy-number data (778 samples)');
-INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (6,'study_tcga_pub_methylation_hm27','all_cases_with_mutation_data',1,'Tumors with methylation data','All samples with methylation (HM27) data (311 samples)');
-INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (7,'study_tcga_pub_mrna','other',1,'Tumors with mRNA data (Agilent microarray)','All samples with mRNA expression data (526 samples)');
-INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (8,'study_tcga_pub_sequenced','other',1,'Sequenced Tumors','All sequenced samples (507 samples)');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (1,'study_tcga_pub_all','other',1,'All Tumors','All tumor samples');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (2,'study_tcga_pub_acgh','other',1,'Tumors aCGH','All tumors with aCGH data');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (3,'study_tcga_pub_cnaseq','other',1,'Tumors with sequencing and aCGH data','All tumor samples that have CNA and sequencing data');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (4,'study_tcga_pub_complete','other',1,'Complete samples (mutations, copy-number, expression)','Samples with complete data');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (5,'study_tcga_pub_log2CNA','other',1,'Tumors log2 copy-number','All tumors with log2 copy-number data');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (6,'study_tcga_pub_methylation_hm27','all_cases_with_mutation_data',1,'Tumors with methylation data','All samples with methylation (HM27) data');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (7,'study_tcga_pub_mrna','other',1,'Tumors with mRNA data (Agilent microarray)','All samples with mRNA expression data');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (8,'study_tcga_pub_sequenced','other',1,'Sequenced Tumors','All sequenced samples');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (9,'study_tcga_pub_cna','other',1,'Tumor Samples with CNA data','All tumors with CNA data');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (10,'study_tcga_pub_rna_seq_v2_mrna','other',1,'Tumor Samples with mRNA data (RNA Seq V2)','All samples with mRNA expression data');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (11,'study_tcga_pub_microrna','other',1,'Tumors with microRNA data (microRNA-Seq)','All samples with microRNA data');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (12,'study_tcga_pub_rppa','other',1,'Tumor Samples with RPPA data','Tumors with reverse phase protein array (RPPA) data for about 200 antibodies');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (13,'study_tcga_pub_3way_complete','other',1,'All Complete Tumors','All tumor samples that have mRNA, CNA and sequencing data');
+INSERT INTO "sample_list" ("LIST_ID", "STABLE_ID", "CATEGORY", "CANCER_STUDY_ID", "NAME", "DESCRIPTION") VALUES (14,'acc_tcga_all','other',2,'All Tumors','All tumor samples');
 
 -- sample_list_list
 INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (1,1);
@@ -605,6 +611,28 @@ INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (8,8);
 INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (8,9);
 INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (8,10);
 INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (8,12);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (9,2);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (9,3);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (9,6);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (9,8);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (9,9);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (9,10);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (9,12);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (10,2);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (10,3);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (10,6);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (10,8);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (10,9);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (10,10);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (10,12);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (13,2);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (13,3);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (13,6);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (13,8);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (13,9);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (13,10);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (13,12);
+INSERT INTO "sample_list_list" ("LIST_ID","SAMPLE_ID") VALUES (14,15);
 
 INSERT INTO "copy_number_seg" ("SEG_ID","CANCER_STUDY_ID","SAMPLE_ID","CHR","START","END","NUM_PROBES","SEGMENT_MEAN") VALUES (50236594, 1, 1, '1', 224556, 180057677, 291, 0.0519);
 INSERT INTO "copy_number_seg" ("SEG_ID","CANCER_STUDY_ID","SAMPLE_ID","CHR","START","END","NUM_PROBES","SEGMENT_MEAN") VALUES (50236593, 1, 2,	'2', 1402650, 190262486, 207, 0.0265);

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
@@ -22,12 +22,27 @@
         </if>
     </sql>
 
+    <sql id="selectDetailed">
+        ,
+        COUNT(CASE WHEN sample_list.STABLE_ID = CONCAT(cancer_study.CANCER_STUDY_IDENTIFIER,'_sequenced') THEN 1 ELSE NULL END) AS sequencedSampleCount,
+        COUNT(CASE WHEN sample_list.STABLE_ID = CONCAT(cancer_study.CANCER_STUDY_IDENTIFIER,'_cna') THEN 1 ELSE NULL END) AS cnaSampleCount,
+        COUNT(CASE WHEN sample_list.STABLE_ID = CONCAT(cancer_study.CANCER_STUDY_IDENTIFIER,'_rna_seq_v2_mrna') THEN 1 ELSE NULL END) AS mrnaRnaSeqV2SampleCount,
+        COUNT(CASE WHEN sample_list.STABLE_ID = CONCAT(cancer_study.CANCER_STUDY_IDENTIFIER,'_microrna') THEN 1 ELSE NULL END) AS mrnaMicroarraySampleCount,
+        COUNT(CASE WHEN sample_list.STABLE_ID = CONCAT(cancer_study.CANCER_STUDY_IDENTIFIER,'_mrna') THEN 1 ELSE NULL END) AS miRnaSampleCount,
+        COUNT(CASE WHEN sample_list.STABLE_ID = CONCAT(cancer_study.CANCER_STUDY_IDENTIFIER,'_methylation_hm27') THEN 1 ELSE NULL END) AS methylationHm27SampleCount,
+        COUNT(CASE WHEN sample_list.STABLE_ID = CONCAT(cancer_study.CANCER_STUDY_IDENTIFIER,'_rppa') THEN 1 ELSE NULL END) AS rppaSampleCount,
+        COUNT(CASE WHEN sample_list.STABLE_ID = CONCAT(cancer_study.CANCER_STUDY_IDENTIFIER,'_3way_complete') THEN 1 ELSE NULL END) AS completeSampleCount,
+        <include refid="org.cbioportal.persistence.mybatis.CancerTypeMapper.select">
+            <property name="prefix" value="typeOfCancer."/>
+        </include>
+    </sql>
+
     <sql id="from">
         FROM cancer_study
+        INNER JOIN sample_list ON cancer_study.CANCER_STUDY_ID = sample_list.CANCER_STUDY_ID
+        INNER JOIN sample_list_list ON sample_list.LIST_ID = sample_list_list.LIST_ID
         <if test="projection == 'DETAILED'">
             INNER JOIN type_of_cancer ON cancer_study.TYPE_OF_CANCER_ID = type_of_cancer.TYPE_OF_CANCER_ID
-            INNER JOIN patient ON cancer_study.CANCER_STUDY_ID = patient.CANCER_STUDY_ID
-            INNER JOIN sample ON patient.INTERNAL_ID = sample.PATIENT_ID
         </if>
     </sql>
 
@@ -36,17 +51,13 @@
         <include refid="select">
             <property name="prefix" value=""/>
         </include>
+        ,
+        COUNT(CASE WHEN sample_list.STABLE_ID = CONCAT(cancer_study.CANCER_STUDY_IDENTIFIER,'_all') THEN 1 ELSE NULL END) AS allSampleCount
         <if test="projection == 'DETAILED'">
-            ,
-            COUNT(*) AS "sampleCount",
-            <include refid="org.cbioportal.persistence.mybatis.CancerTypeMapper.select">
-                <property name="prefix" value="typeOfCancer."/>
-            </include>
+            <include refid="selectDetailed"/>
         </if>
         <include refid="from"/>
-        <if test="projection == 'DETAILED'">
-            GROUP BY cancer_study.CANCER_STUDY_ID
-        </if>
+        GROUP BY cancer_study.CANCER_STUDY_ID
         <if test="sortBy != null and projection != 'ID'">
             ORDER BY ${sortBy} ${direction}
         </if>
@@ -69,18 +80,14 @@
         <include refid="select">
             <property name="prefix" value=""/>
         </include>
+        ,
+        COUNT(CASE WHEN sample_list.STABLE_ID = CONCAT(cancer_study.CANCER_STUDY_IDENTIFIER,'_all') THEN 1 ELSE NULL END) AS allSampleCount
         <if test="projection == 'DETAILED'">
-            ,
-            COUNT(*) AS "sampleCount",
-            <include refid="org.cbioportal.persistence.mybatis.CancerTypeMapper.select">
-                <property name="prefix" value="typeOfCancer."/>
-            </include>
+            <include refid="selectDetailed"/>
         </if>
         <include refid="from"/>
         WHERE cancer_study.CANCER_STUDY_IDENTIFIER = #{studyId}
-        <if test="projection == 'DETAILED'">
-            GROUP BY cancer_study.CANCER_STUDY_ID
-        </if>
+        GROUP BY cancer_study.CANCER_STUDY_ID
     </select>
 
 </mapper>


### PR DESCRIPTION
Added 8 new properties to CancerStudy model to be used in DETAILED projection, and changed sampleCount property to allSampleCount, and moved it to SUMMARY projection from DETAILED projection.

So the new CancerStudy model looks like this now, lines starting with * are only returned in `DETAILED` projection:
```
{
    "allSampleCount": 0,
    "cancerStudyIdentifier": "string",
    "citation": "string",
    *"cnaSampleCount": 0,
    *"completeSampleCount": 0,
    "description": "string",
    "groups": "string",
    "importDate": "2016-11-10T18:03:22.183Z",
    *"methylationHm27SampleCount": 0,
    *"miRnaSampleCount": 0,
    *"mrnaMicroarraySampleCount": 0,
    *"mrnaRnaSeqV2SampleCount": 0,
    "name": "string",
    "pmid": "string",
    "publicStudy": true,
    *"rppaSampleCount": 0,
    *"sequencedSampleCount": 0,
    "shortName": "string",
    "status": 0,
    *"typeOfCancer": {
      *"clinicalTrialKeywords": "string",
      *"dedicatedColor": "string",
      *"name": "string",
      *"parent": "string",
      *"shortName": "string",
      *"typeOfCancerId": "string"
    *},
    "typeOfCancerId": "string"
  }
```

Performance is not much of a concern for this particular Datasets case, because after the first call, it will be cached by MyBatis indefinitely, and the same static Datasets list will be returned from cache for subsequent calls.

Backend development guideline (draft):
https://docs.google.com/document/d/1HjOXWMq4z1JjeZLkw4eq3aG_o0y3IhZa47bGUtdoJ3Y