### PR TITLE
Position mutation count endpoint

### DIFF
--- a/model/src/main/java/org/cbioportal/model/PositionMutationCount.java
+++ b/model/src/main/java/org/cbioportal/model/PositionMutationCount.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.model;
+
+import java.io.Serializable;
+
+/**
+ *
+ * @author abeshoua
+ */
+public class PositionMutationCount implements Serializable {
+	
+	private String hugoGeneSymbol;
+	private Integer codonPosition;
+	private Integer mutationCount;
+
+	public String getHugoGeneSymbol() {
+		return hugoGeneSymbol;
+	}
+
+	public void setHugoGeneSymbol(String hugoGeneSymbol) {
+		this.hugoGeneSymbol = hugoGeneSymbol;
+	}
+
+	public Integer getCodonPosition() {
+		return codonPosition;
+	}
+
+	public void setCodonPosition(Integer codonPosition) {
+		this.codonPosition = codonPosition;
+	}
+
+	public Integer getMutationCount() {
+		return mutationCount;
+	}
+
+	public void setMutationCount(Integer mutationCount) {
+		this.mutationCount = mutationCount;
+	}	
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationCountRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationCountRepository.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+ /*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.cbioportal.persistence;
+
+import java.util.List;
+import org.cbioportal.model.PositionMutationCount;
+
+/**
+ *
+ * @author abeshoua
+ */
+public interface MutationCountRepository {
+	List<PositionMutationCount> getPositionMutationCounts(String hugoGeneSymbol, List<Integer> positions);
+}

--- a/persistence/persistence-mybatis-test/src/test/java/org/cbioportal/persistence/mybatis/MutationCountMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis-test/src/test/java/org/cbioportal/persistence/mybatis/MutationCountMyBatisRepositoryTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+ /*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.cbioportal.persistence.mybatis;
+
+import java.util.LinkedList;
+import java.util.List;
+import org.cbioportal.model.PositionMutationCount;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ *
+ * @author abeshoua
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/testContextDatabase.xml")
+@Configurable
+public class MutationCountMyBatisRepositoryTest {
+
+	@Autowired
+	private MutationCountMyBatisRepository mutationCountMyBatisRepository;
+	
+	@Test
+	public void noPositionsSpecified() {
+		String gene = "BRCA1";
+		List<Integer> positions = new LinkedList<>();
+		List<PositionMutationCount> result = mutationCountMyBatisRepository.getPositionMutationCounts(gene, positions);
+		Assert.assertTrue(result.size() == 3);
+	}
+	@Test
+	public void onePositionSpecifiedPresent() {
+		String gene = "BRCA1";
+		List<Integer> positions = new LinkedList<>();
+		positions.add(61);
+		List<PositionMutationCount> result = mutationCountMyBatisRepository.getPositionMutationCounts(gene, positions);
+		Assert.assertTrue(result.size() == 1);
+		Assert.assertTrue(result.get(0).getCodonPosition() == 61);
+		Assert.assertTrue(result.get(0).getMutationCount() == 1);
+	}
+	@Test
+	public void onePositionSpecifiedNotPresent() {
+		String gene = "BRCA1";
+		List<Integer> positions = new LinkedList<>();
+		positions.add(62);
+		List<PositionMutationCount> result = mutationCountMyBatisRepository.getPositionMutationCounts(gene, positions);
+		Assert.assertTrue(result.isEmpty());
+	}
+	@Test
+	public void positionsSpecifiedOnePresent() {
+		String gene = "AKT1";
+		List<Integer> positions = new LinkedList<>();
+		positions.add(61);
+		positions.add(63);
+		positions.add(121);
+		List<PositionMutationCount> result = mutationCountMyBatisRepository.getPositionMutationCounts(gene, positions);
+		Assert.assertTrue(result.size() == 1);
+		Assert.assertTrue(result.get(0).getCodonPosition() == 61);
+		Assert.assertTrue(result.get(0).getMutationCount() == 1);
+	}
+	@Test
+	public void positionsSpecifiedNonePresent() {
+		String gene = "AKT1";
+		List<Integer> positions = new LinkedList<>();
+		positions.add(62);
+		positions.add(67);
+		positions.add(12341);
+		positions.add(233);
+		List<PositionMutationCount> result = mutationCountMyBatisRepository.getPositionMutationCounts(gene, positions);
+		Assert.assertTrue(result.isEmpty());
+	}
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationCountMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationCountMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+ /*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.cbioportal.persistence.mybatis;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Param;
+import org.cbioportal.model.PositionMutationCount;
+
+/**
+ *
+ * @author abeshoua
+ */
+public interface MutationCountMapper {
+	List<PositionMutationCount> getPositionMutationCounts(@Param("hugoGeneSymbol") String hugoGeneSymbol,
+								@Param("positions") List<Integer> positions);
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationCountMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationCountMyBatisRepository.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+ /*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.cbioportal.persistence.mybatis;
+
+import java.util.List;
+import org.cbioportal.model.PositionMutationCount;
+import org.cbioportal.persistence.MutationCountRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+/**
+ *
+ * @author abeshoua
+ */
+@Repository
+public class MutationCountMyBatisRepository implements MutationCountRepository {
+	@Autowired
+	private MutationCountMapper mutationCountMapper;
+	
+	public List<PositionMutationCount> getPositionMutationCounts(String hugoGeneSymbol, List<Integer> positions) {
+		return mutationCountMapper.getPositionMutationCounts(hugoGeneSymbol, positions);
+	}
+	
+}

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationCountMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationCountMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.cbioportal.persistence.mybatis.MutationCountMapper">
+    <cache/>
+      <select id="getPositionMutationCounts" resultType="org.cbioportal.model.PositionMutationCount">
+        select
+            gene.HUGO_GENE_SYMBOL as hugoGeneSymbol,
+            mutation_event.ONCOTATOR_PROTEIN_POS_START as codonPosition,
+            count(*) as mutationCount
+        from gene,sample,mutation,mutation_event
+        where
+            <!-- Match arguments -->
+            gene.HUGO_GENE_SYMBOL = #{hugoGeneSymbol} 
+            <if test="positions != null and !positions.isEmpty()">
+            and mutation_event.ONCOTATOR_PROTEIN_POS_START in 
+                <foreach item="item" collection="positions" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+            </if>
+                and
+            <!-- Join -->
+            sample.INTERNAL_ID = mutation.SAMPLE_ID and
+            gene.ENTREZ_GENE_ID = mutation.ENTREZ_GENE_ID and
+            mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID and
+            
+            <!-- Looking for mutation at single position -->
+            mutation_event.ONCOTATOR_PROTEIN_POS_START = mutation_event.ONCOTATOR_PROTEIN_POS_END
+            
+        group by gene.HUGO_GENE_SYMBOL, mutation_event.ONCOTATOR_PROTEIN_POS_START
+    </select>
+        
+</mapper>

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -170,11 +170,10 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 
     var getCBioPortalMutationCounts = function (webservice_data) {
 	/* In: - webservice_data, a list of data obtained from the webservice API
-	 * Out: Promise which resolves with map from gene+","+start_pos+","+end_pos to cbioportal mutation count for that position range and gene
+	 * Out: Promise which resolves with map of type [gene]=>[codon position]=>mutation count
 	 */
-	var counts_map = {};
 	var def = new $.Deferred();
-	var to_query = {};
+	var to_query = {}; // [gene]=>[position]=>true, iff it should be queried
 	for (var i = 0; i < webservice_data.length; i++) {
 	    var datum = webservice_data[i];
 	    if (datum.genetic_alteration_type !== "MUTATION_EXTENDED" || datum.simplified_mutation_type !== "missense") {
@@ -182,47 +181,37 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	    }
 	    var gene = datum.hugo_gene_symbol;
 	    var start_pos = datum.protein_start_position;
-	    var end_pos = datum.protein_end_position;
-	    if (gene && start_pos && end_pos && !isNaN(start_pos) && !isNaN(end_pos)) {
-		to_query[gene + ',' + parseInt(start_pos, 10) + ',' + parseInt(end_pos, 10)] = true;
+	    if (gene && start_pos && !isNaN(start_pos)) {
+		to_query[gene] = to_query[gene] || {};
+		to_query[gene][parseInt(start_pos, 10)] = true;
 	    }
 	}
-	var queries = Object.keys(to_query).map(function (x) {
-	    var splitx = x.split(',');
-	    return {
-		gene: splitx[0],
-		start_pos: splitx[1],
-		end_pos: splitx[2]
-	    };
-	});
-	var genes = queries.map(function (q) {
-	    return q.gene;
-	});
-	var starts = queries.map(function (q) {
-	    return q.start_pos;
-	});
-	var ends = queries.map(function (q) {
-	    return q.end_pos;
-	});
-
-	if (queries.length > 0) {
-	    window.cbioportal_client.getMutationCounts({
-		'type': 'count',
-		'per_study': false,
-		'gene': genes,
-		'start': starts,
-		'end': ends,
-		'echo': ['gene', 'start', 'end']
-	    }).then(function (counts) {
-		for (var i = 0; i < counts.length; i++) {
-		    var gene = counts[i].gene;
-		    var start = parseInt(counts[i].start, 10);
-		    var end = parseInt(counts[i].end, 10);
-		    counts_map[gene + ',' + start + ',' + end] = parseInt(counts[i].count, 10);
-		}
-		def.resolve(counts_map);
-	    }).fail(function () {
+	if (Object.keys(to_query).length > 0) {
+	    var query_genes = Object.keys(to_query);
+	    var query_positions = query_genes.map(function(gene) {
+		return Object.keys(to_query[gene]).map(function(pos) { return parseInt(pos, 10); });
+	    });
+	    $.ajax({
+		type: "POST",
+		url: "api-legacy/position-mutation-count",
+		data: {
+		    genes: query_genes,
+		    positions: query_positions
+		},
+		dataType: "json",
+		traditional: true
+	    }).fail(function() {
 		def.reject();
+	    }).then(function(position_mutation_counts) {
+		var gene_to_position_to_count = {};
+		for (var i=0; i<position_mutation_counts.length; i++) {
+		    var gene = position_mutation_counts[i].hugoGeneSymbol;
+		    var position = position_mutation_counts[i].codonPosition;
+		    var count = position_mutation_counts[i].mutationCount;
+		    gene_to_position_to_count[gene] = gene_to_position_to_count[gene] || {};
+		    gene_to_position_to_count[gene][position] = count;
+		}
+		def.resolve(gene_to_position_to_count);
 	    });
 	} else {
 	    def.resolve({});
@@ -327,18 +316,17 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	 */
 	var def = new $.Deferred();
 	var attribute_name = 'cbioportal_mutation_count';
-	getCBioPortalMutationCounts(webservice_data).then(function (counts_map) {
+	getCBioPortalMutationCounts(webservice_data).then(function (gene_to_position_to_count) {
 	    for (var i = 0; i < webservice_data.length; i++) {
 		var datum = webservice_data[i];
-		if (datum.genetic_alteration_type !== "MUTATION_EXTENDED") {
+		if (datum.genetic_alteration_type !== "MUTATION_EXTENDED" || datum.simplified_mutation_type !== "missense") {
 		    continue;
 		}
 		var gene = datum.hugo_gene_symbol;
 		gene && (gene = gene.toUpperCase());
 		var start_pos = datum.protein_start_position;
-		var end_pos = datum.protein_end_position;
-		if (gene && start_pos && end_pos && !isNaN(start_pos) && !isNaN(end_pos)) {
-		    datum[attribute_name] = counts_map[gene + ',' + parseInt(start_pos, 10) + ',' + parseInt(end_pos, 10)];
+		if (gene && start_pos && !isNaN(start_pos)) {
+		    datum[attribute_name] = gene_to_position_to_count[gene][start_pos];
 		}
 	    }
 	    def.resolve(webservice_data);

--- a/service/src/main/java/org/cbioportal/service/MutationCountService.java
+++ b/service/src/main/java/org/cbioportal/service/MutationCountService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+ /*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.cbioportal.service;
+
+import java.util.List;
+import org.cbioportal.model.PositionMutationCount;
+
+/**
+ *
+ * @author abeshoua
+ */
+public interface MutationCountService {
+	List<PositionMutationCount> getPositionMutationCounts(List<String> genes, List<List<Integer>> positions);
+}

--- a/service/src/main/java/org/cbioportal/service/impl/MutationCountServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationCountServiceImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+ /*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.cbioportal.service.impl;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import org.cbioportal.model.PositionMutationCount;
+import org.cbioportal.persistence.MutationCountRepository;
+import org.cbioportal.service.MutationCountService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ *
+ * @author abeshoua
+ */
+@Service
+public class MutationCountServiceImpl implements MutationCountService {
+	
+	@Autowired
+	private MutationCountRepository mutationCountRepository;
+	
+	@Override
+	public List<PositionMutationCount> getPositionMutationCounts(List<String> genes, List<List<Integer>> positions) {
+		List<PositionMutationCount> counts = new LinkedList<>();
+		Iterator<String> geneIt = genes.iterator();
+		Iterator<List<Integer>> positionIt = positions.iterator();
+		while (geneIt.hasNext()) {
+			if (!positionIt.hasNext()) {
+				break;
+			}
+			String nextGene = geneIt.next();
+			List<Integer> nextPositions = positionIt.next();
+			counts.addAll(mutationCountRepository.getPositionMutationCounts(nextGene, nextPositions));
+		}
+		return counts;
+	}
+	
+	
+}

--- a/service/src/test/java/org/cbioportal/service/impl/MutationCountServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MutationCountServiceImplTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+ /*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.cbioportal.service.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.cbioportal.model.PositionMutationCount;
+import org.cbioportal.persistence.MutationCountRepository;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ *
+ * @author abeshoua
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MutationCountServiceImplTest {
+	@InjectMocks
+    private MutationCountServiceImpl mutationCountService;
+
+    @Mock
+    private MutationCountRepository mutationCountRepository;
+    
+    @Test
+    public void getPositionMutationCounts() throws Exception {
+
+        ArrayList<String> testGenes = new ArrayList<>();
+	testGenes.add("BRAF");
+	testGenes.add("KRAS");
+        ArrayList<List<Integer>> testPositions = new ArrayList<>();
+	ArrayList<Integer> brafPositions = new ArrayList<>();
+	ArrayList<Integer> krasPositions = new ArrayList<>();
+	brafPositions.add(1);
+	brafPositions.add(2);
+	krasPositions.add(3);
+	testPositions.add(brafPositions);
+	testPositions.add(krasPositions);
+
+	PositionMutationCount pmc1 = new PositionMutationCount();
+	PositionMutationCount pmc2 = new PositionMutationCount();
+        List<PositionMutationCount> brafResult = new ArrayList<>();
+	List<PositionMutationCount> krasResult = new ArrayList<>();
+	brafResult.add(pmc1);
+	krasResult.add(pmc2);
+
+        Mockito.when(mutationCountRepository.getPositionMutationCounts(org.mockito.Matchers.eq("BRAF"), org.mockito.Matchers.anyList())).thenReturn(brafResult);
+	Mockito.when(mutationCountRepository.getPositionMutationCounts(org.mockito.Matchers.eq("KRAS"), org.mockito.Matchers.anyList())).thenReturn(krasResult);
+	
+	List<PositionMutationCount> expectedResult = new ArrayList<>();
+	expectedResult.add(pmc1);
+	expectedResult.add(pmc2);
+	List<PositionMutationCount> result = mutationCountService.getPositionMutationCounts(testGenes, testPositions);
+	Assert.assertEquals(result, expectedResult);
+    }
+    
+    @Test
+    public void getPositionMutationCountsOnePositionListMissing() throws Exception {
+
+        ArrayList<String> testGenes = new ArrayList<>();
+	testGenes.add("BRAF");
+	testGenes.add("KRAS");
+        ArrayList<List<Integer>> testPositions = new ArrayList<>();
+	ArrayList<Integer> brafPositions = new ArrayList<>();
+	brafPositions.add(1);
+	brafPositions.add(2);
+	testPositions.add(brafPositions);
+
+	PositionMutationCount pmc1 = new PositionMutationCount();
+	PositionMutationCount pmc2 = new PositionMutationCount();
+        List<PositionMutationCount> brafResult = new ArrayList<>();
+	List<PositionMutationCount> krasResult = new ArrayList<>();
+	brafResult.add(pmc1);
+	krasResult.add(pmc2);
+
+        Mockito.when(mutationCountRepository.getPositionMutationCounts(org.mockito.Matchers.eq("BRAF"), org.mockito.Matchers.anyList())).thenReturn(brafResult);
+	Mockito.when(mutationCountRepository.getPositionMutationCounts(org.mockito.Matchers.eq("KRAS"), org.mockito.Matchers.anyList())).thenReturn(krasResult);
+	
+	List<PositionMutationCount> expectedResult = new ArrayList<>();
+	expectedResult.add(pmc1);
+	List<PositionMutationCount> result = mutationCountService.getPositionMutationCounts(testGenes, testPositions);
+	Assert.assertEquals(result, expectedResult);
+    }
+    
+     @Test
+    public void getPositionMutationCountsNoPositions() throws Exception {
+
+        ArrayList<String> testGenes = new ArrayList<>();
+	testGenes.add("BRAF");
+	testGenes.add("KRAS");
+        ArrayList<List<Integer>> testPositions = new ArrayList<>();
+
+	PositionMutationCount pmc1 = new PositionMutationCount();
+	PositionMutationCount pmc2 = new PositionMutationCount();
+        List<PositionMutationCount> brafResult = new ArrayList<>();
+	List<PositionMutationCount> krasResult = new ArrayList<>();
+	brafResult.add(pmc1);
+	krasResult.add(pmc2);
+
+        Mockito.when(mutationCountRepository.getPositionMutationCounts(org.mockito.Matchers.eq("BRAF"), org.mockito.Matchers.anyList())).thenReturn(brafResult);
+	Mockito.when(mutationCountRepository.getPositionMutationCounts(org.mockito.Matchers.eq("KRAS"), org.mockito.Matchers.anyList())).thenReturn(krasResult);
+	
+	List<PositionMutationCount> expectedResult = new ArrayList<>();
+	List<PositionMutationCount> result = mutationCountService.getPositionMutationCounts(testGenes, testPositions);
+	Assert.assertEquals(result, expectedResult);
+    }
+    @Test
+    public void getPositionMutationCountsNoGenes() throws Exception {
+
+        ArrayList<String> testGenes = new ArrayList<>();
+        ArrayList<List<Integer>> testPositions = new ArrayList<>();
+	ArrayList<Integer> brafPositions = new ArrayList<>();
+	ArrayList<Integer> krasPositions = new ArrayList<>();
+	brafPositions.add(1);
+	brafPositions.add(2);
+	krasPositions.add(3);
+	testPositions.add(brafPositions);
+	testPositions.add(krasPositions);
+
+	PositionMutationCount pmc1 = new PositionMutationCount();
+	PositionMutationCount pmc2 = new PositionMutationCount();
+        List<PositionMutationCount> brafResult = new ArrayList<>();
+	List<PositionMutationCount> krasResult = new ArrayList<>();
+	brafResult.add(pmc1);
+	krasResult.add(pmc2);
+
+        Mockito.when(mutationCountRepository.getPositionMutationCounts(org.mockito.Matchers.eq("BRAF"), org.mockito.Matchers.anyList())).thenReturn(brafResult);
+	Mockito.when(mutationCountRepository.getPositionMutationCounts(org.mockito.Matchers.eq("KRAS"), org.mockito.Matchers.anyList())).thenReturn(krasResult);
+	
+	List<PositionMutationCount> expectedResult = new ArrayList<>();
+	List<PositionMutationCount> result = mutationCountService.getPositionMutationCounts(testGenes, testPositions);
+	Assert.assertEquals(result, expectedResult);
+    }
+    @Test
+    public void getPositionMutationCountsNoGenesNoPositions() throws Exception {
+
+        ArrayList<String> testGenes = new ArrayList<>();
+        ArrayList<List<Integer>> testPositions = new ArrayList<>();
+
+	PositionMutationCount pmc1 = new PositionMutationCount();
+	PositionMutationCount pmc2 = new PositionMutationCount();
+        List<PositionMutationCount> brafResult = new ArrayList<>();
+	List<PositionMutationCount> krasResult = new ArrayList<>();
+	brafResult.add(pmc1);
+	krasResult.add(pmc2);
+
+        Mockito.when(mutationCountRepository.getPositionMutationCounts(org.mockito.Matchers.eq("BRAF"), org.mockito.Matchers.anyList())).thenReturn(brafResult);
+	Mockito.when(mutationCountRepository.getPositionMutationCounts(org.mockito.Matchers.eq("KRAS"), org.mockito.Matchers.anyList())).thenReturn(krasResult);
+	
+	List<PositionMutationCount> expectedResult = new ArrayList<>();
+	List<PositionMutationCount> result = mutationCountService.getPositionMutationCounts(testGenes, testPositions);
+	Assert.assertEquals(result, expectedResult);
+    }
+}

--- a/web/src/main/java/org/cbioportal/weblegacy/MutationCountController.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/MutationCountController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.weblegacy;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import java.util.LinkedList;
+import java.util.List;
+import org.cbioportal.model.PositionMutationCount;
+import org.cbioportal.service.MutationCountService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ *
+ * @author abeshoua
+ */
+
+@RestController
+public class MutationCountController {
+
+	@Autowired
+	private MutationCountService mutationCountService;
+	
+	@ApiOperation(value = "Get mutation counts at given single codon positions",
+		nickname = "getPositionMutationCounts",
+		notes = "")
+	@Transactional
+	@RequestMapping(method = {RequestMethod.GET, RequestMethod.POST}, value = "/position-mutation-count")
+	public List<PositionMutationCount> getPositionMutationCounts(@ApiParam(required = true, value = "List of hugo gene symbols") 
+									@RequestParam(required = true) List<String> genes,
+									@ApiParam(required = true, value = "List of corresponding lists of positions") 
+									@RequestParam(required = true) List<List<Integer>> positions) {
+		return mutationCountService.getPositionMutationCounts(genes, positions);
+	}
+}

--- a/web/src/test/java/org/cbioportal/weblegacy/MutationCountControllerConfig.java
+++ b/web/src/test/java/org/cbioportal/weblegacy/MutationCountControllerConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+ /*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.cbioportal.weblegacy;
+
+import java.util.List;
+import org.cbioportal.service.MutationCountService;
+import org.cbioportal.web.config.CustomObjectMapper;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+/**
+ *
+ * @author abeshoua
+ */
+@Configuration
+@EnableWebMvc
+@ComponentScan(basePackages = {"org.cbioportal.weblegacy"}, resourcePattern = "**/*MutationCountController.class")
+public class MutationCountControllerConfig extends WebMvcConfigurerAdapter {
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter = new MappingJackson2HttpMessageConverter();
+        mappingJackson2HttpMessageConverter.setObjectMapper(new CustomObjectMapper());
+        converters.add(mappingJackson2HttpMessageConverter);
+    }
+    @Bean
+    public MutationCountService mutationCountService() {
+        return Mockito.mock(MutationCountService.class);
+    }
+}

--- a/web/src/test/java/org/cbioportal/weblegacy/MutationCountControllerTest.java
+++ b/web/src/test/java/org/cbioportal/weblegacy/MutationCountControllerTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+ /*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.cbioportal.weblegacy;
+
+import java.util.LinkedList;
+import java.util.List;
+import org.cbioportal.model.PositionMutationCount;
+import org.cbioportal.service.MutationCountService;
+import org.cbioportal.web.config.CustomObjectMapper;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ *
+ * @author abeshoua
+ */
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = {MutationCountControllerConfig.class, CustomObjectMapper.class})
+public class MutationCountControllerTest {
+	
+	@Autowired
+	private WebApplicationContext webApplicationContext;
+	
+	@Autowired
+	private MutationCountService mutationCountServiceMock;
+	private MockMvc mockMvc;
+	
+	private PositionMutationCount pmc1;
+	
+	@Before
+	public void setup() {
+		Mockito.reset(mutationCountServiceMock);
+		mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+		pmc1 = new PositionMutationCount();
+		pmc1.setHugoGeneSymbol("BRAF");
+		pmc1.setCodonPosition(600);
+		pmc1.setMutationCount(523);
+	}
+	
+	@Test
+	public void positionMutationCounts() throws Exception {
+		List<PositionMutationCount> mockResponse = new LinkedList<>();
+		mockResponse.add(pmc1);
+		
+		Mockito.when(mutationCountServiceMock.getPositionMutationCounts(org.mockito.Matchers.anyList(), org.mockito.Matchers.anyList())).thenReturn(mockResponse);
+		
+		this.mockMvc.perform(
+			MockMvcRequestBuilders.get("/position-mutation-count")
+			.accept(MediaType.parseMediaType("application/json; charset=UTF-8"))
+			.param("genes", new String[4])
+			.param("positions", new String[4]))
+			.andExpect(MockMvcResultMatchers.status().isOk())
+			.andExpect(MockMvcResultMatchers.content().contentType("application/json;charset=UTF-8"))
+			.andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(1)))
+			.andExpect(MockMvcResultMatchers.jsonPath("$[0].hugoGeneSymbol").value("BRAF"))
+			.andExpect(MockMvcResultMatchers.jsonPath("$[0].codonPosition").value(600))
+			.andExpect(MockMvcResultMatchers.jsonPath("$[0].mutationCount").value(523));
+	}
+	
+}


### PR DESCRIPTION
Implements a new endpoint in the legacy API which gives the total number of mutations in the database for a given codon position. This special case allows us to considerably speed up as opposed to the general case of counting mutations which fall in position ranges.

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@sheridancbio @ersinciftci @jjgao 
