### PR TITLE
Gene set oncoprint tracks

### DIFF
--- a/OPEN-SOURCE-DOCUMENTATION
+++ b/OPEN-SOURCE-DOCUMENTATION
@@ -129,6 +129,7 @@ cbioportal@googlegroups.com.
 * underscore-min
 * dataTables.fixedColumns
 * dc
+* ColorBrewer scheme: PiYG
 * crossfilter
 * packery.pkgd.min
 * d3.layout.cloud
@@ -18614,6 +18615,47 @@ Apache License
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+ColorBrewer scheme: PiYG
+------------------------
+Available under license:
+
+    Apache-Style Software License for ColorBrewer software and
+    ColorBrewer Color Schemes
+
+    Copyright (c) 2002 Cynthia Brewer, Mark Harrower, and The
+    Pennsylvania State University.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you
+    may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied. See the License for the specific language governing
+    permissions and limitations under the License.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions as source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    2. The end-user documentation included with the redistribution, if
+    any, must include the following acknowledgment:
+    "This product includes color specifications and designs developed by
+    Cynthia Brewer (http://colorbrewer.org/)."
+    Alternately, this acknowledgment may appear in the software itself,
+    if and wherever such third-party acknowledgments normally appear.
+    4. The name "ColorBrewer" must not be used to endorse or promote
+    products derived from this software without prior written
+    permission. For written permission, please contact Cynthia Brewer at
+    cbrewer@psu.edu.
+    5. Products derived from this software may not be called
+    "ColorBrewer", nor may "ColorBrewer" appear in their name, without
+    prior written permission of Cynthia Brewer.
 
 crossfilter
 -----------

--- a/portal/src/main/webapp/WEB-INF/jsp/oncoprint/main.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/oncoprint/main.jsp
@@ -71,7 +71,7 @@
                        <textarea id="add_genes_input" rows="5" cols="100" wordwrap="true" placeholder="Type space- or comma-separated genes here, then click 'Add Genes to Heatmap'"></textarea><br>
                        <button id="add_genes_btn" style='font-size:13px; cursor:pointer'>Add Genes to Heatmap</button> <br/>
                        <button id="remove_heatmaps_btn" style='font-size:13px; cursor:pointer'>Remove Heatmap</button> <br/>
-                       <div class="checkbox"><label style='cursor:pointer'><input id="cluster_heatmap_chk" type="checkbox"/>Cluster Heatmap</label></div>
+                       <div class="checkbox"><label id="cluster_heatmap_chk_lbl" style="cursor:pointer"><input id="cluster_heatmap_chk" type="checkbox"/>Cluster Heatmap</label></div>
                    </form>
                </div>
             </div>

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -1212,7 +1212,8 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 			    .then(function (profiles) {
 				fetch_promise.resolve(profiles.filter(function(profile) {
 				    return (profile.genetic_alteration_type === "MRNA_EXPRESSION" ||
-					    profile.genetic_alteration_type === "PROTEIN_LEVEL") &&
+					    profile.genetic_alteration_type === "PROTEIN_LEVEL" ||
+					    profile.genetic_alteration_type === "GENESET_SCORE") &&
 					    profile.show_profile_in_analysis_tab === "1";
 				}));
 		}).fail(function() {
@@ -1581,10 +1582,10 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 				cluster_input[case_ids[i]] = {};
 				//iterate over genetic entities and get the sample data (heatmap data has genetic entityId as key):
 				for (var j = 0; j < heatmapData.length; j++) {
-					var entityId = heatmapData[j].gene;
+					var entityId = heatmapData[j].gene || heatmapData[j].geneset_id;
 					//small validation/defensive programming:
 					if (!entityId) {
-						throw new Error("Unexpected error during getClusteringOrder: attribute 'gene' not found");
+						throw new Error("Unexpected error during getClusteringOrder: attribute 'gene' or 'geneset_id' not found");
 					}
 					var value = heatmapData[j].oncoprint_data[i].profile_data;
 					cluster_input[case_ids[i]][entityId] = value;

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -1497,6 +1497,28 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 	'getPatientHeatmapData': function(genetic_profile_id, genes) {
 	    return getHeatmapDataCached(this, genetic_profile_id, genes, 'patient');
 	},
+	'getSelectedGsvaProfile': makeCachedPromiseFunction(
+		function (self, fetch_promise) {
+		    self.getGeneticProfiles()
+		    .then(function (geneticProfiles) {
+			var genesetProfile = null;
+			for (var i = 0; i < geneticProfiles.length; i++) {
+			    var profile = geneticProfiles[i];
+			    if (profile.genetic_alteration_type === "GENESET_SCORE" &&
+				    profile.datatype === "GSVA-SCORE") {
+				if (genesetProfile !== null) {
+				    throw new Error("Programming error: " +
+					    "multiple geneset score profiles " +
+					    "were selected in the Oncoprint");
+				}
+				genesetProfile = profile;
+			    }
+			}
+			fetch_promise.resolve(genesetProfile);
+		    }).fail(function () {
+			fetch_promise.reject();
+		    });
+		}),
 	/**
 	 * Fetches any sample-level GSVA data for the queried Oncoprint parameters.
 	 *

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -1653,9 +1653,14 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 		    }).fail(function () {
 			fetch_promise.reject();
 		    }).then(function () {
-		        var filtered_genetic_profile_ids = self.getGeneticProfileIds().filter(function(v) {
-                            return profile_types[v] !== "GENESET_SCORE";
-                        });
+			if (self.getQueryGenes() === null || self.getQueryGenes().length === 0) {
+			    // no genetic alteration tracks to populate, return with a resolved promise
+			    fetch_promise.resolve([]);
+			    return;
+			}
+			var filtered_genetic_profile_ids = self.getGeneticProfileIds().filter(function(v) {
+			    return profile_types[v] !== "GENESET_SCORE";
+			});
 			var num_calls = filtered_genetic_profile_ids.length;
 			var all_data = [];
 			for (var i = 0; i < filtered_genetic_profile_ids.length; i++) {
@@ -1865,6 +1870,10 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 	}),
 	'getOncoprintSampleGenomicEventData': makeCachedPromiseFunctionWithSessionFilterOption(
 		function (self, fetch_promise, use_session_filters) {
+	    // if no genes were queried, resolve with an empty list
+	    if (self.getQueryGenes() === null || self.getQueryGenes() === 0) {
+		return fetch_promise.resolve([]).promise();
+	    }
 	    $.when((use_session_filters ? self.getSessionFilteredWebServiceGenomicEventData() : self.getWebServiceGenomicEventData()), 
 	    self.getStudySampleMap(), 
 	    self.getCaseUIDMap(),
@@ -2001,6 +2010,11 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 	}),
 	'getOncoprintPatientGenomicEventData': makeCachedPromiseFunctionWithSessionFilterOption(
 		function (self, fetch_promise, use_session_filters) {
+	    // if no genes were queried, resolve with an empty list
+	    if (self.getQueryGenes() === null || self.getQueryGenes() === 0) {
+		fetch_promise.resolve([]);
+		return;
+	    }
 	    $.when((use_session_filters ? self.getSessionFilteredWebServiceGenomicEventData() : self.getWebServiceGenomicEventData()), 
 	    self.getStudyPatientMap(), 
 	    self.getPatientSampleIdMap(), 

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -928,7 +928,7 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 		    interim_datum.profile_data = parseFloat(receive_datum.profile_data);
 		} else if (sample_or_patient === "sample") {
 		    // this would be a programming error (unexpected output from getGeneticProfileDataBySample)
-		    throw Error("Unexpectedly received multiple heatmap profile data for one sample");
+		    throw new Error("Unexpectedly received multiple heatmap profile data for one sample");
 		} else {
 		    // aggregate samples for this patient by selecting the highest absolute (Z-)score
 		    if (Math.abs(parseFloat(receive_datum.profile_data)) >
@@ -1017,7 +1017,144 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 	    return def.promise();
 	};
     })();
-    
+
+    /**
+     * One cell of sample-level gene set data for the Oncoprint
+     *
+     * @typedef {Object} OncoprintGenesetSampleDatum
+     * @property {string} geneset_id - gene set identifier for this track
+     * @property {string} study - identifier of the study to which this sample belongs
+     * @property {string} sample - identifier of the sample
+     * @property {number} uid - cross-study identifier of this sample in the current Oncoprint
+     * @property {number} profile_data - score of the sample or patient for this gene set
+     */
+    /**
+     * One cell of patient-level gene set data for the Oncoprint
+     *
+     * @typedef {Object} OncoprintGenesetPatientDatum
+     * @property {string} geneset_id - gene set identifier for this track
+     * @property {string} study - identifier of the study to which this patient belongs
+     * @property {string} patient - identifier of the patient
+     * @property {number} uid - cross-study identifier of this patient in the current Oncoprint
+     * @property {number} profile_data - score of the sample or patient for this gene set
+     */
+    /**
+     * One track of heatmap data for the Oncoprint
+     *
+     * @typedef {Object} OncoprintGenesetDataTrack
+     * @property {string} geneset_id - gene set identifier for this track
+     * @property {string} genetic_profile_id - identifier of the genetic profile used for this track
+     * @property {OncoprintGenesetSampleDatum[]|OncoprintGenesetPatientDatum[]} oncoprint_data -
+     * list of objects for individual samples or patients
+     */
+    /**
+     * Fetches Oncoprint heatmap data per gene track for the given profile per sample or patient.
+     *
+     * @param {string} genetic_profile_id - identifier of the genetic profile to query
+     * @param {string[]} geneset_ids - list of gene set identifiers for which to return data
+     * @param {string} sample_or_patient - whether to return data per sample or aggregate to patient level
+     * @returns {Promise<OncoprintGenesetDataTrack[]>}
+     */
+    var getGenesetData = function (genetic_profile_id, geneset_ids, sample_or_patient) {
+	var def = new $.Deferred();
+	// TODO: handle  more than one study
+	var study_id = this.getCancerStudyIds()[0];
+	var sample_ids = this.getSampleIds();
+	var deferred_case_ids = sample_or_patient === "sample" ? sample_ids : this.getPatientIds();
+	geneset_ids = geneset_ids || [];
+	sample_or_patient = sample_or_patient || "sample";
+	var deferred_profile_data, case_set_id = this.getCaseSetId();
+	if (!case_set_id || case_set_id === "-1") {
+	    deferred_profile_data = window.cbioportal_client.getGenesetDataBySample({
+		"genetic_profile_id": [genetic_profile_id],
+		"geneset_ids": geneset_ids,
+		"sample_ids": sample_ids
+	    });
+	} else {
+	    deferred_profile_data = new $.Deferred();
+	    window.cbioportal_client.getGenesetDataBySampleList({
+		"genetic_profile_id": [genetic_profile_id],
+		"geneset_ids": geneset_ids,
+		"sample_list_id": [case_set_id]
+	    }).then(function (data, textStatus, jqXHR) {
+		// the client function returns a jQuery jqXHR object
+		// which resolves with three arguments; the when below
+		// needs a promise that resolves with one
+		deferred_profile_data.resolve(data);
+	    });
+	}
+	$.when(
+	    deferred_profile_data,
+	    this.getPatientSampleIdMap(),
+	    deferred_case_ids,
+	    this.getCaseUIDMap()
+	).then(function (profile_data,
+		sample_to_patient_map,
+		case_ids,
+		case_uid_map) {
+	    var i, j;
+	    var geneset_id, case_id;
+	    // create an object for each sample or patient in each gene set
+	    var data_by_id = Object.create(null);
+	    for (i = 0; i < geneset_ids.length; i++) {
+		geneset_id = geneset_ids[i];
+		data_by_id[geneset_id] = Object.create(null);
+		for (j = 0; j < case_ids.length; j++) {
+		    case_id = case_ids[j];
+		    data_by_id[geneset_id][case_id] = {};
+		    data_by_id[geneset_id][case_id].geneset_id = geneset_id;
+		    data_by_id[geneset_id][case_id].study = study_id;
+		    data_by_id[geneset_id][case_id][sample_or_patient] = case_id;
+		    // index the UID map by sample or patient as appropriate
+		    data_by_id[geneset_id][case_id].uid = case_uid_map[study_id][case_id];
+		    data_by_id[geneset_id][case_id].profile_data = null;
+		}
+	    }
+
+	    // fill profile_data properties with scores
+	    var sample_id, sample_score;
+	    for (i = 0; i < profile_data.length; i++) {
+		geneset_id = profile_data[i].genesetId;
+		sample_id = profile_data[i].sampleId;
+		sample_score = parseFloat(profile_data[i].value);
+		case_id = (sample_or_patient === "sample" ? sample_id : sample_to_patient_map[sample_id]);
+		if (data_by_id[geneset_id][case_id].profile_data === null) {
+		    // set the initial value for this sample or patient
+		    data_by_id[geneset_id][case_id].profile_data = sample_score;
+		} else if (sample_or_patient === "sample") {
+		    // this would be a programming error (unexpected output from getGeneticDataBySample)
+		    throw new Error("Unexpectedly received multiple gene set profile data for one sample");
+		} else {
+		    // aggregate samples for this patient by selecting the highest absolute (GSVA-)score
+		    if (Math.abs(sample_score) > Math.abs(data_by_id[geneset_id][case_id].profile_data)) {
+			data_by_id[geneset_id][case_id].profile_data = sample_score;
+		    }
+		}
+	    }
+
+	    // construct the list to be returned
+	    var track_list = [];
+	    var track_data, oncoprint_data;
+	    for (i = 0; i < geneset_ids.length; i++) {
+		geneset_id = geneset_ids[i];
+		track_data = {};
+		track_data.geneset_id = geneset_id;
+		track_data.genetic_profile_id = genetic_profile_id;
+		oncoprint_data = [];
+		for (j = 0; j < case_ids.length; j++) {
+		    case_id = case_ids[j];
+		    oncoprint_data.push(data_by_id[geneset_id][case_id]);
+		}
+		track_data.oncoprint_data = oncoprint_data;
+		track_list.push(track_data);
+	    }
+	    def.resolve(track_list);
+	}).fail(function () {
+	    def.reject();
+	});
+	return def.promise();
+    };
+
     return {
 	'known_mutation_settings': {
 	    'ignore_unknown': false,
@@ -1360,6 +1497,50 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 	'getPatientHeatmapData': function(genetic_profile_id, genes) {
 	    return getHeatmapDataCached(this, genetic_profile_id, genes, 'patient');
 	},
+	/**
+	 * Fetches any sample-level GSVA data for the queried Oncoprint parameters.
+	 *
+	 * @returns {Promise<OncoprintGenesetDataTrack[]>}
+	 */
+	'getSampleGsvaData': makeCachedPromiseFunction(
+		function (self, fetch_promise) {
+		    self.getSelectedGsvaProfile()
+		    .then(function (gsvaProfile) {
+			console.log("fetching uncached sample-level GSVA data.");
+			var trackListPromise = [];
+			if (gsvaProfile !== null) {
+			    trackListPromise = getGenesetData.call(
+				    self, gsvaProfile.id, self.getQueryGenesets(), "sample");
+			}
+			return trackListPromise;
+		    }).done(function (trackList) {
+			fetch_promise.resolve(trackList);
+		    }).fail(function () {
+			fetch_promise.reject();
+		    });
+		}),
+	/**
+	 * Fetches any patient-level GSVA data for the queried Oncoprint parameters.
+	 *
+	 * @returns {Promise<OncoprintGenesetDataTrack[]>}
+	 */
+	'getPatientGsvaData': makeCachedPromiseFunction(
+		function (self, fetch_promise) {
+		    self.getSelectedGsvaProfile()
+		    .then(function (gsvaProfile) {
+			console.log("fetching uncached patient-level GSVA data.");
+			var trackListPromise = [];
+			if (gsvaProfile !== null) {
+			    trackListPromise = getGenesetData.call(
+				    self, gsvaProfile.id, self.getQueryGenesets(), "patient");
+			}
+			return trackListPromise;
+		    }).done(function (trackList) {
+			fetch_promise.resolve(trackList);
+		    }).fail(function () {
+			fetch_promise.reject();
+		    });
+		}),
 	'getExternalDataStatus': makeCachedPromiseFunction(
 		function(self, fetch_promise) {
 		    self.getWebServiceGenomicEventData().then(function() {

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -131,6 +131,8 @@ var tooltip_utils = {
 		data_header = 'MRNA: ';
 	    } else if (genetic_alteration_type === "PROTEIN_LEVEL") {
 		data_header = 'PROT: ';
+	    } else if (genetic_alteration_type === "GENESET_SCORE") {
+		data_header = 'GSVA: ';
 	    }
 	    if (d.profile_data) {
 		profile_data = d.profile_data.toString();
@@ -672,6 +674,7 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			
 			var total_tracks_to_add = Object.keys(State.genetic_alteration_tracks).length
 						+ heatmap_data.length
+						+ Object.keys(State.geneset_tracks).length
 						+ Object.keys(State.clinical_tracks).length;
 			
 			utils.timeoutSeparatedLoop(Object.keys(State.genetic_alteration_tracks), function (track_line, i) {
@@ -697,7 +700,26 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 					oncoprint.setTrackData(track_id, heatmap_track_data.oncoprint_data, 'uid');
 					oncoprint.setTrackTooltipFn(track_id, tooltip_utils.makeHeatmapTrackTooltip(heatmap_track_data.genetic_alteration_type, 'sample', true));
 					LoadingBar.update((i + Object.keys(State.genetic_alteration_tracks).length) / total_tracks_to_add);
+				});
+			}).then(function () {
+			    return QuerySession.getSelectedGsvaProfile();
+			}).then(function (gsva_profile) {
+			    if (gsva_profile !== null) {
+				console.log("in populateSampleData, calling QuerySession.getSampleGsvaData()");
+				return QuerySession.getSampleGsvaData()
+				.then(function (gsva_data_by_line) {
+				    return utils.timeoutSeparatedLoop(Object.keys(State.geneset_tracks), function(gs_line, i) {
+					console.log("geneset data retrieved, populating sample data for track " + gsva_data_by_line[gs_line].hugo_gene_symbol);
+					var gs_id = State.geneset_tracks[gs_line];
+					oncoprint.setTrackData(gs_id, gsva_data_by_line[gs_line].oncoprint_data, 'uid');
+					// TODO: use something more appropriate than makeHeatmapTrackTooltip
+					oncoprint.setTrackTooltipFn(gs_id, tooltip_utils.makeHeatmapTrackTooltip(gsva_profile.genetic_alteration_type, 'sample', true));
+					LoadingBar.update((i +
+						heatmap_data.length +
+						Object.keys(State.genetic_alteration_tracks).length) / total_tracks_to_add);
 				    });
+				});
+			    }
 			}).then(function () {
 			    return utils.timeoutSeparatedLoop(Object.keys(State.clinical_tracks), function(track_id, i) {
 				var attr = State.clinical_tracks[track_id];
@@ -705,7 +727,10 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 				oncoprint.setTrackData(track_id, clinical_data[attr.attr_id], 'uid');
 				oncoprint.setTrackTooltipFn(track_id, tooltip_utils.makeClinicalTrackTooltip(attr, 'sample', true));
 				oncoprint.setTrackInfo(track_id, "");
-				LoadingBar.update((i + heatmap_data.length + Object.keys(State.genetic_alteration_tracks).length) / total_tracks_to_add);
+				LoadingBar.update((i +
+					Object.keys(State.geneset_tracks).length +
+					heatmap_data.length +
+					Object.keys(State.genetic_alteration_tracks).length) / total_tracks_to_add);
 			    });
 			}).then(function () {
 			    console.log("sample data populated, releasing rendering");
@@ -752,6 +777,7 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			
 			var total_tracks_to_add = Object.keys(State.genetic_alteration_tracks).length
 						+ heatmap_data.length
+						+ Object.keys(State.geneset_tracks).length
 						+ Object.keys(State.clinical_tracks).length;
 			
 			utils.timeoutSeparatedLoop(Object.keys(State.genetic_alteration_tracks), function (track_line, i) {
@@ -779,13 +805,35 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 					LoadingBar.update((i + Object.keys(State.genetic_alteration_tracks).length) / total_tracks_to_add);
 				    });
 			}).then(function () {
+			    return QuerySession.getSelectedGsvaProfile();
+			}).then(function (gsva_profile) {
+			    if (gsva_profile !== null) {
+				console.log("in populatePatientData, calling QuerySession.getPatientGsvaData()");
+				return QuerySession.getPatientGsvaData()
+				.then(function (gsva_data_by_line) {
+				    return utils.timeoutSeparatedLoop(Object.keys(State.geneset_tracks), function(gs_line, i) {
+					console.log("gene set data retrieved, populating sample data for track " + gsva_data_by_line[gs_line].geneset_id);
+					var gs_id = State.geneset_tracks[gs_line];
+					oncoprint.setTrackData(gs_id, gsva_data_by_line[gs_line].oncoprint_data, 'uid');
+					// TODO: use something more appropriate than makeHeatmapTrackTooltip
+					oncoprint.setTrackTooltipFn(gs_id, tooltip_utils.makeHeatmapTrackTooltip(gsva_profile.genetic_alteration_type, 'patient', true));
+					LoadingBar.update((i +
+						heatmap_data.length +
+						Object.keys(State.genetic_alteration_tracks).length) / total_tracks_to_add);
+				    });
+				});
+			    }
+			}).then(function () {
 			    return utils.timeoutSeparatedLoop(Object.keys(State.clinical_tracks), function(track_id, i) {
 				var attr = State.clinical_tracks[track_id];
 				console.log("populating patient data for clinical track " + attr.attr_id);
 				oncoprint.setTrackData(track_id, clinical_data[attr.attr_id], 'uid');
 				oncoprint.setTrackTooltipFn(track_id, tooltip_utils.makeClinicalTrackTooltip(attr, 'patient', true));
 				oncoprint.setTrackInfo(track_id, "");
-				LoadingBar.update((i + heatmap_data.length + Object.keys(State.genetic_alteration_tracks).length) / total_tracks_to_add);
+				LoadingBar.update((i +
+					Object.keys(State.geneset_tracks).length +
+					heatmap_data.length +
+					Object.keys(State.genetic_alteration_tracks).length) / total_tracks_to_add);
 			    });
 			}).then(function () {
 			    console.log("patient data populated");
@@ -941,6 +989,8 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 	    'first_genetic_alteration_track': null,
 	    'genetic_alteration_tracks': {}, // oql line -> track_id
 	    'heatmap_track_groups': {}, // genetic_profile_id -> {genetic_profile_id, track_group_id, gene_to_track_id}
+	    'GENESET_HEATMAP_TRACK_GROUP_INDEX': 30,
+	    'geneset_tracks': {},  // index of queried gene set -> track_id
 	    'clinical_tracks': {}, // track_id -> attr
 	    
 	    'used_clinical_attributes': [],
@@ -1152,6 +1202,61 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			return populateHeatmapTrack(genetic_profile_id, gene, track_id);
 		    }
 		}));
+	    },
+	    'addGenesetTracks': function (genetic_profile_id, geneset_ids) {
+		oncoprint.suppressRendering();
+		var track_ids = [];
+		var i, track_geneset_id, track_params, new_track_id;
+		for (i = 0; i < geneset_ids.length; i++) {
+		    track_geneset_id = geneset_ids[i];
+		    track_params = {
+			'rule_set_params': {
+			    'type': 'gradient',
+			    'legend_label': 'Geneset score',
+			    'value_key': 'profile_data',
+			    'value_range': [-1, 1],
+			    /*
+			     * The PiYG colormap is based on color specifications and designs
+			     * developed by Cynthia Brewer (http://colorbrewer.org).
+			     * The palette has been included under the terms
+			     * of an Apache-stype license (for details, see the file
+			     * OPEN-SOURCE-DOCUMENTATION in the root directory of the cBioPortal
+			     * source distribution).
+			     */
+			    'colors': [
+				[ 39, 100,  25, 1],
+				[ 77, 146,  33, 1],
+				[127, 188,  65, 1],
+				[184, 225, 134, 1],
+				[230, 245, 208, 1],
+				[247, 247, 247, 1],
+				[253, 224, 239, 1],
+				[241, 182, 218, 1],
+				[222, 119, 174, 1],
+				[197,  27, 125, 1],
+				[142,   1,  82, 1]
+			    ],
+			    'value_stop_points': [-1, -0.8, -0.6, -0.4, -0.2,
+				0, 0.2, 0.4, 0.6, 0.8, 1],
+			    'null_color': 'rgba(224,224,224,1)'
+			},
+			'track_label_color': 'grey',
+			'has_column_spacing': false,
+			'track_padding': 0,
+			'label': track_geneset_id,
+			'target_group': this.GENESET_HEATMAP_TRACK_GROUP_INDEX,
+			'removable': true,
+			'description': track_geneset_id + ' gene set scores from ' + genetic_profile_id,
+		    };
+		    new_track_id = oncoprint.addTracks([track_params])[0];
+		    track_ids.push(new_track_id);
+		    if (typeof this.geneset_tracks[0] !== 'undefined') {
+			oncoprint.shareRuleSet(this.geneset_tracks[0], new_track_id);
+		    }
+		    this.geneset_tracks[i] = new_track_id;
+		}
+		oncoprint.releaseRendering();
+		return track_ids;
 	    },
 	    'useAndAddAttribute': function(attr_id) {
 		var attr = this.useAttribute(attr_id);
@@ -1599,6 +1704,18 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 	    });
 	    var ret = $.when.apply(null, promises);
 	    return ret;
+	}).then(function () {
+	    var queried_gene_sets = QuerySession.getQueryGenesets();
+	    if (queried_gene_sets !== null && queried_gene_sets.length > 0) {
+		return QuerySession.getSelectedGsvaProfile()
+		.then(function (gsva_profile) {
+		    console.log("in initOncoprint, adding gene set tracks");
+		    State.addGenesetTracks(gsva_profile.id, queried_gene_sets);
+		});
+	    } else {
+		// nothing to do for gene set tracks; return a resolved promise
+		return $.when();
+	    }
 	}).then(function fetchClinicalAttributes() {
 	    console.log("in initOncoprint, fetching clinical attributes");
 	    QuerySession.getClinicalAttributes()

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -927,6 +927,10 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 	};
 	
 	var updateAlteredPercentIndicator = function(state) {
+	    if (QuerySession.getQueryGenes() === null ||
+		    QuerySession.getQueryGenes().length === 0) {
+		return;
+	    }
 	    $.when(QuerySession.getSequencedSamples(), QuerySession.getSequencedPatients(), QuerySession.getPatientIds())
 		    .then(function(sequenced_samples, sequenced_patients, patients) {
 			var altered_ids = state.getAlteredIds();
@@ -1927,7 +1931,10 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 		    })(profiles[i]);
 		}
 
-		$(toolbar_selector + ' #oncoprint_diagram_heatmap_menu #add_genes_input').val(QuerySession.getQueryGenes().join(" "));
+		var query_genes = QuerySession.getQueryGenes();
+		if (query_genes !== null && query_genes.length > 0) {
+		    $(toolbar_selector + ' #oncoprint_diagram_heatmap_menu #add_genes_input').val(query_genes.join(" "));
+		}
 		$(toolbar_selector + ' #oncoprint_diagram_heatmap_menu #oncoprint_diagram_heatmap_profiles').click(function (evt) {
 		    // suppress dropdown hiding
 		    evt.stopPropagation();

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
@@ -1596,6 +1596,7 @@ var OncoprintLabelView = (function () {
 	this.cell_heights_view_space = {};
 	this.label_middles_view_space = {};
 	this.labels = {};
+	this.label_colors = {};
 	this.track_descriptions = {};
 	this.tracks = [];
 	this.minimum_track_height = Number.POSITIVE_INFINITY;
@@ -1738,6 +1739,10 @@ var OncoprintLabelView = (function () {
 	view.ctx.fillStyle = 'black';
 	var tracks = view.tracks;
 	for (var i=0; i<tracks.length; i++) {
+	    if (view.label_colors && view.label_colors[tracks[i]]) {
+		//override color, if set:
+		view.ctx.fillStyle = view.label_colors[tracks[i]];
+	    }
 	    view.ctx.fillText(shortenLabelIfNecessary(view, view.labels[tracks[i]]), 0, view.label_middles_view_space[tracks[i]]);
 	}
 	if (view.dragged_label_track_id !== null) {
@@ -1855,6 +1860,7 @@ var OncoprintLabelView = (function () {
     OncoprintLabelView.prototype.addTracks = function (model, track_ids) {
 	for (var i=0; i<track_ids.length; i++) {
 	    this.labels[track_ids[i]] = model.getTrackLabel(track_ids[i]);
+	    this.label_colors[track_ids[i]] = model.getTrackLabelColor(track_ids[i]);
 	}
 	updateFromModel(this, model);
 	resizeAndClear(this, model);
@@ -3180,6 +3186,7 @@ var OncoprintModel = (function () {
 	
 	// Track Properties
 	this.track_label = {};
+	this.track_label_color = {};
 	this.track_description = {};
 	this.cell_height = {};
 	this.track_padding = {};
@@ -3724,7 +3731,7 @@ var OncoprintModel = (function () {
 		    params.data_id_key, params.tooltipFn,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction,
-		    params.data, params.rule_set);
+		    params.data, params.rule_set, params.track_label_color);
 	}
 	this.track_tops.update();
     }
@@ -3734,8 +3741,9 @@ var OncoprintModel = (function () {
 	    data_id_key, tooltipFn,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction,
-	    data, rule_set) {
+	    data, rule_set, track_label_color) {
 	model.track_label[track_id] = ifndef(label, "Label");
+	model.track_label_color[track_id] = ifndef(track_label_color, "black");
 	model.track_description[track_id] = ifndef(description, "");
 	model.cell_height[track_id] = ifndef(cell_height, 23);
 	model.track_padding[track_id] = ifndef(track_padding, 5);
@@ -4030,6 +4038,10 @@ var OncoprintModel = (function () {
 
     OncoprintModel.prototype.getTrackLabel = function (track_id) {
 	return this.track_label[track_id];
+    }
+    
+    OncoprintModel.prototype.getTrackLabelColor = function (track_id) {
+	return this.track_label_color[track_id];
     }
     
     OncoprintModel.prototype.getTrackDescription = function(track_id) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
@@ -18,6 +18,7 @@ var OncoprintLabelView = (function () {
 	this.cell_heights_view_space = {};
 	this.label_middles_view_space = {};
 	this.labels = {};
+	this.label_colors = {};
 	this.track_descriptions = {};
 	this.tracks = [];
 	this.minimum_track_height = Number.POSITIVE_INFINITY;
@@ -160,6 +161,10 @@ var OncoprintLabelView = (function () {
 	view.ctx.fillStyle = 'black';
 	var tracks = view.tracks;
 	for (var i=0; i<tracks.length; i++) {
+	    if (view.label_colors && view.label_colors[tracks[i]]) {
+		//override color, if set:
+		view.ctx.fillStyle = view.label_colors[tracks[i]];
+	    }
 	    view.ctx.fillText(shortenLabelIfNecessary(view, view.labels[tracks[i]]), 0, view.label_middles_view_space[tracks[i]]);
 	}
 	if (view.dragged_label_track_id !== null) {
@@ -277,6 +282,7 @@ var OncoprintLabelView = (function () {
     OncoprintLabelView.prototype.addTracks = function (model, track_ids) {
 	for (var i=0; i<track_ids.length; i++) {
 	    this.labels[track_ids[i]] = model.getTrackLabel(track_ids[i]);
+	    this.label_colors[track_ids[i]] = model.getTrackLabelColor(track_ids[i]);
 	}
 	updateFromModel(this, model);
 	resizeAndClear(this, model);

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintmodel.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintmodel.js
@@ -128,6 +128,7 @@ var OncoprintModel = (function () {
 	
 	// Track Properties
 	this.track_label = {};
+	this.track_label_color = {};
 	this.track_description = {};
 	this.cell_height = {};
 	this.track_padding = {};
@@ -672,7 +673,7 @@ var OncoprintModel = (function () {
 		    params.data_id_key, params.tooltipFn,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction,
-		    params.data, params.rule_set);
+		    params.data, params.rule_set, params.track_label_color);
 	}
 	this.track_tops.update();
     }
@@ -682,8 +683,9 @@ var OncoprintModel = (function () {
 	    data_id_key, tooltipFn,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction,
-	    data, rule_set) {
+	    data, rule_set, track_label_color) {
 	model.track_label[track_id] = ifndef(label, "Label");
+	model.track_label_color[track_id] = ifndef(track_label_color, "black");
 	model.track_description[track_id] = ifndef(description, "");
 	model.cell_height[track_id] = ifndef(cell_height, 23);
 	model.track_padding[track_id] = ifndef(track_padding, 5);
@@ -978,6 +980,10 @@ var OncoprintModel = (function () {
 
     OncoprintModel.prototype.getTrackLabel = function (track_id) {
 	return this.track_label[track_id];
+    }
+    
+    OncoprintModel.prototype.getTrackLabelColor = function (track_id) {
+	return this.track_label_color[track_id];
     }
     
     OncoprintModel.prototype.getTrackDescription = function(track_id) {


### PR DESCRIPTION
This PR is part of the Gene Sets implementation done by The Hyve.

Changes proposed in this pull request:
* Add gene set score heatmap tracks to the Oncoprint

  Based on the queried gene set score profiles, add a special track group
  underneath all other tracks, that displays the scores in a heatmap with
  a distinct colour scheme.

* Enable Oncoprint queries with only gene sets (and no genes)

## Screenshot ##
![Screenshot of an Oncoprint view containing a clustered heatmap of gene set scores](https://cloud.githubusercontent.com/assets/4929431/23707527/0971afee-0413-11e7-97f3-7b213b32382f.png)

## How to test ##
* In [`docs/Import-Gene-Sets.md`](https://github.com/cBioPortal/cbioportal/blob/geneset_importer/docs/Import-Gene-Sets.md) we have included both a [quick example](https://github.com/cBioPortal/cbioportal/blob/geneset_importer/docs/Import-Gene-Sets.md#quick-example) to import gene sets, gene set hierarchy, gene set test study, as well as a complete description of the import process.
* An updated Seed-DB to 2.1.0, including all 18025 MSigDB gene sets, a hierarchical tree yaml file and a loadable test study (`gbm_tcga`) with GSVA scores and pvalues can be found in [this PR to Datahub](https://github.com/cBioPortal/datahub/pull/25).
* At a later time we will provide a test server that includes all gene set PRs