### PR TITLE
Hide unsequenced samples/patients in oncoprint

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/oncoprint/main.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/oncoprint/main.jsp
@@ -112,7 +112,7 @@
                </div>
             </div>
             <div class="btn-group btn-group-sm"   id="oncoprint_diagram_view_menu">
-               <button type="button" class="btn btn-default dropdown-toggle" id="oncoprint_diagram_mutation_color_dropdown" data-toggle="dropdown" style="background-color:#efefef;margin:0px">
+               <button type="button" class="btn btn-default dropdown-toggle" id="oncoprint_diagram_view_dropdown" data-toggle="dropdown" style="background-color:#efefef;margin:0px">
                  <span>View</span>&nbsp;<span class="caret"></span>
                </button>
                <div class="dropdown-menu" style="padding: 10px 5px; width: 270px;min-width: 270px;">
@@ -122,7 +122,8 @@
                            <div class="radio"><label><input type="radio" name="datatype"  value="sample"> Events per sample</label></div>
                            <div class="radio"><label><input type="radio" name="datatype"  value="patient"> Events per patient</label></div>
                        </fieldset>
-                       <div class="checkbox"><label><input type="checkbox" name="show_unaltered" value="show_unaltered"> Show unaltered columns</label></div>
+                       <div class="checkbox"><label><input type="checkbox" name="show_unsequenced" value="show_unsequenced"><span id="show_unsequenced_label"> Show unsequenced columns</span></label></div>
+                       <div class="checkbox"><label><input type="checkbox" name="show_unaltered" value="show_unaltered"><span id="show_unaltered_label">Show unaltered columns</span></label></div>
                        <div class="checkbox"><label><input type="checkbox" name="show_whitespace" value="show_whitespace"> Show whitespace between columns</label></div>
                        <div class="checkbox"><label><input type="checkbox" name="show_clinical_legends" value="show_clinical_legends"> Show legends for clinical tracks</label></div>
                    </form>
@@ -130,7 +131,7 @@
             </div>
             
             <div class="btn-group btn-group-sm"   id="oncoprint_diagram_download_menu">
-               <button type="button" class="btn btn-default dropdown-toggle" id="oncoprint_diagram_mutation_color_dropdown" data-toggle="dropdown" style="background-color:#efefef;margin:0px">
+               <button type="button" class="btn btn-default dropdown-toggle" id="oncoprint_diagram_download_dropdown" data-toggle="dropdown" style="background-color:#efefef;margin:0px">
                  <span>Download</span>&nbsp;<span class="caret"></span>
                </button>
                <div class="dropdown-menu" style="padding: 10px 5px; width: 70px;min-width: 70px;">

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -1733,6 +1733,91 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	    });
 	    return fetch_promise.promise();
 	}),
+	'getUnsequencedSamplesBasedOnSequencedSampleList': makeCachedPromiseFunction(
+		function(self, fetch_promise) {
+		    var sample_list_ids = self.getCancerStudyIds().map(function(cancer_study_id) {
+			return cancer_study_id + "_sequenced";
+		    });
+		    var sample_ids = self.getSampleIds();
+		    window.cbioportal_client.getSampleLists({'sample_list_ids':sample_list_ids}).then(function(sample_lists) {
+			fetch_promise.resolve(sample_lists.reduce(function(map, next) {
+			    var sequenced_samples = next.sample_ids.reduce(function(map, next) { map[next] = true; return map;}, {});
+			    var unsequenced_samples = sample_ids.reduce(function(map, next) {
+				if (!sequenced_samples[next]) {
+				    map[next] = true;
+				}
+				return map;
+			    }, {});
+			    map[next.study_id] = unsequenced_samples;
+			    return map;
+			}, {}));
+		    }).fail(function() {
+			fetch_promise.reject();
+		    });
+		}),
+	'getUnsequencedPatientsBasedOnSequencedSampleList': makeCachedPromiseFunction(
+		function(self, fetch_promise) {
+		    var sample_list_ids = self.getCancerStudyIds().map(function(cancer_study_id) {
+			return cancer_study_id + "_sequenced";
+		    });
+		    $.when(self.getPatientIds(), self.getPatientSampleIdMap(), window.cbioportal_client.getSampleLists({'sample_list_ids':sample_list_ids})).then(function(patient_ids, sample_to_patient, sample_lists) {
+			fetch_promise.resolve(sample_lists.reduce(function(map, next) {
+			    var sequenced_patients = next.sample_ids.reduce(function(map, next) {
+				var patient = sample_to_patient[next];
+				if (typeof patient !== "undefined") {
+				    map[patient] = true;
+				}
+				return map;
+			    }, {});
+			    var unsequenced_patients = patient_ids.reduce(function(map, next) {
+				if (!sequenced_patients[next]) {
+				    map[next] = true;
+				}
+				return map;
+			    }, {});
+			    map[next.study_id] = unsequenced_patients;
+			    return map;
+			}, {}));
+		    }).fail(function() {
+			fetch_promise.reject();
+		    });
+	    }),
+	    'getUnsequencedSampleUIDsBasedOnSequencedSampleList': makeCachedPromiseFunction(
+		    function(self, fetch_promise) {
+			$.when(self.getUnsequencedSamplesBasedOnSequencedSampleList(), self.getCaseUIDMap())
+				.then(function(unsequenced_samples, case_uid_map) {
+				    var ret = [];
+				    var studies = Object.keys(unsequenced_samples);
+				    for (var i=0; i<studies.length; i++) {
+					var study_uid_map = case_uid_map[studies[i]];
+					var unsequenced_sample_uids = Object.keys(unsequenced_samples[studies[i]]);
+					for (var j=0; j<unsequenced_sample_uids.length; j++) {
+					    ret.push(study_uid_map[unsequenced_sample_uids[j]]);
+					}
+				    }
+				    fetch_promise.resolve(ret);
+				}).fail(function() {
+				    fetch_promise.reject();
+				});
+		    }),
+	    'getUnsequencedPatientUIDsBasedOnSequencedSampleList': makeCachedPromiseFunction(
+		    function(self, fetch_promise) {
+			$.when(self.getUnsequencedPatientsBasedOnSequencedSampleList(), self.getCaseUIDMap())
+				.then(function(unsequenced_patients, case_uid_map) {
+				    var ret = [];
+				    var studies = Object.keys(unsequenced_patients);
+				    for (var i=0; i<studies.length; i++) {
+					var study_uid_map = case_uid_map[studies[i]];
+					var unsequenced_patient_uids = Object.keys(unsequenced_patients[studies[i]]);
+					for (var j=0; j<unsequenced_patient_uids.length; j++) {
+					    ret.push(study_uid_map[unsequenced_patient_uids[j]]);
+					}
+				    }
+				    fetch_promise.resolve(ret);
+				}).fail(function() {
+				    fetch_promise.reject();
+				});
+		    }),
 	'getMutualAlterationCounts': makeCachedPromiseFunctionWithSessionFilterOption(
 		function (self, fetch_promise, use_session_filters) {
 	    self.getAlteredSampleSetsByGene(use_session_filters).then(function (altered_samples_by_gene) {

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -710,14 +710,13 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			}).then(function () {
 			    console.log("sample data populated, releasing rendering");
 			    oncoprint.keepSorted();
-			    if (State.unaltered_cases_hidden) {
-				oncoprint.hideIds(unaltered_sample_uids, true);
-			    }
+			    oncoprint.updateHorzZoomToFitIds(altered_sample_uids);
+			    State.updateHiddenColumns();
 			    oncoprint.releaseRendering();
 			    LoadingBar.msg("");
 			    LoadingBar.hide();
 			    updateAlteredPercentIndicator(State);
-			    oncoprint.updateHorzZoomToFitIds(altered_sample_uids);
+			    updateViewMenuLabels(State);
 			    done.resolve();
 			});
 		    }).fail(function() {
@@ -791,17 +790,15 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			    console.log("patient data populated");
 			    console.log("sorting");
 			    oncoprint.keepSorted();
-			    if (State.unaltered_cases_hidden) {
-				console.log("hiding unaltered cases");
-				oncoprint.hideIds(unaltered_patient_uids, true);
-			    }
+			    console.log("setting horz zoom to fit");
+			    oncoprint.updateHorzZoomToFitIds(altered_patient_uids);
+			    State.updateHiddenColumns();
 			    console.log("releasing rendering");
 			    oncoprint.releaseRendering();
 			    LoadingBar.msg("");
 			    LoadingBar.hide();
-			    updateAlteredPercentIndicator(State);   					
-			    console.log("setting horz zoom to fit");
-			    oncoprint.updateHorzZoomToFitIds(altered_patient_uids);
+			    updateAlteredPercentIndicator(State);
+			    updateViewMenuLabels(State);
 			    done.resolve();
 			});
 		    }).fail(function() {
@@ -869,6 +866,14 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 	};
 	var setSortOrder = function(order) {
 	    oncoprint.setSortConfig({'type':'order', 'order':order});
+	};
+	
+	var updateViewMenuLabels = function(state) {
+	    var columns = (state.using_sample_data ? "samples" : "patients");
+	    $(toolbar_selector).find('#oncoprint_diagram_view_menu #show_unsequenced_label')
+		    .text("Show unsequenced "+columns);
+	    $(toolbar_selector).find('#oncoprint_diagram_view_menu #show_unaltered_label')
+		    .text("Show unaltered "+columns);
 	};
 	
 	var updateAlteredPercentIndicator = function(state) {
@@ -952,6 +957,7 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 	    'cell_padding_on': true,
 	    'using_sample_data': (URL.getInitDataType() === 'sample'),
 	    'unaltered_cases_hidden': false,
+	    'unsequenced_cases_hidden': false,
 	    'clinical_track_legends_shown': true,
 	    'mutations_colored_by_type': true,
 	    'sorted_by_mutation_type': true,
@@ -1044,16 +1050,16 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			return case_uid_map[study_id][id];
 		    };
 		    var proxy_promise;
+		    updateAlteredPercentIndicator(self);
+		    updateViewMenuLabels(self);
 		    if (sample_or_patient === 'sample') {
 			self.using_sample_data = true;
 			URL.update();
-			updateAlteredPercentIndicator(self);
 			console.log("in setDataType, calling populateSampleData()");
 			proxy_promise = populateSampleData();
 		    } else if (sample_or_patient === 'patient') {
 			self.using_sample_data = false;
 			URL.update();
-			updateAlteredPercentIndicator(self);
 			console.log("in setDataType, calling populatePatientData()");
 			proxy_promise = populatePatientData();
 		    }
@@ -1298,6 +1304,42 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 		}
 		return Object.keys(unaltered).filter(function(x) { return !!unaltered[x]; });
 	    },
+	    'updateHiddenColumns': function() {
+		var to_hide = {};
+		var unaltered_promise = new $.Deferred();
+		var unsequenced_promise = new $.Deferred();
+		if (this.unaltered_cases_hidden) {
+		    (this.using_sample_data ? 
+			QuerySession.getUnalteredSampleUIDs(true) : 
+			QuerySession.getUnalteredPatientUIDs(true)).then(function(unaltered_uids) {
+			    for (var i=0; i<unaltered_uids.length; i++) {
+				to_hide[unaltered_uids[i]] = true;
+			    }
+			    unaltered_promise.resolve();
+			}, function() {
+			    unaltered_promise.resolve();
+			});
+		} else {
+		    unaltered_promise.resolve();
+		}
+		if (this.unsequenced_cases_hidden) {
+		    (this.using_sample_data ? 
+			QuerySession.getUnsequencedSampleUIDsBasedOnSequencedSampleList() : 
+			QuerySession.getUnsequencedPatientUIDsBasedOnSequencedSampleList()).then(function(unsequenced_uids) {
+			    for (var i=0; i<unsequenced_uids.length; i++) {
+				to_hide[unsequenced_uids[i]] = true;
+			    }
+			    unsequenced_promise.resolve();
+			}, function() {
+			    unsequenced_promise.resolve();
+			});
+		} else {
+		    unsequenced_promise.resolve();
+		}
+		$.when(unaltered_promise, unsequenced_promise).then(function() {
+		    oncoprint.hideIds(Object.keys(to_hide), true);
+		});
+	    }
 	};
 	
 	loadFromLocalStorage(State);
@@ -2015,26 +2057,22 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 		oncoprint.setCellPaddingOn(State.cell_padding_on);
 	    });
 	})();
+	(function setUpHideUnsequencedCases() {
+	    var $show_unsequenced_checkbox = $(toolbar_selector).find('#oncoprint_diagram_view_menu')
+		    .find('input[type="checkbox"][name="show_unsequenced"]');
+	    $show_unsequenced_checkbox[0].checked = !State.unsequenced_cases_hidden;
+	    $show_unsequenced_checkbox.change(function () {
+		State.unsequenced_cases_hidden = !($show_unsequenced_checkbox.is(":checked"));
+		State.updateHiddenColumns();
+	    });
+	})();
 	(function setUpHideUnalteredCases() {
 	    var $show_unaltered_checkbox = $(toolbar_selector).find('#oncoprint_diagram_view_menu')
 		    .find('input[type="checkbox"][name="show_unaltered"]');
 	    $show_unaltered_checkbox[0].checked = !State.unaltered_cases_hidden;
 	    $show_unaltered_checkbox.change(function () {
 		State.unaltered_cases_hidden = !($show_unaltered_checkbox.is(":checked"));
-		if (State.unaltered_cases_hidden) {
-		    (State.using_sample_data ? QuerySession.getUnalteredSampleUIDs(true) : QuerySession.getUnalteredPatientUIDs(true)).then(function (unaltered_uids) {
-			oncoprint.hideIds(unaltered_uids, true);
-		    });
-		} else {
-		    oncoprint.hideIds([], true);
-		}
-	    });
-	})();
-	(function setUpZoomToFit() {
-	    setUpButton($(toolbar_selector + ' #oncoprint_zoomtofit'), [], ["Zoom to fit altered cases in screen"], null, function () {
-		// TODO: assume multiple studies
-		oncoprint.setHorzZoomToFit(State.getAlteredIds());
-		oncoprint.scrollTo(0);
+		State.updateHiddenColumns();
 	    });
 	})();
 	(function setUpSortByAndColorBy() {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
@@ -3432,15 +3432,20 @@ var OncoprintModel = (function () {
 	    return 1;
 	}
 	var id_to_index_map = this.getVisibleIdToIndexMap();
-	var indexes = ids.map(function(id) { return id_to_index_map[id]; });
-	var max = Number.NEGATIVE_INFINITY;
-	var min = Number.POSITIVE_INFINITY;
-	for (var i=0; i<indexes.length; i++) {
-	    max = Math.max(indexes[i], max);
-	    min = Math.min(indexes[i], min);
+	var indexes = ids.map(function(id) { return id_to_index_map[id]; })
+			 .filter(function(index) { return (typeof index !== "undefined"); });
+	if (indexes.length) {
+	    var max = Number.NEGATIVE_INFINITY;
+	    var min = Number.POSITIVE_INFINITY;
+	    for (var i = 0; i < indexes.length; i++) {
+		max = Math.max(indexes[i], max);
+		min = Math.min(indexes[i], min);
+	    }
+	    var num_cols = max - min + 1;
+	    return this.getHorzZoomToFitNumCols(width, num_cols);
+	} else {
+	    return 1;
 	}
-	var num_cols = max - min + 1;
-	return this.getHorzZoomToFitNumCols(width, num_cols);
     }
     
     OncoprintModel.prototype.getMinHorzZoom = function() {
@@ -6610,6 +6615,9 @@ var OncoprintWebGLCellView = (function () {
 	for (var i=0; i<id_and_first_vertex.length; i++) {
 	    var num_to_add = (i === id_and_first_vertex.length - 1 ? num_items : id_and_first_vertex[i+1][1]) - id_and_first_vertex[i][1];
 	    var column = id_to_index[id_and_first_vertex[i][0]];
+	    if (typeof column === "undefined") {
+		column = -1000; // render offscreen if vertex not supposed to be visible
+	    }
 	    for (var j=0; j<num_to_add; j++) {
 		vertex_column_array.push(column);
 	    }

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintmodel.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintmodel.js
@@ -380,15 +380,20 @@ var OncoprintModel = (function () {
 	    return 1;
 	}
 	var id_to_index_map = this.getVisibleIdToIndexMap();
-	var indexes = ids.map(function(id) { return id_to_index_map[id]; });
-	var max = Number.NEGATIVE_INFINITY;
-	var min = Number.POSITIVE_INFINITY;
-	for (var i=0; i<indexes.length; i++) {
-	    max = Math.max(indexes[i], max);
-	    min = Math.min(indexes[i], min);
+	var indexes = ids.map(function(id) { return id_to_index_map[id]; })
+			 .filter(function(index) { return (typeof index !== "undefined"); });
+	if (indexes.length) {
+	    var max = Number.NEGATIVE_INFINITY;
+	    var min = Number.POSITIVE_INFINITY;
+	    for (var i = 0; i < indexes.length; i++) {
+		max = Math.max(indexes[i], max);
+		min = Math.min(indexes[i], min);
+	    }
+	    var num_cols = max - min + 1;
+	    return this.getHorzZoomToFitNumCols(width, num_cols);
+	} else {
+	    return 1;
 	}
-	var num_cols = max - min + 1;
-	return this.getHorzZoomToFitNumCols(width, num_cols);
     }
     
     OncoprintModel.prototype.getMinHorzZoom = function() {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintwebglcellview.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintwebglcellview.js
@@ -551,6 +551,9 @@ var OncoprintWebGLCellView = (function () {
 	for (var i=0; i<id_and_first_vertex.length; i++) {
 	    var num_to_add = (i === id_and_first_vertex.length - 1 ? num_items : id_and_first_vertex[i+1][1]) - id_and_first_vertex[i][1];
 	    var column = id_to_index[id_and_first_vertex[i][0]];
+	    if (typeof column === "undefined") {
+		column = -1000; // render offscreen if vertex not supposed to be visible
+	    }
 	    for (var j=0; j<num_to_add; j++) {
 		vertex_column_array.push(column);
 	    }
@@ -694,7 +697,6 @@ var OncoprintWebGLCellView = (function () {
 	renderAllTracks(this, model);
     }
     OncoprintWebGLCellView.prototype.setTrackGroupOrder = function(model) {
-	clearZoneBuffers(this, model);
 	renderAllTracks(this, model);
     }
     


### PR DESCRIPTION
Also small polish where instead of "Show unaltered columns" in the View menu, now it says "Show unaltered samples/patients"

# Checks
- [ ] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.