### PR TITLE
Travis - quickfix run on deprecated infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+group: deprecated
 sudo: required
 language: java
 jdk: oraclejdk7


### PR DESCRIPTION
The MySQL upgrade on Travis causes a problem where the mysql client can't
connect to the docker mysql anymore. This change makes Travis run on the
deprecated infrastructure instead.