### PR TITLE
fixed unicode problem in the about us page

### DIFF
--- a/docs/About-Us.md
+++ b/docs/About-Us.md
@@ -66,4 +66,4 @@ The cBioPortal for Cancer Genomics was originally developed at [Memorial Sloan K
 * American Association for Cancer Research (AACR) through Project GENIE
 * Adenoid Cystic Carcinoma Research Foundation
 * Robertson Foundation
-* Marie-José and Henry R. Kravis Center for Molecular Oncology at MSK
+* Marie-Jos&eacute;e and Henry R. Kravis Center for Molecular Oncology at MSK


### PR DESCRIPTION
Somehow the about_us page cannot handle the unicode: http://www.cbioportal.org/about_us.jsp

![image](https://cloud.githubusercontent.com/assets/840895/20756643/6b2f5530-b6e1-11e6-95f4-8566145fd082.png)
