### PR TITLE
fix anchor syntax for readthedocs

### DIFF
--- a/docs/Import-the-Seed-Database.md
+++ b/docs/Import-the-Seed-Database.md
@@ -12,7 +12,7 @@ After download, the files can be unzipped by entering the following command:
 
 ## Import the cBioPortal Database
 
-*Important:*  Before importing, make sure that you have [followed the pre-build steps](Pre-Build-Steps#Create-the-cBioPortal-MySQL-Databases-and-User) for creating the `cbioportal` database.  
+*Important:*  Before importing, make sure that you have [followed the pre-build steps](Pre-Build-Steps.md#create-the-cbioportal-mysql-databases-and-user) for creating the `cbioportal` database.
 
 Then import the seed database via the `mysql` commands:
 


### PR DESCRIPTION
fix anchor syntax for readthedocs

Changes proposed in this pull request:
add the .md file extension .. we believe links are filename based

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/backend

