### PR TITLE
restored support for db schema version 1.3.2

### DIFF
--- a/core/src/main/resources/db/migration.sql
+++ b/core/src/main/resources/db/migration.sql
@@ -148,7 +148,6 @@ CREATE TABLE `structural_variant` (
 );
 UPDATE info SET DB_SCHEMA_VERSION="1.3.0";
 
-<<<<<<< HEAD
 ##version: 1.3.1
 DROP TABLE IF EXISTS entity_attribute;
 DROP TABLE IF EXISTS attribute_metadata;
@@ -193,10 +192,13 @@ CREATE TABLE `structural_variant` (
 );
 UPDATE info SET DB_SCHEMA_VERSION="1.3.1";
 
-##version: 1.4.0
+##version: 1.3.2
 -- increase varchar size to accomodate reference or tumor seq alleles larger than 255 chars
 ALTER TABLE `mutation_event` MODIFY COLUMN `REFERENCE_ALLELE` varchar(400);
 ALTER TABLE `mutation_event` MODIFY COLUMN `TUMOR_SEQ_ALLELE` varchar(400);
+UPDATE info SET DB_SCHEMA_VERSION="1.3.2";
+
+##version: 1.4.0
 -- alter version number to distinguish from cbioportal web application version numbering
 ALTER TABLE info MODIFY COLUMN DB_SCHEMA_VERSION VARCHAR(24);
 UPDATE info SET DB_SCHEMA_VERSION="1.4.0";


### PR DESCRIPTION
migration.sql now recognizes 1.3.2 schema databases and migrates them to 1.4.0

Changes proposed in this pull request:
- add 1.3.2 section to migration.sql
- remove git clash markup from file

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@cBioPortal/backend