### PR TITLE
Validator: Scientific notation and NA values

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1155,34 +1155,34 @@ class MutationsExtendedValidator(Validator):
     
     def checkVerificationStatus(self, value):
         # if value is not blank, then it should be one of these:
-        if self.checkNotBlank(value) and value.lower() not in ('verified', 'unknown'):
+        if self.checkNotBlank(value) and value.lower() not in ('verified', 'unknown', 'na'):
             return False
         return True
     
     def checkValidationStatus(self, value):
         # if value is not blank, then it should be one of these:
         if self.checkNotBlank(value) and value.lower() not in ('untested', 'inconclusive',
-                                 'valid', 'invalid'):
+                                 'valid', 'invalid', 'na'):
             return False
         return True
     
     def check_t_alt_count(self, value):
-        if not self.checkInt(value) and value != '':
+        if not self.checkInt(value) and value not in ('', '.'):
             return False
         return True
     
     def check_t_ref_count(self, value):
-        if not self.checkInt(value) and value != '':
+        if not self.checkInt(value) and value not in ('', '.'):
             return False
         return True
     
     def check_n_alt_count(self, value):
-        if not self.checkInt(value) and value != '':
+        if not self.checkInt(value) and value not in ('', '.'):
             return False
         return True
 
     def check_n_ref_count(self, value):
-        if not self.checkInt(value) and value != '':
+        if not self.checkInt(value) and value not in ('', '.'):
             return False
         return True
 
@@ -1912,6 +1912,12 @@ class SegValidator(Validator):
                                'cause': value})
             elif col_name in ('loc.start', 'loc.end'):
                 try:
+                    # convert possible scientific notation to python scientific notation
+                    if "e+" in value:
+                        value = float(value.replace("e+", "e"))
+                        if not value.is_integer():
+                            # raise value error 'Genomic position is not an integer'
+                            raise ValueError()
                     parsed_coords[col_name] = int(value)
                 except ValueError:
                     self.logger.error(


### PR DESCRIPTION
# What? Why?
Add some possible scenarios that should not error. When recreating staging files for the CCLE study, I noticed some values are causing errors in the validator. The importer does not complain about them. As far as I noticed, these values do not break anything.

The first fix is for when a chromosomal location is written in scientific notation, such as `115,000,000` written as `1.15e+08` in the CNA segmented data:

![screen shot 2017-03-16 at 10 32 44](https://cloud.githubusercontent.com/assets/9624990/23989856/5f8bf2d2-0a34-11e7-9764-ecb3b8f5efe6.png)

The second fix affects a couple of optional columns in the mutations data, after running Maf2Maf:

![screen shot 2017-03-16 at 10 32 55](https://cloud.githubusercontent.com/assets/9624990/23989857/5fa82b32-0a34-11e7-9014-43df4ba0ea26.png)
