### PR TITLE
Document the installation of requests for the validator

### DIFF
--- a/docs/Data-Loading.md
+++ b/docs/Data-Loading.md
@@ -18,7 +18,12 @@ Getting your study data into cBioPortal requires four steps:
 If you have a git clone of cBioPortal, the relevant scripts can be found in the folder: `<your_cbioportal_dir>/core/src/main/scripts/importer`
 
 ### Dependencies
-The scripts run in `python 2`. If you want the scripts to be able to generate html reports (recommended way for reading the validation errors, if any), then you will also need to install `jinja2`. You can use this command: 
+The scripts run in `python 2`, and they require the module `requests`. You can use this command to install the module:
+```console
+$ sudo pip2 install requests
+```
+
+If you want the scripts to be able to generate html reports (recommended way for reading the validation errors, if any), then you will also need to install `jinja2`. You can use this command: 
 ```console
 $ sudo pip2 install jinja2
 ```


### PR DESCRIPTION
Currently, the validator needs the Python module `requests` to work, and it is not documented. This PR documents how to install `requests`.