### PR TITLE
Added `IMPORT_DATE` usage for importing cancer studies

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
@@ -34,6 +34,7 @@ package org.mskcc.cbio.portal.dao;
 
 import java.sql.*;
 import java.text.*;
+import java.time.LocalDate;
 import java.util.*;
 import org.apache.commons.lang.StringUtils;
 import org.mskcc.cbio.portal.model.*;
@@ -297,7 +298,7 @@ public final class DaoCancerStudy {
             pstmt = con.prepareStatement("INSERT INTO cancer_study " +
                     "( `CANCER_STUDY_IDENTIFIER`, `NAME`, "
                     + "`DESCRIPTION`, `PUBLIC`, `TYPE_OF_CANCER_ID`, "
-                    + "`PMID`, `CITATION`, `GROUPS`, `SHORT_NAME`, `STATUS` ) VALUES (?,?,?,?,?,?,?,?,?,?)",
+                    + "`PMID`, `CITATION`, `GROUPS`, `SHORT_NAME`, `STATUS`, `IMPORT_DATE` ) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
                     Statement.RETURN_GENERATED_KEYS);
             pstmt.setString(1, stableId);
             pstmt.setString(2, cancerStudy.getName());
@@ -317,6 +318,7 @@ public final class DaoCancerStudy {
             //data loading process can set this to AVAILABLE:
             //TODO - use this field in parts of the system that build up the list of studies to display in home page:
             pstmt.setInt(10, Status.UNAVAILABLE.ordinal());
+            pstmt.setDate(11, java.sql.Date.valueOf(LocalDate.now()));
             pstmt.executeUpdate();
             rs = pstmt.getGeneratedKeys();
             if (rs.next()) {
@@ -601,6 +603,7 @@ public final class DaoCancerStudy {
         cancerStudy.setGroupsInUpperCase(rs.getString("GROUPS"));
         cancerStudy.setShortName(rs.getString("SHORT_NAME"));
         cancerStudy.setInternalId(rs.getInt("CANCER_STUDY_ID"));
+        cancerStudy.setImportDate(rs.getDate("IMPORT_DATE"));
         return cancerStudy;
     }
 

--- a/core/src/main/java/org/mskcc/cbio/portal/model/CancerStudy.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/model/CancerStudy.java
@@ -35,6 +35,7 @@ package org.mskcc.cbio.portal.model;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import org.mskcc.cbio.portal.dao.*;
@@ -64,6 +65,7 @@ public class CancerStudy {
     private String citation;
     private Set<String> groups;
     private String shortName;
+    private Date importDate;
     
 
     /**
@@ -451,5 +453,19 @@ public class CancerStudy {
     
     public String getTypeOfCancer() throws DaoException {
         return DaoTypeOfCancer.getTypeOfCancerById(this.typeOfCancerId).getName();
+    }
+
+    /**
+     * @return the importDate
+     */
+    public Date getImportDate() {
+        return importDate;
+    }
+
+    /**
+     * @param importDate the importDate to set
+     */
+    public void setImportDate(Date importDate) {
+        this.importDate = importDate;
     }
 }


### PR DESCRIPTION
# What? Why?
Cancer study field `IMPORT_DATE` was not getting used but would be useful info to have. 


Changes proposed in this pull request:
This PR makes the necessary changes in `DaoCancerStudy.java` and `CancerStudy.java` to start using the `IMPORT_DATE` field again.

# Checks
- [ ] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/backend

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>