### PR TITLE
Omit CIViC spinners in mutations tab if disabled

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/cross_cancer_results.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/cross_cancer_results.jsp
@@ -406,9 +406,11 @@ if (sessionError != null) {  %>
     <span class='annotation-item chang_hotspot' alt='{{changHotspotAlt}}'>
         <img width='{{hotspotsImgWidth}}' height='{{hotspotsImgHeight}}' src='{{hotspotsImgSrc}}' alt='Recurrent Hotspot Symbol'>
     </span>
+    <% if (showCivic) { %>
     <span class='annotation-item civic' proteinChange='{{proteinChange}}' geneSymbol='{{geneSymbol}}'>
         <img width='14' height='14' src='images/ajax-loader.gif' alt='Civic Variant Entry'>
     </span>
+    <% } %>
 </script>
 
 <script type="text/template" id="studies-with-no-data-tmpl">

--- a/portal/src/main/webapp/WEB-INF/jsp/mutation_details.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/mutation_details.jsp
@@ -53,9 +53,11 @@
     <span class='annotation-item chang_hotspot' alt='{{changHotspotAlt}}'>
         <img width='{{hotspotsImgWidth}}' height='{{hotspotsImgHeight}}' src='{{hotspotsImgSrc}}' alt='Recurrent Hotspot Symbol'>
     </span>
+    <% if (showCivic) { %>
     <span class='annotation-item civic' proteinChange='{{proteinChange}}' geneSymbol='{{geneSymbol}}'>
         <img width='14' height='14' src='images/ajax-loader.gif' alt='Civic Variant Entry'>
     </span>
+    <% } %>
 </script>
 
 <style type="text/css" title="currentStyle">


### PR DESCRIPTION
Due to a missed conditional, the Annotation column of the mutations
tab showed loading spinner icons for CIViC even if the integration
was disabled, both in the single-study and cross-cancer versions
of the query result views. This adds the conditional and omits the
tags as appropriate.

Tested both with integration enabled and disabled; behaves as I
would expect in both cases.