### PR TITLE
Correct documented path to migration.sql

### DIFF
--- a/docs/Updating-your-cBioPortal-installation.md
+++ b/docs/Updating-your-cBioPortal-installation.md
@@ -48,7 +48,7 @@ To run the migration script first go to the scripts folder
 `<your_cbioportal_dir>/core/src/main/scripts` 
 and then run the following command:
 ```console
-$ python migrate_db.py --properties-file <your_cbioportal_dir>/src/main/resources/portal.properties --sql <your_cbioportal_dir>/db-scripts/src/main/resources/db/migration.sql
+$ python migrate_db.py --properties-file <your_cbioportal_dir>/src/main/resources/portal.properties --sql <your_cbioportal_dir>/db-scripts/src/main/resources/migration.sql
 ```
 This should result in the following output:
 ```console


### PR DESCRIPTION
Commit b6f8d00d2e07d6346b7d3c9a170d924520765c52 broke the documented
command to upgrade the database schema to the version expected by
the portal during installation, by making a mistake in the path to
one of the required files. This fixes the path, so that the command
runs as documented again.