### PR TITLE
consistency and flexibility fixes to cgds db schema

### DIFF
--- a/db-scripts/src/main/resources/cgds.sql
+++ b/db-scripts/src/main/resources/cgds.sql
@@ -106,7 +106,7 @@ CREATE TABLE `type_of_cancer` (
 CREATE TABLE `cancer_study` (
   `CANCER_STUDY_ID` int(11) NOT NULL auto_increment,
   `CANCER_STUDY_IDENTIFIER` varchar(255),
-  `TYPE_OF_CANCER_ID` varchar(25) NOT NULL,
+  `TYPE_OF_CANCER_ID` varchar(63) NOT NULL,
   `NAME` varchar(255) NOT NULL,
   `SHORT_NAME` varchar(64) NOT NULL,
   `DESCRIPTION` varchar(1024) NOT NULL,
@@ -127,7 +127,7 @@ CREATE TABLE `users` (
   `NAME` varchar(255) NOT NULL,
   `ENABLED` BOOLEAN NOT NULL,
   PRIMARY KEY (`EMAIL`)
-) DEFAULT CHARSET=utf8;
+);
 
 -- --------------------------------------------------------
 CREATE TABLE `authorities` (
@@ -150,7 +150,7 @@ CREATE TABLE `sample` (
   `STABLE_ID` varchar(50) NOT NULL,
   `SAMPLE_TYPE` varchar(255) NOT NULL,
   `PATIENT_ID` int(11) NOT NULL,
-  `TYPE_OF_CANCER_ID` varchar(25) NOT NULL,
+  `TYPE_OF_CANCER_ID` varchar(63) NOT NULL,
   PRIMARY KEY (`INTERNAL_ID`),
   FOREIGN KEY (`PATIENT_ID`) REFERENCES `patient` (`INTERNAL_ID`) ON DELETE CASCADE,
   FOREIGN KEY (`TYPE_OF_CANCER_ID`) REFERENCES `type_of_cancer` (`TYPE_OF_CANCER_ID`)
@@ -703,6 +703,6 @@ CREATE TABLE `clinical_event_data` (
 -- --------------------------------------------------------
 CREATE TABLE `info` (
   `DB_SCHEMA_VERSION` varchar(24)
-) DEFAULT CHARSET=utf8;
+);
 -- THIS MUST BE KEPT IN SYNC WITH db.version PROPERTY IN pom.xml
-INSERT INTO info VALUES ('2.0.1');
+INSERT INTO info VALUES ('2.1.0');

--- a/db-scripts/src/main/resources/migration.sql
+++ b/db-scripts/src/main/resources/migration.sql
@@ -55,8 +55,6 @@ UPDATE info SET DB_SCHEMA_VERSION="1.2.1";
 ##version: 1.3.0
 DROP TABLE IF EXISTS `clinical_trial_keywords`;
 DROP TABLE IF EXISTS `clinical_trials`;
-ALTER TABLE `users` CONVERT TO CHARACTER SET utf8;
-ALTER TABLE `info` CONVERT TO CHARACTER SET utf8;
 ALTER TABLE `gene` MODIFY COLUMN `ENTREZ_GENE_ID` int(11) NOT NULL;
 ALTER TABLE `gene_alias` MODIFY COLUMN `ENTREZ_GENE_ID` int(11) NOT NULL;
 ALTER TABLE `uniprot_id_mapping` MODIFY COLUMN `ENTREZ_GENE_ID` int(11) NOT NULL;
@@ -211,9 +209,9 @@ CREATE TABLE `genetic_entity` (
   `ENTITY_TYPE` varchar(45) NOT NULL,
   PRIMARY KEY (`ID`)
 );
+
 -- update gene table to use genetic_element:
-ALTER TABLE `gene` 
-ADD COLUMN `GENETIC_ENTITY_ID` INT NULL AFTER `HUGO_GENE_SYMBOL`;
+ALTER TABLE `gene` ADD COLUMN `GENETIC_ENTITY_ID` INT NULL AFTER `HUGO_GENE_SYMBOL`;
 
 -- add temporary column to support migration:
 ALTER TABLE `genetic_entity` 
@@ -221,13 +219,11 @@ ADD COLUMN `TMP_GENE_ID` INT NOT NULL AFTER `ENTITY_TYPE`,
 ADD UNIQUE INDEX `TMP_GENE_ID_UNIQUE` (`TMP_GENE_ID` ASC);
 
 -- populate genetic_entity
-insert into genetic_entity (entity_type, tmp_gene_id)
-(Select 'GENE', ENTREZ_GENE_ID from gene);
+INSERT INTO genetic_entity (entity_type, tmp_gene_id)
+(SELECT 'GENE', ENTREZ_GENE_ID FROM gene);
 
 -- update gene table to have GENETIC_ENTITY_ID point to the correct one:
-UPDATE gene
-INNER JOIN genetic_entity ON gene.ENTREZ_GENE_ID = genetic_entity.TMP_GENE_ID
-SET GENETIC_ENTITY_ID = genetic_entity.ID;
+UPDATE gene INNER JOIN genetic_entity ON gene.ENTREZ_GENE_ID = genetic_entity.TMP_GENE_ID SET GENETIC_ENTITY_ID = genetic_entity.ID;
 
 -- add UQ and FK constraint for GENETIC_ENTITY_ID in gene table:
 ALTER TABLE `gene` 
@@ -252,8 +248,7 @@ CREATE TABLE `genetic_alteration_new` (
 INSERT INTO genetic_alteration_new
 (GENETIC_PROFILE_ID, GENETIC_ENTITY_ID, `VALUES`)
 SELECT genetic_alteration.GENETIC_PROFILE_ID, genetic_entity.ID, genetic_alteration.`VALUES`
-FROM genetic_alteration 
-INNER JOIN genetic_entity ON genetic_alteration.ENTREZ_GENE_ID = genetic_entity.TMP_GENE_ID;
+FROM genetic_alteration INNER JOIN genetic_entity ON genetic_alteration.ENTREZ_GENE_ID = genetic_entity.TMP_GENE_ID;
 
 -- drop old genetic_alteration
 DROP TABLE genetic_alteration;
@@ -261,12 +256,14 @@ DROP TABLE genetic_alteration;
 RENAME TABLE `genetic_alteration_new` TO `genetic_alteration`;
 -- drop temporary column:
 ALTER TABLE `genetic_entity` DROP COLUMN `TMP_GENE_ID`;
-
-
 -- ========================== end of genetic_entity related migration =============================================
-
 UPDATE info SET DB_SCHEMA_VERSION="2.0.0";
 
 ##version: 2.0.1
 ALTER TABLE `genetic_profile` MODIFY COLUMN `SHOW_PROFILE_IN_ANALYSIS_TAB` BOOLEAN NOT NULL;
 UPDATE info SET DB_SCHEMA_VERSION="2.0.1";
+
+##version: 2.1.0
+ALTER TABLE `cancer_study` MODIFY COLUMN `TYPE_OF_CANCER_ID` varchar(63) NOT NULL;
+ALTER TABLE `sample` MODIFY COLUMN `TYPE_OF_CANCER_ID` varchar(63) NOT NULL;
+UPDATE info SET DB_SCHEMA_VERSION="2.1.0";

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <tomcat.catalina.scope>provided</tomcat.catalina.scope>
 
     <!-- THIS SHOULD BE KEPT IN SYNC TO VERSION IN CGDS.SQL -->
-    <db.version>2.0.1</db.version>
+    <db.version>2.1.0</db.version>
 
   </properties>
 


### PR DESCRIPTION
# What? Why?
In enabling foreign key constraints, some discrepancies in field widths were noticed. These are adjusted in this PR, and we also remove references to character set encoding specifiers in cgds.sql and migration.sql. Choice of database engine and character set encoding will be left to installers to choose and manage according to their local policies and needs.

Changes proposed in this pull request:
- adjust fieldwidth of TYPE_OF_CANCER_ID to match across tables (for foreign key compatibility)
- drop references to utf8 character set encoding (we wish to allow deployers to choose their own encoding policy)
- some code style adjustments

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

\# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/backend
