### PR TITLE
Fix docs MRNA table

### DIFF
--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -390,7 +390,7 @@ For historical reasons, cBioPortal expects the `stable_id` to be one of those li
 
 <table>
 <thead>
-<tr><th>datatype</th><th>stable_id</th><th>description</th></th>
+<tr><th>datatype</th><th>stable_id</th><th>description</th></tr>
 </thead>
 <tr><td>CONTINUOUS</td><td>mrna_U133</td><td>Affymetrix U133 Array</td></tr>
 <tr><td>Z-SCORE</td><td>mrna_U133_Zscores</td><td>Affymetrix U133 Array</td></tr>
@@ -1092,11 +1092,12 @@ The first column is the GENESET_ID. This contains the EXTERNAL_ID or "stable id"
 
 The cells contain the GSVA(-like) score: which is real number, between -1.0 and 1.0, representing the score for the gene set in the respective sample, or NA when the score for the gene set in the respective sample could not be (or was not) calculated. Example with 2 gene sets and 3 samples: 
 
-| GENESET_ID                      | TCGA-AO-A0J | TCGA-A2-A0Y | TCGA-A2-A0S |
-|---------------------------------|-------------|-------------|-------------|
-| GO_POTASSIUM_ION_TRANSPOR       | -0.987      | 0.423       | -0.879      |
-| GO_GLUCURONATE_METABOLIC_PROCES | 0.546       | 0.654       | 0.123       |
-| ..                              |             |             |             |
+<table>
+<thead><tr><th>GENESET_ID</th><th>TCGA-AO-A0J</th><th>TCGA-A2-A0Y</th><th>TCGA-A2-A0S</th></tr></thead>
+<tr><td>GO_POTASSIUM_ION_TRANSPOR</td><td>-0.987</td><td>0.423</td><td>-0.879</td></tr>
+<tr><td>GO_GLUCURONATE_METABOLIC_PROCES</td><td>0.546</td><td>0.654</td><td>0.123</td></tr>
+<tr><td>..</td><td></td><td></td><td></td></tr>
+</table>
 
 ### GSVA p-value meta file
 
@@ -1135,8 +1136,9 @@ The first column is the GENESET_ID. This contains the EXTERNAL_ID or "stable id"
 
 The cells contain the p-value for the GSVA score: A real number, between 0.0 and 1.0, representing the p-value for the GSVA score calculated for the gene set in the respective sample, or NA when the score for the gene is also NA. Example with 2 gene sets and 3 samples: 
 
-| GENESET_ID                      | TCGA-AO-A0J | TCGA-A2-A0Y | TCGA-A2-A0S |
-|---------------------------------|-------------|-------------|-------------|
-| GO_POTASSIUM_ION_TRANSPOR       | 0.0811      | 0.0431      | 0.0087      |
-| GO_GLUCURONATE_METABOLIC_PROCES | 0.6621      | 0.0031      | 1.52e-9     |
-| ..                              |             |             |             |
+<table>
+<thead><tr><th>GENESET_ID</th><th>TCGA-AO-A0J</th><th>TCGA-A2-A0Y</th><th>TCGA-A2-A0S</th></tr></thead>
+<tr><td>GO_POTASSIUM_ION_TRANSPOR</td><td>0.0811</td><td>0.0431</td><td>0.0087</td></tr>
+<tr><td>GO_GLUCURONATE_METABOLIC_PROCES</td><td>0.6621</td><td>0.0031</td><td>1.52e-9</td></tr>
+<tr><td>..</td><td></td><td></td><td></td></tr>
+</table>

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -388,23 +388,26 @@ The expression metadata file should contain the following fields:
 #### Supported stable_id values for MRNA_EXPRESSION
 For historical reasons, cBioPortal expects the `stable_id` to be one of those listed in the following static set.
 
-datatype | stable_id | description
---- | --- | ---
-CONTINUOUS|mrna_U133|Affymetrix U133 Array
-Z-SCORE|mrna_U133_Zscores|Affymetrix U133 Array
-CONTINUOUS|rna_seq_mrna|RNA-seq data
-Z-SCORE|rna_seq_mrna_median_Zscores|RNA-seq data
-CONTINUOUS|rna_seq_v2_mrna|RNA-seq data
-Z-SCORE|rna_seq_v2_mrna_median_Zscores|RNA-seq data
-CONTINUOUS|mirna|MicroRNA data
-Z-SCORE|mirna_median_Zscores|MicroRNA data
-Z-SCORE|mrna_merged_median_Zscores|?
-CONTINUOUS|mrna|mRNA data
-Z-SCORE|mrna_median_Zscores|mRNA data
-DISCRETE|mrna_outliers|mRNA data of outliers
-Z-SCORE|mrna_zbynorm|?
-CONTINUOUS|rna_seq_mrna_capture|data from Roche mRNA Capture Kit
-Z-SCORE|rna_seq_mrna_capture_Zscores|data from Roche mRNA Capture Kit
+<table>
+<thead>
+<tr><th>datatype</th><th>stable_id</th><th>description</th></th>
+</thead>
+<tr><td>CONTINUOUS</td><td>mrna_U133</td><td>Affymetrix U133 Array</td></tr>
+<tr><td>Z-SCORE</td><td>mrna_U133_Zscores</td><td>Affymetrix U133 Array</td></tr>
+<tr><td>Z-SCORE</td><td>rna_seq_mrna_median_Zscores</td><td>RNA-seq data</td></tr>
+<tr><td>Z-SCORE</td><td>mrna_median_Zscores</td><td>mRNA data</td></tr>
+<tr><td>CONTINUOUS</td><td>rna_seq_mrna</td><td>RNA-seq data</td></tr>
+<tr><td>CONTINUOUS</td><td>rna_seq_v2_mrna</td><td>RNA-seq data</td></tr>
+<tr><td>Z-SCORE</td><td>rna_seq_v2_mrna_median_Zscores</td><td>RNA-seq data</td></tr>
+<tr><td>CONTINUOUS</td><td>mirna</td><td>MicroRNA data</td></tr>
+<tr><td>Z-SCORE</td><td>mirna_median_Zscores</td><td>MicroRNA data</td></tr>
+<tr><td>Z-SCORE</td><td>mrna_merged_median_Zscores</td><td>?</td></tr>
+<tr><td>CONTINUOUS</td><td>mrna</td><td>mRNA data</td></tr>
+<tr><td>DISCRETE</td><td>mrna_outliers</td><td>mRNA data of outliers</td></tr>
+<tr><td>Z-SCORE</td><td>mrna_zbynorm</td><td>?</td></tr>
+<tr><td>CONTINUOUS</td><td>rna_seq_mrna_capture</td><td>data from Roche mRNA Capture Kit</td></tr>
+<tr><td>Z-SCORE</td><td>rna_seq_mrna_capture_Zscores</td><td>data from Roche mRNA Capture Kit</td></tr>
+</table>
 
 
 #### Example


### PR DESCRIPTION
Change markdown to HTML style table. Overlooked item in issue #1620.

Also fix UTF8 character in about_us page (Marie-José). Problem is that readthedocs does not work well with html5 entities, whereas showdown used in `about_us.jsp` does not work well with UTF8. Since the about_us.jsp is prolly used more often I picked the solution that makes that work. CC: @aderidder 