### PR TITLE
Add sample label color for xenograft and cfdna

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/patient_view/patient_view.jsp
@@ -1051,6 +1051,8 @@ function outputClinicalData() {
         if (caseTypeNorm==="metastasis") return "red";
         if (caseTypeNorm==="progressed") return "orange";
         if (caseTypeNorm==="recurrence") return "orange";
+        if (caseTypeNorm==="xenograft") return "pink";
+        if (caseTypeNorm==="cfdna") return "blue";
         return "black";
     }
 

--- a/portal/src/main/webapp/css/patient-view/clinical-attributes.css
+++ b/portal/src/main/webapp/css/patient-view/clinical-attributes.css
@@ -23,9 +23,10 @@
 .clinical-attribute[attr-id="ERG_FUSION_ACGH"],
 .clinical-attribute[attr-id="SERUM_PSA"],
 .clinical-attribute[attr-id="DRIVER_MUTATIONS"],
-.clinical-attribute[attr-id="SAMPLE_CLASS"],
 .clinical-attribute[attr-id="DERIVED_NORMALIZED_CASE_TYPE"],
-.clinical-attribute[attr-id="DERIVED_SAMPLE_LOCATION"] {
+.clinical-attribute[attr-id="DERIVED_SAMPLE_LOCATION"],
+.clinical-attribute[attr-id="MOUSE_STRAIN"],
+.clinical-attribute[attr-id="BREAST_CANCER_RECEPTOR_STATUS"] {
     display: inline;
     order: 6;
 }

--- a/portal/src/main/webapp/css/patient-view/main.css
+++ b/portal/src/main/webapp/css/patient-view/main.css
@@ -97,6 +97,7 @@
 }
 #more-patient-info a {
     display: inline-flex;
+    flex-wrap: wrap;
 }
 .more-sample-info {
     display: inline-flex;

--- a/portal/src/main/webapp/js/src/patient-view/util/ClinicalAttributesUtil.js
+++ b/portal/src/main/webapp/js/src/patient-view/util/ClinicalAttributesUtil.js
@@ -112,6 +112,10 @@ window.ClinicalAttributesUtil = (function() {
             caseTypeNormalized = 'recurrence';
           } else if (caseTypeLower.indexOf('progr') >= 0) {
             caseTypeNormalized = 'progressed';
+          } else if (caseTypeLower.indexOf('xeno') >= 0) {
+            caseTypeNormalized = 'xenograft';
+          } else if (caseTypeLower.indexOf('cfdna') >= 0) {
+            caseTypeNormalized = 'cfdna';
           } else if (caseTypeLower.indexOf('prim') >= 0 || 
                     caseTypeLower.indexOf('prim') >= 0) {
             caseTypeNormalized = 'primary';
@@ -125,7 +129,7 @@ window.ClinicalAttributesUtil = (function() {
       return caseTypeNormalized;
     }
 
-    var caseTypeNormalized = normalizedCaseType(clinicalData, ['SAMPLE_TYPE', 'TUMOR_TISSUE_SITE', 'TUMOR_TYPE']);
+    var caseTypeNormalized = normalizedCaseType(clinicalData, ['SAMPLE_CLASS', 'SAMPLE_TYPE', 'TUMOR_TISSUE_SITE', 'TUMOR_TYPE']);
     if (caseTypeNormalized !== null) {
       var loc;
 


### PR DESCRIPTION
On patient view add sample label color for both xenograft (pink) and cfdna
(blue). Show extra attributes on patient view i.e. MOUSE_STRAIN and BREAST_CANCER_RECEPTOR_STATUS. Also fix issue with text at top of patient view not properly wrapping.

@jjgao 
![screen shot 2017-02-28 at 10 53 32 pm](https://cloud.githubusercontent.com/assets/1334004/23445340/c2547f34-fe08-11e6-8224-817ac134eb94.png)

