### PR TITLE
Cleanup how context is used in gene panel importers

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GeneticProfileUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GeneticProfileUtil.java
@@ -89,7 +89,7 @@ public class GeneticProfileUtil {
     }
     
     public static int getGenePanelId(String panelId) {
-        GenePanelRepository genePanelRepository = SpringUtil.getGenePanelRepository();  
+        GenePanelRepository genePanelRepository = (GenePanelRepository)SpringUtil.getApplicationContext().getBean("geenPanelRepository");  
         GenePanel genePanel = genePanelRepository.getGenePanelByStableId(panelId).get(0);
         return genePanel.getInternalId();
     }

--- a/core/src/main/java/org/mskcc/cbio/portal/util/SpringUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/SpringUtil.java
@@ -52,18 +52,7 @@ public class SpringUtil
     private static ApplicationContext context;
     private static GenericXmlApplicationContext applicationContext;
 
-    public static GenePanelRepository getGenePanelRepository() {
-        if (applicationContext == null) {
-            applicationContext = new GenericXmlApplicationContext();
-            applicationContext.getEnvironment().setActiveProfiles("dbcp");
-            applicationContext.load("classpath:applicationContext-business.xml");
-            applicationContext.refresh();
-        }
-        
-        return (GenePanelRepository)applicationContext.getBean("genePanelRepository");
-    }    
- 
-    @Autowired   
+    @Autowired
     public void setAccessControl(AccessControl accessControl) {
         log.debug("Setting access control");
         SpringUtil.accessControl = accessControl;
@@ -80,7 +69,7 @@ public class SpringUtil
             context = new ClassPathXmlApplicationContext("classpath:applicationContext-business.xml");
         }
     }
-    
+
     /**
      * Get the app context as initialized or refreshed by initDataSource()
      *
@@ -93,7 +82,7 @@ public class SpringUtil
     /**
      * setter to allow override by unit test classes (which run in different context, connecting
      * to test DB).
-     * 
+     *
      * @param context
      */
     public static void setApplicationContext(ApplicationContext context) {
@@ -101,9 +90,9 @@ public class SpringUtil
     }
 
     /**
-     * Directly injects a context into the class, so we don't need to open 
-     * any more XML files. 
-     * 
+     * Directly injects a context into the class, so we don't need to open
+     * any more XML files.
+     *
      * @param context
      */
     public static synchronized void initDataSource(ApplicationContext context)


### PR DESCRIPTION
Signed-off-by: zheins <zackheins@gmail.com>

# What? Why?
Cleanup of the way the context is used in the `ImportGenePanel` and `ImportGenePanelProfileMap` files to use existing context. This was an issue that prevented transactional imports from executing properly.

Changes proposed in this pull request:
- Remove the data source initialization in `ImportGenePanel` and `ImportGenePanelProfileMap`
- Get the `GenePanelRepository` bean from the existing context
- Remove unnecessary method in `SpringUtil` class.

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@n1zea144 
