### PR TITLE
Improve error handling when no studies

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
@@ -187,7 +187,14 @@ public class QueryBuilder extends HttpServlet {
 
         //  Get all Cancer Types
         try {
-			List<CancerStudy> cancerStudyList = accessControl.getCancerStudies();
+            List<CancerStudy> cancerStudyList = accessControl.getCancerStudies();
+            if ((cancerStudyList.size() == 1 &&
+                cancerStudyList.get(0).getCancerStudyStableId().equals("all")) ||
+                    cancerStudyList.size() == 0) {
+                throw new ProtocolException("No cancer studies accessible; " +
+                    "either provide credentials to access private studies, " +
+                    "or ask administrator to load public ones.");
+            }
 
             if (cancerTypeId == null) {
                 cancerTypeId = cancerStudyList.get(0).getCancerStudyStableId();
@@ -274,10 +281,10 @@ public class QueryBuilder extends HttpServlet {
             xdebug.logMsg(this, "Got Database Exception:  " + e.getMessage());
             forwardToErrorPage(httpServletRequest, httpServletResponse,
                                DB_CONNECT_ERROR, xdebug);
-        } catch (ProtocolException e) {
+        } catch (ProtocolException e) { // currently this is only from no studies
             xdebug.logMsg(this, "Got Protocol Exception:  " + e.getMessage());
             forwardToErrorPage(httpServletRequest, httpServletResponse,
-                               DB_CONNECT_ERROR, xdebug);
+                               e.getMsg(), xdebug);
         }
     }
 
@@ -565,7 +572,7 @@ public class QueryBuilder extends HttpServlet {
                     }
                 }
             }
-        } 
+        }
 
         return errorsExist;
     }

--- a/core/src/main/java/org/mskcc/cbio/portal/util/internal/AccessControlImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/internal/AccessControlImpl.java
@@ -94,9 +94,7 @@ public class AccessControlImpl implements AccessControl {
         if (finalCancerStudiesList.size() > 1) {
             return finalCancerStudiesList;
         } else {
-            throw new ProtocolException("No cancer studies accessible; "+
-                                        "either provide credentials to access private studies, " +
-                                        "or ask administrator to load public ones.\n");
+            throw new ProtocolException("No cancer studies.");
         }
     }
 


### PR DESCRIPTION
# What? Why?
Fix #2184 

Changes proposed in this pull request:
- Correct error message when there are no cancer studies in database
- Display error if user does not have permission to access any study in database

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@n1zea144 

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:

![nostudies](https://cloud.githubusercontent.com/assets/1458628/23682426/a5c18208-038b-11e7-8dc5-f535e514fee6.jpg)

![nopermission](https://cloud.githubusercontent.com/assets/1458628/23682869/c14bf09c-038d-11e7-8648-a8c25d66911d.jpg)
