### PR TITLE
Add checks inside calls to JdbcUtil.closeAll

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2015 - 2017 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -32,14 +32,12 @@
 
 package org.mskcc.cbio.portal.dao;
 
-import org.mskcc.cbio.portal.util.*;
-
-import org.apache.commons.logging.*;
-
 import java.sql.*;
 import java.util.*;
 import javax.sql.DataSource;
 import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.logging.*;
+import org.mskcc.cbio.portal.util.*;
 
 /**
  * Connection Utility for JDBC.
@@ -48,57 +46,54 @@ import org.apache.commons.dbcp.BasicDataSource;
  * @author Ersin Ciftci
  */
 public class JdbcUtil {
-    private static DataSource ds;
+    private static DataSource dataSource;
     private static Map<String,Integer> activeConnectionCount = new HashMap<String,Integer>(); // keep track of the number of active connection per class/requester
     private static final Log LOG = LogFactory.getLog(JdbcUtil.class);
-    
+
     /**
      * Gets the data source
      * @return the data source
      */
     public static DataSource getDataSource() {
-        if (ds==null) ds = initDataSource();
-    	return ds;
+        if (dataSource == null) {
+            dataSource = initDataSource();
+        }
+        return dataSource;
     }
-    
+
     /**
      * Sets the data source
      * @param value the data source
      */
     public static void setDataSource(DataSource value) {
-    	ds = value;
+        dataSource = value;
     }
-    
+
     private static DataSource initDataSource() {
         DatabaseProperties dbProperties = DatabaseProperties.getInstance();
         String host = dbProperties.getDbHost();
         String userName = dbProperties.getDbUser();
         String password = dbProperties.getDbPassword();
         String database = dbProperties.getDbName();
-
         String url ="jdbc:mysql://" + host + "/" + database +
                         "?user=" + userName + "&password=" + password +
                         "&zeroDateTimeBehavior=convertToNull";
-        
         //  Set up poolable data source
-        BasicDataSource ds = new BasicDataSource();
-        ds.setDriverClassName("com.mysql.jdbc.Driver");
-        ds.setUsername(userName);
-        ds.setPassword(password);
-        ds.setUrl(url);
-
+        BasicDataSource dataSource = new BasicDataSource();
+        dataSource.setDriverClassName("com.mysql.jdbc.Driver");
+        dataSource.setUsername(userName);
+        dataSource.setPassword(password);
+        dataSource.setUrl(url);
         //  By pooling/reusing PreparedStatements, we get a major performance gain
-        ds.setPoolPreparedStatements(true);
-        ds.setMaxActive(100);
-        
+        dataSource.setPoolPreparedStatements(true);
+        dataSource.setMaxActive(100);
         activeConnectionCount = new HashMap<String,Integer>();
-        
-        return ds;
+        return dataSource;
     }
 
     /**
      * Gets Connection to the Database.
-     * 
+     *
      * @param clazz class
      * @return Live Connection to Database.
      * @throws java.sql.SQLException Error Connecting to Database.
@@ -106,10 +101,10 @@ public class JdbcUtil {
     public static Connection getDbConnection(Class clazz) throws SQLException {
         return getDbConnection(clazz.getName());
     }
-    
+
     /**
      * Gets Connection to the Database.
-     * 
+     *
      * @param requester name
      * @return Live Connection to Database.
      * @throws java.sql.SQLException Error Connecting to Database.
@@ -117,21 +112,17 @@ public class JdbcUtil {
     private static Connection getDbConnection(String requester) throws SQLException {
         // this method should be syncronized
         // but may slow the speed?
-        
         Connection con;
         try {
             con = getDataSource().getConnection();
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             logMessage(e.getMessage());
             throw new SQLException(e);
         }
-
-        if (requester!=null) {
+        if (requester != null) {
             Integer count = activeConnectionCount.get(requester);
-            activeConnectionCount.put(requester, count==null ? 1 : (count+1));
+            activeConnectionCount.put(requester, count == null ? 1 : (count + 1));
         }
-        
         return con;
     }
 
@@ -143,19 +134,17 @@ public class JdbcUtil {
     public static void closeConnection(Class clazz, Connection con) {
         closeConnection(clazz.getName(), con);
     }
-    
+
     private static void closeConnection(String requester, Connection con) {
         try {
             if (con != null && !con.isClosed()) {
                 con.close();
-                
                 if (requester!=null) {
-                    int count = activeConnectionCount.get(requester)-1;
-                    if (count<0) {
+                    int count = activeConnectionCount.get(requester) - 1;
+                    if (count < 0) {
                         // since adding connection is not synchronized, the count may not be the real one
                         count = 0;
                     }
-                    
                     activeConnectionCount.put(requester, count);
                 }
             }
@@ -171,8 +160,8 @@ public class JdbcUtil {
      * @param rs  ResultSet Object.
      */
     public static void closeAll(ResultSet rs) {
-                JdbcUtil.closeAll((String)null, null, null, rs);
-        }
+        JdbcUtil.closeAll((String)null, null, null, rs);
+    }
 
     /**
      * Frees Database Connection.
@@ -181,8 +170,7 @@ public class JdbcUtil {
      * @param ps  Prepared Statement Object.
      * @param rs  ResultSet Object.
      */
-    public static void closeAll(Class clazz, Connection con, PreparedStatement ps,
-            ResultSet rs) {
+    public static void closeAll(Class clazz, Connection con, PreparedStatement ps, ResultSet rs) {
         closeAll(clazz.getName(), con, ps, rs);
     }
 
@@ -192,23 +180,26 @@ public class JdbcUtil {
      * @param con Connection Object.
      * @param rs  ResultSet Object.
      */
-    private static void closeAll(String requester, Connection con, PreparedStatement ps,
-                                 ResultSet rs) {
+    private static void closeAll(String requester, Connection con, PreparedStatement ps, ResultSet rs) {
         if (rs != null) {
             try {
-                rs.close();
+                if (!rs.isClosed()) {
+                    rs.close();
+                }
             } catch (SQLException e) {
                 e.printStackTrace();
             }
         }
         if (ps != null) {
             try {
-                ps.close();
+                if (!ps.isClosed()) {
+                    ps.close();
+                }
             } catch (SQLException e) {
                 e.printStackTrace();
             }
         }
-        closeConnection(requester, con);        
+        closeConnection(requester, con);
     }
 
     /**
@@ -223,7 +214,9 @@ public class JdbcUtil {
         closeConnection(requester, con);
         if (rs != null) {
             try {
-                rs.close();
+                if (!rs.isClosed()) {
+                    rs.close();
+                }
             } catch (SQLException e) {
                 e.printStackTrace();
             }
@@ -236,18 +229,18 @@ public class JdbcUtil {
         }
         System.err.println(message);
     }
-    
+
     // is it good to put the two methods below here?
     static Integer readIntegerFromResultSet(ResultSet rs, String column) throws SQLException {
         int i = rs.getInt(column);
         return rs.wasNull() ? null : i;
     }
-    
+
     static Long readLongFromResultSet(ResultSet rs, String column) throws SQLException {
         long l = rs.getInt(column);
         return rs.wasNull() ? null : l;
     }
-    
+
     static Double readDoubleFromResultSet(ResultSet rs, String column) throws SQLException {
         double d = rs.getDouble(column);
         return rs.wasNull() ? null : d;
@@ -261,7 +254,6 @@ public class JdbcUtil {
      * @throws SQLException
      */
     public static void disableForeignKeyCheck(Connection con) throws SQLException {
-
         Statement stmt = con.createStatement();
         stmt.execute("SET FOREIGN_KEY_CHECKS=0");
         stmt.close();
@@ -273,7 +265,6 @@ public class JdbcUtil {
      * @throws SQLException
      */
     public static void enableForeignKeyCheck(Connection con) throws SQLException {
-
         Statement stmt = con.createStatement();
         stmt.execute("SET FOREIGN_KEY_CHECKS=1");
         stmt.close();


### PR DESCRIPTION
# What/Why
Exception stack traces are printed if a statement or result set object (which has already been closed) is passed in to closeAll()

Changes proposed in this pull request:
- if statement or resultset are already closed, do not close again
Also clean up code style
# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/backend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
