### PR TITLE
Adjust migration.sql to match cgds.sql history

### DIFF
--- a/db-scripts/src/main/resources/migration.sql
+++ b/db-scripts/src/main/resources/migration.sql
@@ -213,7 +213,7 @@ CREATE TABLE `genetic_entity` (
 );
 -- update gene table to use genetic_element:
 ALTER TABLE `gene` 
-ADD COLUMN `GENETIC_ENTITY_ID` INT NULL;
+ADD COLUMN `GENETIC_ENTITY_ID` INT NULL AFTER `HUGO_GENE_SYMBOL`;
 
 -- add temporary column to support migration:
 ALTER TABLE `genetic_entity` 
@@ -235,11 +235,7 @@ CHANGE COLUMN `GENETIC_ENTITY_ID` `GENETIC_ENTITY_ID` INT NOT NULL,
 ADD UNIQUE INDEX `GENETIC_ENTITY_ID_UNIQUE` (`GENETIC_ENTITY_ID` ASC);
 
 ALTER TABLE `gene` 
-ADD CONSTRAINT `fk_gene_1`
-  FOREIGN KEY (`GENETIC_ENTITY_ID`)
-  REFERENCES `genetic_entity` (`ID`)
-  ON DELETE NO ACTION
-  ON UPDATE NO ACTION;
+ADD FOREIGN KEY (`GENETIC_ENTITY_ID`) REFERENCES `genetic_entity` (`ID`) ON DELETE CASCADE;
 
 -- migrate genetic_alteration table in a similar way, pointing to GENETIC_ENTITY_ID 
 -- instead of ENTREZ_GENE_ID (note: the INSERT part can take some time [~20 min], 


### PR DESCRIPTION
Partial Fixes for issue #2173

Changes proposed in this pull request:
- order of fields in gene table corrected
- foreign key cascade clause made to match
- also, cgds.sql does not name constraints, so that has been removed. We should investigate the naming of constraints and decide to apply this globally or not.

In this PR, migration.sql is made consistent with cgds.sql (taking cgds.sql as the definition of the table schemas).
In a future PR, some changes to cgds.sql and migration.sql will likely be added as well, potentially adding custom names to the foreign key constraints. Note that some installers who have previously used the erroneous migration.sql script will have non-matching database schemas in the databases .. this will include a different ordering of columns in the gene table. Installers will need to correct these differences manually if they cause problems. (Probably no problems will occur for normal use)

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@cBioPortal/backend
@pieterlukasse 
@jjgao 