### PR TITLE
On patient timeline, size any LAB_TEST with RESULT

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/patient_view/clinical_timeline.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/patient_view/clinical_timeline.jsp
@@ -200,12 +200,30 @@
                         .setTimepointsDisplay("Imaging", "square")
                         .orderTracks(["Specimen", "Surgery", "Status", "Diagnostics", "Diagnostic", "Imaging", "Lab_test", "Treatment"])
                         .splitByClinicalAttributes("Lab_test", "TEST")
-                        .sizeByClinicalAttribute("PSA", "RESULT")
-                        .sizeByClinicalAttribute("ALK", "RESULT")
-                        .sizeByClinicalAttribute("TEST", "RESULT")
-                        .sizeByClinicalAttribute("HGB", "RESULT")
-                        .sizeByClinicalAttribute("PHOS", "RESULT")
-                        .sizeByClinicalAttribute("LDH", "RESULT")
+                var splitData = window.pvTimeline.data();
+                // Get TEST names that have a RESULT field in their clinical
+                // tooltip table. We assume the RESULT field contains
+                // integer/float values that can be used to size the dots on the
+                // timeline by 
+                var testsWithResults = splitData.filter(function(x) {
+                    return x.parent_track === 'Lab_test' && 
+                           _.all(x.times.map(
+                                      function(t) {
+                                          return t.tooltip_tables.length === 1 && 
+                                                 t.tooltip_tables[0].filter(function(a) {return a[0] === 'RESULT'}).length > 0;
+                                      })
+                    )
+                }).map(function(x) {
+                    return x.label;
+                });
+                // Scale dot size on timepoint by RESULT field
+                testsWithResults.forEach(function(test) {
+                    window.pvTimeline =
+                        window.pvTimeline
+                        .sizeByClinicalAttribute(test, "RESULT")
+                })
+                window.pvTimeline =
+                        window.pvTimeline
                         .splitByClinicalAttributes("Treatment", ["SUBTYPE", "AGENT"])
                         .collapseAll()
                         .toggleTrackCollapse("Specimen")


### PR DESCRIPTION
Previously only few hard coded LAB_TESTs are sized by the integer/float value
of RESULT field. Now any LAB_TEST that has a RESULT field is scaled
accordingly.

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
Before:
![screen shot 2016-11-16 at 4 54 56 pm](https://cloud.githubusercontent.com/assets/1334004/20367405/4c621382-ac1d-11e6-87c9-27356c3df27a.png)

After:
![screen shot 2016-11-16 at 4 53 12 pm](https://cloud.githubusercontent.com/assets/1334004/20367349/1466be38-ac1d-11e6-9989-4b48201fab73.png)

# Notify reviewers
@jjgao @ritikakundra 

