### PR TITLE
Allow context to be set in Gene Panel importers

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanel.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanel.java
@@ -40,14 +40,16 @@ import org.cbioportal.model.Gene;
 import joptsimple.*;
 import org.mskcc.cbio.portal.util.ProgressMonitor;
 import org.mskcc.cbio.portal.util.SpringUtil;
+import org.springframework.context.ApplicationContext;
 
 /**
  *
  * @author heinsz
  */
 public class ImportGenePanel extends ConsoleRunnable {
-    
+  
     private File genePanelFile;
+    private ApplicationContext context;
 
     @Override
     public void run() {
@@ -55,7 +57,7 @@ public class ImportGenePanel extends ConsoleRunnable {
             String progName = "ImportGenePanel";
             String description = "Import gene panel files.";
             // usage: --data <data_file.txt> --meta <meta_file.txt> --loadMode [directLoad|bulkLoad (default)] [--noprogress]
-	
+  
             OptionParser parser = new OptionParser();
             OptionSpec<String> data = parser.accepts( "data",
                    "gene panel file" ).withRequiredArg().describedAs( "data_file.txt" ).ofType( String.class );
@@ -77,33 +79,35 @@ public class ImportGenePanel extends ConsoleRunnable {
                         progName, description, parser,
                         "'data' argument required.");
             }
-            
-            SpringUtil.initDataSource();
+          
+            if (context == null) {
+                SpringUtil.initDataSource();              
+            }
             setFile(genePanel_f);
-            importData();            
+            importData();          
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
-    
+  
     public void importData() throws Exception {
         ProgressMonitor.setCurrentMessage("Reading data from:  " + genePanelFile.getAbsolutePath());
-        Properties properties = new Properties();    
+        Properties properties = new Properties();  
         properties.load(new FileInputStream(genePanelFile));
-        
-        GenePanelRepository genePanelRepository = SpringUtil.getGenePanelRepository();
-        
+      
+        GenePanelRepository genePanelRepository = context == null ? SpringUtil.getGenePanelRepository() : (GenePanelRepository)context.getBean("genePanelRepository");
+      
         String stableId = getPropertyValue("stable_id", properties, true);
         String description = getPropertyValue("description", properties, false);
-        Set<Integer> genes = getGenes("gene_list", properties, genePanelRepository);        
-        
-		GenePanel genePanel = new GenePanel();
+        Set<Integer> genes = getGenes("gene_list", properties, genePanelRepository);      
+      
+        GenePanel genePanel = new GenePanel();
         List<GenePanel> genePanelResult = genePanelRepository.getGenePanelByStableId(stableId);
         boolean panelUsed = false;
         if (genePanelResult != null && genePanelResult.size() > 0) {
-			genePanel = genePanelResult.get(0);
+            genePanel = genePanelResult.get(0);
             if (genePanelRepository.sampleProfileMappingExistsByPanel(genePanel.getInternalId())) {
                 ProgressMonitor.logWarning("Gene panel " + stableId + " already exists in databasel and is being used! Cannot import the gene panel!");
                 panelUsed = true;
@@ -113,7 +117,7 @@ public class ImportGenePanel extends ConsoleRunnable {
                 ProgressMonitor.logWarning("Gene panel " + stableId + " already exists in the database but is not being used. Overwriting old gene panel data.");
             }
         }
-        
+      
         if(!panelUsed) {
             Map<String, Object> map = new HashMap<String, Object>();
             map.put("stableId", stableId);
@@ -126,30 +130,30 @@ public class ImportGenePanel extends ConsoleRunnable {
                 map.put("panelId", genePanel.getInternalId());
                 map.put("genes", genes);
                 genePanelRepository.insertGenePanelList(map);
-            }                
+            }              
         }
     }
-    
+  
     private static String getPropertyValue(String propertyName, Properties properties, boolean noSpaceAllowed) throws IllegalArgumentException {
         String propertyValue = properties.getProperty(propertyName).trim();
-        
+      
         if (propertyValue == null || propertyValue.length() == 0) {
             throw new IllegalArgumentException(propertyName + " is not specified.");
         }
-        
+      
         if (noSpaceAllowed && propertyValue.contains(" ")) {
             throw new IllegalArgumentException(propertyName + " cannot contain spaces: " + propertyValue);
         }
-        
+      
         return propertyValue;
     }
-    
+  
     private static Set<Integer> getGenes(String propertyName, Properties properties, GenePanelRepository genePanelRepository) {
         String propertyValue = properties.getProperty(propertyName).trim();
         if (propertyValue == null || propertyValue.length() == 0) {
             throw new IllegalArgumentException(propertyName + " is not specified.");
         } 
-        
+      
         Set<Integer> geneIds = new HashSet<>();
         String[] genes = propertyValue.split("\t");
         for (String panelGene : genes) {
@@ -169,21 +173,21 @@ public class ImportGenePanel extends ConsoleRunnable {
                 if (gene == null) {
                     gene = genePanelRepository.getGeneByAlias(panelGene);
                 }
-                
+              
                 if (gene != null) {
                     geneIds.add(gene.getEntrezGeneId());
                 }
             }
         }
-        
+      
         return geneIds;
     }
-            
+          
     public void setFile(File genePanelFile)
     {
         this.genePanelFile = genePanelFile;
-    }    
-    
+    }  
+  
     /**
      * Makes an instance to run with the given command line arguments.
      *
@@ -192,7 +196,7 @@ public class ImportGenePanel extends ConsoleRunnable {
     public ImportGenePanel(String[] args) {
         super(args);
     }
-    
+  
     /**
      * Runs the command as a script and exits with an appropriate exit code.
      *
@@ -201,5 +205,9 @@ public class ImportGenePanel extends ConsoleRunnable {
     public static void main(String[] args) {
         ConsoleRunnable runner = new ImportGenePanel(args);
         runner.runInConsole();
+    }
+  
+    public void setContext(ApplicationContext context) {
+        this.context = context;      
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanelProfileMap.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanelProfileMap.java
@@ -41,16 +41,18 @@ import org.cbioportal.model.*;
 import joptsimple.*;
 import org.mskcc.cbio.portal.util.ProgressMonitor;
 import org.mskcc.cbio.portal.util.SpringUtil;
+import org.springframework.context.ApplicationContext;
 
 /**
  *
  * @author heinsz
  */
 public class ImportGenePanelProfileMap extends ConsoleRunnable {
-    
+  
     private File genePanelProfileMapFile;
     private static Properties properties;
     private String cancerStudyStableId;
+    private ApplicationContext context;
 
     @Override
     public void run() {
@@ -58,7 +60,7 @@ public class ImportGenePanelProfileMap extends ConsoleRunnable {
             String progName = "ImportGenePanelProfileMap";
             String description = "Import gene panel profile map files.";
             // usage: --data <data_file.txt> --meta <meta_file.txt> --loadMode [directLoad|bulkLoad (default)] [--noprogress]
-	
+  
             OptionParser parser = new OptionParser();
             OptionSpec<String> data = parser.accepts( "data",
                    "gene panel file" ).withRequiredArg().describedAs( "data_file.txt" ).ofType( String.class );
@@ -82,7 +84,7 @@ public class ImportGenePanelProfileMap extends ConsoleRunnable {
                         progName, description, parser,
                         "'data' argument required.");
             }
-            
+          
             if( options.has( meta ) ){
                 properties = new TrimmedProperties();
                 properties.load(new FileInputStream(options.valueOf(meta)));
@@ -91,22 +93,23 @@ public class ImportGenePanelProfileMap extends ConsoleRunnable {
                 throw new UsageException(
                         progName, description, parser,
                         "'meta' argument required.");
-            }            
-            
-            SpringUtil.initDataSource();
+            }          
+            if (context == null) {
+                SpringUtil.initDataSource();
+            }
             setFile(genePanel_f);
-            importData();            
+            importData();          
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
-    
+  
     public void importData() throws Exception {
         ProgressMonitor.setCurrentMessage("Reading data from:  " + genePanelProfileMapFile.getAbsolutePath());
-        GenePanelRepository genePanelRepository = SpringUtil.getGenePanelRepository();     
-        
+        GenePanelRepository genePanelRepository = context == null ? SpringUtil.getGenePanelRepository() : (GenePanelRepository)context.getBean("genePanelRepository");
+      
         FileReader reader =  new FileReader(genePanelProfileMapFile);
         BufferedReader buff = new BufferedReader(reader);
         List<String> profiles = getProfilesLine(buff);
@@ -116,7 +119,7 @@ public class ImportGenePanelProfileMap extends ConsoleRunnable {
         }
         profiles.remove((int)sampleIdIndex);
         List<Integer> profileIds = getProfileIds(profiles, genePanelRepository);
-        
+      
         // delete if the profile mapping are there already
         for (Integer id : profileIds) {
             if(genePanelRepository.sampleProfileMappingExistsByProfile(id)) {
@@ -129,11 +132,11 @@ public class ImportGenePanelProfileMap extends ConsoleRunnable {
             List<String> data  = new LinkedList<>(Arrays.asList(line.split("\t")));
             String sampleId = data.get(sampleIdIndex);
             Sample sample = genePanelRepository.getSampleByStableIdAndStudyId(sampleId, cancerStudyStableId);
-            
+          
             data.remove((int)sampleIdIndex);
             for (int i = 0; i < data.size(); i++) {
-                List<GenePanel> genePanelList = genePanelRepository.getGenePanelByStableId(data.get(i));              
-                if (genePanelList != null && genePanelList.size() > 0) {       
+                List<GenePanel> genePanelList = genePanelRepository.getGenePanelByStableId(data.get(i));            
+                if (genePanelList != null && genePanelList.size() > 0) {     
                     GenePanel genePanel = genePanelList.get(0);
                     Map<String, Object> map = new HashMap<>();
                     map.put("sampleId", sample.getInternalId());
@@ -144,28 +147,28 @@ public class ImportGenePanelProfileMap extends ConsoleRunnable {
                 else {
                     ProgressMonitor.logWarning("No gene panel exists: " + data.get(i));
                 }
-            }            
-        }                                  
+            }          
+        }                                
     }
-    
-    public List<String> getProfilesLine(BufferedReader buff) throws Exception {        
+  
+    public List<String> getProfilesLine(BufferedReader buff) throws Exception {      
         String line = buff.readLine();
         while(line.startsWith("#")) {
             line = buff.readLine();
         }
-        
+      
         List<String> profiles = new LinkedList<>(Arrays.asList(line.split("\t")));
-        
+      
         return profiles;
     }
-    
+  
     public List<Integer> getProfileIds(List<String> profiles, GenePanelRepository genePanelRepository) {
         List<Integer> geneticProfileIds = new LinkedList<>();
         for(String profile : profiles) {
             if (!profile.startsWith(cancerStudyStableId)) {
                 profile = cancerStudyStableId + "_" + profile;
             }
-            GeneticProfile geneticProfile = genePanelRepository.getGeneticProfileByStableId(profile);            
+            GeneticProfile geneticProfile = genePanelRepository.getGeneticProfileByStableId(profile);          
             if (geneticProfile != null) {
                 geneticProfileIds.add(geneticProfile.getGeneticProfileId());
             }
@@ -175,13 +178,13 @@ public class ImportGenePanelProfileMap extends ConsoleRunnable {
         }
         return geneticProfileIds;
     }
-    
-            
+  
+          
     public void setFile(File genePanelProfileMapFile)
     {
         this.genePanelProfileMapFile = genePanelProfileMapFile;
-    }    
-    
+    }  
+  
     /**
      * Makes an instance to run with the given command line arguments.
      *
@@ -190,7 +193,7 @@ public class ImportGenePanelProfileMap extends ConsoleRunnable {
     public ImportGenePanelProfileMap(String[] args) {
         super(args);
     }
-    
+  
     /**
      * Runs the command as a script and exits with an appropriate exit code.
      *
@@ -199,5 +202,9 @@ public class ImportGenePanelProfileMap extends ConsoleRunnable {
     public static void main(String[] args) {
         ConsoleRunnable runner = new ImportGenePanelProfileMap(args);
         runner.runInConsole();
+    }
+  
+    public void setContext(ApplicationContext context) {
+        this.context = context;
     }
 }


### PR DESCRIPTION
# What? Why?
There needs to be a way to set the application context in `ImportGenePanel` and `ImportGenePanelProfileMap` externally in case of running transactionally.

Changes proposed in this pull request:
- Add `setContext()` methods in both classes
- Check if context is set when getting the `GenePanelRepository` bean. If it is, get the bean from it. Otherwise, use the `SpringUtil` class to get it.
- General code cleanup (tabs to spaces, trailing white space removal)

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@n1zea144 