### PR TITLE
Use getGeneticProfileDataBySampleList when possible

### DIFF
--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -168,6 +168,24 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	return upper_exc;
     };
 
+    var getGeneticProfileDataForQueryCases = function(self, genetic_profile_id, genes) {
+	var def;
+	var case_set_id = self.getCaseSetId();
+	if (!case_set_id || case_set_id === "-1") {
+	    def = window.cbioportal_client.getGeneticProfileDataBySample({
+		'genetic_profile_ids': [genetic_profile_id],
+		'genes': genes.map(function(x) { return x.toUpperCase(); }),
+		'sample_ids': self.getSampleIds()
+	    });
+	} else {
+	    def = window.cbioportal_client.getGeneticProfileDataBySampleList({
+		'genetic_profile_ids': [genetic_profile_id],
+		'genes': genes.map(function(x) { return x.toUpperCase(); }),
+		'sample_list_id': [case_set_id]
+	    });
+	}
+	return def;
+    };
     var getCBioPortalMutationCounts = function (webservice_data) {
 	/* In: - webservice_data, a list of data obtained from the webservice API
 	 * Out: Promise which resolves with map from gene+","+start_pos+","+end_pos to cbioportal mutation count for that position range and gene
@@ -941,11 +959,7 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	var deferred_case_ids = sample_or_patient === "sample" ? sample_ids : self.getPatientIds();
 	genes = genes || [];
 	sample_or_patient = sample_or_patient || "sample";
-	$.when(window.cbioportal_client.getGeneticProfileDataBySample({
-		'genetic_profile_ids': [genetic_profile_id],
-		'genes': genes.map(function(x) { return x.toUpperCase(); }).filter(function(x) { return x.length > 0; }),
-		'sample_ids': sample_ids
-	    }),
+	$.when(getGeneticProfileDataForQueryCases(self, genetic_profile_id, genes.map(function(x) { return x.toUpperCase(); }).filter(function(x) { return x.length > 0; })),
 	    self.getPatientSampleIdMap(),
 	    deferred_case_ids,
 	    self.getCaseUIDMap(),
@@ -1409,13 +1423,11 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 			var all_data = [];
 			for (var i = 0; i < self.getGeneticProfileIds().length; i++) {
 			    (function (I) {
-				window.cbioportal_client.getGeneticProfileDataBySample({
-				    'genetic_profile_ids': [genetic_profile_ids[I]],
-				    'genes': self.getQueryGenes().map(function (x) {
-					return x.toUpperCase();
-				    }),
-				    'sample_ids': self.getSampleIds()
-				}).fail(function () {
+				getGeneticProfileDataForQueryCases(self, 
+								[genetic_profile_ids[I]], 
+								self.getQueryGenes().map(function (x) {
+								    return x.toUpperCase();
+								})).fail(function () {
 				    fetch_promise.reject();
 				}).then(function (data) {
 				    var genetic_alteration_type = profile_types[genetic_profile_ids[I]];


### PR DESCRIPTION
To speed up cbioportal-client cache fetching, it helps to index data by sample list instead of by sample when possible, so that you only need to access one bucket instead of as many buckets as there are samples (significant speedup on, e.g., IMPACT)

Me and @pieterlukasse actually made this change at last year's hackathon, I'm not sure why it got reverted.

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@pieterlukasse

@cBioPortal/frontend