### PR TITLE
fix bug where patients with multiple samples with same clinical value…

### DIFF
--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -552,7 +552,12 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 			    datum_to_add.attr_val_counts[data_to_combine[j].attr_val] += 1;
 			}
 		    }
-		    datum_to_add.attr_val = "Mixed";
+		    var attr_vals = Object.keys(datum_to_add.attr_val_counts);
+		    if (attr_vals.length > 1) {
+			datum_to_add.attr_val = "Mixed";
+		    } else if (attr_vals.length === 1) {
+			datum_to_add.attr_val = attr_vals[0];
+		    }
 		} else if (datatype.toLowerCase() === "counts_map") {
 		    for (var j = 0; j < data_to_combine.length; j++) {
 			for (var k in data_to_combine[j].attr_val) {


### PR DESCRIPTION
In a clinical track, if a patient has multiple samples, then sometimes the value would be labeled as `Mixed` even if all the samples had the same clinical value. This PR fixes that.

# Checks
- [ ] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).