### PR TITLE
Added validation to block commas and other special characters in sample id

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1700,6 +1700,14 @@ class SampleClinicalValidator(ClinicalValidator):
                         extra={'line_number': self.line_number,
                                'column_number': col_index + 1,
                                'cause': value})
+                # this one gives problems in old parts of the java code such as CnaJSON.processCnaFractionsRequest(),
+                # so block commas in sample id:
+                if ',' in value:
+                    self.logger.error(
+                        'Comma (,) in SAMPLE_ID is not supported',
+                        extra={'line_number': self.line_number,
+                               'column_number': col_index + 1,
+                               'cause': value})
                 if value in self.sample_id_lines:
                     if value.startswith('TCGA-'):
                         self.logger.warning(

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1669,6 +1669,8 @@ class SampleClinicalValidator(ClinicalValidator):
 
     REQUIRED_HEADERS = ['SAMPLE_ID', 'PATIENT_ID']
     PROP_IS_PATIENT_ATTRIBUTE = '0'
+    INVALID_SAMPLE_ID_CHARACTERS = set(',;+/=*')
+
 
     def __init__(self, *args, **kwargs):
         """Initialize the validator to track sample ids defined."""
@@ -1700,11 +1702,12 @@ class SampleClinicalValidator(ClinicalValidator):
                         extra={'line_number': self.line_number,
                                'column_number': col_index + 1,
                                'cause': value})
-                # this one gives problems in old parts of the java code such as CnaJSON.processCnaFractionsRequest(),
-                # so block commas in sample id:
-                if ',' in value:
+                # invalid characters in sample_id can cause problems in different parts of the portal code,
+                # so block them here:
+                if any((c in self.INVALID_SAMPLE_ID_CHARACTERS) for c in value):
                     self.logger.error(
-                        'Comma (,) in SAMPLE_ID is not supported',
+                        'A number of special characters, such as ' + str(list(self.INVALID_SAMPLE_ID_CHARACTERS)) +
+                        ' are not allowed in SAMPLE_ID',
                         extra={'line_number': self.line_number,
                                'column_number': col_index + 1,
                                'cause': value})

--- a/core/src/test/scripts/test_data/data_clin_wrong_ids.txt
+++ b/core/src/test/scripts/test_data/data_clin_wrong_ids.txt
@@ -1,0 +1,11 @@
+#Patient Identifier	Sample Identifier	Subtype	Cancer Type	Cancer Type Detailed
+#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.	Disease type.	Cancer Type Detailed.
+#STRING	STRING	STRING	STRING	STRING
+#1	1	1	1	1
+PATIENT_ID	SAMPLE_ID	SUBTYPE	CANCER_TYPE	CANCER_TYPE_DETAILED
+TEST-PAT1	TEST-PAT1- SAMPLE1	Luminal A	Cancer_type20	Cancer_type20_Sub16
+TEST-PAT1	TEST-PAT1,SAMPLE2	Luminal B	Cancer_type27	Cancer_type27_Sub16
+TEST-PAT1	TEST-PAT1;SAMPLE3	basal-like	Cancer_type8	Cancer_type8_Sub13
+TEST-PAT1	TEST+PAT1/SAMPLE4	basal-like	Cancer_type17	Cancer_type17_Sub10
+TEST-PAT1	TEST-PAT1-SAMPLE5	Her2 enriched	Cancer_type27	Cancer_type27_Sub18
+TEST-PAT1	TEST-PAT1*SAMPLE6	Luminal A	Cancer_type7	Cancer_type7_Sub13

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -256,6 +256,28 @@ class ClinicalValuesTestCase(DataFileTestCase):
         self.assertEqual(record.line_number, 11)
         self.assertEqual(record.column_number, 2)
 
+    def test_sample_with_invalid_characters_in_sample_id(self):
+        """Test when a invalid characters are found in SAMPLE_ID."""
+        self.logger.setLevel(logging.WARNING)
+        record_list = self.validate('data_clin_wrong_ids.txt',
+                                    validateData.SampleClinicalValidator)
+        self.assertEqual(len(record_list), 5)
+        record_iterator = iter(record_list)
+        record = record_iterator.next()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.line_number, 6)
+        self.assertIn('White space', record.getMessage())
+        record = record_iterator.next()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.line_number, 7)
+        self.assertIn('special characters', record.getMessage())
+        # last one:
+        record = record_list.pop()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.line_number, 11)
+        self.assertIn('special characters', record.getMessage())
+
+
 
 class PatientAttrFileTestCase(PostClinicalDataFileTestCase):
 


### PR DESCRIPTION
# What? Why?

Added validation to block commas and some other special characters in sample id (`,;+/=*`) since these can cause problems in the portal. 

E.g. commas in sample ids give problems in old parts of the java code such as CnaJSON.processCnaFractionsRequest(). The other characters have been verified to give problems in Clinical tab. The `;` was also added as a precaution to this list of disallowed characters.

Changes proposed in this pull request:
- small new check on sample id in clinical file

# Notify reviewers
@zheins 