### PR TITLE
Define NCBI build, genomic build and species in portal.properties

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/model/CopyNumberSegmentFile.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/model/CopyNumberSegmentFile.java
@@ -37,7 +37,8 @@ public class CopyNumberSegmentFile
     public static enum ReferenceGenomeId
     {
         hg18("hg18"),
-        hg19("hg19");
+        hg19("hg19"),
+    	mm10("mm10");
 
         private String propertyName;
         

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/FetchPfamGraphicsData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/FetchPfamGraphicsData.java
@@ -39,6 +39,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import org.mskcc.cbio.portal.util.ConsoleUtil;
+import org.mskcc.cbio.portal.util.GlobalProperties;
 import org.mskcc.cbio.portal.util.ProgressMonitor;
 
 /**
@@ -72,9 +73,12 @@ public class FetchPfamGraphicsData
 		// 2. check if a certain uniprot id is already mapped in the file
 		// 3. populate key set if incremental option is selected
 		Set<String> keySet = initKeySet(outputFilename, incremental);
-                
-                Set<String> uniprotAccs = ImportUniProtIdMapping.getSwissProtAccessionHuman();
-                
+				Set<String> uniprotAccs = null;
+				String species = GlobalProperties.getSpecies();
+		    	if (!(species.equals("human") || species.equals("mouse"))){
+		    		throw new Error("Species not supported: " + species);
+				} 
+		    	uniprotAccs = ImportUniProtIdMapping.getSwissProtAccession(species);
                 ProgressMonitor.setMaxValue(uniprotAccs.size());
 
 		// read all

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportUniProtIdMapping.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportUniProtIdMapping.java
@@ -54,7 +54,12 @@ public final class ImportUniProtIdMapping {
     }
 
     public void importData() throws DaoException, IOException {
-        Set<String> swissAccessions = getSwissProtAccessionHuman();
+        Set<String> swissAccessions = null;
+        String species = GlobalProperties.getSpecies();
+    	if (!(species.equals("human") || species.equals("mouse"))){
+    		throw new Error("Species not supported: " + species);
+		} 
+    	swissAccessions = ImportUniProtIdMapping.getSwissProtAccession(species);
         
         MySQLbulkLoader.bulkLoadOn();
         
@@ -92,9 +97,17 @@ public final class ImportUniProtIdMapping {
         MySQLbulkLoader.flushAll();
     }
     
-    public static Set<String> getSwissProtAccessionHuman() throws IOException {
-        String strURL = "http://www.uniprot.org/uniprot/?query="
-                + "taxonomy%3ahuman+AND+reviewed%3ayes&force=yes&format=list";
+    public static Set<String> getSwissProtAccession(String species) throws IOException {
+    	String strURL = null;
+    	if (species.equals("human")){
+    		strURL = "http://www.uniprot.org/uniprot/?query="
+                    + "taxonomy%3ahuman+AND+reviewed%3ayes&force=yes&format=list";
+		} else if (species.equals("mouse")){
+			strURL = "http://www.uniprot.org/uniprot/?query="
+                    + "taxonomy%3amouse+AND+reviewed%3ayes&force=yes&format=list";
+		} else {
+			throw new Error("Species not supported:"+species);
+		}
         
         URL url = new URL(strURL);
 

--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -223,6 +223,12 @@ public class GlobalProperties {
     public static final String DISABLED_TABS = "disabled_tabs";
     
     public static final String PRIORITY_STUDIES = "priority_studies";
+    public static final String SPECIES = "species";
+    public static final String DEFAULT_SPECIES = "human";
+    public static final String NCBI_BUILD = "ncbi.build";
+    public static final String DEFAULT_NCBI_BUILD = "37";
+    public static final String UCSC_BUILD = "ucsc.build";
+    public static final String DEFAULT_UCSC_BUILD = "hg19";
     
     private static Log LOG = LogFactory.getLog(GlobalProperties.class);
     private static Properties properties = initializeProperties();
@@ -601,6 +607,21 @@ public class GlobalProperties {
         String dataSetsFooter = properties.getProperty(SKIN_DATASETS_FOOTER);
         return dataSetsFooter == null ? DEFAULT_SKIN_DATASETS_FOOTER : dataSetsFooter;
     }
+    
+    public static String getSpecies(){
+    	String species = properties.getProperty(SPECIES);
+    	return species == null ? DEFAULT_SPECIES : species;
+    	}
+
+    public static String getNCBIBuild(){
+    	String NCBIBuild = properties.getProperty(NCBI_BUILD);
+    	return NCBIBuild == null ? DEFAULT_NCBI_BUILD : NCBIBuild;
+    	}
+   
+    public static String getGenomicBuild(){
+    	String genomicBuild = properties.getProperty(UCSC_BUILD);
+    	return genomicBuild == null ? DEFAULT_UCSC_BUILD : genomicBuild;
+    	}
 
     public static String getLinkToPatientView(String caseId, String cancerStudyId)
     {

--- a/core/src/main/java/org/mskcc/cbio/portal/util/MutationDataUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/MutationDataUtils.java
@@ -265,6 +265,7 @@ public class MutationDataUtils {
         mutationData.put(MUTATION_STATUS, mutation.getMutationStatus());
         mutationData.put(VALIDATION_STATUS, mutation.getValidationStatus());
         mutationData.put(SEQUENCING_CENTER, this.getSequencingCenter(mutation));
+        mutationData.put(GlobalProperties.getNCBIBuild(), this.getNcbiBuild(mutation));
         mutationData.put(NCBI_BUILD_NO, this.getNcbiBuild(mutation));
         mutationData.put(CHR, this.getChromosome(mutation));
         mutationData.put(START_POS, mutation.getStartPosition());

--- a/core/src/main/scripts/importer/metaImport.py
+++ b/core/src/main/scripts/importer/metaImport.py
@@ -57,8 +57,11 @@ def interface():
                                        action='store_true',
                                        help='Skip tests requiring information '
                                             'from the cBioPortal installation')
+    parser.add_argument('-P', '--portal_properties', type=str,
+                        help='portal.properties file path (default: assumed hg19)',
+                        required=False) 
     parser.add_argument('-jar', '--jar_path', type=str, required=False,
-                        help='Path to scripts JAR file')
+                        help='Path to scripts JAR file (default: $PORTAL_HOME/scripts/target/scripts-*.jar)')
     parser.add_argument('-html', '--html_table', type=str,
                         help='path to html report')
     parser.add_argument('-v', '--verbose', action='store_true',

--- a/portal/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -119,7 +119,14 @@ if (dbError != null && userMessage != null) {  %>
     <img src="images/warning.gif" alt="warning"/>
     The version of the portal is out of sync with the database! Please contact the site administrator to update the database.<br/><%= dbError %>
 </p>
-<% } 
+<% }
+String species = GlobalProperties.getSpecies();
+if (!(species.equals("human") || species.equals("mouse"))) { %>
+<p id="species-warning" style="background-color:red;display:block;">
+    <img src="images/warning.gif" alt="warning"/>
+    The species defined is not supported. Please check the portal.properties file.<br/><%= species %>
+</p>
+<% }
 String sessionError = (String) request.getAttribute(SessionServiceRequestWrapper.SESSION_ERROR);
 if (sessionError != null) {  %>
 <p id="session-warning" style="background-color:red;display:block;">

--- a/portal/src/main/webapp/WEB-INF/jsp/step4_json.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/step4_json.jsp
@@ -66,8 +66,8 @@
         });
     </script>
 
-<textarea rows='5' cols='80' id='gene_list' placeholder="Enter HUGO Gene Symbols or Gene Aliases" required
-name='<%= QueryBuilder.GENE_LIST %>' title='Enter HUGO Gene Symbols or Gene Aliases'><%
+<textarea rows='5' cols='80' id='gene_list' placeholder="Enter Gene Symbols or Gene Aliases" required
+name='<%= QueryBuilder.GENE_LIST %>' title='Enter Gene Symbols or Gene Aliases'><%
     if (localGeneList != null && localGeneList.length() > 0) {
 	    String geneListWithSemis =
 			    org.mskcc.cbio.portal.oncoPrintSpecLanguage.Utilities.appendSemis(localGeneList);

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -178,3 +178,8 @@ disabled_tabs=
 # study ids and categories to force to top of study selector
 # format is category1#study1a,study1b,study1c;category2#study2
 priority_studies=
+
+# species and genomic information
+species=human
+ncbi.build=37
+ucsc.build=hg19


### PR DESCRIPTION
Here, 'species', 'genome build' and 'NCBI build' are established as global variables (in portal.properties). The default values from these variables are the ones cBioPortal currently uses (from human). However, when these variables refer to mouse, mouse studies can be loaded (if the database contains genes, gene aliases, and Pfam domains from mouse).

The portal.properties file should incorporate these new variables. Examples:
For mouse:
`species=mouse`
`ncbi.build=38`
`ucsc.build=mm10` 

For human (or leave them empty):
`species=human`
`ncbi.build=37`
`ucsc.build=hg19` 

Specifying other species in portal.properties will raise an error message in the home page (similar to when the database is out of sync).

Also, to load the studies a new optional parameter `-P` is introduced in `metaImport.py`, which it should point to either `portal.properties` or a file which contains the new global variables to properly validate the imported files. If no file is specified, it would take as default parameters: species=human, ncbi.build=37, and ucsc.build=hg19.

@n1zea144 I ask you to review this PR, since it is mainly the #2102, but without the gene length introduced in #1678 which was messy and confusing. While redoing the PR I also introduced changes following the comments you wrote in the previous PR. You might also want to take a look at PR #1678 for the gene length changes.