### PR TITLE
Fixed order of mutation vs mutation_event insert

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
@@ -33,7 +33,6 @@
 package org.mskcc.cbio.portal.dao;
 
 import org.mskcc.cbio.portal.model.*;
-import org.mskcc.cbio.portal.model.ExtendedMutation.*;
 import org.mskcc.cbio.portal.util.MutationKeywordUtils;
 
 import org.apache.commons.lang.StringUtils;
@@ -52,6 +51,11 @@ public final class DaoMutation {
         if (!MySQLbulkLoader.isBulkLoad()) {
             throw new DaoException("You have to turn on MySQLbulkLoader in order to insert mutations");
         } else {
+        	int result = 1;
+        	if (newMutationEvent) {
+        		//add event first, as mutation has a Foreign key constraint to the event:
+        		result = addMutationEvent(mutation.getEvent())+1;
+            } 
             MySQLbulkLoader.getMySQLbulkLoader("mutation").insertRecord(
                     Long.toString(mutation.getMutationEventId()),
                     Integer.toString(mutation.getGeneticProfileId()),
@@ -80,11 +84,7 @@ public final class DaoMutation {
                     Integer.toString(mutation.getTumorRefCount()),
                     Integer.toString(mutation.getNormalAltCount()),
                     Integer.toString(mutation.getNormalRefCount()));
-            if (newMutationEvent) {
-                return addMutationEvent(mutation.getEvent())+1;
-            } else {
-                return 1;
-            }
+            return result;
         }
     }
 


### PR DESCRIPTION
# What? Why?
This fixes an importer issue for FUSION data. The cause was similar to the issue #1858 

Changes proposed in this pull request:
- FUSION data is inserted in correct order: first a `mutation_event` record is created and then a `mutation` record

# Notify reviewers
@jjgao @zheins @n1zea144 
