### PR TITLE
Support for gene panel & gene panel matrix data in validateData.py & cbioportalImporter.py

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanel.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanel.java
@@ -79,6 +79,7 @@ public class ImportGenePanel extends ConsoleRunnable {
             }
 
             setFile(genePanel_f);
+            SpringUtil.initDataSource();
             importData();
         } catch (RuntimeException e) {
             throw e;

--- a/core/src/main/scripts/importer/cbioportalImporter.py
+++ b/core/src/main/scripts/importer/cbioportalImporter.py
@@ -108,6 +108,11 @@ def import_study_data(jvm_args, meta_filename, data_filename):
         args.append(data_filename)
         args.append("--study")
         args.append(meta_file_dict['cancer_study_identifier'])
+    elif importer == "org.mskcc.cbio.portal.scripts.ImportGenePanelProfileMap":
+        args.append("--meta")
+        args.append(meta_filename)
+        args.append("--data")				
+        args.append(data_filename)
     else:
         args.append("--data")
         args.append(data_filename)
@@ -173,6 +178,7 @@ def process_directory(jvm_args, study_directory):
     cancer_type_filepairs = []
     sample_attr_filepair = None
     regular_filepairs = []
+    gene_panel_matrix_filepair = None
 
     # read all meta files (excluding case lists) to determine what to import
     for f in meta_filenames:
@@ -203,6 +209,9 @@ def process_directory(jvm_args, study_directory):
                         sample_attr_filepair[0], f))
             sample_attr_filepair = (
                 f, os.path.join(study_directory, metadata['data_filename']))
+        elif meta_file_type == MetaFileTypes.GENE_PANEL_MATRIX:
+            gene_panel_matrix_filepair = (
+                (f, os.path.join(study_directory, metadata['data_filename'])))
         else:
             regular_filepairs.append(
                 (f, os.path.join(study_directory, metadata['data_filename'])))
@@ -229,6 +238,9 @@ def process_directory(jvm_args, study_directory):
     # Now, import everything else
     for meta_filename, data_filename in regular_filepairs:
         import_study_data(jvm_args, meta_filename, data_filename)
+
+    if gene_panel_matrix_filepair is not None:
+        import_study_data(jvm_args, gene_panel_matrix_filepair[0], gene_panel_matrix_filepair[1])
 
     # do the case lists
     case_list_dirname = os.path.join(study_directory, 'case_lists')

--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -46,6 +46,7 @@ class MetaFileTypes(object):
     TIMELINE = 'meta_timeline'
     CASE_LIST = 'case_list'
     MUTATION_SIGNIFICANCE = 'meta_mutsig'
+    GENE_PANEL_MATRIX = 'meta_gene_panel_matrix'
 
 # fields allowed in each meta file type, maps to True if required
 META_FIELD_MAP = {
@@ -85,7 +86,8 @@ META_FIELD_MAP = {
         'show_profile_in_analysis_tab': True,
         'profile_name': True,
         'profile_description': True,
-        'data_filename': True
+        'data_filename': True,
+        'gene_panel': False
     },
     MetaFileTypes.CNA_LOG2: {
         'cancer_study_identifier': True,
@@ -125,7 +127,8 @@ META_FIELD_MAP = {
         'profile_description': True,
         'data_filename': True,
         'normal_samples_list': False,
-        'swissprot_identifier': False
+        'swissprot_identifier': False,
+        'gene_panel': False
     },
     MetaFileTypes.EXPRESSION: {
         'cancer_study_identifier': True,
@@ -155,7 +158,8 @@ META_FIELD_MAP = {
         'show_profile_in_analysis_tab': True,
         'profile_name': True,
         'profile_description': True,
-        'data_filename': True
+        'data_filename': True,
+        'gene_panel': False
     },
     MetaFileTypes.FUSION: {
         'cancer_study_identifier': True,
@@ -165,7 +169,8 @@ META_FIELD_MAP = {
         'show_profile_in_analysis_tab': True,
         'profile_name': True,
         'profile_description': True,
-        'data_filename': True
+        'data_filename': True,
+        'gene_panel': False
     },
     MetaFileTypes.GISTIC_GENES: {
         'cancer_study_identifier': True,
@@ -193,6 +198,12 @@ META_FIELD_MAP = {
         'genetic_alteration_type': True,
         'datatype': True,
         'data_filename': True
+    },
+    MetaFileTypes.GENE_PANEL_MATRIX: {
+        'cancer_study_identifier': True,
+        'genetic_alteration_type': True,
+        'datatype': True,
+        'data_filename': True
     }
 }
 
@@ -213,7 +224,8 @@ IMPORTER_CLASSNAME_BY_META_TYPE = {
     MetaFileTypes.GISTIC_GENES: "org.mskcc.cbio.portal.scripts.ImportGisticData",
     MetaFileTypes.TIMELINE: "org.mskcc.cbio.portal.scripts.ImportTimelineData",
     MetaFileTypes.CASE_LIST: IMPORT_CASE_LIST_CLASS,
-    MetaFileTypes.MUTATION_SIGNIFICANCE: "org.mskcc.cbio.portal.scripts.ImportMutSigData"
+    MetaFileTypes.MUTATION_SIGNIFICANCE: "org.mskcc.cbio.portal.scripts.ImportMutSigData",
+    MetaFileTypes.GENE_PANEL_MATRIX: "org.mskcc.cbio.portal.scripts.ImportGenePanelProfileMap"
 }
 
 IMPORTER_REQUIRES_METADATA = {
@@ -222,7 +234,8 @@ IMPORTER_REQUIRES_METADATA = {
     "org.mskcc.cbio.portal.scripts.ImportGisticData" : False,
     "org.mskcc.cbio.portal.scripts.ImportMutSigData" : False,
     "org.mskcc.cbio.portal.scripts.ImportProfileData" : True,
-    "org.mskcc.cbio.portal.scripts.ImportTimelineData" : True
+    "org.mskcc.cbio.portal.scripts.ImportTimelineData" : True,
+    "org.mskcc.cbio.portal.scripts.ImportGenePanelProfileMap" : False
 }
 
 # ------------------------------------------------------------------------------
@@ -455,6 +468,7 @@ def get_meta_file_type(metaDictionary, logger, filename):
         # others
         ("METHYLATION", "CONTINUOUS"): MetaFileTypes.METHYLATION,
         ("FUSION", "FUSION"): MetaFileTypes.FUSION,
+        ("GENE_PANEL_MATRIX", "GENE_PANEL_MATRIX"): MetaFileTypes.GENE_PANEL_MATRIX,
         # cross-sample molecular statistics (for gene selection)
         ("GISTIC_GENES_AMP", "Q-VALUE"): MetaFileTypes.GISTIC_GENES,
         ("GISTIC_GENES_DEL", "Q-VALUE"): MetaFileTypes.GISTIC_GENES,

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -70,7 +70,8 @@ VALIDATOR_IDS = {
     cbioportal_common.MetaFileTypes.RPPA:'RPPAValidator',
     cbioportal_common.MetaFileTypes.GISTIC_GENES: 'GisticGenesValidator',
     cbioportal_common.MetaFileTypes.TIMELINE:'TimelineValidator',
-    cbioportal_common.MetaFileTypes.MUTATION_SIGNIFICANCE:'MutationSignificanceValidator'
+    cbioportal_common.MetaFileTypes.MUTATION_SIGNIFICANCE:'MutationSignificanceValidator',
+    cbioportal_common.MetaFileTypes.GENE_PANEL_MATRIX:'GenePanelMatrixValidator'
 }
 
 
@@ -365,7 +366,7 @@ class Validator(object):
                     self.logger.info('Ignoring missing or invalid header comments. '
                         'Continuing with validation...')                    
                     self.fill_in_attr_defs = True
-
+            
             # read five data lines to detect quotes in the tsv file
             first_data_lines = []
             for i, line in enumerate(data_file):
@@ -452,7 +453,7 @@ class Validator(object):
         parsed, True otherwise.
         """
         return True
-
+    
     def checkHeader(self, cols):
 
         """Check that the header has the correct items and set self.cols.
@@ -2077,6 +2078,12 @@ class MutationSignificanceValidator(Validator):
     ALLOW_BLANKS = True
     pass
 
+class GenePanelMatrixValidator(Validator):
+
+    REQUIRED_HEADERS = ['SAMPLE_ID']
+    # TODO check that other column headers are valid profile stable ids
+    # TODO check that sample ids are references in clincal data file
+    # TODO check that referenced gene panel stable id is valid
 
 class RPPAValidator(FeaturewiseFileValidator):
 

--- a/core/src/test/java/org/mskcc/cbio/portal/scripts/TestIntegrationTest.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/scripts/TestIntegrationTest.java
@@ -25,6 +25,7 @@ package org.mskcc.cbio.portal.scripts;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -54,6 +55,7 @@ import org.mskcc.cbio.portal.dao.MySQLbulkLoader;
 import org.mskcc.cbio.portal.model.*;
 import org.mskcc.cbio.portal.persistence.MutationMapperLegacy;
 import org.mskcc.cbio.portal.service.ApiService;
+import org.mskcc.cbio.portal.util.SpringUtil;
 import org.mskcc.cbio.portal.util.ConsoleUtil;
 import org.mskcc.cbio.portal.util.ProgressMonitor;
 import org.mskcc.cbio.portal.util.TransactionalScripts;
@@ -84,12 +86,14 @@ public class TestIntegrationTest {
     private ApplicationContext applicationContext;
     
     @Before
-    public void setUp() throws DaoException, JsonParseException, JsonMappingException, IOException {
+    public void setUp() throws DaoException, JsonParseException, JsonMappingException, IOException, Exception {
+        SpringUtil.setApplicationContext(applicationContext);
         ProgressMonitor.setConsoleMode(false);
         ProgressMonitor.resetWarnings();
         DaoCancerStudy.reCacheAll();
         DaoGeneOptimized.getInstance().reCache();
         loadGenes();
+        loadGenePanel();
     }
     
     /**
@@ -325,6 +329,16 @@ public class TestIntegrationTest {
 
         MySQLbulkLoader.flushAll();
         
+    }
+
+    /**
+     * Loads a gene panel used by this test.
+     * 
+     */
+    private void loadGenePanel() throws Exception {
+        ImportGenePanel gp = new ImportGenePanel(null);
+        gp.setFile(new File("src/test/scripts/test_data/study_es_0/gene_panel_example.txt"));
+        gp.importData();
     }
     
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/core/src/test/scripts/test_data/study_es_0/data_gene_panel_matrix.txt
+++ b/core/src/test/scripts/test_data/study_es_0/data_gene_panel_matrix.txt
@@ -1,0 +1,2 @@
+SAMPLE_ID	study_es_0_mutations
+TCGA-A1-A0SB-01	example_gene_panel_stable_id

--- a/core/src/test/scripts/test_data/study_es_0/gene_panel_example.txt
+++ b/core/src/test/scripts/test_data/study_es_0/gene_panel_example.txt
@@ -1,0 +1,3 @@
+stable_id: example_gene_panel_stable_id
+description: Example gene panel meta file for testing purposes.
+gene_list:	AKT1	BRCA1	CDKN1A	EGFR	FOXP1	HRAS	KRAS	POLE	SMAD2	TP53

--- a/core/src/test/scripts/test_data/study_es_0/meta_fusion.txt
+++ b/core/src/test/scripts/test_data/study_es_0/meta_fusion.txt
@@ -6,3 +6,4 @@ profile_description: Fusions.
 show_profile_in_analysis_tab: true
 profile_name: Fusions
 data_filename: data_fusions.txt
+gene_panel: example_gene_panel_stable_id

--- a/core/src/test/scripts/test_data/study_es_0/meta_gene_panel_matrix.txt
+++ b/core/src/test/scripts/test_data/study_es_0/meta_gene_panel_matrix.txt
@@ -1,0 +1,4 @@
+cancer_study_identifier: study_es_0
+genetic_alteration_type: GENE_PANEL_MATRIX
+datatype: GENE_PANEL_MATRIX
+data_filename: data_gene_panel_matrix.txt

--- a/core/src/test/scripts/test_data/study_es_0/result_report.html
+++ b/core/src/test/scripts/test_data/study_es_0/result_report.html
@@ -576,6 +576,57 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
+              id="heading_-3034954899059960691">
+          <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
+          <a role="button" data-toggle="collapse" aria-expanded="true"
+              aria-controls="collapse_-3034954899059960691" href="#collapse_-3034954899059960691">
+            <span class="badge">3</span>
+            <h4 class="panel-title">data_gene_panel_matrix.txt</h4>
+          </a>
+        </div>
+        <div class="panel-collapse collapse" role="tabpanel"
+              aria-labelledby="heading_-3034954899059960691" id="collapse_-3034954899059960691">
+          <div class="panel-body">
+            <table class="table">
+            <thead>
+              <tr>
+                <th></th>
+                <th>Line Number</th>
+                <th>Column Number</th>
+                <th>Message</th>
+                <th>Value Encountered</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="info">
+                <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
+                <td>&ndash;</td>
+                <td>&ndash;</td>
+                <td>Starting validation of file</td>
+                <td>&ndash;</td>
+              </tr>
+              <tr class="success">
+                <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
+                <td>&ndash;</td>
+                <td>&ndash;</td>
+                <td>Validation of file complete</td>
+                <td>&ndash;</td>
+              </tr>
+              <tr class="success">
+                <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
+                <td>&ndash;</td>
+                <td>&ndash;</td>
+                <td>Read 2 lines. Lines with warning: 0. Lines with error: 0</td>
+                <td>&ndash;</td>
+              </tr>
+            </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="panel panel-success">
+        <div class="panel-heading" role="tab"
               id="heading_4479070818687924185">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
@@ -973,6 +1024,50 @@
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
               aria-labelledby="heading_4502431930035627579" id="collapse_4502431930035627579">
+          <div class="panel-body">
+            <table class="table">
+            <thead>
+              <tr>
+                <th></th>
+                <th>Line Number</th>
+                <th>Column Number</th>
+                <th>Message</th>
+                <th>Value Encountered</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="info">
+                <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
+                <td>&ndash;</td>
+                <td>&ndash;</td>
+                <td>Starting validation of meta file</td>
+                <td>&ndash;</td>
+              </tr>
+              <tr class="success">
+                <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
+                <td>&ndash;</td>
+                <td>&ndash;</td>
+                <td>Validation of meta file complete</td>
+                <td>&ndash;</td>
+              </tr>
+            </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="panel panel-success">
+        <div class="panel-heading" role="tab"
+              id="heading_28174920185682614">
+          <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
+          <a role="button" data-toggle="collapse" aria-expanded="true"
+              aria-controls="collapse_28174920185682614" href="#collapse_28174920185682614">
+            <span class="badge">2</span>
+            <h4 class="panel-title">meta_gene_panel_matrix.txt</h4>
+          </a>
+        </div>
+        <div class="panel-collapse collapse" role="tabpanel"
+              aria-labelledby="heading_28174920185682614" id="collapse_28174920185682614">
           <div class="panel-body">
             <table class="table">
             <thead>

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -1009,6 +1009,8 @@ description: Targeted (410 cancer genes) sequencing of various tumor types via M
 gene_list: ABL1    ACVR1   AKT1    AKT3 ...
 ```
 
+For information on importing gene panels please visit: [Importering-gene-panels](Importing-gene-panels.md).
+
 #### Sample-Profile Matrix
 
 The second component to gene panel data is associating samples and profile to the panel which applies. The following column is required :
@@ -1034,7 +1036,9 @@ SAMPLE_ID_2<TAB>NA<TAB>NA<TAB> ...
 The sample-profile matrix requires a meta file should contain the following fields:
 
 1. **cancer_study_identifier**: same value as specified in [study meta file](#cancer-study)
-2. **data_filename**: your datafile
+2. **genetic_alteration_type**: GENE_PANEL_MATRIX
+3. **datatype**: GENE_PANEL_MATRIX
+4. **data_filename**: your datafile
 
 If all samples in a genetic profile will have the same gene panel associated with them, an optional field can be specified in the meta data file of that datatype called **gene_panel**. If this is present, the sample-profile matrix will automatically be generated and the gene panel applied if it exists in the database already.
 

--- a/docs/Importing-gene-panels.md
+++ b/docs/Importing-gene-panels.md
@@ -1,0 +1,22 @@
+# Importing Gene Panels
+
+This page describes how to import a gene panel into the cBioPortal database.  It assumes the following requirements have been satisfied:
+
+1. The cBioPortal software has been correctly [built from source](Build-from-Source.md).
+2. The gene panel to import is in the proper file format.  See [File Format](File-Formats.md#gene-panel-data) for more information.
+3. A `JAVA_HOME` environment variable has been properly defined which points to a local installation of Java.
+4. The `PORTAL_HOME` environment variable has been properly defined.  See [Pre-Build-Steps](Pre-Build-Steps.md#set-the-portal-home-variable) for more information.
+
+The following command is used to import a gene panel into the cBioPortal database:
+```
+$JAVA_HOME/bin/java -cp $PORTAL_HOME/scripts/target/scripts-*.jar org.mskcc.cbio.portal.scripts.ImportGenePanel --data core/src/test/scripts/test_data/study_es_0/gene_panel_example.txt
+```
+In this example, we are loading the example gene panel which resides in the sample dataset study_es_0.
+
+If a gene panel exists in the database with the same name as the one being imported, and there exists cancer study data that refers to this gene panel, this command will abort.  In order to import the gene panel in this situation, either remove the cancer study from the database that refers to this gene panel or explicitly remove the gene panel from the data and then rerun the ImportGenePanel command.  To remove the gene panel from the database, run the following commands fromthe MySQL console:
+
+```
+delete from gene_panel_list where internal_id = (select internal_id from gene_panel where stable_id = "example_gene_panel_stable_id");
+delete from gene_panel where stable_id = "example_gene_panel_stable_id";
+```
+In this example we are removing the gene panel with the stable_id `example_gene_panel_stable_id`, the example gene_panel from the study_es_0 sample dataset.


### PR DESCRIPTION
Support for gene panel & gene panel matrix data in validateData.py & cbioportalImporter.py.

Gene panel data consists of two files, a gene panel file which contains meta data about the panel, including a gene list, and a matrix file which maps a gene panel to a sample-genetic profile pair.  Some notes:

- Since the gene panel file is very similar to any meta file, it was decided that gene panel data files should have a meta_gene_panel prefix in its name so that it can leverage existing meta file validation support already provide in validateData.py.  Unfortunately, because the gene panel file is being treated as a meta file, it is not possible to leverage the existing checkGeneIdentification code which is buried with the datafile - Validator class design.
- Since a gene panel stable id is not tied to a particular cancer study, code that checks for a valid genetic_alteration_type and stable_id was relaxed when the gene panel meta file is processed.
- A minimal check for required headers is implemented in GenePanelMatrixValidator.  Additional checks as described in the class can be implemented in a future effort.
- Since a gene panel file exists outside of a study, metaImport.py was not updated as its current implementation is study centric data importing.  Providing this support is better left in the hands of its author.
