### PR TITLE
Fix hotspot annotation bug

### DIFF
--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -1,6 +1,16 @@
 window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_ids, study_sample_map, z_score_threshold, rppa_score_threshold,
 	case_set_properties) {
 
+    var signOfDiff = function(a,b) {
+	if (a < b) {
+	    return -1;
+	} else if (a > b) {
+	    return 1;
+	} else {
+	    return 0;
+	}
+    };
+    
     var deepCopyObject = function (obj) {
 	return $.extend(true, ($.isArray(obj) ? [] : {}), obj);
     };
@@ -447,7 +457,7 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 			    .map(function (x) {
 				return parseInt(x, 10);
 			    })
-			    .sort();
+			    .sort(function(a,b) { return signOfDiff(a,b); });
 		}
 		for (var i = 0; i < missense_mutation_webservice_data.length; i++) {
 		    var datum = missense_mutation_webservice_data[i];


### PR DESCRIPTION
# What? Why?
Fixes https://github.com/cBioPortal/cbioportal/issues/1984

Javascript array sort apparently does a string comparison by default, even when sorting numbers, so an explicit numerical comparator has been added. This fixes the issue where some hotspot mutations were not being annotated as such.

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
![image](https://cloud.githubusercontent.com/assets/636232/21113681/838c1df2-c078-11e6-8223-5506a92889cf.png)


# Notify reviewers
@cBioPortal/frontend 
@schultzn 