### PR TITLE
Fix driver-passenger sort priority

### DIFF
--- a/portal/src/main/webapp/js/src/oncoprint/webgl/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/setup.js
@@ -281,7 +281,7 @@ var comparator_utils = {
 		    return ({'true': 1, 'false': 2})[!!m];
 		}
 	    } else if (!distinguish_mutation_types && distinguish_recurrent) {
-		_order = makeComparatorMetric([['inframe_rec', 'missense_rec', 'promoter_rec'], ['inframe', 'missense', 'promoter', 'trunc', 'trunc_rec'], undefined]); 
+		_order = makeComparatorMetric([['inframe_rec', 'missense_rec', 'promoter_rec', 'trunc_rec', 'inframe', 'promoter', 'trunc',], 'missense', undefined]); 
 	    } else if (distinguish_mutation_types && !distinguish_recurrent) {
 		_order = makeComparatorMetric([['trunc', 'trunc_rec'], ['inframe','inframe_rec'], ['promoter', 'promoter_rec'], ['missense', 'missense_rec'], undefined, true, false]);
 	    } else if (distinguish_mutation_types && distinguish_recurrent) {


### PR DESCRIPTION
Treat everything besides passenger missense as the same ("driver") when sorting by mutation recurrence and not mutation type in oncoprint.

Fix https://github.com/cBioPortal/cbioportal/issues/2065

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
Before: 
![image](https://cloud.githubusercontent.com/assets/636232/22045080/378b012c-dce6-11e6-8fc6-e6d7f30136a6.png)

After:
![image](https://cloud.githubusercontent.com/assets/636232/22045204/d505c568-dce6-11e6-9464-7adb3913b6cf.png)
