### PR TITLE
Fixes to reduce build warnings

### DIFF
--- a/business/src/main/java/org/mskcc/cbio/portal/service/ApiService.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/service/ApiService.java
@@ -121,7 +121,7 @@ public class ApiService {
 		List<String> genetic_profile_ids = new LinkedList<>();
 		genetic_profile_ids.add(genetic_profile_id);
 		List<Mutation> mutations = mutationService.getMutationsDetailed(genetic_profile_ids, new LinkedList<String>(), sample_ids, null);
-		HashMap<String, List<Mutation>> mutationsBySample = new HashMap<>();
+		HashMap<String, LinkedList<Mutation>> mutationsBySample = new HashMap<>();
 		for (Mutation mutation:  mutations) {
 			String id = mutation.getSampleId().toString();
 			if (!mutationsBySample.containsKey(id)) {
@@ -131,8 +131,8 @@ public class ApiService {
 		}
 		List<MutationSignature> signatures = new LinkedList<>();
 		if (context_size_on_each_side_of_snp == 0) {
-			for (Map.Entry kv: mutationsBySample.entrySet()) {
-				signatures.add(MutationSignatureFactory.NoContextMutationSignature((String)kv.getKey(), (List<Mutation>)kv.getValue()));
+			for (Map.Entry<String, LinkedList<Mutation>> kv: mutationsBySample.entrySet()) {
+                                signatures.add(MutationSignatureFactory.NoContextMutationSignature((String)kv.getKey(), kv.getValue()));
 			}
 		}
 		// TODO: implement other contexts

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportFusionData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportFusionData.java
@@ -32,13 +32,12 @@
 
 package org.mskcc.cbio.portal.scripts;
 
+import java.io.*;
+import java.util.*;
+import org.mskcc.cbio.maf.*;
 import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.*;
 import org.mskcc.cbio.portal.util.*;
-import org.mskcc.cbio.maf.*;
-
-import java.io.*;
-import java.util.*;
 
 /**
  * Imports a fusion file.
@@ -47,146 +46,110 @@ import java.util.*;
  *
  * @author Selcuk Onur Sumer
  */
-public class ImportFusionData
-{
-	public static final String FUSION = "Fusion";
+public class ImportFusionData {
+    public static final String FUSION = "Fusion";
+    private File fusionFile;
+    private int geneticProfileId;
+    private String genePanel;
 
-	private File fusionFile;
-	private int geneticProfileId;
-                     private String genePanel;
+    public ImportFusionData(File fusionFile, int geneticProfileId, String genePanel) {
+        this.fusionFile = fusionFile;
+        this.geneticProfileId = geneticProfileId;
+        this.genePanel = genePanel;
+    }
 
-	public ImportFusionData(File fusionFile,
-			int geneticProfileId, String genePanel)
-	{
-		this.fusionFile = fusionFile;
-		this.geneticProfileId = geneticProfileId;
-                                           this.genePanel = genePanel;
-	}
-
-	public void importData() throws IOException, DaoException
-	{
-		Map<ExtendedMutation.MutationEvent, ExtendedMutation.MutationEvent> existingEvents =
-				new HashMap<ExtendedMutation.MutationEvent, ExtendedMutation.MutationEvent>();
-
-		for (ExtendedMutation.MutationEvent event : DaoMutation.getAllMutationEvents())
-		{
-			existingEvents.put(event, event);
-		}
-
-		long mutationEventId = DaoMutation.getLargestMutationEventId();
-
-		FileReader reader = new FileReader(this.fusionFile);
-		BufferedReader buf = new BufferedReader(reader);
-		DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
-
-		//  The MAF File Changes fairly frequently, and we cannot use column index constants.
-		String line = buf.readLine();
-		line = line.trim();
-
-		FusionFileUtil fusionUtil = new FusionFileUtil(line);
-
-		boolean addEvent;
-
+    public void importData() throws IOException, DaoException {
+        Map<ExtendedMutation.MutationEvent, ExtendedMutation.MutationEvent> existingEvents =
+                new HashMap<ExtendedMutation.MutationEvent, ExtendedMutation.MutationEvent>();
+        for (ExtendedMutation.MutationEvent event : DaoMutation.getAllMutationEvents()) {
+            existingEvents.put(event, event);
+        }
+        long mutationEventId = DaoMutation.getLargestMutationEventId();
+        FileReader reader = new FileReader(this.fusionFile);
+        BufferedReader buf = new BufferedReader(reader);
+        DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
+        //  The MAF File Changes fairly frequently, and we cannot use column index constants.
+        String line = buf.readLine();
+        line = line.trim();
+        FusionFileUtil fusionUtil = new FusionFileUtil(line);
+        boolean addEvent;
         GeneticProfile geneticProfile = DaoGeneticProfile.getGeneticProfileById(geneticProfileId);
-		while ((line = buf.readLine()) != null)
-		{
+        while ((line = buf.readLine()) != null) {
             ProgressMonitor.incrementCurValue();
             ConsoleUtil.showProgress();
-
-			if( !line.startsWith("#") && line.trim().length() > 0)
-			{
-				FusionRecord record = fusionUtil.parseRecord(line);
-
-				// process case id
-				String barCode = record.getTumorSampleID();
-				// backwards compatible part (i.e. in the new process, the sample should already be there. TODO - replace this workaround later with an exception:
-				Sample sample = DaoSample.getSampleByCancerStudyAndSampleId(geneticProfile.getCancerStudyId(),
+            if( !line.startsWith("#") && line.trim().length() > 0) {
+                FusionRecord record = fusionUtil.parseRecord(line);
+                // process case id
+                String barCode = record.getTumorSampleID();
+                // backwards compatible part (i.e. in the new process, the sample should already be there.
+                //TODO - replace this workaround later with an exception:
+                Sample sample = DaoSample.getSampleByCancerStudyAndSampleId(
+                        geneticProfile.getCancerStudyId(),
                         StableIdUtil.getSampleId(barCode));
-				if (sample == null ) {
-					ImportDataUtil.addPatients(new String[] { barCode }, geneticProfileId);
-	                // add the sample (except if it is a 'normal' sample):
-					ImportDataUtil.addSamples(new String[] { barCode }, geneticProfileId);
-				}
-		        // check again (repeated because of workaround above):
-				sample = DaoSample.getSampleByCancerStudyAndSampleId(geneticProfile.getCancerStudyId(),
-                                                                            StableIdUtil.getSampleId(barCode));
-		        // can be null in case of 'normal' sample:
-		        if (sample == null) {
-		        	assert StableIdUtil.isNormal(barCode);
-		        	line = buf.readLine();
-		        	continue;
-		        }
-				if (!DaoSampleProfile.sampleExistsInGeneticProfile(sample.getInternalId(), geneticProfileId))
-				{
-                                                                                                            if (genePanel != null) {
-                                                                                                                DaoSampleProfile.addSampleProfile(sample.getInternalId(), geneticProfileId, GeneticProfileUtil.getGenePanelId(genePanel));
-                                                                                                            }
-                                                                                                            else {
-                                                                                                                DaoSampleProfile.addSampleProfile(sample.getInternalId(), geneticProfileId, null);
-                                                                                                            }      
-				}
-
-				//  Assume we are dealing with Entrez Gene Ids (this is the best / most stable option)
-				String geneSymbol = record.getHugoGeneSymbol();
-				long entrezGeneId = record.getEntrezGeneId();
-				CanonicalGene gene = null;
-
-				if (entrezGeneId != TabDelimitedFileUtil.NA_LONG)
-				{
-					gene = daoGene.getGene(entrezGeneId);
-				}
-
-				if (gene == null) {
-					// If Entrez Gene ID Fails, try Symbol.
-					gene = daoGene.getNonAmbiguousGene(geneSymbol, null);
-				}
-
-				if(gene == null)
-				{
-					ProgressMonitor.logWarning("Gene not found:  " + geneSymbol + " ["
-					                    + entrezGeneId + "]. Ignoring it "
-					                    + "and all fusion data associated with it!");
-				}
-				else
-				{
-					// create a mutation instance with default values
-					ExtendedMutation mutation = ExtendedMutationUtil.newMutation();
-
-					mutation.setGeneticProfileId(geneticProfileId);
-					mutation.setSampleId(sample.getInternalId());
-					mutation.setGene(gene);
-					mutation.setSequencingCenter(record.getCenter());
-					mutation.setProteinChange(record.getFusion());
-
-					// TODO we may need get mutation type from the file
-					// instead of defining a constant
-					mutation.setMutationType(FUSION);
-
-					ExtendedMutation.MutationEvent event = existingEvents.get(mutation.getEvent());
-
-					if (event != null)
-					{
-						mutation.setEvent(event);
-						addEvent = false;
-					}
-					else
-					{
-						mutation.setMutationEventId(++mutationEventId);
-						existingEvents.put(mutation.getEvent(), mutation.getEvent());
-						addEvent = true;
-					}
-
-					// add fusion (as a mutation)
-					DaoMutation.addMutation(mutation, addEvent);                                                                                      
-				}
-			}
-		}
-
-		buf.close();
-
-		if( MySQLbulkLoader.isBulkLoad())
-		{
-			MySQLbulkLoader.flushAll();
-		}
-	}
+                if (sample == null) {
+                    ImportDataUtil.addPatients(new String[] { barCode }, geneticProfileId);
+                    // add the sample (except if it is a 'normal' sample):
+                    ImportDataUtil.addSamples(new String[] { barCode }, geneticProfileId);
+                }
+                // check again (repeated because of workaround above):
+                sample = DaoSample.getSampleByCancerStudyAndSampleId(geneticProfile.getCancerStudyId(),
+                        StableIdUtil.getSampleId(barCode));
+                // can be null in case of 'normal' sample:
+                if (sample == null) {
+                    assert StableIdUtil.isNormal(barCode);
+                    line = buf.readLine();
+                    continue;
+                }
+                if (!DaoSampleProfile.sampleExistsInGeneticProfile(sample.getInternalId(), geneticProfileId)) {
+                    if (genePanel != null) {
+                        DaoSampleProfile.addSampleProfile(sample.getInternalId(), geneticProfileId, GeneticProfileUtil.getGenePanelId(genePanel));
+                    } else {
+                        DaoSampleProfile.addSampleProfile(sample.getInternalId(), geneticProfileId, null);
+                    }
+                }
+                //  Assume we are dealing with Entrez Gene Ids (this is the best / most stable option)
+                String geneSymbol = record.getHugoGeneSymbol();
+                long entrezGeneId = record.getEntrezGeneId();
+                CanonicalGene gene = null;
+                if (entrezGeneId != TabDelimitedFileUtil.NA_LONG) {
+                    gene = daoGene.getGene(entrezGeneId);
+                }
+                if (gene == null) {
+                    // If Entrez Gene ID Fails, try Symbol.
+                    gene = daoGene.getNonAmbiguousGene(geneSymbol, null);
+                }
+                if(gene == null) {
+                    ProgressMonitor.logWarning("Gene not found:  " + geneSymbol + " ["
+                            + entrezGeneId + "]. Ignoring it "
+                            + "and all fusion data associated with it!");
+                } else {
+                    // create a mutation instance with default values
+                    ExtendedMutation mutation = ExtendedMutationUtil.newMutation();
+                    mutation.setGeneticProfileId(geneticProfileId);
+                    mutation.setSampleId(sample.getInternalId());
+                    mutation.setGene(gene);
+                    mutation.setSequencingCenter(record.getCenter());
+                    mutation.setProteinChange(record.getFusion());
+                    // TODO we may need get mutation type from the file
+                    // instead of defining a constant
+                    mutation.setMutationType(FUSION);
+                    ExtendedMutation.MutationEvent event = existingEvents.get(mutation.getEvent());
+                    if (event != null) {
+                        mutation.setEvent(event);
+                        addEvent = false;
+                    } else {
+                        mutation.setMutationEventId(++mutationEventId);
+                        existingEvents.put(mutation.getEvent(), mutation.getEvent());
+                        addEvent = true;
+                    }
+                    // add fusion (as a mutation)
+                    DaoMutation.addMutation(mutation, addEvent);
+                }
+            }
+        }
+        buf.close();
+        if( MySQLbulkLoader.isBulkLoad()) {
+            MySQLbulkLoader.flushAll();
+        }
+    }
 }

--- a/core/src/main/java/org/mskcc/cbio/portal/util/XDebug.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/XDebug.java
@@ -44,8 +44,8 @@ import javax.servlet.http.HttpServletRequest;
  * displayed at the bottom of the JSP page.
  */
 public class XDebug {
-    private ArrayList messages;
-    private ArrayList parameters;
+    private ArrayList<XDebugMessage> messages;
+    private ArrayList<XDebugParameter> parameters;
     private Date startTime;
     private Date stopTime;
     private long timeElapsed;
@@ -55,8 +55,8 @@ public class XDebug {
      * Constructor.
      */
     public XDebug() {
-       messages = new ArrayList();
-       parameters = new ArrayList();
+       messages = new ArrayList<XDebugMessage>();
+       parameters = new ArrayList<XDebugParameter>();
        startTime = null;
        stopTime = null;
        timeElapsed = -1;
@@ -196,7 +196,7 @@ public class XDebug {
             log.append("No Log Messages");
         }
         for (int i = 0; i < messages.size(); i++) {
-            XDebugMessage msg = (XDebugMessage) messages.get(i);
+            XDebugMessage msg = messages.get(i);
             log.append(msg.getMessage() + "\n");
         }
         return log.toString();

--- a/persistence/persistence-mybatis-test/pom.xml
+++ b/persistence/persistence-mybatis-test/pom.xml
@@ -69,7 +69,9 @@
 			</plugin>
       
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>default-jar</id>
@@ -83,7 +85,9 @@
 			</plugin>
 			
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-install-plugin</artifactId>
+				<version>2.5.2</version>
 				<executions>
 					<execution>
 						<id>default-install</id>


### PR DESCRIPTION
# Maven build throws several distracting warnings
- three files are modified to avoid unchecked type conversion or unspecified version warnings
- after these fixes, all remaining similar warnings are limited to core module
- one file has a cleanup of code style (no semantic changes)

Maven build throws several warnings and caution messages
  'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing
  - fixed by update to persistence/persistence-mybatis-test/pom.xml
  ApiService.java uses unchecked or unsafe operations
  - fixed by update to ApiService.java
  XDebug.java: Some input files use unchecked or unsafe operations
  - fixed by update to XDebug.java
Also, standardized sytle of ImportFusionData.java (no semantic change)

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/backend
