### PR TITLE
Increase varchar size for allele fields in `MUTATION_EVENT`

### DIFF
--- a/core/src/main/resources/db/cgds.sql
+++ b/core/src/main/resources/db/cgds.sql
@@ -335,8 +335,8 @@ CREATE TABLE `mutation_event` (
   `CHR` varchar(5),
   `START_POSITION` bigint(20),
   `END_POSITION` bigint(20),
-  `REFERENCE_ALLELE` varchar(255),
-  `TUMOR_SEQ_ALLELE` varchar(255),
+  `REFERENCE_ALLELE` varchar(400),
+  `TUMOR_SEQ_ALLELE` varchar(400),
   `PROTEIN_CHANGE` varchar(255),
   `MUTATION_TYPE` varchar(255) COMMENT 'e.g. Missense, Nonsence, etc.',
   `FUNCTIONAL_IMPACT_SCORE` varchar(50) COMMENT 'Result from OMA/XVAR.',
@@ -736,4 +736,4 @@ CREATE TABLE `info` (
   `DB_SCHEMA_VERSION` varchar(8)
 ) DEFAULT CHARSET=utf8;
 -- THIS MUST BE KEPT IN SYNC WITH db.version PROPERTY IN pom.xml
-INSERT INTO info VALUES ('1.3.0');
+INSERT INTO info VALUES ('1.3.2');

--- a/core/src/main/resources/db/migration.sql
+++ b/core/src/main/resources/db/migration.sql
@@ -146,3 +146,9 @@ CREATE TABLE `structural_variant` (
   FOREIGN KEY (`GENETIC_PROFILE_ID`) REFERENCES `genetic_profile` (`GENETIC_PROFILE_ID`) ON DELETE CASCADE
 );
 UPDATE info SET DB_SCHEMA_VERSION="1.3.0";
+
+##version: 1.3.2
+-- increase varchar size to accomodate reference or tumor seq alleles larger than 255 chars
+ALTER TABLE `mutation_event` MODIFY COLUMN `REFERENCE_ALLELE` varchar(400);
+ALTER TABLE `mutation_event` MODIFY COLUMN `TUMOR_SEQ_ALLELE` varchar(400);
+UPDATE info SET DB_SCHEMA_VERSION="1.3.2";

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <tomcat.catalina.scope>provided</tomcat.catalina.scope>
 
     <!-- THIS SHOULD BE KEPT IN SYNC TO VERSION IN CGDS.SQL -->
-    <db.version>1.3.0</db.version>
+    <db.version>1.3.2</db.version>
 
   </properties>
 


### PR DESCRIPTION
# What? Why?
Import was throwing a Data Truncation exception for allele values that were larger than 255 chars. 

Changes proposed in this pull request:
* `migration.sql`: increased sizes of `REFERENCE_ALLELE` and `TUMOR_SEQ_ALLELE` to 400 chars from 255 chars to prevent MySQL data truncation exceptions
* updated `cgds.sql` to reflect these changes

# Checks
- [ ] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/backend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>