### PR TITLE
Adding API implementation for GeneticData

### DIFF
--- a/model/src/main/java/org/cbioportal/model/Gene.java
+++ b/model/src/main/java/org/cbioportal/model/Gene.java
@@ -2,7 +2,7 @@ package org.cbioportal.model;
 
 import java.io.Serializable;
 
-public class Gene implements Serializable {
+public class Gene extends GeneticEntity implements Serializable {
 
     private Integer entrezGeneId;
     private String hugoGeneSymbol;

--- a/model/src/main/java/org/cbioportal/model/Gene.java
+++ b/model/src/main/java/org/cbioportal/model/Gene.java
@@ -58,4 +58,14 @@ public class Gene extends GeneticEntity implements Serializable {
     public void setChromosome(String chromosome) {
         this.chromosome = chromosome;
     }
+
+	@Override
+	public String getEntityStableId() {
+		return entrezGeneId+"";
+	}
+
+	@Override
+	public EntityType getEntityType() {
+		return EntityType.GENE;
+	}
 }

--- a/model/src/main/java/org/cbioportal/model/Geneset.java
+++ b/model/src/main/java/org/cbioportal/model/Geneset.java
@@ -6,11 +6,9 @@ public class Geneset extends GeneticEntity implements Serializable {
 
     private Integer internalId;
     private String genesetId;
-    private String nameShort;
     private String name;
+    private String description;
     private String refLink;
-    private String version;
-
 
 	public Integer getInternalId() {
 		return internalId;
@@ -28,14 +26,6 @@ public class Geneset extends GeneticEntity implements Serializable {
 		this.genesetId = genesetId;
 	}
 
-	public String getNameShort() {
-		return nameShort;
-	}
-
-	public void setNameShort(String nameShort) {
-		this.nameShort = nameShort;
-	}
-
 	public String getName() {
 		return name;
 	}
@@ -44,20 +34,20 @@ public class Geneset extends GeneticEntity implements Serializable {
 		this.name = name;
 	}
 
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
 	public String getRefLink() {
 		return refLink;
 	}
 
 	public void setRefLink(String refLink) {
 		this.refLink = refLink;
-	}
-
-	public String getVersion() {
-		return version;
-	}
-
-	public void setVersion(String version) {
-		this.version = version;
 	}
 
 	@Override

--- a/model/src/main/java/org/cbioportal/model/Geneset.java
+++ b/model/src/main/java/org/cbioportal/model/Geneset.java
@@ -1,0 +1,72 @@
+package org.cbioportal.model;
+
+import java.io.Serializable;
+
+public class Geneset extends GeneticEntity implements Serializable {
+
+    private Integer internalId;
+    private String genesetId;
+    private String nameShort;
+    private String name;
+    private String refLink;
+    private String version;
+
+
+	public Integer getInternalId() {
+		return internalId;
+	}
+
+	public void setInternalId(Integer internalId) {
+		this.internalId = internalId;
+	}
+
+	public String getGenesetId() {
+		return genesetId;
+	}
+
+	public void setGenesetId(String genesetId) {
+		this.genesetId = genesetId;
+	}
+
+	public String getNameShort() {
+		return nameShort;
+	}
+
+	public void setNameShort(String nameShort) {
+		this.nameShort = nameShort;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getRefLink() {
+		return refLink;
+	}
+
+	public void setRefLink(String refLink) {
+		this.refLink = refLink;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	@Override
+	public String getEntityStableId() {
+		return genesetId;
+	}
+	
+	@Override
+	public EntityType getEntityType() {
+		return EntityType.GENE_SET;
+	}
+}

--- a/model/src/main/java/org/cbioportal/model/Geneset.java
+++ b/model/src/main/java/org/cbioportal/model/Geneset.java
@@ -67,6 +67,6 @@ public class Geneset extends GeneticEntity implements Serializable {
 	
 	@Override
 	public EntityType getEntityType() {
-		return EntityType.GENE_SET;
+		return EntityType.GENESET;
 	}
 }

--- a/model/src/main/java/org/cbioportal/model/GeneticData.java
+++ b/model/src/main/java/org/cbioportal/model/GeneticData.java
@@ -6,12 +6,13 @@ public class GeneticData implements Serializable {
 
     private Integer geneticProfileId;
     private String geneticProfileStableId;
-    private Integer entrezGeneId;
+    private Integer geneticEntityId;
+    private String entityStableId;
     private Integer sampleId;
     private String sampleStableId;
     private String value;
     private GeneticProfile geneticProfile;
-    private Gene gene;
+    private GeneticEntity geneticEntity;
     private Sample sample;
 
     public Integer getGeneticProfileId() {
@@ -30,14 +31,22 @@ public class GeneticData implements Serializable {
         this.geneticProfileStableId = geneticProfileStableId;
     }
 
-    public Integer getEntrezGeneId() {
-        return entrezGeneId;
+    public Integer getGeneticEntityId() {
+        return geneticEntityId;
     }
 
-    public void setEntrezGeneId(Integer entrezGeneId) {
-        this.entrezGeneId = entrezGeneId;
+    public void setGeneticEntityId(Integer geneticEntityId) {
+        this.geneticEntityId = geneticEntityId;
     }
-
+    
+    public String getGeneticEntityStableId() {
+		return entityStableId;
+	}
+    
+	public void setGeneticEntityStableId(String entityStableId) {
+		this.entityStableId = entityStableId;
+	}
+    
     public Integer getSampleId() {
         return sampleId;
     }
@@ -70,12 +79,12 @@ public class GeneticData implements Serializable {
         this.geneticProfile = geneticProfile;
     }
 
-    public Gene getGene() {
-        return gene;
+    public GeneticEntity getGeneticEntity() {
+        return geneticEntity;
     }
 
-    public void setGene(Gene gene) {
-        this.gene = gene;
+    public void setGeneticEntity(GeneticEntity geneticEntity) {
+        this.geneticEntity = geneticEntity;
     }
 
     public Sample getSample() {
@@ -85,4 +94,33 @@ public class GeneticData implements Serializable {
     public void setSample(Sample sample) {
         this.sample = sample;
     }
+
+    /**
+     * Compare based on the fields that should always be filled
+     */
+	@Override
+	public boolean equals(Object o){
+	    if (o == null) return false;
+	    if (o == this) return true;
+	    if (!(o instanceof GeneticData))return false;
+	    GeneticData other = (GeneticData)o;
+	    
+		boolean result = true;
+		//check mandatory fields for equality:
+		result = this.getGeneticEntity().getEntityId().equals(other.getGeneticEntity().getEntityId());
+		result = this.getGeneticEntity().getEntityStableId().equals(other.getGeneticEntity().getEntityStableId());
+		result = this.getGeneticEntityId().equals(other.getGeneticEntityId());
+		result = this.getGeneticEntityStableId().equals(other.getGeneticEntityStableId());
+		
+		result = this.getGeneticProfileId().equals(other.getGeneticProfileId()) && result;
+		result = this.getGeneticProfileStableId().equals(other.getGeneticProfileStableId()) && result;
+		
+		result = this.getSampleId().equals(other.getSampleId()) && result;
+		result = this.getSampleStableId().equals(other.getSampleStableId()) && result;
+		
+		result = this.getValue().equals(other.getValue()) && result;
+		
+		return result;
+	}
+	
 }

--- a/model/src/main/java/org/cbioportal/model/GeneticData.java
+++ b/model/src/main/java/org/cbioportal/model/GeneticData.java
@@ -2,6 +2,8 @@ package org.cbioportal.model;
 
 import java.io.Serializable;
 
+import org.cbioportal.model.GeneticEntity.EntityType;
+
 public class GeneticData implements Serializable {
 
     private Integer geneticProfileId;
@@ -85,6 +87,10 @@ public class GeneticData implements Serializable {
 
     public void setGeneticEntity(GeneticEntity geneticEntity) {
         this.geneticEntity = geneticEntity;
+    }
+    
+    public EntityType getGeneticEntityType() {
+    	return geneticEntity.getEntityType();
     }
 
     public Sample getSample() {

--- a/model/src/main/java/org/cbioportal/model/GeneticData.java
+++ b/model/src/main/java/org/cbioportal/model/GeneticData.java
@@ -7,7 +7,7 @@ public class GeneticData implements Serializable {
     private Integer geneticProfileId;
     private String geneticProfileStableId;
     private Integer geneticEntityId;
-    private String entityStableId;
+    private String geneticEntityStableId;
     private Integer sampleId;
     private String sampleStableId;
     private String value;
@@ -40,11 +40,11 @@ public class GeneticData implements Serializable {
     }
     
     public String getGeneticEntityStableId() {
-		return entityStableId;
+		return geneticEntityStableId;
 	}
     
-	public void setGeneticEntityStableId(String entityStableId) {
-		this.entityStableId = entityStableId;
+	public void setGeneticEntityStableId(String geneticEntityStableId) {
+		this.geneticEntityStableId = geneticEntityStableId;
 	}
     
     public Integer getSampleId() {
@@ -107,8 +107,6 @@ public class GeneticData implements Serializable {
 	    
 		boolean result = true;
 		//check mandatory fields for equality:
-		result = this.getGeneticEntity().getEntityId().equals(other.getGeneticEntity().getEntityId());
-		result = this.getGeneticEntity().getEntityStableId().equals(other.getGeneticEntity().getEntityStableId());
 		result = this.getGeneticEntityId().equals(other.getGeneticEntityId());
 		result = this.getGeneticEntityStableId().equals(other.getGeneticEntityStableId());
 		

--- a/model/src/main/java/org/cbioportal/model/GeneticDataSamples.java
+++ b/model/src/main/java/org/cbioportal/model/GeneticDataSamples.java
@@ -1,0 +1,26 @@
+package org.cbioportal.model;
+
+import java.io.Serializable;
+
+public class GeneticDataSamples implements Serializable {
+
+    private Integer geneticProfileId;
+    private String orderedSamplesList;
+
+    public Integer getGeneticProfileId() {
+        return geneticProfileId;
+    }
+
+    public void setGeneticProfileId(Integer geneticProfileId) {
+        this.geneticProfileId = geneticProfileId;
+    }
+
+    public String getOrderedSamplesList() {
+    	//TODO do we want to return as List<> here?
+        return orderedSamplesList;
+    }
+
+    public void setOrderedSamplesList(String orderedSamplesList) {
+        this.orderedSamplesList = orderedSamplesList;
+    }
+}

--- a/model/src/main/java/org/cbioportal/model/GeneticDataValues.java
+++ b/model/src/main/java/org/cbioportal/model/GeneticDataValues.java
@@ -1,0 +1,34 @@
+package org.cbioportal.model;
+
+import java.io.Serializable;
+
+public class GeneticDataValues implements Serializable {
+
+    private Integer geneticProfileId;
+    private Integer geneticEntityId;
+    private String orderedValuesList;
+
+    public Integer getGeneticProfileId() {
+        return geneticProfileId;
+    }
+
+    public void setGeneticProfileId(Integer geneticProfileId) {
+        this.geneticProfileId = geneticProfileId;
+    }
+
+    public Integer getGeneticEntityId() {
+        return geneticEntityId;
+    }
+
+    public void setGeneticEntityId(Integer geneticEntityId) {
+        this.geneticEntityId = geneticEntityId;
+    }
+    
+    public String getOrderedValuesList() {
+        return orderedValuesList;
+    }
+
+    public void setOrderedValuesList(String orderedValuesList) {
+        this.orderedValuesList = orderedValuesList;
+    }
+}

--- a/model/src/main/java/org/cbioportal/model/GeneticEntity.java
+++ b/model/src/main/java/org/cbioportal/model/GeneticEntity.java
@@ -30,7 +30,7 @@ public abstract class GeneticEntity implements Serializable  {
 	public static enum EntityType
     {
         GENE,
-        GENE_SET,
+        GENESET,
         PHOSPHOPROTEIN;
     }
 	

--- a/model/src/main/java/org/cbioportal/model/GeneticEntity.java
+++ b/model/src/main/java/org/cbioportal/model/GeneticEntity.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016 The Hyve B.V.
+ * This code is licensed under the GNU Affero General Public License (AGPL),
+ * version 3, or (at your option) any later version.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.model;
+
+import java.io.Serializable;
+
+public class GeneticEntity implements Serializable  {
+
+	public static enum EntityType
+    {
+        GENE,
+        GENE_SET,
+        PHOSPHOPROTEIN;
+    }
+	
+	private Integer entityId;
+	private String entityStableId;
+    private EntityType entityType;
+
+    public Integer getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(Integer entityId) {
+        this.entityId = entityId;
+    }
+    
+    public String getEntityStableId() {
+        return entityStableId;
+    }
+
+    public void setEntityStableId(String entityStableId) {
+        this.entityStableId = entityStableId;
+    }
+    
+    public EntityType getEntityType() {
+        return entityType;
+    }
+
+    public void setEntityType(EntityType entityType) {
+        this.entityType = entityType;
+    }
+    
+}

--- a/model/src/main/java/org/cbioportal/model/GeneticEntity.java
+++ b/model/src/main/java/org/cbioportal/model/GeneticEntity.java
@@ -25,7 +25,7 @@ package org.cbioportal.model;
 
 import java.io.Serializable;
 
-public class GeneticEntity implements Serializable  {
+public abstract class GeneticEntity implements Serializable  {
 
 	public static enum EntityType
     {
@@ -35,8 +35,6 @@ public class GeneticEntity implements Serializable  {
     }
 	
 	private Integer entityId;
-	private String entityStableId;
-    private EntityType entityType;
 
     public Integer getEntityId() {
         return entityId;
@@ -46,20 +44,9 @@ public class GeneticEntity implements Serializable  {
         this.entityId = entityId;
     }
     
-    public String getEntityStableId() {
-        return entityStableId;
-    }
-
-    public void setEntityStableId(String entityStableId) {
-        this.entityStableId = entityStableId;
-    }
+    public abstract String getEntityStableId();
     
-    public EntityType getEntityType() {
-        return entityType;
-    }
+    public abstract EntityType getEntityType();
 
-    public void setEntityType(EntityType entityType) {
-        this.entityType = entityType;
-    }
     
 }

--- a/model/src/main/java/org/cbioportal/model/GeneticProfile.java
+++ b/model/src/main/java/org/cbioportal/model/GeneticProfile.java
@@ -20,7 +20,8 @@ public class GeneticProfile implements Serializable {
         PHOSPHORYLATION,
         PROTEIN_LEVEL,
         PROTEIN_ARRAY_PROTEIN_LEVEL, //TODO - remove? I think this is not used anymore...
-        PROTEIN_ARRAY_PHOSPHORYLATION; //TODO - remove? I think this is not used anymore...
+        PROTEIN_ARRAY_PHOSPHORYLATION, //TODO - remove? I think this is not used anymore...
+        GENESET_SCORE;
     }
 
     private Integer geneticProfileId;

--- a/model/src/main/java/org/cbioportal/model/GeneticProfile.java
+++ b/model/src/main/java/org/cbioportal/model/GeneticProfile.java
@@ -19,8 +19,8 @@ public class GeneticProfile implements Serializable {
         METHYLATION_BINARY,
         PHOSPHORYLATION,
         PROTEIN_LEVEL,
-        PROTEIN_ARRAY_PROTEIN_LEVEL,
-        PROTEIN_ARRAY_PHOSPHORYLATION;
+        PROTEIN_ARRAY_PROTEIN_LEVEL, //TODO - remove? I think this is not used anymore...
+        PROTEIN_ARRAY_PHOSPHORYLATION; //TODO - remove? I think this is not used anymore...
     }
 
     private Integer geneticProfileId;

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenesetRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenesetRepository.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 The Hyve B.V.
+ * This code is licensed under the GNU Affero General Public License (AGPL),
+ * version 3, or (at your option) any later version.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.cbioportal.persistence;
+
+import java.util.List;
+
+import org.cbioportal.model.Geneset;
+import org.cbioportal.model.meta.BaseMeta;
+
+public interface GenesetRepository {
+
+    List<Geneset> getAllGenesets(String projection, Integer pageSize, Integer pageNumber, String sortBy, String direction);
+
+    BaseMeta getMetaGenesets();
+
+    Geneset getGenesetByGenesetId(String genesetId);
+
+    List<Geneset> fetchGenesetsByGenesetIds(List<String> genesetIds, String projection);
+
+    BaseMeta fetchMetaGenesetsByGenesetIds(List<String> genesetIds);
+    
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenesetRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenesetRepository.java
@@ -34,6 +34,8 @@ public interface GenesetRepository {
     BaseMeta getMetaGenesets();
 
     Geneset getGenesetByGenesetId(String genesetId);
+    
+    Geneset getGenesetByGeneticEntityId(Integer entityId);
 
     List<Geneset> fetchGenesetsByGenesetIds(List<String> genesetIds, String projection);
 

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GeneticDataRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GeneticDataRepository.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016 The Hyve B.V.
+ * This code is licensed under the GNU Affero General Public License (AGPL),
+ * version 3, or (at your option) any later version.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.persistence;
+
+import java.util.List;
+
+import org.cbioportal.model.GeneticDataSamples;
+import org.cbioportal.model.GeneticDataValues;
+
+public interface GeneticDataRepository {
+
+    List<GeneticDataValues> getGeneticDataValuesInGeneticProfile(String geneticProfileId, List<Integer> geneticEntityIds, Integer pageSize,
+			Integer pageNumber);
+
+    GeneticDataSamples getGeneticDataSamplesInGeneticProfile(String geneticProfileId, Integer pageSize,
+			Integer pageNumber);
+
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GeneticEntityRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GeneticEntityRepository.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.cbioportal.persistence;
+
+import org.cbioportal.model.GeneticEntity;
+import org.cbioportal.model.GeneticEntity.EntityType;
+
+public interface GeneticEntityRepository {
+
+	GeneticEntity getGeneticEntity(String entityStableId, EntityType gene);
+	
+	GeneticEntity getGeneticEntity(Integer entityId, EntityType gene);
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SampleRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SampleRepository.java
@@ -22,4 +22,6 @@ public interface SampleRepository {
     List<Sample> fetchSamples(List<String> studyIds, List<String> sampleIds, String projection);
 
     BaseMeta fetchMetaSamples(List<String> studyIds, List<String> sampleIds);
+
+	List<Sample> fetchSamplesInSameStudyByInternalIds(String studyId, List<Integer> sampleIds, String projection);
 }

--- a/persistence/persistence-mybatis-test/src/test/resources/testSql.sql
+++ b/persistence/persistence-mybatis-test/src/test/resources/testSql.sql
@@ -46,6 +46,7 @@ CREATE TABLE "type_of_cancer" (
 CREATE TABLE "gene" (
   "ENTREZ_GENE_ID" INTEGER NOT NULL,
   "HUGO_GENE_SYMBOL" VARCHAR(255) NOT NULL,
+  "GENETIC_ENTITY_ID" INTEGER, -- just a quick fix for GeneMapper.xml to work. TODO this part of the file should not exist...use cgds.sql instead. TODO 2 - add genetic_entity insert statements when making tests that involve this table
   "TYPE" VARCHAR(50),
   "CYTOBAND" VARCHAR(50),
   "LENGTH" INTEGER,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneMapper.java
@@ -52,6 +52,9 @@ public interface GeneMapper {
 
     Gene getGeneByHugoGeneSymbol(@Param("hugoGeneSymbol") String hugoGeneSymbol,
                                  @Param("projection") String projection);
+    
+    Gene getGeneByGeneticEntityId(@Param("geneticEntityId") Integer geneticEntityId,
+            @Param("projection") String projection);
 
     List<String> getAliasesOfGeneByEntrezGeneId(@Param("entrezGeneId") Integer entrezGeneId);
 

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenesetMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenesetMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 Memorial Sloan Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -29,25 +29,33 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+package org.cbioportal.persistence.mybatis;
 
-package org.mskcc.cbio.portal.model;
+import java.util.List;
 
-// Copied to org.cbioportal.model.GeneticProfile.GeneticAlterationType, if you alter this,
-// don't forget to change the other one too
-public enum GeneticAlterationType {
-    MUTATION_EXTENDED,
-    FUSION,
-    STRUCTURAL_VARIANT,
-    COPY_NUMBER_ALTERATION,
-    MICRO_RNA_EXPRESSION,
-    MRNA_EXPRESSION,
-    MRNA_EXPRESSION_NORMALS,
-    RNA_EXPRESSION,
-    METHYLATION,
-    METHYLATION_BINARY,
-    PHOSPHORYLATION,
-    PROTEIN_LEVEL,
-    PROTEIN_ARRAY_PROTEIN_LEVEL,
-    PROTEIN_ARRAY_PHOSPHORYLATION,
-	GENESET_SCORE;
-};
+import org.apache.ibatis.annotations.Param;
+import org.cbioportal.model.Geneset;
+import org.cbioportal.model.meta.BaseMeta;
+
+public interface GenesetMapper {
+
+    List<Geneset> getGenesets(@Param("projection") String projection,
+                        @Param("limit") Integer limit,
+                        @Param("offset") Integer offset,
+                        @Param("sortBy") String sortBy,
+                        @Param("direction") String direction);
+
+    BaseMeta getMetaGenesets();
+
+    Geneset getGenesetByInternalId(@Param("genesetId") Integer internalId,
+            @Param("projection") String projection);
+    
+    Geneset getGenesetByGenesetId(@Param("genesetId") String genesetId,
+                               @Param("projection") String projection);
+
+    Geneset getGenesetByGeneticEntityId(@Param("geneticEntityId") Integer geneticEntityId,
+            @Param("projection") String projection);
+
+    List<Geneset> getGenesetsByGenesetIds(@Param("genesetIds") List<String> genesetIds,
+            @Param("projection") String projection);
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenesetMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenesetMyBatisRepository.java
@@ -70,6 +70,12 @@ public class GenesetMyBatisRepository implements GenesetRepository {
 	}
 
 	@Override
+	public Geneset getGenesetByGeneticEntityId(Integer entityId) {
+		
+		return genesetMapper.getGenesetByGeneticEntityId(entityId, PersistenceConstants.DETAILED_PROJECTION);
+	}
+	
+	@Override
 	public List<Geneset> fetchGenesetsByGenesetIds(List<String> genesetIds, String projection) {
 		
 		return genesetMapper.getGenesetsByGenesetIds(genesetIds, projection);
@@ -80,5 +86,4 @@ public class GenesetMyBatisRepository implements GenesetRepository {
 		// TODO Auto-generated method stub
 		return null;
 	}
-   
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenesetMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenesetMyBatisRepository.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.cbioportal.persistence.mybatis;
+
+import java.util.List;
+
+import org.cbioportal.model.Geneset;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.persistence.GenesetRepository;
+import org.cbioportal.persistence.PersistenceConstants;
+import org.cbioportal.persistence.mybatis.util.OffsetCalculator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class GenesetMyBatisRepository implements GenesetRepository {
+
+    @Autowired
+    GenesetMapper genesetMapper;
+    @Autowired
+    private OffsetCalculator offsetCalculator;
+
+	@Override
+	public List<Geneset> getAllGenesets(String projection, Integer pageSize, Integer pageNumber, String sortBy,
+			String direction) {
+		
+		return genesetMapper.getGenesets(projection, pageSize, offsetCalculator.calculate(pageSize, pageNumber), sortBy,
+                direction);
+	}
+
+	@Override
+	public BaseMeta getMetaGenesets() {
+
+		return genesetMapper.getMetaGenesets();
+	}
+
+	@Override
+	public Geneset getGenesetByGenesetId(String genesetId) {
+		
+		return genesetMapper.getGenesetByGenesetId(genesetId, PersistenceConstants.DETAILED_PROJECTION);
+	}
+
+	@Override
+	public List<Geneset> fetchGenesetsByGenesetIds(List<String> genesetIds, String projection) {
+		
+		return genesetMapper.getGenesetsByGenesetIds(genesetIds, projection);
+	}
+
+	@Override
+	public BaseMeta fetchMetaGenesetsByGenesetIds(List<String> genesetIds) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+   
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticDataMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticDataMapper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016 The Hyve B.V.
+ * This code is licensed under the GNU Affero General Public License (AGPL),
+ * version 3, or (at your option) any later version.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.persistence.mybatis;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Param;
+import org.cbioportal.model.GeneticData;
+import org.cbioportal.model.GeneticDataSamples;
+import org.cbioportal.model.GeneticDataValues;
+import org.cbioportal.model.meta.BaseMeta;
+
+public interface GeneticDataMapper {
+
+	List<GeneticData> getGeneticData(@Param("geneticProfileIds") List<String> geneticProfileIds,
+                            @Param("projection") String projection,
+                            @Param("limit") Integer limit,
+                            @Param("offset") Integer offset);
+	
+	List<GeneticDataValues> getGeneticDataValues(@Param("geneticProfileIds") List<String> geneticProfileIds,
+			@Param("geneticEntityIds") List<Integer> geneticEntityIds,
+            @Param("limit") Integer limit,
+            @Param("offset") Integer offset);
+
+	
+	List<GeneticDataSamples> getGeneticDataSamples(@Param("geneticProfileIds") List<String> geneticProfileIds,
+            @Param("limit") Integer limit,
+            @Param("offset") Integer offset);
+
+
+	BaseMeta getMetaGeneticData(@Param("geneticProfileIds") List<String> geneticProfileIds);
+
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticDataMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticDataMyBatisRepository.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016 The Hyve B.V.
+ * This code is licensed under the GNU Affero General Public License (AGPL),
+ * version 3, or (at your option) any later version.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.persistence.mybatis;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.cbioportal.model.GeneticDataSamples;
+import org.cbioportal.model.GeneticDataValues;
+import org.cbioportal.persistence.GeneticDataRepository;
+import org.cbioportal.persistence.mybatis.util.OffsetCalculator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class GeneticDataMyBatisRepository implements GeneticDataRepository {
+	@Autowired
+    private GeneticDataMapper geneticDataMapper;
+    @Autowired
+    private OffsetCalculator offsetCalculator;
+
+    @Override
+    public List<GeneticDataValues> getGeneticDataValuesInGeneticProfile(String geneticProfileId, List<Integer> geneticEntityIds, Integer pageSize,
+			Integer pageNumber) {
+    	//get values csv:
+        return geneticDataMapper.getGeneticDataValues(Arrays.asList(geneticProfileId), geneticEntityIds, pageSize, 
+                offsetCalculator.calculate(pageSize, pageNumber));
+    }
+
+    @Override
+    public GeneticDataSamples getGeneticDataSamplesInGeneticProfile(String geneticProfileId, Integer pageSize,
+			Integer pageNumber) {
+    	//get values csv:
+        List<GeneticDataSamples> result = geneticDataMapper.getGeneticDataSamples(Arrays.asList(geneticProfileId), pageSize, 
+                offsetCalculator.calculate(pageSize, pageNumber));
+        if (result != null && result.size() > 0) {
+        	//only one result item expected for this query: //TODO validate if size > 1?
+        	return result.get(0);
+        }
+        return null;
+    }
+
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticEntityMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticEntityMyBatisRepository.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016 The Hyve B.V.
+ * This code is licensed under the GNU Affero General Public License (AGPL),
+ * version 3, or (at your option) any later version.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.persistence.mybatis;
+
+import org.cbioportal.model.GeneticEntity;
+import org.cbioportal.model.GeneticEntity.EntityType;
+import org.cbioportal.persistence.GeneticEntityRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class GeneticEntityMyBatisRepository implements GeneticEntityRepository {
+
+    @Autowired
+    private GeneMapper geneMapper;
+
+    @Override
+    public GeneticEntity getGeneticEntity(String entityStableId, EntityType type) {
+    	
+    	if (type.equals(EntityType.GENE)) {
+    		//TODO - use a global cache that is initialized on startup with all gene x entity id mappings.
+
+    		//for GENE, the stable id is Entrez, which is numeric, so convert first:
+			try {
+				int entrezGeneId = Integer.parseInt(entityStableId);
+				return geneMapper.getGeneByEntrezGeneId(entrezGeneId, null);
+			} catch (NumberFormatException e) {
+				throw new IllegalArgumentException("Entrez gene id should be a number. Given value is not valid: " + entityStableId);
+			}
+    	}
+    	else {
+    		throw new UnsupportedOperationException("not implemented yet for other entities");
+    	}    		
+    }
+	
+    @Override
+    public GeneticEntity getGeneticEntity(Integer entityId, EntityType type) {
+    	if (type.equals(EntityType.GENE)) {
+    		return geneMapper.getGeneByGeneticEntityId(entityId, null); 
+    	}
+    	else {
+    		throw new UnsupportedOperationException("not implemented yet for other entities");
+    	}
+    }
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticEntityVirtualRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticEntityVirtualRepository.java
@@ -59,7 +59,7 @@ public class GeneticEntityVirtualRepository implements GeneticEntityRepository {
 			} catch (NumberFormatException e) {
 				throw new IllegalArgumentException("Entrez gene id should be a number. Given value is not valid: " + entityStableId);
 			}
-    	} else if (type.equals(EntityType.GENE_SET)) {
+    	} else if (type.equals(EntityType.GENESET)) {
     		return genesetMapper.getGenesetByGenesetId(entityStableId, null);
     	} else {
     		throw new UnsupportedOperationException("not implemented yet for other entities");
@@ -71,7 +71,7 @@ public class GeneticEntityVirtualRepository implements GeneticEntityRepository {
 
     	if (type.equals(EntityType.GENE)) {
     		return geneMapper.getGeneByGeneticEntityId(entityId, null); 
-    	} else if (type.equals(EntityType.GENE_SET)) {
+    	} else if (type.equals(EntityType.GENESET)) {
     		return genesetMapper.getGenesetByGeneticEntityId(entityId, null);
     	} else {
     		throw new UnsupportedOperationException("not implemented yet for other entities");

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticEntityVirtualRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticEntityVirtualRepository.java
@@ -29,8 +29,15 @@ import org.cbioportal.persistence.GeneticEntityRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
+/**
+ * This repository implementation does not map to a single table but is rather 
+ * a utility class that can be used to get any genetic entity by stable id and type. 
+ * 
+ * @author pieter
+ *
+ */
 @Repository
-public class GeneticEntityMyBatisRepository implements GeneticEntityRepository {
+public class GeneticEntityVirtualRepository implements GeneticEntityRepository {
 
     @Autowired
     private GeneMapper geneMapper;

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticEntityVirtualRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GeneticEntityVirtualRepository.java
@@ -41,6 +41,10 @@ public class GeneticEntityVirtualRepository implements GeneticEntityRepository {
 
     @Autowired
     private GeneMapper geneMapper;
+    
+    @Autowired
+    private GenesetMapper genesetMapper;
+    
 
     @Override
     public GeneticEntity getGeneticEntity(String entityStableId, EntityType type) {
@@ -55,18 +59,21 @@ public class GeneticEntityVirtualRepository implements GeneticEntityRepository {
 			} catch (NumberFormatException e) {
 				throw new IllegalArgumentException("Entrez gene id should be a number. Given value is not valid: " + entityStableId);
 			}
-    	}
-    	else {
+    	} else if (type.equals(EntityType.GENE_SET)) {
+    		return genesetMapper.getGenesetByGenesetId(entityStableId, null);
+    	} else {
     		throw new UnsupportedOperationException("not implemented yet for other entities");
     	}    		
     }
 	
     @Override
     public GeneticEntity getGeneticEntity(Integer entityId, EntityType type) {
+
     	if (type.equals(EntityType.GENE)) {
     		return geneMapper.getGeneByGeneticEntityId(entityId, null); 
-    	}
-    	else {
+    	} else if (type.equals(EntityType.GENE_SET)) {
+    		return genesetMapper.getGenesetByGeneticEntityId(entityId, null);
+    	} else {
     		throw new UnsupportedOperationException("not implemented yet for other entities");
     	}
     }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/SampleMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/SampleMapper.java
@@ -17,6 +17,15 @@ public interface SampleMapper {
                             @Param("sortBy") String sortBy,
                             @Param("direction") String direction);
 
+    List<Sample> getSamplesInSameStudyByInternalIds(@Param("studyId") String studyId,
+            @Param("patientId") String patientId,
+            @Param("sampleIds") List<Integer> sampleInternalIds,
+            @Param("projection") String projection,
+            @Param("limit") Integer limit,
+            @Param("offset") Integer offset,
+            @Param("sortBy") String sortBy,
+            @Param("direction") String direction);
+    
     BaseMeta getMetaSamples(@Param("studyIds") List<String> studyIds,
                             @Param("patientId") String patientId,
                             @Param("sampleIds") List<String> sampleIds);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepository.java
@@ -60,6 +60,12 @@ public class SampleMyBatisRepository implements SampleRepository {
 
         return sampleMapper.getSamples(studyIds, null, sampleIds, projection, 0, 0, null, null);
     }
+    
+    @Override
+    public List<Sample> fetchSamplesInSameStudyByInternalIds(String studyId, List<Integer> sampleIds, String projection) {
+    	 
+    	return sampleMapper.getSamplesInSameStudyByInternalIds(studyId, null, sampleIds, projection, 0, 0, null, null);
+    }
 
     @Override
     public BaseMeta fetchMetaSamples(List<String> studyIds, List<String> sampleIds) {

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GeneMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GeneMapper.xml
@@ -6,7 +6,8 @@
 
     <sql id="select">
         gene.ENTREZ_GENE_ID AS "${prefix}entrezGeneId",
-        gene.HUGO_GENE_SYMBOL AS "${prefix}hugoGeneSymbol"
+        gene.HUGO_GENE_SYMBOL AS "${prefix}hugoGeneSymbol",
+        gene.GENETIC_ENTITY_ID as "${prefix}entityId"
         <if test="projection == 'SUMMARY' || projection == 'DETAILED'">
             ,
             gene.TYPE AS "${prefix}type",
@@ -54,6 +55,15 @@
         </include>
         FROM gene
         WHERE gene.HUGO_GENE_SYMBOL = #{hugoGeneSymbol}
+    </select>
+    
+    <select id="getGeneByGeneticEntityId" resultType="org.cbioportal.model.Gene">
+        SELECT
+        <include refid="select">
+            <property name="prefix" value=""/>
+        </include>
+        FROM gene
+        WHERE gene.GENETIC_ENTITY_ID = #{geneticEntityId}
     </select>
 
     <select id="getAliasesOfGeneByEntrezGeneId" resultType="string">

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetMapper.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.cbioportal.persistence.mybatis.GenesetMapper">
+    <cache/>
+
+    <sql id="select">
+        geneset.ID AS "${prefix}internalId",
+        geneset.EXTERNAL_ID AS "${prefix}genesetId",
+        geneset.GENETIC_ENTITY_ID as "${prefix}entityId",
+        geneset.NAME_SHORT as "${prefix}nameShort",
+        geneset.NAME_SHORT as "${prefix}nameShort",
+        geneset.NAME as "${prefix}name",
+        geneset.REF_LINK as "${prefix}refLink",
+        geneset.VERSION as "${prefix}version"
+    </sql>
+
+    <select id="getGenesets" resultType="org.cbioportal.model.Geneset">
+        SELECT
+        <include refid="select">
+            <property name="prefix" value=""/>
+        </include>
+        FROM geneset
+        <if test="sortBy != null and projection != 'ID'">
+            ORDER BY ${sortBy} ${direction}
+        </if>
+        <if test="projection == 'ID'">
+            ORDER BY geneset.EXTERNAL_ID ASC
+        </if>
+        <if test="limit != null and limit != 0">
+            LIMIT #{limit} OFFSET #{offset}
+        </if>
+    </select>
+
+    <select id="getMetaGenesets" resultType="org.cbioportal.model.meta.BaseMeta">
+        SELECT
+        COUNT(*) AS totalCount
+        FROM geneset
+    </select>
+
+    <select id="getGenesetByInternalId" resultType="org.cbioportal.model.Geneset">
+        SELECT
+        <include refid="select">
+            <property name="prefix" value=""/>
+        </include>
+        FROM geneset
+        WHERE geneset.ID = #{internalId}
+    </select>
+
+    <select id="getGenesetByGenesetId" resultType="org.cbioportal.model.Geneset">
+        SELECT
+        <include refid="select">
+            <property name="prefix" value=""/>
+        </include>
+        FROM geneset
+        WHERE geneset.EXTERNAL_ID = #{genesetId}
+    </select>
+    
+    <select id="getGenesetByGeneticEntityId" resultType="org.cbioportal.model.Geneset">
+        SELECT
+        <include refid="select">
+            <property name="prefix" value=""/>
+        </include>
+        FROM geneset
+        WHERE geneset.GENETIC_ENTITY_ID = #{geneticEntityId}
+    </select>
+
+    <select id="getGenesetsByGenesetIds" resultType="org.cbioportal.model.Geneset">
+        SELECT
+        <include refid="select">
+            <property name="prefix" value=""/>
+        </include>
+        FROM geneset
+        WHERE geneset.EXTERNAL_ID IN
+        <foreach item="item" collection="genesetIds" open="(" separator="," close=")">
+            #{item}
+        </foreach>
+    </select>
+
+</mapper>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetMapper.xml
@@ -8,11 +8,9 @@
         geneset.ID AS "${prefix}internalId",
         geneset.EXTERNAL_ID AS "${prefix}genesetId",
         geneset.GENETIC_ENTITY_ID as "${prefix}entityId",
-        geneset.NAME_SHORT as "${prefix}nameShort",
-        geneset.NAME_SHORT as "${prefix}nameShort",
         geneset.NAME as "${prefix}name",
+        geneset.DESCRIPTION as "${prefix}description",
         geneset.REF_LINK as "${prefix}refLink",
-        geneset.VERSION as "${prefix}version"
     </sql>
 
     <select id="getGenesets" resultType="org.cbioportal.model.Geneset">

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetMapper.xml
@@ -10,7 +10,7 @@
         geneset.GENETIC_ENTITY_ID as "${prefix}entityId",
         geneset.NAME as "${prefix}name",
         geneset.DESCRIPTION as "${prefix}description",
-        geneset.REF_LINK as "${prefix}refLink",
+        geneset.REF_LINK as "${prefix}refLink"
     </sql>
 
     <select id="getGenesets" resultType="org.cbioportal.model.Geneset">

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GeneticDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GeneticDataMapper.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.cbioportal.persistence.mybatis.GeneticDataMapper">
+    <cache/> <!--  TODO - check this -->
+
+    <sql id="select">
+        genetic_alteration.VALUES AS "${prefix}orderedValuesList"
+    </sql>
+
+    <sql id="from">
+        FROM genetic_alteration
+        INNER JOIN genetic_profile ON genetic_profile.GENETIC_PROFILE_ID = genetic_alteration.GENETIC_PROFILE_ID
+    </sql>
+
+    <sql id="where">
+        <where>
+           genetic_profile.STABLE_ID IN (
+	           <foreach index="i" collection="geneticProfileIds" separator=",">
+	           	#{geneticProfileIds[${i}]}
+	           </foreach>
+           )
+        </where>
+    </sql>
+
+    <select id="getGeneticDataValues" resultType="org.cbioportal.model.GeneticDataValues">
+        SELECT genetic_alteration.GENETIC_PROFILE_ID as "geneticProfileId", 
+          genetic_alteration.GENETIC_ENTITY_ID as "geneticEntityId",
+          genetic_alteration.VALUES AS "orderedValuesList"
+        FROM genetic_alteration
+        INNER JOIN genetic_profile ON genetic_profile.GENETIC_PROFILE_ID = genetic_alteration.GENETIC_PROFILE_ID
+        <include refid="where"/>
+        <if test="geneticEntityIds != null">
+           AND genetic_alteration.GENETIC_ENTITY_ID IN (
+	           <foreach index="i" collection="geneticEntityIds" separator=",">
+	           	#{geneticEntityIds[${i}]}
+	           </foreach>
+           )
+        </if>
+        <if test="limit != null and limit != 0">
+	    <!-- add specific ordering, in case limit is specified -->
+	    ORDER BY genetic_alteration.GENETIC_PROFILE_ID, genetic_alteration.GENETIC_ENTITY_ID
+	    <!-- subset is done in java layer because CSV field ORDERED_SAMPLE_LIST is decomposed into
+	     many items there
+            LIMIT #{limit} OFFSET #{offset} -->
+        </if>
+    </select>
+    
+    
+    <select id="getGeneticDataSamples" resultType="org.cbioportal.model.GeneticDataSamples">
+        SELECT genetic_profile_samples.GENETIC_PROFILE_ID as "geneticProfileId", 
+          genetic_profile_samples.ORDERED_SAMPLE_LIST as "orderedSamplesList"
+        FROM genetic_profile_samples
+        INNER JOIN genetic_profile ON genetic_profile.GENETIC_PROFILE_ID = genetic_profile_samples.GENETIC_PROFILE_ID
+        <include refid="where"/>
+        <if test="limit != null and limit != 0">
+	    <!-- add specific ordering, in case limit is specified -->
+	    ORDER BY genetic_profile_samples.GENETIC_PROFILE_ID
+	    <!-- subset is done in java layer because CSV field ORDERED_SAMPLE_LIST is decomposed into
+	     many items there
+            LIMIT #{limit} OFFSET #{offset} -->
+        </if>
+    </select>
+
+    
+</mapper>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleMapper.xml
@@ -43,6 +43,22 @@
             </if>
         </where>
     </sql>
+    
+    <sql id="whereInternal">
+        <where>
+            cancer_study.CANCER_STUDY_IDENTIFIER = #{studyId}
+            <if test="sampleIds != null">
+                AND sample.INTERNAL_ID IN (
+                <foreach index="i" collection="sampleIds" separator=",">
+                    #{sampleIds[${i}]}
+                </foreach>
+                )
+            </if>
+            <if test="patientId != null">
+                AND patient.STABLE_ID = #{patientId}
+            </if>
+        </where>
+    </sql>
 
     <select id="getSamples" resultType="org.cbioportal.model.Sample">
         SELECT
@@ -51,6 +67,24 @@
         </include>
         <include refid="from"/>
         <include refid="where"/>
+        <if test="sortBy != null and projection != 'ID'">
+            ORDER BY ${sortBy} ${direction}
+        </if>
+        <if test="projection == 'ID'">
+            ORDER BY sample.STABLE_ID ASC
+        </if>
+        <if test="limit != null and limit != 0">
+            LIMIT #{limit} OFFSET #{offset}
+        </if>
+    </select>
+
+    <select id="getSamplesInSameStudyByInternalIds" resultType="org.cbioportal.model.Sample">
+        SELECT
+        <include refid="select">
+            <property name="prefix" value=""/>
+        </include>
+        <include refid="from"/>
+        <include refid="whereInternal"/>
         <if test="sortBy != null and projection != 'ID'">
             ORDER BY ${sortBy} ${direction}
         </if>

--- a/service/src/main/java/org/cbioportal/service/GeneticDataService.java
+++ b/service/src/main/java/org/cbioportal/service/GeneticDataService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016 The Hyve B.V.
+ * This code is licensed under the GNU Affero General Public License (AGPL),
+ * version 3, or (at your option) any later version.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.service;
+
+import java.util.List;
+
+import org.cbioportal.model.GeneticData;
+import org.cbioportal.model.GeneticEntity.EntityType;
+import org.cbioportal.model.meta.BaseMeta;
+
+public interface GeneticDataService {
+
+    BaseMeta getMetaGeneticDataInGeneticProfile(String geneticProfileId);
+
+	List<GeneticData> getAllGeneticDataInGeneticProfile(String geneticProfileId, 
+			String projectionName, Integer pageSize, Integer pageNumber);
+
+	List<GeneticData> fetchGeneticDataInGeneticProfile(String geneticProfileId, EntityType geneticEntityType, List<String> geneticEntityIds, 
+			String projectionName, Integer pageSize, Integer pageNumber);
+
+	List<GeneticData> fetchGeneticDataInGeneticProfile(String geneticProfileId, EntityType geneticEntityType, List<String> geneticEntityIds, String caseListId,
+			String projectionName, Integer pageSize, Integer pageNumber);
+
+	List<GeneticData> fetchGeneticDataInGeneticProfile(String geneticProfileId, EntityType geneticEntityType, List<String> geneticEntityIds, List<String> caseIds, 
+			String projectionName, Integer pageSize, Integer pageNumber);
+}

--- a/service/src/main/java/org/cbioportal/service/impl/GeneticDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GeneticDataServiceImpl.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2016 The Hyve B.V.
+ * This code is licensed under the GNU Affero General Public License (AGPL),
+ * version 3, or (at your option) any later version.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.service.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.cbioportal.model.GeneticData;
+import org.cbioportal.model.GeneticDataSamples;
+import org.cbioportal.model.GeneticDataValues;
+import org.cbioportal.model.GeneticEntity;
+import org.cbioportal.model.GeneticEntity.EntityType;
+import org.cbioportal.model.GeneticProfile;
+import org.cbioportal.model.GeneticProfile.GeneticAlterationType;
+import org.cbioportal.model.Sample;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.persistence.GeneticDataRepository;
+import org.cbioportal.persistence.GeneticEntityRepository;
+import org.cbioportal.persistence.GeneticProfileRepository;
+import org.cbioportal.persistence.SampleRepository;
+import org.cbioportal.service.GeneticDataService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GeneticDataServiceImpl implements GeneticDataService {
+
+    @Autowired
+    private GeneticDataRepository geneticDataRepository;
+    
+    @Autowired
+    private GeneticProfileRepository geneticProfileRepository;
+    
+    @Autowired
+    private GeneticEntityRepository geneticEntityRepository;
+    
+    @Autowired
+    private SampleRepository sampleRepository;
+    
+    private static final List<GeneticAlterationType> geneBasedTypes = Arrays.asList(GeneticAlterationType.MICRO_RNA_EXPRESSION,
+			GeneticAlterationType.MRNA_EXPRESSION,
+			GeneticAlterationType.MRNA_EXPRESSION_NORMALS,
+			GeneticAlterationType.RNA_EXPRESSION,
+			GeneticAlterationType.COPY_NUMBER_ALTERATION,
+			GeneticAlterationType.METHYLATION,
+			GeneticAlterationType.METHYLATION_BINARY,
+			GeneticAlterationType.PHOSPHORYLATION, //TODO - this will be "protein based" at some point, not gene based
+			GeneticAlterationType.PROTEIN_LEVEL, //TODO - this will be "protein based" at some point, not gene based
+			GeneticAlterationType.PROTEIN_ARRAY_PROTEIN_LEVEL, //TODO - remove? I think this is not used anymore...
+			GeneticAlterationType.PROTEIN_ARRAY_PHOSPHORYLATION); //TODO - remove? I think this is not used anymore...
+
+	private static final int INVALID_ENTITY_ID = -1;
+    
+    @Override
+    public List<GeneticData> getAllGeneticDataInGeneticProfile(String geneticProfileId, String projectionName, Integer pageSize,
+			Integer pageNumber) {
+    	
+    	//get genetic profile info:
+    	GeneticProfile geneticProfile = geneticProfileRepository.getGeneticProfile(geneticProfileId);
+    	EntityType entityType = geneBasedTypes.contains(geneticProfile.getGeneticAlterationType()) ? EntityType.GENE: null;
+    	return getGeneticDataInGeneticProfile(geneticProfileId, entityType, null, null, projectionName, pageSize, pageNumber);
+    }
+    
+    private List<GeneticData> getGeneticDataInGeneticProfile(String geneticProfileId, EntityType geneticEntityType, List<String> geneticEntityStableIds, 
+    		List<String> sampleStableIds, String projectionName, Integer pageSize, Integer pageNumber) {
+    	
+    	//get samples:  
+    	//TODO ? -  pageSize, pageNumber are not really used in these 2 methods. Maybe remove for clarity? Paging is implemented manually in the loop below.
+    	GeneticDataSamples samples = geneticDataRepository.getGeneticDataSamplesInGeneticProfile(geneticProfileId, pageSize, pageNumber);
+    	//get list of genes and respective sample values:
+    	List<Integer> geneticEntityIds = getInternalEntityIds(geneticEntityStableIds, geneticEntityType); 
+    	List<GeneticDataValues> geneticItemListAndValues = geneticDataRepository.getGeneticDataValuesInGeneticProfile(geneticProfileId, geneticEntityIds, 
+    			pageSize, pageNumber);
+    	Set<String> sampleStableIdsSet = sampleStableIds != null ? new HashSet<>(sampleStableIds) : null;
+    	
+    	//get genetic profile info:
+    	GeneticProfile geneticProfile = geneticProfileRepository.getGeneticProfile(geneticProfileId);
+    	
+    	List<GeneticData> result = new ArrayList<GeneticData>();
+    	//if any data was found:
+    	if (samples != null) {
+	    	//merge the values and samples into a list of GeneticData items:
+	    	String[] sampleInternalIdsList = samples.getOrderedSamplesList().split(",");
+	    	Map<Integer,Sample> sampleIdToStableIdMap = getSampleStableIdsList(geneticProfile, sampleInternalIdsList);
+	    	//variables for simple paging implementation:
+	    	int itemIdx = 0;
+	    	Integer start = calculateOffset(pageSize, pageNumber);
+	    	Integer end = null;
+	    	if (start != null) {
+	    		end = start + pageSize;
+	    	}
+	    	//iterate over geneListAndValues and samples and match items together, 
+	    	//producing the final list of GeneticData items:
+	    	for (GeneticDataValues geneDataValues : geneticItemListAndValues) {
+	    		String[] values = geneDataValues.getOrderedValuesList().split(",");
+	    		for (int i = 0; i < values.length; i++) {
+	    			int sampleInternalId = Integer.parseInt(sampleInternalIdsList[i]);
+	    			Sample sample = sampleIdToStableIdMap.get(sampleInternalId);
+	    			//filter samples:
+	    			//if the samples should be filtered and sample is no one of the selected samples, then continue to next one:
+	    			if (sampleStableIds != null && !sampleStableIdsSet.contains(sample.getStableId())) {
+	    				continue;
+	    			}
+	    			//if start/end are null or if the item is part of the specified page, add:
+	    			if (end == null || (itemIdx >= start && itemIdx < end)) {
+		    			String value = values[i];
+		    			GeneticData geneticDataItem = getSimpleFlatGeneticDataItem(geneticProfile, sample,
+		    					geneDataValues.getGeneticEntityId(), value);
+		    			result.add(geneticDataItem);
+	    			}
+	    			itemIdx++;
+	    		}
+	    		//avoid unnecessary iterations if end is specified:
+	    		if (end != null && itemIdx >= end) {
+	    			break;
+	    		}
+	    	}
+    	}
+        return result;
+    }
+    
+    private List<Integer> getInternalEntityIds(List<String> geneticEntityStableIds, EntityType geneticEntityType) {
+    	List<Integer> result = null;
+    	if (geneticEntityStableIds != null) {
+    		result = new ArrayList<Integer>();
+    		for (String geneticEntityStableId : geneticEntityStableIds) {
+    			//TODO support multiple ids in 1 query, to avoid this loop and speed up a bit...although gain will be minimal since geneticEntityStableIds list length won't be larger than ~300 for now
+    			GeneticEntity entity = geneticEntityRepository.getGeneticEntity(geneticEntityStableId, geneticEntityType);
+    			if (entity != null) {
+    				result.add(entity.getEntityId());
+    			} else {
+    				//TODO what to do when entity is null? Throw error? For now, add a number that maps to no entity:
+    				result.add(INVALID_ENTITY_ID);
+    			}
+    			
+    		}
+    	}
+		return result;
+	}
+
+    /**
+     * Calculate offset.
+     * 
+     * note: this is a duplication of org.cbioportal.persistence.mybatis.util.OffsetCalculator. Alternative would be 
+     * to add the persistence.mybatis module as a dependency in service module...not really worth it just for this:
+     */
+    private Integer calculateOffset(Integer pageSize, Integer pageNumber) {
+
+        return pageSize == null || pageNumber == null ? null : pageSize * pageNumber;
+    }
+    
+    private Map<Integer,Sample> getSampleStableIdsList(GeneticProfile geneticProfile, String[] sampleInternalIdsList) {
+    	
+    	List<Integer> sampleInternalIds = new ArrayList<Integer>();
+    	for (String internalId : sampleInternalIdsList) {
+    		sampleInternalIds.add(Integer.parseInt(internalId));
+    	}
+    	
+    	List<Sample> samples = sampleRepository.fetchSamplesInSameStudyByInternalIds(geneticProfile.getCancerStudyIdentifier(), sampleInternalIds, null);
+    	Map<Integer,Sample> sampleIdToStableIdMap = new HashMap<Integer,Sample>();
+    	for (Sample sample : samples) {
+    		sampleIdToStableIdMap.put(sample.getInternalId(), sample);
+    	}
+    	return sampleIdToStableIdMap;    
+	}
+
+	@Override
+    public BaseMeta getMetaGeneticDataInGeneticProfile(String geneticProfileId) {
+		
+		//result will be samples lenght x number of gene records:
+		GeneticDataSamples samples = geneticDataRepository.getGeneticDataSamplesInGeneticProfile(geneticProfileId, null, null);
+    	//get list of genes and respective sample values:
+    	List<GeneticDataValues> geneticItemListAndValues = geneticDataRepository.getGeneticDataValuesInGeneticProfile(geneticProfileId, null, null, null);
+    	int totalCount = 0;
+    	BaseMeta meta = new BaseMeta();
+    	if (samples != null) {
+    		//nr samples x nr genetic items
+	    	totalCount = samples.getOrderedSamplesList().split(",").length * geneticItemListAndValues.size();
+    	}
+    	meta.setTotalCount(totalCount);
+		//TODO maybe implement select count(*) in repository later to make this method a bit faster?
+        return meta;
+    }
+    
+    private GeneticData getSimpleFlatGeneticDataItem(GeneticProfile geneticProfile, Sample sample, Integer entityId, String value){
+    	GeneticData item = new GeneticData();
+    	
+    	GeneticEntity geneticEntity;
+    	
+    	if (geneBasedTypes.contains(geneticProfile.getGeneticAlterationType())) { 
+    		geneticEntity = geneticEntityRepository.getGeneticEntity(entityId, EntityType.GENE);
+    	}
+    	else {
+    		throw new UnsupportedOperationException("the profile type '" + geneticProfile.getGeneticAlterationType() + 
+    				"' is not(yet) supported via this api...");
+    	}
+    	
+		item.setGeneticEntity(geneticEntity);
+    	item.setGeneticEntityId(entityId);
+    	item.setGeneticEntityStableId(geneticEntity.getEntityStableId());
+    	
+    	item.setGeneticProfileId(geneticProfile.getGeneticProfileId());
+    	item.setGeneticProfileStableId(geneticProfile.getStableId());
+    	
+    	item.setSampleId(sample.getInternalId());
+    	item.setSampleStableId(sample.getStableId());
+    	
+    	item.setValue(value);
+    	
+    	return item;
+    }
+
+	@Override
+	public List<GeneticData> fetchGeneticDataInGeneticProfile(String geneticProfileId, EntityType geneticEntityType, List<String> geneticEntityStableIds,
+			String projectionName, Integer pageSize, Integer pageNumber) {
+		
+		return getGeneticDataInGeneticProfile(geneticProfileId, geneticEntityType, geneticEntityStableIds, null, projectionName, pageSize, pageNumber);
+	}
+    
+	@Override
+	public List<GeneticData> fetchGeneticDataInGeneticProfile(String geneticProfileId, EntityType geneticEntityType, List<String> geneticEntityStableIds,
+			String caseListId, String projectionName, Integer pageSize, Integer pageNumber) {
+		//get samples for given case list:
+		List<String> caseIds = null;
+		//TODO - waiting for CaseList repository implementation. For now, returning all:
+		return getGeneticDataInGeneticProfile(geneticProfileId, geneticEntityType, geneticEntityStableIds, caseIds, projectionName, pageSize, pageNumber);
+	}
+
+	@Override
+	public List<GeneticData> fetchGeneticDataInGeneticProfile(String geneticProfileId, EntityType geneticEntityType, List<String> geneticEntityStableIds,
+			List<String> caseIds, String projectionName, Integer pageSize, Integer pageNumber) {
+		
+		return getGeneticDataInGeneticProfile(geneticProfileId, geneticEntityType, geneticEntityStableIds, caseIds, projectionName, pageSize, pageNumber);
+	}    
+}

--- a/service/src/main/java/org/cbioportal/service/impl/GeneticDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GeneticDataServiceImpl.java
@@ -215,8 +215,9 @@ public class GeneticDataServiceImpl implements GeneticDataService {
     	
     	if (geneBasedTypes.contains(geneticProfile.getGeneticAlterationType())) { 
     		geneticEntity = geneticEntityRepository.getGeneticEntity(entityId, EntityType.GENE);
-    	}
-    	else {
+    	} else if (geneticProfile.getGeneticAlterationType().equals(GeneticAlterationType.GENESET_SCORE)) {
+    		geneticEntity = geneticEntityRepository.getGeneticEntity(entityId, EntityType.GENE_SET);
+    	} else {
     		throw new UnsupportedOperationException("the profile type '" + geneticProfile.getGeneticAlterationType() + 
     				"' is not(yet) supported via this api...");
     	}

--- a/service/src/main/java/org/cbioportal/service/impl/GeneticDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GeneticDataServiceImpl.java
@@ -216,7 +216,7 @@ public class GeneticDataServiceImpl implements GeneticDataService {
     	if (geneBasedTypes.contains(geneticProfile.getGeneticAlterationType())) { 
     		geneticEntity = geneticEntityRepository.getGeneticEntity(entityId, EntityType.GENE);
     	} else if (geneticProfile.getGeneticAlterationType().equals(GeneticAlterationType.GENESET_SCORE)) {
-    		geneticEntity = geneticEntityRepository.getGeneticEntity(entityId, EntityType.GENE_SET);
+    		geneticEntity = geneticEntityRepository.getGeneticEntity(entityId, EntityType.GENESET);
     	} else {
     		throw new UnsupportedOperationException("the profile type '" + geneticProfile.getGeneticAlterationType() + 
     				"' is not(yet) supported via this api...");

--- a/service/src/test/java/org/cbioportal/service/impl/GeneticDataServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GeneticDataServiceImplTest.java
@@ -1,0 +1,183 @@
+package org.cbioportal.service.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.cbioportal.model.Gene;
+import org.cbioportal.model.GeneticData;
+import org.cbioportal.model.GeneticDataSamples;
+import org.cbioportal.model.GeneticDataValues;
+import org.cbioportal.model.GeneticEntity;
+import org.cbioportal.model.GeneticProfile;
+import org.cbioportal.model.GeneticProfile.GeneticAlterationType;
+import org.cbioportal.model.Sample;
+import org.cbioportal.model.GeneticEntity.EntityType;
+import org.cbioportal.persistence.GeneticDataRepository;
+import org.cbioportal.persistence.GeneticEntityRepository;
+import org.cbioportal.persistence.GeneticProfileRepository;
+import org.cbioportal.persistence.SampleRepository;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GeneticDataServiceImplTest extends BaseServiceImplTest {
+
+    @InjectMocks
+    private GeneticDataServiceImpl geneticDataService;
+    
+    @Mock
+    private GeneticDataRepository geneticDataRepository;
+    
+    @Mock
+    private GeneticEntityRepository geneticEntityRepository;
+    
+    @Mock
+    private GeneticProfileRepository geneticProfileRepository;
+    
+    @Mock
+    private SampleRepository sampleRepository;
+
+    //test data
+    private String geneticProfileStableId = "acc_tcga_mrna";
+    private String studyId = "acc_tcga";
+
+	/**
+	 * This is executed n times, for each of the n test methods below:
+	 * @throws DaoException
+	 */
+    @Before 
+    public void setUp() {
+    	//genes in this test
+    	Gene gene1 = new Gene();
+    	gene1.setEntityId(1);
+    	gene1.setEntityStableId("GENE_1");
+    	Mockito.when(geneticEntityRepository.getGeneticEntity("GENE_1", GeneticEntity.EntityType.GENE)).thenReturn(gene1);
+    	Mockito.when(geneticEntityRepository.getGeneticEntity(1, GeneticEntity.EntityType.GENE)).thenReturn(gene1);
+    	Gene gene2 = new Gene();
+    	gene2.setEntityId(2);
+    	gene2.setEntityStableId("GENE_2");
+    	Mockito.when(geneticEntityRepository.getGeneticEntity("GENE_2", GeneticEntity.EntityType.GENE)).thenReturn(gene2);
+    	Mockito.when(geneticEntityRepository.getGeneticEntity(2, GeneticEntity.EntityType.GENE)).thenReturn(gene2);
+    	
+        //stub for genetic profile
+        GeneticProfile dummyGeneticProfile = new GeneticProfile();
+        dummyGeneticProfile.setStableId(geneticProfileStableId);
+        dummyGeneticProfile.setGeneticProfileId(1);
+        dummyGeneticProfile.setCancerStudyIdentifier(studyId);
+        dummyGeneticProfile.setGeneticAlterationType(GeneticAlterationType.MRNA_EXPRESSION);
+        Mockito.when(geneticProfileRepository.getGeneticProfile(geneticProfileStableId)).thenReturn(dummyGeneticProfile);
+        
+        //stub for samples
+        Sample sample1 = new Sample();
+    	sample1.setInternalId(1);
+    	sample1.setStableId("SAMPLE_1");
+    	Mockito.when(sampleRepository.getSampleInStudy(studyId, "SAMPLE_1")).thenReturn(sample1);
+    	Sample sample2 = new Sample();
+    	sample2.setInternalId(2);
+    	sample2.setStableId("SAMPLE_2");
+    	Mockito.when(sampleRepository.getSampleInStudy(studyId, "SAMPLE_2")).thenReturn(sample2);
+    	Mockito.when(sampleRepository.fetchSamplesInSameStudyByInternalIds(studyId, Arrays.asList(1,2), null)).thenReturn(
+    			Arrays.asList(sample1, sample2));
+    	
+	}
+
+    @Test
+    public void testGetAndFetchGeneticDataInGeneticProfile() throws Exception {
+    	
+        GeneticProfile geneticProfile = geneticProfileRepository.getGeneticProfile(geneticProfileStableId);
+        
+        //stub the genet list and values to be returned by repository methods that will be used by the method being tested here:
+        List<GeneticDataValues> geneListAndValues = new ArrayList<GeneticDataValues>();
+        geneListAndValues.add(new GeneticDataValues());
+        geneListAndValues.get(0).setGeneticEntityId(1);
+        geneListAndValues.get(0).setGeneticProfileId(geneticProfile.getGeneticProfileId());
+        geneListAndValues.get(0).setOrderedValuesList("0.2,34.99");
+        geneListAndValues.add(new GeneticDataValues());
+        geneListAndValues.get(1).setGeneticEntityId(2);
+        geneListAndValues.get(1).setGeneticProfileId(geneticProfile.getGeneticProfileId());
+        geneListAndValues.get(1).setOrderedValuesList("0.89,15.09");
+        //parameters don't matter much here, we want it to return geneListAndValues:
+        Mockito.when(geneticDataRepository.getGeneticDataValuesInGeneticProfile(Mockito.anyString(), Mockito.anyListOf(Integer.class), 
+        		Mockito.anyInt(), Mockito.anyInt())).thenReturn(geneListAndValues);
+        
+        //stub the samples to be returned by repository method: 
+        GeneticDataSamples samples = new GeneticDataSamples();
+        samples.setGeneticProfileId(geneticProfile.getGeneticProfileId());
+        samples.setOrderedSamplesList("1,2"); //these are ids for SAMPLE_1,SAMPLE_2
+        //parameters don't matter much here, we want it to return samples list:
+        Mockito.when(geneticDataRepository.getGeneticDataSamplesInGeneticProfile(Mockito.anyString(), 
+        		Mockito.anyInt(), Mockito.anyInt())).thenReturn(samples);
+        
+    	//call the method to be tested: getAllGeneticDataInGeneticProfile 
+        //and check if it correctly combines GeneticDataSamples and GeneticDataValues
+        //into the corresponding list of GeneticData elements:
+    	List<GeneticData> result = geneticDataService.getAllGeneticDataInGeneticProfile(geneticProfileStableId,  PROJECTION,  PAGE_SIZE, PAGE_NUMBER);
+    	//expect 4 items:
+    	Assert.assertEquals(4,  result.size());
+    	
+    	//what we expect: 2 samples x 2 genetic entities = 4 GeneticData items:
+    	//SAMPLE_1:
+    	//   GENE_1 value: 0.2
+    	//   GENE_2 value: 0.89
+    	//SAMPLE_2:
+    	//   GENE_1 value: 34.99
+    	//   GENE_2 value: 15.09
+    	List<GeneticData> expectedGeneticDataList = new ArrayList<GeneticData>();
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem("SAMPLE_1", "GENE_1", "0.2"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem("SAMPLE_2", "GENE_1", "34.99"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem("SAMPLE_1", "GENE_2", "0.89"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem("SAMPLE_2", "GENE_2", "15.09"));
+
+        Assert.assertEquals(expectedGeneticDataList, result);
+        
+        //test paging:
+    	result = geneticDataService.getAllGeneticDataInGeneticProfile(geneticProfileStableId,  PROJECTION,  2, PAGE_NUMBER);
+    	//expect 2 items:
+    	Assert.assertEquals(2, result.size());
+    	
+    	//test samples/fetch:
+    	result = geneticDataService.fetchGeneticDataInGeneticProfile(geneticProfileStableId, EntityType.GENE, Arrays.asList("1"), Arrays.asList("SAMPLE_1"),
+    			PROJECTION,  PAGE_SIZE, PAGE_NUMBER);
+    	//expect 2 items:
+    	Assert.assertEquals(2, result.size());
+    	//null test
+    	result = geneticDataService.fetchGeneticDataInGeneticProfile(geneticProfileStableId, EntityType.GENE, Arrays.asList("1"), Arrays.asList("SAMPLE_3"),
+    			PROJECTION,  PAGE_SIZE, PAGE_NUMBER);
+    	//expect 0 items:
+    	Assert.assertEquals(0, result.size());
+    }
+
+    private GeneticData getSimpleFlatGeneticDataItem(String sampleStableId, String entityStableId, String value){
+    	GeneticData item = new GeneticData();
+
+    	GeneticEntity geneticEntity = geneticEntityRepository.getGeneticEntity(entityStableId, GeneticEntity.EntityType.GENE);
+    	Gene entity = new Gene();
+    	entity.setEntityId(geneticEntity.getEntityId());
+		entity.setEntityStableId(entityStableId);
+		entity.setEntrezGeneId(((Gene)geneticEntity).getEntrezGeneId());
+		item.setGeneticEntity(entity);
+    	item.setGeneticEntityId(geneticEntity.getEntityId());
+    	item.setGeneticEntityStableId(entityStableId);
+
+    	
+    	GeneticProfile geneticProfile = geneticProfileRepository.getGeneticProfile(geneticProfileStableId);
+    	item.setGeneticProfileId(geneticProfile.getGeneticProfileId());
+    	item.setGeneticProfileStableId(geneticProfile.getStableId());
+    	
+    	Sample sample = sampleRepository.getSampleInStudy(studyId, sampleStableId); //TODO stub this one
+    	item.setSampleId(sample.getInternalId());
+    	item.setSampleStableId(sampleStableId);
+    	
+    	item.setValue(value);
+    	
+    	return item;
+    }
+
+}

--- a/service/src/test/java/org/cbioportal/service/impl/GeneticDataServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GeneticDataServiceImplTest.java
@@ -57,13 +57,13 @@ public class GeneticDataServiceImplTest extends BaseServiceImplTest {
     	//genes in this test
     	Gene gene1 = new Gene();
     	gene1.setEntityId(1);
-    	gene1.setEntityStableId("GENE_1");
-    	Mockito.when(geneticEntityRepository.getGeneticEntity("GENE_1", GeneticEntity.EntityType.GENE)).thenReturn(gene1);
+    	gene1.setEntrezGeneId(1001);
+    	Mockito.when(geneticEntityRepository.getGeneticEntity("1001", GeneticEntity.EntityType.GENE)).thenReturn(gene1);
     	Mockito.when(geneticEntityRepository.getGeneticEntity(1, GeneticEntity.EntityType.GENE)).thenReturn(gene1);
     	Gene gene2 = new Gene();
     	gene2.setEntityId(2);
-    	gene2.setEntityStableId("GENE_2");
-    	Mockito.when(geneticEntityRepository.getGeneticEntity("GENE_2", GeneticEntity.EntityType.GENE)).thenReturn(gene2);
+    	gene2.setEntrezGeneId(2002);
+    	Mockito.when(geneticEntityRepository.getGeneticEntity("2002", GeneticEntity.EntityType.GENE)).thenReturn(gene2);
     	Mockito.when(geneticEntityRepository.getGeneticEntity(2, GeneticEntity.EntityType.GENE)).thenReturn(gene2);
     	
         //stub for genetic profile
@@ -124,16 +124,16 @@ public class GeneticDataServiceImplTest extends BaseServiceImplTest {
     	
     	//what we expect: 2 samples x 2 genetic entities = 4 GeneticData items:
     	//SAMPLE_1:
-    	//   GENE_1 value: 0.2
-    	//   GENE_2 value: 0.89
+    	//   1001 value: 0.2
+    	//   2002 value: 0.89
     	//SAMPLE_2:
-    	//   GENE_1 value: 34.99
-    	//   GENE_2 value: 15.09
+    	//   1001 value: 34.99
+    	//   2002 value: 15.09
     	List<GeneticData> expectedGeneticDataList = new ArrayList<GeneticData>();
-        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem("SAMPLE_1", "GENE_1", "0.2"));
-        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem("SAMPLE_2", "GENE_1", "34.99"));
-        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem("SAMPLE_1", "GENE_2", "0.89"));
-        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem("SAMPLE_2", "GENE_2", "15.09"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem("SAMPLE_1", "1001", "0.2"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem("SAMPLE_2", "1001", "34.99"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem("SAMPLE_1", "2002", "0.89"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem("SAMPLE_2", "2002", "15.09"));
 
         Assert.assertEquals(expectedGeneticDataList, result);
         
@@ -158,14 +158,8 @@ public class GeneticDataServiceImplTest extends BaseServiceImplTest {
     	GeneticData item = new GeneticData();
 
     	GeneticEntity geneticEntity = geneticEntityRepository.getGeneticEntity(entityStableId, GeneticEntity.EntityType.GENE);
-    	Gene entity = new Gene();
-    	entity.setEntityId(geneticEntity.getEntityId());
-		entity.setEntityStableId(entityStableId);
-		entity.setEntrezGeneId(((Gene)geneticEntity).getEntrezGeneId());
-		item.setGeneticEntity(entity);
     	item.setGeneticEntityId(geneticEntity.getEntityId());
     	item.setGeneticEntityStableId(entityStableId);
-
     	
     	GeneticProfile geneticProfile = geneticProfileRepository.getGeneticProfile(geneticProfileStableId);
     	item.setGeneticProfileId(geneticProfile.getGeneticProfileId());

--- a/web/src/main/java/org/cbioportal/web/GeneController.java
+++ b/web/src/main/java/org/cbioportal/web/GeneController.java
@@ -88,7 +88,7 @@ public class GeneController {
             @RequestBody List<String> geneIds) throws PageSizeTooBigException {
 
         if (geneIds.size() > PagingConstants.MAX_PAGE_SIZE) {
-            throw new PageSizeTooBigException(geneIds.size());
+            throw new PageSizeTooBigException(geneIds.size()); //TODO - is this correct? Missing API documentation on how one can specify page size parameter 
         }
 
         if (projection == Projection.META) {

--- a/web/src/main/java/org/cbioportal/web/GeneticDataController.java
+++ b/web/src/main/java/org/cbioportal/web/GeneticDataController.java
@@ -93,10 +93,10 @@ public class GeneticDataController {
             @RequestParam(defaultValue = "SUMMARY") Projection projection,
             @ApiParam(required = true, value = "Search criteria to return the values for a given set of samples and genetic entity items (e.g. genes). "
             		+ "geneticEntityIds: The list of identifiers for the genetic entities of interest. "
-            		+ "If entity type is GENE: list of Entrez Gene IDs. If entity type is GENESET: list of gene set identifiers"
+            		+ "If entity type is GENE: list of Entrez Gene IDs. If entity type is GENESET: list of gene set identifiers. "
             		+ "Use one of these if you want to specify a subset of samples:"
-            		+ "(1) caseListId: Identifier of pre-defined case list with samples to query, e.g. brca_tcga_all " 
-            		+ "or (2) caseIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01")
+            		+ "(1) sampleListId: Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all " 
+            		+ "or (2) sampleIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01")
             @RequestBody GeneticDataFilterCriteria geneticDataFilterCriteria,
             @ApiParam("Page size of the result list")
 	        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize, 
@@ -107,15 +107,15 @@ public class GeneticDataController {
             //TODO 
     		return null;
         } else {
-        	if (geneticDataFilterCriteria.getCaseListId() != null && geneticDataFilterCriteria.getCaseListId().trim().length() > 0) {
+        	if (geneticDataFilterCriteria.getSampleListId() != null && geneticDataFilterCriteria.getSampleListId().trim().length() > 0) {
         		return new ResponseEntity<>(
                 		geneticDataService.fetchGeneticDataInGeneticProfile(geneticProfileId, geneticEntityType,
-                				geneticDataFilterCriteria.getGeneticEntityIds(), geneticDataFilterCriteria.getCaseListId(),
+                				geneticDataFilterCriteria.getGeneticEntityIds(), geneticDataFilterCriteria.getSampleListId(),
                 				projection.name(), pageSize, pageNumber), HttpStatus.OK);
-        	} else if (geneticDataFilterCriteria.getCaseIds() != null) {
+        	} else if (geneticDataFilterCriteria.getSampleIds() != null) {
         		return new ResponseEntity<>(
                 		geneticDataService.fetchGeneticDataInGeneticProfile(geneticProfileId, geneticEntityType,
-                				geneticDataFilterCriteria.getGeneticEntityIds(), geneticDataFilterCriteria.getCaseIds(),
+                				geneticDataFilterCriteria.getGeneticEntityIds(), geneticDataFilterCriteria.getSampleIds(),
                 				projection.name(), pageSize, pageNumber), HttpStatus.OK);
         	} else {
         		return new ResponseEntity<>(

--- a/web/src/main/java/org/cbioportal/web/GeneticDataController.java
+++ b/web/src/main/java/org/cbioportal/web/GeneticDataController.java
@@ -99,7 +99,7 @@ public class GeneticDataController {
             		+ "or (2) sampleIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01")
             @RequestBody GeneticDataFilterCriteria geneticDataFilterCriteria,
             @ApiParam("Page size of the result list")
-	        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize, 
+	        @RequestParam(defaultValue = PagingConstants.DEFAULT_MAX_PAGE_SIZE) Integer pageSize, 
 	        @ApiParam("Page number of the result list")
 	        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber) throws PageSizeTooBigException {
 

--- a/web/src/main/java/org/cbioportal/web/GeneticDataController.java
+++ b/web/src/main/java/org/cbioportal/web/GeneticDataController.java
@@ -1,10 +1,19 @@
 package org.cbioportal.web;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import java.util.List;
+
 import org.cbioportal.model.GeneticData;
+import org.cbioportal.model.GeneticEntity.EntityType;
+import org.cbioportal.service.GeneticDataService;
+import org.cbioportal.web.exception.PageSizeTooBigException;
+import org.cbioportal.web.parameter.GeneticDataFilterCriteria;
+import org.cbioportal.web.parameter.HeaderKeyConstants;
 import org.cbioportal.web.parameter.PagingConstants;
 import org.cbioportal.web.parameter.Projection;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,12 +22,17 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 @RestController
 @Api(tags = "Genetic Data", description = " ")
 public class GeneticDataController {
 
+	@Autowired
+    private GeneticDataService geneticDataService;
+	
     @RequestMapping(value = "/studies/{studyId}/samples/{sampleId}/genetic-data", method = RequestMethod.GET)
     @ApiOperation("Get all genetic data of a sample in a study")
     public ResponseEntity<List<GeneticData>> getAllGeneticDataInSampleInStudy(@PathVariable String studyId,
@@ -27,7 +41,7 @@ public class GeneticDataController {
                                                                                                @RequestParam(defaultValue = "SUMMARY") Projection projection,
                                                                                                @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
                                                                                                @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber) {
-
+    	//TODO remove? I don't think there is any use case for this method...
         throw new UnsupportedOperationException();
     }
 
@@ -39,18 +53,77 @@ public class GeneticDataController {
                                                                                                 @RequestParam(defaultValue = "SUMMARY") Projection projection,
                                                                                                 @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
                                                                                                 @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber) {
-
+    	//TODO remove? I don't think there is any use case for this method...
         throw new UnsupportedOperationException();
     }
 
-    @RequestMapping(value = "/genetic-profiles/{geneticProfileId}/genetic-data", method = RequestMethod.GET)
+    @RequestMapping(value = "/genetic-profiles/{geneticProfileId}/genetic-data", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all genetic data in a genetic profile")
-    public ResponseEntity<List<GeneticData>> getAllGeneticDataInGeneticProfile(@PathVariable String geneticProfileId,
-                                                                                                @RequestParam(defaultValue = "SUMMARY") Projection projection,
-                                                                                                @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
-                                                                                                @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber) {
+    public ResponseEntity<List<GeneticData>> getAllGeneticDataInGeneticProfile(
+    		@ApiParam(required = true, value = "Genetic profile ID, e.g. brca_tcga_mrna")
+    		@PathVariable String geneticProfileId,
+    		@ApiParam("Level of detail of the response, e.g. META, SUMMARY or DETAILED")
+    		@RequestParam(defaultValue = "SUMMARY") Projection projection,
+    		@ApiParam("Page size of the result list")
+	        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
+	        @ApiParam("Page number of the result list")
+	        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber) {
 
-        throw new UnsupportedOperationException();
+    	if (projection == Projection.META) {
+            HttpHeaders responseHeaders = new HttpHeaders();
+            responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, geneticDataService.getMetaGeneticDataInGeneticProfile(geneticProfileId)
+                    .getTotalCount().toString());
+            return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(
+            		geneticDataService.getAllGeneticDataInGeneticProfile(geneticProfileId, projection.name(), pageSize, pageNumber), HttpStatus.OK);
+        }
+    }
+    
+    
+    @RequestMapping(value = "/genetic-profiles/{geneticProfileId}/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Fetch genetic data items by profile Id, gene ids and sample ids")
+    public ResponseEntity<List<GeneticData>> fetchGeneticDataItems(
+    		@ApiParam(required = true, value = "Genetic profile ID, e.g. brca_tcga_mrna")
+    		@PathVariable String geneticProfileId,
+            @ApiParam(required = true, value ="Entity type. Possible values: GENE or GENESET")
+    		@RequestParam(defaultValue = "GENE") EntityType geneticEntityType,
+    		@ApiParam("Level of detail of the response")
+            @RequestParam(defaultValue = "SUMMARY") Projection projection,
+            @ApiParam(required = true, value = "Search criteria to return the values for a given set of samples and genetic entity items (e.g. genes). "
+            		+ "geneticEntityIds: The list of identifiers for the genetic entities of interest. "
+            		+ "If entity type is GENE: list of Entrez Gene IDs. If entity type is GENESET: list of gene set identifiers"
+            		+ "Use one of these if you want to specify a subset of samples:"
+            		+ "(1) caseListId: Identifier of pre-defined case list with samples to query, e.g. brca_tcga_all " 
+            		+ "or (2) caseIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01")
+            @RequestBody GeneticDataFilterCriteria geneticDataFilterCriteria,
+            @ApiParam("Page size of the result list")
+	        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize, 
+	        @ApiParam("Page number of the result list")
+	        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber) throws PageSizeTooBigException {
+
+    	if (projection == Projection.META) {
+            //TODO 
+    		return null;
+        } else {
+        	if (geneticDataFilterCriteria.getCaseListId() != null && geneticDataFilterCriteria.getCaseListId().trim().length() > 0) {
+        		return new ResponseEntity<>(
+                		geneticDataService.fetchGeneticDataInGeneticProfile(geneticProfileId, geneticEntityType,
+                				geneticDataFilterCriteria.getGeneticEntityIds(), geneticDataFilterCriteria.getCaseListId(),
+                				projection.name(), pageSize, pageNumber), HttpStatus.OK);
+        	} else if (geneticDataFilterCriteria.getCaseIds() != null) {
+        		return new ResponseEntity<>(
+                		geneticDataService.fetchGeneticDataInGeneticProfile(geneticProfileId, geneticEntityType,
+                				geneticDataFilterCriteria.getGeneticEntityIds(), geneticDataFilterCriteria.getCaseIds(),
+                				projection.name(), pageSize, pageNumber), HttpStatus.OK);
+        	} else {
+        		return new ResponseEntity<>(
+                		geneticDataService.fetchGeneticDataInGeneticProfile(geneticProfileId, geneticEntityType,
+                				geneticDataFilterCriteria.getGeneticEntityIds(), 
+                				projection.name(), pageSize, pageNumber), HttpStatus.OK);
+        	}
+        }
     }
 
     @RequestMapping(value = "/genetic-data/query", method = RequestMethod.POST)

--- a/web/src/main/java/org/cbioportal/web/mixin/GeneticDataMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/GeneticDataMixin.java
@@ -1,10 +1,11 @@
 package org.cbioportal.web.mixin;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.cbioportal.model.Gene;
+import org.cbioportal.model.GeneticEntity;
 import org.cbioportal.model.GeneticProfile;
 import org.cbioportal.model.Sample;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GeneticDataMixin {
 
@@ -12,13 +13,24 @@ public class GeneticDataMixin {
     private Integer geneticProfileId;
     @JsonProperty("geneticProfileId")
     private String geneticProfileStableId;
-    private Integer entrezGeneId;
+    
+    @JsonIgnore
+    private Integer geneticEntityId;
+    @JsonProperty("geneticEntityId")
+    private String geneticEntityStableId;
+    
     @JsonIgnore
     private Integer sampleId;
-    @JsonProperty("sampleStableId")
+    @JsonProperty("sampleId")
     private String sampleStableId;
+    
     private String value;
+    
+    @JsonIgnore
     private GeneticProfile geneticProfile;
-    private Gene gene;
+    @JsonIgnore
+    private GeneticEntity geneticEntity;
+    @JsonIgnore
     private Sample sample;
+    
 }

--- a/web/src/main/java/org/cbioportal/web/mixin/GeneticDataMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/GeneticDataMixin.java
@@ -1,6 +1,7 @@
 package org.cbioportal.web.mixin;
 
 import org.cbioportal.model.GeneticEntity;
+import org.cbioportal.model.GeneticEntity.EntityType;
 import org.cbioportal.model.GeneticProfile;
 import org.cbioportal.model.Sample;
 
@@ -18,6 +19,7 @@ public class GeneticDataMixin {
     private Integer geneticEntityId;
     @JsonProperty("geneticEntityId")
     private String geneticEntityStableId;
+    private EntityType geneticEntityType;
     
     @JsonIgnore
     private Integer sampleId;

--- a/web/src/main/java/org/cbioportal/web/parameter/GeneticDataFilterCriteria.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/GeneticDataFilterCriteria.java
@@ -14,11 +14,11 @@ public class GeneticDataFilterCriteria {
 	//If entity type is GENE: list of Entrez Gene IDs. If entity type is GENESET: list of gene set identifiers
     private List<String> geneticEntityIds;
 
-    //Identifier of pre-defined case list with samples to query. E.g. brca_tcga_all 
-    private String caseListId;
+    //Identifier of pre-defined sample list with samples to query. E.g. brca_tcga_all 
+    private String sampleListId;
 
     //Full list of samples or patients to query, E.g. list with TCGA-AR-A1AR-01, TCGA-BH-A1EO-01...
-    private List<String> caseIds;
+    private List<String> sampleIds;
 
 	public List<String> getGeneticEntityIds() {
 		return geneticEntityIds;
@@ -28,20 +28,20 @@ public class GeneticDataFilterCriteria {
 		this.geneticEntityIds = geneticEntityIds;
 	}
 
-	public String getCaseListId() {
-		return caseListId;
+	public String getSampleListId() {
+		return sampleListId;
 	}
 
-	public void setCaseListId(String caseListId) {
-		this.caseListId = caseListId;
+	public void setSampleListId(String sampleListId) {
+		this.sampleListId = sampleListId;
 	}
 
-	public List<String> getCaseIds() {
-		return caseIds;
+	public List<String> getSampleIds() {
+		return sampleIds;
 	}
 
-	public void setCaseIds(List<String> caseIds) {
-		this.caseIds = caseIds;
+	public void setSampleIds(List<String> sampleIds) {
+		this.sampleIds = sampleIds;
 	} 
 
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/GeneticDataFilterCriteria.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/GeneticDataFilterCriteria.java
@@ -1,0 +1,47 @@
+package org.cbioportal.web.parameter;
+
+import java.util.List;
+
+/**
+ * Wrapper class for specifying filter criteria for GeneticData items
+ * in the GeneticDataController services.
+ *  
+ * @author pieter
+ *
+ */
+public class GeneticDataFilterCriteria {
+	//The list of identifiers for the genetic entities of interest. 
+	//If entity type is GENE: list of Entrez Gene IDs. If entity type is GENESET: list of gene set identifiers
+    private List<String> geneticEntityIds;
+
+    //Identifier of pre-defined case list with samples to query. E.g. brca_tcga_all 
+    private String caseListId;
+
+    //Full list of samples or patients to query, E.g. list with TCGA-AR-A1AR-01, TCGA-BH-A1EO-01...
+    private List<String> caseIds;
+
+	public List<String> getGeneticEntityIds() {
+		return geneticEntityIds;
+	}
+
+	public void setGeneticEntityIds(List<String> geneticEntityIds) {
+		this.geneticEntityIds = geneticEntityIds;
+	}
+
+	public String getCaseListId() {
+		return caseListId;
+	}
+
+	public void setCaseListId(String caseListId) {
+		this.caseListId = caseListId;
+	}
+
+	public List<String> getCaseIds() {
+		return caseIds;
+	}
+
+	public void setCaseIds(List<String> caseIds) {
+		this.caseIds = caseIds;
+	} 
+
+}

--- a/web/src/main/java/org/cbioportal/web/parameter/PagingConstants.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/PagingConstants.java
@@ -3,7 +3,8 @@ package org.cbioportal.web.parameter;
 public class PagingConstants {
 
     public static final String DEFAULT_PAGE_SIZE = "1000";
-    public static final Integer MAX_PAGE_SIZE = 1000;
+    public static final Integer MAX_PAGE_SIZE = Integer.MAX_VALUE;
+    public static final String DEFAULT_MAX_PAGE_SIZE = "2147483647";
     public static final Integer MIN_PAGE_SIZE = 1;
     public static final String DEFAULT_PAGE_NUMBER = "0";
     public static final Integer MIN_PAGE_NUMBER = 0;

--- a/web/src/test/java/org/cbioportal/web/GeneticDataControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GeneticDataControllerTest.java
@@ -66,31 +66,28 @@ public class GeneticDataControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(4)))
-                .andExpect(MockMvcResultMatchers.jsonPath("$[0].geneticEntity.entrezGeneId").value(1)); 
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].geneticEntityId").value("1001")); 
 
     }
 
 	private List<GeneticData> createGeneticDataList() {
 		List<GeneticData> expectedGeneticDataList = new ArrayList<GeneticData>();
-        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem(1, "SAMPLE_1", 1, 1, "GENE_1", "0.2"));
-        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem(2, "SAMPLE_2", 1, 1, "GENE_1", "34.99"));
-        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem(1, "SAMPLE_1", 2, 2, "GENE_2", "0.89"));
-        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem(2, "SAMPLE_2", 2, 2, "GENE_2", "15.09"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem(1, "SAMPLE_1", 1001, 1, "0.2"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem(2, "SAMPLE_2", 1001, 1, "34.99"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem(1, "SAMPLE_1", 2002, 2, "0.89"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem(2, "SAMPLE_2", 2002, 2, "15.09"));
         
 		return expectedGeneticDataList;
 	}
 
 	private GeneticData getSimpleFlatGeneticDataItem( 
 			int sampleId, String sampleStableId, 
-			int entrezGeneId, int entityId, String entityStableId, 
+			int entrezGeneId, int entityId,
 			String value){
 		GeneticData item = new GeneticData();
 	
-		Gene entity = new Gene();
-		entity.setEntityId(entityId);
-		entity.setEntityStableId(entityStableId);
-		entity.setEntrezGeneId(entrezGeneId); // not totally flat because we want to set entrez id in this case as well
-		item.setGeneticEntity(entity);
+		item.setGeneticEntityId(entityId);
+		item.setGeneticEntityStableId(entrezGeneId+"");
 		
 		item.setGeneticProfileId(geneticProfileId);
 		item.setGeneticProfileStableId(geneticProfileStableId);

--- a/web/src/test/java/org/cbioportal/web/GeneticDataControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GeneticDataControllerTest.java
@@ -85,7 +85,8 @@ public class GeneticDataControllerTest {
 			int entrezGeneId, int entityId,
 			String value){
 		GeneticData item = new GeneticData();
-	
+		Gene gene = new Gene();
+		item.setGeneticEntity(gene);
 		item.setGeneticEntityId(entityId);
 		item.setGeneticEntityStableId(entrezGeneId+"");
 		

--- a/web/src/test/java/org/cbioportal/web/GeneticDataControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GeneticDataControllerTest.java
@@ -1,0 +1,107 @@
+package org.cbioportal.web;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.cbioportal.model.Gene;
+import org.cbioportal.model.GeneticData;
+import org.cbioportal.service.GeneticDataService;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration("/applicationContext-web.xml")
+@Configuration
+public class GeneticDataControllerTest {
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Autowired
+    private GeneticDataService geneticDataService;
+    private MockMvc mockMvc;
+
+    @Bean
+    public GeneticDataService geneticDataService() {
+        return Mockito.mock(GeneticDataService.class);
+    }
+
+    //test data
+    private int geneticProfileId = 1;
+    private String geneticProfileStableId = "acc_tcga_mrna";
+    
+    @Before
+    public void setUp() throws Exception {
+
+        Mockito.reset(geneticDataService);
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+    }
+
+    @Test
+    public void  getAllGenesDefaultProjection() throws Exception {
+
+    	List<GeneticData> geneticDataList = createGeneticDataList();
+
+        Mockito.when(geneticDataService.getAllGeneticDataInGeneticProfile(Mockito.anyString(), 
+        		Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt())).thenReturn(geneticDataList);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/genetic-profiles/"+ geneticProfileStableId + "/genetic-data")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(4)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].geneticEntity.entrezGeneId").value(1)); 
+
+    }
+
+	private List<GeneticData> createGeneticDataList() {
+		List<GeneticData> expectedGeneticDataList = new ArrayList<GeneticData>();
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem(1, "SAMPLE_1", 1, 1, "GENE_1", "0.2"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem(2, "SAMPLE_2", 1, 1, "GENE_1", "34.99"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem(1, "SAMPLE_1", 2, 2, "GENE_2", "0.89"));
+        expectedGeneticDataList.add(getSimpleFlatGeneticDataItem(2, "SAMPLE_2", 2, 2, "GENE_2", "15.09"));
+        
+		return expectedGeneticDataList;
+	}
+
+	private GeneticData getSimpleFlatGeneticDataItem( 
+			int sampleId, String sampleStableId, 
+			int entrezGeneId, int entityId, String entityStableId, 
+			String value){
+		GeneticData item = new GeneticData();
+	
+		Gene entity = new Gene();
+		entity.setEntityId(entityId);
+		entity.setEntityStableId(entityStableId);
+		entity.setEntrezGeneId(entrezGeneId); // not totally flat because we want to set entrez id in this case as well
+		item.setGeneticEntity(entity);
+		
+		item.setGeneticProfileId(geneticProfileId);
+		item.setGeneticProfileStableId(geneticProfileStableId);
+		
+		item.setSampleId(sampleId);
+		item.setSampleStableId(sampleStableId);
+		
+		item.setValue(value);
+		
+		return item;
+	}
+    
+
+}


### PR DESCRIPTION
# What? Why?
This adds new endpoints and respective implementations for retrieving genetic data (aka genetic alteration data). It uses the new genetic entity data model introduced in #1902. 

Changes proposed in this pull request:
- implementation of existing endpoint: `/api/genetic-profiles/{geneticProfileId}/genetic-data`
- created new endpoint with respective implementation: ` /genetic-profiles/{geneticProfileId}/fetch`

See also [proposal document](https://docs.google.com/document/d/12T0gTzArDdjxn74xcdXfdbxeeo_yDK6Kp24S9UWVFjs/edit). 

# Checks

# Notify reviewers
@ersinciftci @sheridancbio 