### PR TITLE
fix to avoid parsing error message in console when using IE11 or Chrome

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/step4_json.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/step4_json.jsp
@@ -48,7 +48,7 @@
     </script>
 
     <% if (localTabIndex.equals(QueryBuilder.TAB_VISUALIZE)) { %>
-        <% out.println("<span style='font-size:120%; color:black'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href='onco_query_lang_desc.jsp' onclick='return popitup('onco_query_lang_desc.jsp')'>Advanced: Onco Query Language (OQL)</a></span>"); %>
+        <% out.println("<span style='font-size:120%; color:black'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href='onco_query_lang_desc.jsp' onclick='return popitup(\"onco_query_lang_desc.jsp\")'>Advanced: Onco Query Language (OQL)</a></span>"); %>
     <% } %>
     
     <div style='padding-top:10px;padding-bottom:5px;'>


### PR DESCRIPTION
# What? Why?
Fix a small issue that makes IE11 show an error message in the browsers console. 


# Notify reviewers
@yichaoS can you please review this one? It's just a small change.