### PR TITLE
Extra details for HTTPS config in SAML scenario

### DIFF
--- a/docs/Authenticating-Users-via-SAML.md
+++ b/docs/Authenticating-Users-via-SAML.md
@@ -111,6 +111,16 @@ If you need to export the public certificate associated within your keystore, ru
 
     keytool -export -keystore samlKeystore.jks -alias secure-key -file cBioPortal.cer
 
+##### HTTPS and Tomcat
+
+:warning: If you already have an official (non-self-signed) SSL certificate, and need to get your site 
+running on HTTPS directly from Tomcat, then you need to import your certificate into the keystore instead. 
+See [this Tomcat documentation page](https://tomcat.apache.org/tomcat-8.0-doc/ssl-howto.html) for more details.
+
+:warning: An extra warning for when configuring HTTPS for Tomcat: use the same password for 
+both keystore and secure-key. This seems to be an extra restriction by Tomcat.
+
+
 ## Modifying portal.properties
 
 Within portal.properties, make sure that:


### PR DESCRIPTION
# What? Why?
Some extra details regarding HTTPS setup in tomcat. 

HTTPS is relevant when working on a server that needs to be protected by authentication. In some cases, users might want to configure this directly on tomcat. There are some details that one should pay attention to when doing this in the context of configuring SAML as documented here. This PR adds these details to the SAML documentation. 

Changes proposed in this pull request:
- small extra paragraph about HTTPS configuration

# Notify reviewers
@mandawilson 