### PR TITLE
Fix to the DB_SCHEMA_VERSION setting in cgds.sql

### DIFF
--- a/core/src/main/resources/db/cgds.sql
+++ b/core/src/main/resources/db/cgds.sql
@@ -692,7 +692,7 @@ CREATE TABLE `clinical_event_data` (
 
 -- --------------------------------------------------------
 CREATE TABLE `info` (
-  `DB_SCHEMA_VERSION` varchar(8)
+  `DB_SCHEMA_VERSION` varchar(24)
 ) DEFAULT CHARSET=utf8;
 -- THIS MUST BE KEPT IN SYNC WITH db.version PROPERTY IN pom.xml
-INSERT INTO info VALUES ('1.3.0');
+INSERT INTO info VALUES ('1.4.0');

--- a/core/src/main/resources/db/migration.sql
+++ b/core/src/main/resources/db/migration.sql
@@ -191,3 +191,8 @@ CREATE TABLE `structural_variant` (
   FOREIGN KEY (`GENETIC_PROFILE_ID`) REFERENCES `genetic_profile` (`GENETIC_PROFILE_ID`) ON DELETE CASCADE
 );
 UPDATE info SET DB_SCHEMA_VERSION="1.3.1";
+
+##version: 1.4.0
+-- alter version number to distinguish from cbioportal web application version numbering
+ALTER TABLE info MODIFY COLUMN DB_SCHEMA_VERSION VARCHAR(24);
+UPDATE info SET DB_SCHEMA_VERSION="1.4.0";

--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -163,7 +163,13 @@ def run_migration(db_version, sql_filename, connection, cursor):
             continue
 
         # skip blank lines
-        if len(line.strip()) < 1 or line.startswith('#'):
+        if len(line.strip()) < 1:
+            continue
+        # skip comments
+        if line.startswith('#'):
+            continue
+        # skip sql comments
+        if line.startswith('--') and len(line) > 2 and line[2].isspace():
             continue
         # only execute sql line if the last version seen in the file is greater than the db_version
         if run_line:

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <tomcat.catalina.scope>provided</tomcat.catalina.scope>
 
     <!-- THIS SHOULD BE KEPT IN SYNC TO VERSION IN CGDS.SQL -->
-    <db.version>1.3.1</db.version>
+    <db.version>1.4.0</db.version>
 
   </properties>
 


### PR DESCRIPTION
In PR #1818 the DB_SCHEMA_VERSION setting in cgds.sql should have been updated to 1.3.1, but it was not. (migration.sql and pom.xml were updated to 1.3.1, and the table schema were adjusted in cgds.sql)

This change fixes the DB_SCHEMA_VERSION to match (bringing cdgs.sql into sync with migration.sql for the rc branch.)

Also, the version number for rc is skewed upwards to 100.0.0
This is to help distinguish the database schema version from the cbioportal web application release version number. (these numbers should not be expected to match, so this avoids confusion and makes clear that there are two separate things being versioned (the web application itself, and the database version)

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/backend

- migration.sql and pom.xml refer to 1.3.1, and cgds.sql reflects that schema
- 1.3.1 was used "reused" during adjustment PR#1850
- cgds.sql value had not been updated as it should have been in PR#1818 (was still 1.3.0)