### PR TITLE
Return 404 when a path variable can't be found

### DIFF
--- a/service/src/main/java/org/cbioportal/service/ClinicalAttributeService.java
+++ b/service/src/main/java/org/cbioportal/service/ClinicalAttributeService.java
@@ -3,6 +3,7 @@ package org.cbioportal.service;
 import org.cbioportal.model.ClinicalAttribute;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.service.exception.ClinicalAttributeNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 
 import java.util.List;
 
@@ -14,10 +15,10 @@ public interface ClinicalAttributeService {
     BaseMeta getMetaClinicalAttributes();
 
     ClinicalAttribute getClinicalAttribute(String studyId, String clinicalAttributeId)
-            throws ClinicalAttributeNotFoundException;
+        throws ClinicalAttributeNotFoundException, StudyNotFoundException;
 
     List<ClinicalAttribute> getAllClinicalAttributesInStudy(String studyId, String projection, Integer pageSize,
-                                                     Integer pageNumber, String sortBy, String direction);
+                                                     Integer pageNumber, String sortBy, String direction) throws StudyNotFoundException;
 
-    BaseMeta getMetaClinicalAttributesInStudy(String studyId);
+    BaseMeta getMetaClinicalAttributesInStudy(String studyId) throws StudyNotFoundException;
 }

--- a/service/src/main/java/org/cbioportal/service/ClinicalDataService.java
+++ b/service/src/main/java/org/cbioportal/service/ClinicalDataService.java
@@ -2,6 +2,9 @@ package org.cbioportal.service;
 
 import org.cbioportal.model.ClinicalData;
 import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.service.exception.PatientNotFoundException;
+import org.cbioportal.service.exception.SampleNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 
 import java.util.List;
 
@@ -9,22 +12,22 @@ public interface ClinicalDataService {
 
     List<ClinicalData> getAllClinicalDataOfSampleInStudy(String studyId, String sampleId, String attributeId,
                                                          String projection, Integer pageSize, Integer pageNumber,
-                                                         String sortBy, String direction);
+                                                         String sortBy, String direction) throws SampleNotFoundException, StudyNotFoundException;
 
-    BaseMeta getMetaSampleClinicalData(String studyId, String sampleId, String attributeId);
+    BaseMeta getMetaSampleClinicalData(String studyId, String sampleId, String attributeId) throws SampleNotFoundException, StudyNotFoundException;
 
     List<ClinicalData> getAllClinicalDataOfPatientInStudy(String studyId, String patientId, String attributeId,
                                                                  String projection, Integer pageSize,
-                                                                 Integer pageNumber, String sortBy, String direction);
+                                                                 Integer pageNumber, String sortBy, String direction) throws PatientNotFoundException, StudyNotFoundException;
 
-    BaseMeta getMetaPatientClinicalData(String studyId, String patientId, String attributeId);
+    BaseMeta getMetaPatientClinicalData(String studyId, String patientId, String attributeId) throws PatientNotFoundException, StudyNotFoundException;
 
     List<ClinicalData> getAllClinicalDataInStudy(String studyId, String attributeId,
                                                                   String clinicalDataType, String projection,
                                                                   Integer pageSize, Integer pageNumber, String sortBy,
-                                                                  String direction);
+                                                                  String direction) throws StudyNotFoundException;
 
-    BaseMeta getMetaAllClinicalData(String studyId, String attributeId, String clinicalDataType);
+    BaseMeta getMetaAllClinicalData(String studyId, String attributeId, String clinicalDataType) throws StudyNotFoundException;
 
     List<ClinicalData> fetchClinicalData(List<String> studyIds, List<String> ids, String attributeId,
                                                           String clinicalDataType, String projection);

--- a/service/src/main/java/org/cbioportal/service/ClinicalEventService.java
+++ b/service/src/main/java/org/cbioportal/service/ClinicalEventService.java
@@ -2,6 +2,8 @@ package org.cbioportal.service;
 
 import org.cbioportal.model.ClinicalEvent;
 import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.service.exception.PatientNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 
 import java.util.List;
 
@@ -9,7 +11,7 @@ public interface ClinicalEventService {
     
     List<ClinicalEvent> getAllClinicalEventsOfPatientInStudy(String studyId, String patientId, String projection, 
                                                              Integer pageSize, Integer pageNumber, String sortBy, 
-                                                             String direction);
+                                                             String direction) throws PatientNotFoundException, StudyNotFoundException;
 
-    BaseMeta getMetaPatientClinicalEvents(String studyId, String patientId);
+    BaseMeta getMetaPatientClinicalEvents(String studyId, String patientId) throws PatientNotFoundException, StudyNotFoundException;
 }

--- a/service/src/main/java/org/cbioportal/service/CopyNumberSegmentService.java
+++ b/service/src/main/java/org/cbioportal/service/CopyNumberSegmentService.java
@@ -2,6 +2,8 @@ package org.cbioportal.service;
 
 import org.cbioportal.model.CopyNumberSeg;
 import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.service.exception.SampleNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 
 import java.util.List;
 
@@ -9,9 +11,9 @@ public interface CopyNumberSegmentService {
 
     List<CopyNumberSeg> getCopyNumberSegmentsInSampleInStudy(String studyId, String sampleId, String projection,
                                                              Integer pageSize, Integer pageNumber, String sortBy,
-                                                             String direction);
+                                                             String direction) throws SampleNotFoundException, StudyNotFoundException;
 
-    BaseMeta getMetaCopyNumberSegmentsInSampleInStudy(String studyId, String sampleId);
+    BaseMeta getMetaCopyNumberSegmentsInSampleInStudy(String studyId, String sampleId) throws SampleNotFoundException, StudyNotFoundException;
 
     List<CopyNumberSeg> fetchCopyNumberSegments(List<String> studyIds, List<String> sampleIds, String projection);
 

--- a/service/src/main/java/org/cbioportal/service/GeneService.java
+++ b/service/src/main/java/org/cbioportal/service/GeneService.java
@@ -46,7 +46,7 @@ public interface GeneService {
 
     Gene getGene(String geneId) throws GeneNotFoundException;
 
-    List<String> getAliasesOfGene(String geneId);
+    List<String> getAliasesOfGene(String geneId) throws GeneNotFoundException;
 
     List<Gene> fetchGenes(List<String> geneIds, String geneIdType, String projection);
 

--- a/service/src/main/java/org/cbioportal/service/GeneticProfileService.java
+++ b/service/src/main/java/org/cbioportal/service/GeneticProfileService.java
@@ -3,6 +3,7 @@ package org.cbioportal.service;
 import org.cbioportal.model.GeneticProfile;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.service.exception.GeneticProfileNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 
 import java.util.List;
 
@@ -16,7 +17,7 @@ public interface GeneticProfileService {
     GeneticProfile getGeneticProfile(String geneticProfileId) throws GeneticProfileNotFoundException;
 
     List<GeneticProfile> getAllGeneticProfilesInStudy(String studyId, String projection, Integer pageSize,
-                                                      Integer pageNumber, String sortBy, String direction);
+                                                      Integer pageNumber, String sortBy, String direction) throws StudyNotFoundException;
 
-    BaseMeta getMetaGeneticProfilesInStudy(String studyId);
+    BaseMeta getMetaGeneticProfilesInStudy(String studyId) throws StudyNotFoundException;
 }

--- a/service/src/main/java/org/cbioportal/service/MutationService.java
+++ b/service/src/main/java/org/cbioportal/service/MutationService.java
@@ -6,6 +6,7 @@ import org.cbioportal.model.MutationSampleCountByGene;
 import org.cbioportal.model.MutationSampleCountByKeyword;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.model.meta.MutationMeta;
+import org.cbioportal.service.exception.GeneticProfileNotFoundException;
 
 import java.util.List;
 
@@ -13,22 +14,22 @@ public interface MutationService {
     
     List<Mutation> getMutationsInGeneticProfileBySampleListId(String geneticProfileId, String sampleListId, 
                                                               String projection, Integer pageSize, Integer pageNumber,
-                                                              String sortBy, String direction);
+                                                              String sortBy, String direction) throws GeneticProfileNotFoundException;
 
 
-    MutationMeta getMetaMutationsInGeneticProfileBySampleListId(String geneticProfileId, String sampleListId);
+    MutationMeta getMetaMutationsInGeneticProfileBySampleListId(String geneticProfileId, String sampleListId) throws GeneticProfileNotFoundException;
 
     List<Mutation> fetchMutationsInGeneticProfile(String geneticProfileId, List<String> sampleIds, String projection,
                                                   Integer pageSize, Integer pageNumber, String sortBy,
-                                                  String direction);
+                                                  String direction) throws GeneticProfileNotFoundException;
 
-    MutationMeta fetchMetaMutationsInGeneticProfile(String geneticProfileId, List<String> sampleIds);
+    MutationMeta fetchMetaMutationsInGeneticProfile(String geneticProfileId, List<String> sampleIds) throws GeneticProfileNotFoundException;
 
-    List<MutationSampleCountByGene> getSampleCountByEntrezGeneIds(String geneticProfileId, List<Integer> entrezGeneIds);
+    List<MutationSampleCountByGene> getSampleCountByEntrezGeneIds(String geneticProfileId, List<Integer> entrezGeneIds) throws GeneticProfileNotFoundException;
 
-    List<MutationSampleCountByKeyword> getSampleCountByKeywords(String geneticProfileId, List<String> keywords);
+    List<MutationSampleCountByKeyword> getSampleCountByKeywords(String geneticProfileId, List<String> keywords) throws GeneticProfileNotFoundException;
 
-    List<MutationCount> getMutationCountsInGeneticProfileBySampleListId(String geneticProfileId, String sampleListId);
+    List<MutationCount> getMutationCountsInGeneticProfileBySampleListId(String geneticProfileId, String sampleListId) throws GeneticProfileNotFoundException;
 
-    List<MutationCount> fetchMutationCountsInGeneticProfile(String geneticProfileId, List<String> sampleIds);
+    List<MutationCount> fetchMutationCountsInGeneticProfile(String geneticProfileId, List<String> sampleIds) throws GeneticProfileNotFoundException;
 }

--- a/service/src/main/java/org/cbioportal/service/PatientService.java
+++ b/service/src/main/java/org/cbioportal/service/PatientService.java
@@ -3,17 +3,18 @@ package org.cbioportal.service;
 import org.cbioportal.model.Patient;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.service.exception.PatientNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 
 import java.util.List;
 
 public interface PatientService {
 
     List<Patient> getAllPatientsInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber,
-                                        String sortBy, String direction);
+                                        String sortBy, String direction) throws StudyNotFoundException;
 
-    BaseMeta getMetaPatientsInStudy(String studyId);
+    BaseMeta getMetaPatientsInStudy(String studyId) throws StudyNotFoundException;
 
-    Patient getPatientInStudy(String studyId, String patientId) throws PatientNotFoundException;
+    Patient getPatientInStudy(String studyId, String patientId) throws PatientNotFoundException, StudyNotFoundException;
 
     List<Patient> fetchPatients(List<String> studyIds, List<String> patientIds, String projection);
 

--- a/service/src/main/java/org/cbioportal/service/SampleListService.java
+++ b/service/src/main/java/org/cbioportal/service/SampleListService.java
@@ -3,6 +3,7 @@ package org.cbioportal.service;
 import org.cbioportal.model.SampleList;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.service.exception.SampleListNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 
 import java.util.List;
 
@@ -17,9 +18,9 @@ public interface SampleListService {
     SampleList getSampleList(String sampleListId) throws SampleListNotFoundException;
 
     List<SampleList> getAllSampleListsInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber,
-                                              String sortBy, String direction);
+                                              String sortBy, String direction) throws StudyNotFoundException;
 
-    BaseMeta getMetaSampleListsInStudy(String studyId);
+    BaseMeta getMetaSampleListsInStudy(String studyId) throws StudyNotFoundException;
 
-    List<String> getAllSampleIdsInSampleList(String sampleListId);
+    List<String> getAllSampleIdsInSampleList(String sampleListId) throws SampleListNotFoundException;
 }

--- a/service/src/main/java/org/cbioportal/service/SampleService.java
+++ b/service/src/main/java/org/cbioportal/service/SampleService.java
@@ -2,23 +2,25 @@ package org.cbioportal.service;
 
 import org.cbioportal.model.Sample;
 import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 
 import java.util.List;
 
 public interface SampleService {
 
     List<Sample> getAllSamplesInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber,
-                                      String sortBy, String direction);
+                                      String sortBy, String direction) throws StudyNotFoundException;
 
-    BaseMeta getMetaSamplesInStudy(String studyId);
+    BaseMeta getMetaSamplesInStudy(String studyId) throws StudyNotFoundException;
 
-    Sample getSampleInStudy(String studyId, String sampleId) throws SampleNotFoundException;
+    Sample getSampleInStudy(String studyId, String sampleId) throws SampleNotFoundException, StudyNotFoundException;
 
     List<Sample> getAllSamplesOfPatientInStudy(String studyId, String patientId, String projection, Integer pageSize,
-                                               Integer pageNumber, String sortBy, String direction);
+                                               Integer pageNumber, String sortBy, String direction) throws StudyNotFoundException, PatientNotFoundException;
 
-    BaseMeta getMetaSamplesOfPatientInStudy(String studyId, String patientId);
+    BaseMeta getMetaSamplesOfPatientInStudy(String studyId, String patientId) throws StudyNotFoundException, PatientNotFoundException;
 
     List<Sample> fetchSamples(List<String> studyIds, List<String> sampleIds, String projection);
 

--- a/service/src/main/java/org/cbioportal/service/SignificantCopyNumberRegionService.java
+++ b/service/src/main/java/org/cbioportal/service/SignificantCopyNumberRegionService.java
@@ -2,13 +2,14 @@ package org.cbioportal.service;
 
 import org.cbioportal.model.Gistic;
 import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.service.exception.StudyNotFoundException;
 
 import java.util.List;
 
 public interface SignificantCopyNumberRegionService {
     
     List<Gistic> getSignificantCopyNumberRegions(String studyId, String projection, Integer pageSize, 
-                                                 Integer pageNumber, String sortBy, String direction);
+                                                 Integer pageNumber, String sortBy, String direction) throws StudyNotFoundException;
 
-    BaseMeta getMetaSignificantCopyNumberRegions(String studyId);
+    BaseMeta getMetaSignificantCopyNumberRegions(String studyId) throws StudyNotFoundException;
 }

--- a/service/src/main/java/org/cbioportal/service/SignificantlyMutatedGeneService.java
+++ b/service/src/main/java/org/cbioportal/service/SignificantlyMutatedGeneService.java
@@ -2,13 +2,14 @@ package org.cbioportal.service;
 
 import org.cbioportal.model.MutSig;
 import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.service.exception.StudyNotFoundException;
 
 import java.util.List;
 
 public interface SignificantlyMutatedGeneService {
     
     List<MutSig> getSignificantlyMutatedGenes(String studyId, String projection, Integer pageSize, Integer pageNumber,
-                                              String sortBy, String direction);
+                                              String sortBy, String direction) throws StudyNotFoundException;
 
-    BaseMeta getMetaSignificantlyMutatedGenes(String studyId);
+    BaseMeta getMetaSignificantlyMutatedGenes(String studyId) throws StudyNotFoundException;
 }

--- a/service/src/main/java/org/cbioportal/service/impl/ClinicalAttributeServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ClinicalAttributeServiceImpl.java
@@ -1,10 +1,13 @@
 package org.cbioportal.service.impl;
 
+import org.cbioportal.model.CancerStudy;
 import org.cbioportal.model.ClinicalAttribute;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.ClinicalAttributeRepository;
 import org.cbioportal.service.ClinicalAttributeService;
+import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.ClinicalAttributeNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -17,6 +20,8 @@ public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
 
     @Autowired
     private ClinicalAttributeRepository clinicalAttributeRepository;
+    @Autowired
+    private StudyService studyService;
 
     @Override
     @PostFilter("hasPermission(filterObject.cancerStudyIdentifier, 'CancerStudy', 'read')")
@@ -36,7 +41,9 @@ public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public ClinicalAttribute getClinicalAttribute(String studyId, String clinicalAttributeId)
-            throws ClinicalAttributeNotFoundException {
+        throws ClinicalAttributeNotFoundException, StudyNotFoundException {
+
+        studyService.getStudy(studyId);
 
         ClinicalAttribute clinicalAttribute = clinicalAttributeRepository.getClinicalAttribute(studyId,
                 clinicalAttributeId);
@@ -52,7 +59,9 @@ public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<ClinicalAttribute> getAllClinicalAttributesInStudy(String studyId, String projection, Integer pageSize,
                                                                    Integer pageNumber, String sortBy,
-                                                                   String direction) {
+                                                                   String direction) throws StudyNotFoundException {
+
+        studyService.getStudy(studyId);
 
         return clinicalAttributeRepository.getAllClinicalAttributesInStudy(studyId, projection, pageSize, pageNumber,
                 sortBy, direction);
@@ -60,7 +69,9 @@ public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaClinicalAttributesInStudy(String studyId) {
+    public BaseMeta getMetaClinicalAttributesInStudy(String studyId) throws StudyNotFoundException {
+
+        studyService.getStudy(studyId);
 
         return clinicalAttributeRepository.getMetaClinicalAttributesInStudy(studyId);
     }

--- a/service/src/main/java/org/cbioportal/service/impl/ClinicalDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ClinicalDataServiceImpl.java
@@ -4,6 +4,12 @@ import org.cbioportal.model.ClinicalData;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.ClinicalDataRepository;
 import org.cbioportal.service.ClinicalDataService;
+import org.cbioportal.service.PatientService;
+import org.cbioportal.service.SampleService;
+import org.cbioportal.service.StudyService;
+import org.cbioportal.service.exception.PatientNotFoundException;
+import org.cbioportal.service.exception.SampleNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -16,31 +22,44 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
 
     @Autowired
     private ClinicalDataRepository clinicalDataRepository;
+    @Autowired
+    private StudyService studyService;
+    @Autowired
+    private PatientService patientService;
+    @Autowired
+    private SampleService sampleService;
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public List<ClinicalData> getAllClinicalDataOfSampleInStudy(String studyId, String sampleId,
-                                                                String attributeId, String projection,
-                                                                Integer pageSize, Integer pageNumber,
-                                                                String sortBy, String direction) {
+    public List<ClinicalData> getAllClinicalDataOfSampleInStudy(String studyId, String sampleId, String attributeId, 
+                                                                String projection, Integer pageSize, Integer pageNumber,
+                                                                String sortBy, String direction)
+        throws SampleNotFoundException, StudyNotFoundException {
 
+        sampleService.getSampleInStudy(studyId, sampleId);
+        
         return clinicalDataRepository.getAllClinicalDataOfSampleInStudy(studyId, sampleId, attributeId, projection,
                 pageSize, pageNumber, sortBy, direction);
     }
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaSampleClinicalData(String studyId, String sampleId, String attributeId) {
+    public BaseMeta getMetaSampleClinicalData(String studyId, String sampleId, String attributeId)
+        throws SampleNotFoundException, StudyNotFoundException {
+
+        sampleService.getSampleInStudy(studyId, sampleId);
 
         return clinicalDataRepository.getMetaSampleClinicalData(studyId, sampleId, attributeId);
     }
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public List<ClinicalData> getAllClinicalDataOfPatientInStudy(String studyId, String patientId,
-                                                                        String attributeId, String projection,
-                                                                        Integer pageSize, Integer pageNumber,
-                                                                        String sortBy, String direction) {
+    public List<ClinicalData> getAllClinicalDataOfPatientInStudy(String studyId, String patientId, String attributeId, 
+                                                                 String projection, Integer pageSize, 
+                                                                 Integer pageNumber, String sortBy, String direction)
+        throws PatientNotFoundException, StudyNotFoundException {
+        
+        patientService.getPatientInStudy(studyId, patientId);
 
         return clinicalDataRepository.getAllClinicalDataOfPatientInStudy(studyId, patientId, attributeId, projection,
                 pageSize, pageNumber, sortBy, direction);
@@ -48,17 +67,21 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaPatientClinicalData(String studyId, String patientId, String attributeId) {
+    public BaseMeta getMetaPatientClinicalData(String studyId, String patientId, String attributeId)
+        throws PatientNotFoundException, StudyNotFoundException {
+
+        patientService.getPatientInStudy(studyId, patientId);
 
         return clinicalDataRepository.getMetaPatientClinicalData(studyId, patientId, attributeId);
     }
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public List<ClinicalData> getAllClinicalDataInStudy(String studyId, String attributeId,
-                                                                         String clinicalDataType, String projection,
-                                                                         Integer pageSize, Integer pageNumber,
-                                                                         String sortBy, String direction) {
+    public List<ClinicalData> getAllClinicalDataInStudy(String studyId, String attributeId, String clinicalDataType, 
+                                                        String projection, Integer pageSize, Integer pageNumber,
+                                                        String sortBy, String direction) throws StudyNotFoundException {
+        
+        studyService.getStudy(studyId);
 
         return clinicalDataRepository.getAllClinicalDataInStudy(studyId, attributeId, clinicalDataType, projection,
                 pageSize, pageNumber, sortBy, direction);
@@ -66,23 +89,25 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaAllClinicalData(String studyId, String attributeId, String clinicalDataType) {
+    public BaseMeta getMetaAllClinicalData(String studyId, String attributeId, String clinicalDataType) 
+        throws StudyNotFoundException {
 
+        studyService.getStudy(studyId);
+        
         return clinicalDataRepository.getMetaAllClinicalData(studyId, attributeId, clinicalDataType);
     }
 
     @Override
     @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
-    public List<ClinicalData> fetchClinicalData(List<String> studyIds, List<String> ids,
-                                                                 String attributeId, String clinicalDataType,
-                                                                 String projection) {
+    public List<ClinicalData> fetchClinicalData(List<String> studyIds, List<String> ids, String attributeId, 
+                                                String clinicalDataType, String projection) {
 
         return clinicalDataRepository.fetchClinicalData(studyIds, ids, attributeId, clinicalDataType, projection);
     }
 
     @Override
     @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
-    public BaseMeta fetchMetaClinicalData(List<String> studyIds, List<String> ids, String attributeId,
+    public BaseMeta fetchMetaClinicalData(List<String> studyIds, List<String> ids, String attributeId, 
                                           String clinicalDataType) {
 
         return clinicalDataRepository.fetchMetaClinicalData(studyIds, ids, attributeId, clinicalDataType);

--- a/service/src/main/java/org/cbioportal/service/impl/ClinicalEventServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ClinicalEventServiceImpl.java
@@ -5,6 +5,9 @@ import org.cbioportal.model.ClinicalEventData;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.ClinicalEventRepository;
 import org.cbioportal.service.ClinicalEventService;
+import org.cbioportal.service.PatientService;
+import org.cbioportal.service.exception.PatientNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -17,12 +20,17 @@ public class ClinicalEventServiceImpl implements ClinicalEventService {
     
     @Autowired
     private ClinicalEventRepository clinicalEventRepository;
+    @Autowired
+    private PatientService patientService;
     
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<ClinicalEvent> getAllClinicalEventsOfPatientInStudy(String studyId, String patientId, String projection, 
                                                                     Integer pageSize, Integer pageNumber, String sortBy, 
-                                                                    String direction) {
+                                                                    String direction) throws PatientNotFoundException, 
+        StudyNotFoundException {
+        
+        patientService.getPatientInStudy(studyId, patientId);
 
         List<ClinicalEvent> clinicalEvents = clinicalEventRepository.getAllClinicalEventsOfPatientInStudy(studyId,
             patientId, projection, pageSize, pageNumber, sortBy, direction);
@@ -41,7 +49,10 @@ public class ClinicalEventServiceImpl implements ClinicalEventService {
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaPatientClinicalEvents(String studyId, String patientId) {
+    public BaseMeta getMetaPatientClinicalEvents(String studyId, String patientId) throws PatientNotFoundException, 
+        StudyNotFoundException {
+
+        patientService.getPatientInStudy(studyId, patientId);
         
         return clinicalEventRepository.getMetaPatientClinicalEvents(studyId, patientId);
     }

--- a/service/src/main/java/org/cbioportal/service/impl/CopyNumberSegmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CopyNumberSegmentServiceImpl.java
@@ -4,6 +4,9 @@ import org.cbioportal.model.CopyNumberSeg;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.CopyNumberSegmentRepository;
 import org.cbioportal.service.CopyNumberSegmentService;
+import org.cbioportal.service.SampleService;
+import org.cbioportal.service.exception.SampleNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -15,13 +18,18 @@ public class CopyNumberSegmentServiceImpl implements CopyNumberSegmentService {
 
     @Autowired
     private CopyNumberSegmentRepository copyNumberSegmentRepository;
+    @Autowired
+    private SampleService sampleService;
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<CopyNumberSeg> getCopyNumberSegmentsInSampleInStudy(String studyId, String sampleId,
                                                                     String projection, Integer pageSize,
                                                                     Integer pageNumber, String sortBy,
-                                                                    String direction) {
+                                                                    String direction) throws SampleNotFoundException, 
+        StudyNotFoundException {
+        
+        sampleService.getSampleInStudy(studyId, sampleId);
 
         return copyNumberSegmentRepository.getCopyNumberSegmentsInSampleInStudy(studyId, sampleId, projection, pageSize,
             pageNumber, sortBy, direction);
@@ -29,7 +37,10 @@ public class CopyNumberSegmentServiceImpl implements CopyNumberSegmentService {
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaCopyNumberSegmentsInSampleInStudy(String studyId, String sampleId) {
+    public BaseMeta getMetaCopyNumberSegmentsInSampleInStudy(String studyId, String sampleId)
+        throws SampleNotFoundException, StudyNotFoundException {
+
+        sampleService.getSampleInStudy(studyId, sampleId);
         
         return copyNumberSegmentRepository.getMetaCopyNumberSegmentsInSampleInStudy(studyId, sampleId);
     }

--- a/service/src/main/java/org/cbioportal/service/impl/GeneServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GeneServiceImpl.java
@@ -92,7 +92,9 @@ public class GeneServiceImpl implements GeneService {
     }
 
     @Override
-    public List<String> getAliasesOfGene(String geneId) {
+    public List<String> getAliasesOfGene(String geneId) throws GeneNotFoundException {
+        
+        getGene(geneId);
 
         if (isInteger(geneId)) {
             return geneRepository.getAliasesOfGeneByEntrezGeneId(Integer.valueOf(geneId));

--- a/service/src/main/java/org/cbioportal/service/impl/GeneticProfileServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GeneticProfileServiceImpl.java
@@ -4,7 +4,9 @@ import org.cbioportal.model.GeneticProfile;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.GeneticProfileRepository;
 import org.cbioportal.service.GeneticProfileService;
+import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.GeneticProfileNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -17,6 +19,8 @@ public class GeneticProfileServiceImpl implements GeneticProfileService {
 
     @Autowired
     private GeneticProfileRepository geneticProfileRepository;
+    @Autowired
+    private StudyService studyService;
 
     @Override
     @PostFilter("hasPermission(filterObject, 'read')")
@@ -47,15 +51,21 @@ public class GeneticProfileServiceImpl implements GeneticProfileService {
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<GeneticProfile> getAllGeneticProfilesInStudy(String studyId, String projection, Integer pageSize,
-                                                             Integer pageNumber, String sortBy, String direction) {
+                                                             Integer pageNumber, String sortBy, String direction) 
+        throws StudyNotFoundException {
 
+        studyService.getStudy(studyId);
+        
         return geneticProfileRepository.getAllGeneticProfilesInStudy(studyId, projection, pageSize, pageNumber, sortBy,
                 direction);
     }
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaGeneticProfilesInStudy(String studyId) {
+    public BaseMeta getMetaGeneticProfilesInStudy(String studyId) throws StudyNotFoundException {
+
+        studyService.getStudy(studyId);
+        
         return geneticProfileRepository.getMetaGeneticProfilesInStudy(studyId);
     }
 }

--- a/service/src/main/java/org/cbioportal/service/impl/PatientServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/PatientServiceImpl.java
@@ -4,7 +4,9 @@ import org.cbioportal.model.Patient;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.PatientRepository;
 import org.cbioportal.service.PatientService;
+import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.PatientNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -16,25 +18,34 @@ public class PatientServiceImpl implements PatientService {
 
     @Autowired
     private PatientRepository patientRepository;
+    @Autowired
+    private StudyService studyService;
     
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<Patient> getAllPatientsInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber, 
-                                               String sortBy, String direction) {
+                                               String sortBy, String direction) throws StudyNotFoundException {
+        
+        studyService.getStudy(studyId);
         
         return patientRepository.getAllPatientsInStudy(studyId, projection, pageSize, pageNumber, sortBy, direction);
     }
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaPatientsInStudy(String studyId) {
+    public BaseMeta getMetaPatientsInStudy(String studyId) throws StudyNotFoundException {
+
+        studyService.getStudy(studyId);
         
         return patientRepository.getMetaPatientsInStudy(studyId);
     }
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public Patient getPatientInStudy(String studyId, String patientId) throws PatientNotFoundException {
+    public Patient getPatientInStudy(String studyId, String patientId) throws PatientNotFoundException, 
+        StudyNotFoundException {
+
+        studyService.getStudy(studyId);
 
         Patient patient = patientRepository.getPatientInStudy(studyId, patientId);
 

--- a/service/src/main/java/org/cbioportal/service/impl/SampleListServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleListServiceImpl.java
@@ -5,7 +5,9 @@ import org.cbioportal.model.SampleListSampleCount;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.SampleListRepository;
 import org.cbioportal.service.SampleListService;
+import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.SampleListNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.access.prepost.PostFilter;
@@ -20,6 +22,8 @@ public class SampleListServiceImpl implements SampleListService {
 
     @Autowired
     private SampleListRepository sampleListRepository;
+    @Autowired
+    private StudyService studyService;
 
     @Override
     @PostFilter("hasPermission(filterObject, 'read')")
@@ -61,7 +65,10 @@ public class SampleListServiceImpl implements SampleListService {
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<SampleList> getAllSampleListsInStudy(String studyId, String projection, Integer pageSize,
-                                                     Integer pageNumber, String sortBy, String direction) {
+                                                     Integer pageNumber, String sortBy, String direction) 
+        throws StudyNotFoundException {
+        
+        studyService.getStudy(studyId);
 
         List<SampleList> sampleLists = sampleListRepository.getAllSampleListsInStudy(studyId, projection, pageSize, 
             pageNumber, sortBy, direction);
@@ -75,14 +82,18 @@ public class SampleListServiceImpl implements SampleListService {
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaSampleListsInStudy(String studyId) {
+    public BaseMeta getMetaSampleListsInStudy(String studyId) throws StudyNotFoundException {
+
+        studyService.getStudy(studyId);
 
         return sampleListRepository.getMetaSampleListsInStudy(studyId);
     }
 
     @Override
     @PreAuthorize("hasPermission(#sampleListId, 'SampleList', 'read')")
-    public List<String> getAllSampleIdsInSampleList(String sampleListId) {
+    public List<String> getAllSampleIdsInSampleList(String sampleListId) throws SampleListNotFoundException {
+        
+        getSampleList(sampleListId);
 
         return sampleListRepository.getAllSampleIdsInSampleList(sampleListId);
     }

--- a/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
@@ -3,8 +3,12 @@ package org.cbioportal.service.impl;
 import org.cbioportal.model.Sample;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.SampleRepository;
+import org.cbioportal.service.PatientService;
 import org.cbioportal.service.SampleService;
+import org.cbioportal.service.StudyService;
+import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -16,26 +20,37 @@ public class SampleServiceImpl implements SampleService {
 
     @Autowired
     private SampleRepository sampleRepository;
+    @Autowired
+    private StudyService studyService;
+    @Autowired
+    private PatientService patientService;
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<Sample> getAllSamplesInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber,
-                                             String sortBy, String direction) {
+                                             String sortBy, String direction) throws StudyNotFoundException {
+        
+        studyService.getStudy(studyId);
 
         return sampleRepository.getAllSamplesInStudy(studyId, projection, pageSize, pageNumber, sortBy, direction);
     }
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaSamplesInStudy(String studyId) {
+    public BaseMeta getMetaSamplesInStudy(String studyId) throws StudyNotFoundException {
+
+        studyService.getStudy(studyId);
 
         return sampleRepository.getMetaSamplesInStudy(studyId);
     }
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public Sample getSampleInStudy(String studyId, String sampleId) throws SampleNotFoundException {
+    public Sample getSampleInStudy(String studyId, String sampleId) throws SampleNotFoundException, 
+        StudyNotFoundException {
 
+        studyService.getStudy(studyId);
+        
         Sample sample = sampleRepository.getSampleInStudy(studyId, sampleId);
 
         if (sample == null) {
@@ -49,7 +64,10 @@ public class SampleServiceImpl implements SampleService {
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<Sample> getAllSamplesOfPatientInStudy(String studyId, String patientId, String projection,
                                                       Integer pageSize, Integer pageNumber, String sortBy,
-                                                      String direction) {
+                                                      String direction) throws StudyNotFoundException, 
+        PatientNotFoundException {
+        
+        patientService.getPatientInStudy(studyId, patientId);
 
         return sampleRepository.getAllSamplesOfPatientInStudy(studyId, patientId, projection, pageSize, pageNumber,
                 sortBy, direction);
@@ -57,7 +75,10 @@ public class SampleServiceImpl implements SampleService {
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaSamplesOfPatientInStudy(String studyId, String patientId) {
+    public BaseMeta getMetaSamplesOfPatientInStudy(String studyId, String patientId) throws StudyNotFoundException, 
+        PatientNotFoundException {
+
+        patientService.getPatientInStudy(studyId, patientId);
 
         return sampleRepository.getMetaSamplesOfPatientInStudy(studyId, patientId);
     }

--- a/service/src/main/java/org/cbioportal/service/impl/SignificantCopyNumberRegionServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SignificantCopyNumberRegionServiceImpl.java
@@ -5,6 +5,8 @@ import org.cbioportal.model.GisticToGene;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.SignificantCopyNumberRegionRepository;
 import org.cbioportal.service.SignificantCopyNumberRegionService;
+import org.cbioportal.service.StudyService;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -17,11 +19,16 @@ public class SignificantCopyNumberRegionServiceImpl implements SignificantCopyNu
     
     @Autowired
     private SignificantCopyNumberRegionRepository significantCopyNumberRegionRepository;
+    @Autowired
+    private StudyService studyService;
     
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<Gistic> getSignificantCopyNumberRegions(String studyId, String projection, Integer pageSize, 
-                                                        Integer pageNumber, String sortBy, String direction) {
+                                                        Integer pageNumber, String sortBy, String direction) 
+        throws StudyNotFoundException {
+        
+        studyService.getStudy(studyId);
         
         List<Gistic> gisticList = significantCopyNumberRegionRepository.getSignificantCopyNumberRegions(studyId, 
             projection, pageSize, pageNumber, sortBy, direction);
@@ -40,7 +47,9 @@ public class SignificantCopyNumberRegionServiceImpl implements SignificantCopyNu
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaSignificantCopyNumberRegions(String studyId) {
+    public BaseMeta getMetaSignificantCopyNumberRegions(String studyId) throws StudyNotFoundException {
+
+        studyService.getStudy(studyId);
         
         return significantCopyNumberRegionRepository.getMetaSignificantCopyNumberRegions(studyId);
     }

--- a/service/src/main/java/org/cbioportal/service/impl/SignificantlyMutatedGeneServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SignificantlyMutatedGeneServiceImpl.java
@@ -4,6 +4,8 @@ import org.cbioportal.model.MutSig;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.SignificantlyMutatedGeneRepository;
 import org.cbioportal.service.SignificantlyMutatedGeneService;
+import org.cbioportal.service.StudyService;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -15,11 +17,16 @@ public class SignificantlyMutatedGeneServiceImpl implements SignificantlyMutated
 
     @Autowired
     private SignificantlyMutatedGeneRepository significantlyMutatedGeneRepository;
+    @Autowired
+    private StudyService studyService;
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<MutSig> getSignificantlyMutatedGenes(String studyId, String projection, Integer pageSize,
-                                                     Integer pageNumber, String sortBy, String direction) {
+                                                     Integer pageNumber, String sortBy, String direction) 
+        throws StudyNotFoundException {
+        
+        studyService.getStudy(studyId);
 
         return significantlyMutatedGeneRepository.getSignificantlyMutatedGenes(studyId, projection, pageSize,
             pageNumber, sortBy, direction);
@@ -27,7 +34,9 @@ public class SignificantlyMutatedGeneServiceImpl implements SignificantlyMutated
 
     @Override
     @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
-    public BaseMeta getMetaSignificantlyMutatedGenes(String studyId) {
+    public BaseMeta getMetaSignificantlyMutatedGenes(String studyId) throws StudyNotFoundException {
+
+        studyService.getStudy(studyId);
         
         return significantlyMutatedGeneRepository.getMetaSignificantlyMutatedGenes(studyId);
     }

--- a/service/src/test/java/org/cbioportal/service/impl/ClinicalAttributeServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ClinicalAttributeServiceImplTest.java
@@ -1,9 +1,12 @@
 package org.cbioportal.service.impl;
 
+import org.cbioportal.model.CancerStudy;
 import org.cbioportal.model.ClinicalAttribute;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.ClinicalAttributeRepository;
+import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.ClinicalAttributeNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,6 +26,8 @@ public class ClinicalAttributeServiceImplTest extends BaseServiceImplTest {
     
     @Mock
     private ClinicalAttributeRepository clinicalAttributeRepository;
+    @Mock
+    private StudyService studyService;
     
     @Test
     public void getAllClinicalAttributes() throws Exception {
@@ -58,6 +63,13 @@ public class ClinicalAttributeServiceImplTest extends BaseServiceImplTest {
         clinicalAttributeService.getClinicalAttribute(STUDY_ID, CLINICAL_ATTRIBUTE_ID);
     }
 
+    @Test(expected = StudyNotFoundException.class)
+    public void getClinicalAttributeStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        clinicalAttributeService.getClinicalAttribute(STUDY_ID, CLINICAL_ATTRIBUTE_ID);
+    }
+
     @Test
     public void getClinicalAttribute() throws Exception {
         
@@ -85,7 +97,14 @@ public class ClinicalAttributeServiceImplTest extends BaseServiceImplTest {
             PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
 
         Assert.assertEquals(expectedClinicalAttributeList, result);
-        
+    }
+
+    @Test(expected = StudyNotFoundException.class)
+    public void getAllClinicalAttributesInStudyNotFound() throws Exception {
+
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        clinicalAttributeService.getAllClinicalAttributesInStudy(STUDY_ID, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, 
+            DIRECTION);
     }
 
     @Test
@@ -96,5 +115,12 @@ public class ClinicalAttributeServiceImplTest extends BaseServiceImplTest {
         BaseMeta result = clinicalAttributeService.getMetaClinicalAttributesInStudy(STUDY_ID);
 
         Assert.assertEquals(expectedBaseMeta, result);
+    }
+
+    @Test(expected = StudyNotFoundException.class)
+    public void getMetaClinicalAttributesInStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        clinicalAttributeService.getMetaClinicalAttributesInStudy(STUDY_ID);
     }
 }

--- a/service/src/test/java/org/cbioportal/service/impl/ClinicalDataServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ClinicalDataServiceImplTest.java
@@ -4,6 +4,12 @@ import junit.framework.Assert;
 import org.cbioportal.model.ClinicalData;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.ClinicalDataRepository;
+import org.cbioportal.service.PatientService;
+import org.cbioportal.service.SampleService;
+import org.cbioportal.service.StudyService;
+import org.cbioportal.service.exception.PatientNotFoundException;
+import org.cbioportal.service.exception.SampleNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -22,6 +28,12 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
 
     @Mock
     private ClinicalDataRepository clinicalDataRepository;
+    @Mock
+    private StudyService studyService;
+    @Mock
+    private PatientService patientService;
+    @Mock
+    private SampleService sampleService;
 
     @Test
     public void getAllClinicalDataOfSampleInStudy() throws Exception {
@@ -40,6 +52,15 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedSampleClinicalDataList, result);
     }
 
+    @Test(expected = SampleNotFoundException.class)
+    public void getAllClinicalDataOfSampleInStudySampleNotFound() throws Exception {
+        
+        Mockito.when(sampleService.getSampleInStudy(STUDY_ID, SAMPLE_ID)).thenThrow(new SampleNotFoundException(
+            STUDY_ID, SAMPLE_ID));
+        clinicalDataService.getAllClinicalDataOfSampleInStudy(STUDY_ID, SAMPLE_ID, CLINICAL_ATTRIBUTE_ID, PROJECTION, 
+            PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+    }
+
     @Test
     public void getMetaSampleClinicalData() throws Exception {
 
@@ -51,6 +72,14 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
         BaseMeta result = clinicalDataService.getMetaSampleClinicalData(STUDY_ID, SAMPLE_ID, CLINICAL_ATTRIBUTE_ID);
 
         Assert.assertEquals(expectedBaseMeta, result);
+    }
+
+    @Test(expected = SampleNotFoundException.class)
+    public void getMetaSampleClinicalDataSampleNotFound() throws Exception {
+
+        Mockito.when(sampleService.getSampleInStudy(STUDY_ID, SAMPLE_ID)).thenThrow(new SampleNotFoundException(
+            STUDY_ID, SAMPLE_ID));
+        clinicalDataService.getMetaSampleClinicalData(STUDY_ID, SAMPLE_ID, CLINICAL_ATTRIBUTE_ID);
     }
 
     @Test
@@ -70,6 +99,15 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedPatientClinicalDataList, result);
     }
 
+    @Test(expected = PatientNotFoundException.class)
+    public void getAllClinicalDataOfPatientInStudyPatientNotFound() throws Exception {
+        
+        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenThrow(new PatientNotFoundException(
+            STUDY_ID, PATIENT_ID));
+        clinicalDataService.getAllClinicalDataOfPatientInStudy(STUDY_ID, PATIENT_ID, CLINICAL_ATTRIBUTE_ID, PROJECTION, 
+            PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+    }
+
     @Test
     public void getMetaPatientClinicalData() throws Exception {
 
@@ -81,6 +119,14 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
         BaseMeta result = clinicalDataService.getMetaPatientClinicalData(STUDY_ID, PATIENT_ID, CLINICAL_ATTRIBUTE_ID);
 
         Assert.assertEquals(expectedBaseMeta, result);
+    }
+
+    @Test(expected = PatientNotFoundException.class)
+    public void getMetaPatientClinicalDataPatientNotFound() throws Exception {
+
+        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenThrow(new PatientNotFoundException(
+            STUDY_ID, PATIENT_ID));
+        clinicalDataService.getMetaPatientClinicalData(STUDY_ID, PATIENT_ID, CLINICAL_ATTRIBUTE_ID);
     }
 
     @Test
@@ -101,6 +147,14 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedSampleClinicalDataList, result);
     }
 
+    @Test(expected = StudyNotFoundException.class)
+    public void getAllClinicalDataInStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        clinicalDataService.getAllClinicalDataInStudy(STUDY_ID, CLINICAL_ATTRIBUTE_ID, CLINICAL_DATA_TYPE, PROJECTION, 
+            PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+    }
+
     @Test
     public void getMetaAllClinicalData() throws Exception {
 
@@ -113,6 +167,13 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
         BaseMeta result = clinicalDataService.getMetaAllClinicalData(STUDY_ID, CLINICAL_ATTRIBUTE_ID, CLINICAL_DATA_TYPE);
 
         Assert.assertEquals((Integer) 5, result.getTotalCount());
+    }
+
+    @Test(expected = StudyNotFoundException.class)
+    public void getMetaAllClinicalDataStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        clinicalDataService.getMetaAllClinicalData(STUDY_ID, CLINICAL_ATTRIBUTE_ID, CLINICAL_DATA_TYPE);
     }
 
     @Test

--- a/service/src/test/java/org/cbioportal/service/impl/ClinicalEventServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ClinicalEventServiceImplTest.java
@@ -4,6 +4,8 @@ import org.cbioportal.model.ClinicalEvent;
 import org.cbioportal.model.ClinicalEventData;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.ClinicalEventRepository;
+import org.cbioportal.service.PatientService;
+import org.cbioportal.service.exception.PatientNotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +26,8 @@ public class ClinicalEventServiceImplTest extends BaseServiceImplTest {
     
     @Mock
     private ClinicalEventRepository clinicalEventRepository;
+    @Mock
+    private PatientService patientService;
     
     @Test
     public void getAllClinicalEventsOfPatientInStudy() throws Exception {
@@ -53,6 +57,15 @@ public class ClinicalEventServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(clinicalEventData, result.get(0).getAttributes().get(0));
     }
 
+    @Test(expected = PatientNotFoundException.class)
+    public void getAllClinicalEventsOfPatientInStudyPatientNotFound() throws Exception {
+
+        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenThrow(new PatientNotFoundException(
+            STUDY_ID, PATIENT_ID));
+        clinicalEventService.getAllClinicalEventsOfPatientInStudy(STUDY_ID, PATIENT_ID, PROJECTION, PAGE_SIZE, 
+            PAGE_NUMBER, SORT, DIRECTION);
+    }
+
     @Test
     public void getMetaPatientClinicalEvents() throws Exception {
 
@@ -61,6 +74,14 @@ public class ClinicalEventServiceImplTest extends BaseServiceImplTest {
             .thenReturn(expectedBaseMeta);
         BaseMeta result = clinicalEventService.getMetaPatientClinicalEvents(STUDY_ID, PATIENT_ID);
 
-        org.junit.Assert.assertEquals(expectedBaseMeta, result);
+        Assert.assertEquals(expectedBaseMeta, result);
+    }
+
+    @Test(expected = PatientNotFoundException.class)
+    public void getMetaPatientClinicalEventsPatientNotFound() throws Exception {
+        
+        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenThrow(new PatientNotFoundException(
+            STUDY_ID, PATIENT_ID));
+        clinicalEventService.getMetaPatientClinicalEvents(STUDY_ID, PATIENT_ID);
     }
 }

--- a/service/src/test/java/org/cbioportal/service/impl/CopyNumberSegmentServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/CopyNumberSegmentServiceImplTest.java
@@ -4,6 +4,8 @@ import junit.framework.Assert;
 import org.cbioportal.model.CopyNumberSeg;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.CopyNumberSegmentRepository;
+import org.cbioportal.service.SampleService;
+import org.cbioportal.service.exception.SampleNotFoundException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -23,6 +25,8 @@ public class CopyNumberSegmentServiceImplTest extends BaseServiceImplTest {
     
     @Mock
     private CopyNumberSegmentRepository copyNumberSegmentRepository;
+    @Mock
+    private SampleService sampleService;
 
     @Test
     public void getCopyNumberSegmentsInSampleInStudy() throws Exception {
@@ -40,6 +44,15 @@ public class CopyNumberSegmentServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedCopyNumberSegList, result);
     }
 
+    @Test(expected = SampleNotFoundException.class)
+    public void getCopyNumberSegmentsInSampleInStudySampleNotFound() throws Exception {
+        
+        Mockito.when(sampleService.getSampleInStudy(STUDY_ID, SAMPLE_ID)).thenThrow(new SampleNotFoundException(
+            STUDY_ID, SAMPLE_ID));
+        copyNumberSegmentService.getCopyNumberSegmentsInSampleInStudy(STUDY_ID, SAMPLE_ID, PROJECTION, PAGE_SIZE, 
+            PAGE_NUMBER, SORT, DIRECTION);
+    }
+
     @Test
     public void getMetaCopyNumberSegmentsInSampleInStudy() throws Exception {
 
@@ -51,6 +64,14 @@ public class CopyNumberSegmentServiceImplTest extends BaseServiceImplTest {
         BaseMeta result = copyNumberSegmentService.getMetaCopyNumberSegmentsInSampleInStudy(STUDY_ID, SAMPLE_ID);
 
         Assert.assertEquals(expectedBaseMeta, result);
+    }
+
+    @Test(expected = SampleNotFoundException.class)
+    public void getMetaCopyNumberSegmentsInSampleInStudySampleNotFound() throws Exception {
+        
+        Mockito.when(sampleService.getSampleInStudy(STUDY_ID, SAMPLE_ID)).thenThrow(new SampleNotFoundException(
+            STUDY_ID, SAMPLE_ID));
+        copyNumberSegmentService.getMetaCopyNumberSegmentsInSampleInStudy(STUDY_ID, SAMPLE_ID);
     }
 
     @Test

--- a/service/src/test/java/org/cbioportal/service/impl/GeneServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GeneServiceImplTest.java
@@ -109,6 +109,8 @@ public class GeneServiceImplTest extends BaseServiceImplTest {
     @Test
     public void getAliasesOfGeneByEntrezGeneId() throws Exception {
 
+        Gene expectedGene = new Gene();
+        Mockito.when(geneRepository.getGeneByEntrezGeneId(ENTREZ_GENE_ID)).thenReturn(expectedGene);
         List<String> expectedAliases = new ArrayList<>();
         expectedAliases.add("alias");
         Mockito.when(geneRepository.getAliasesOfGeneByEntrezGeneId(ENTREZ_GENE_ID)).thenReturn(expectedAliases);
@@ -117,15 +119,31 @@ public class GeneServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedAliases, result);
     }
 
+    @Test(expected = GeneNotFoundException.class)
+    public void getAliasesOfGeneByEntrezGeneIdGeneNotFound() throws Exception {
+        
+        Mockito.when(geneRepository.getGeneByEntrezGeneId(ENTREZ_GENE_ID)).thenReturn(null);
+        geneService.getAliasesOfGene(ENTREZ_GENE_ID.toString());
+    }
+
     @Test
     public void getAliasesOfGeneByHugoGeneSymbol() throws Exception {
 
+        Gene expectedGene = new Gene();
+        Mockito.when(geneRepository.getGeneByHugoGeneSymbol(HUGO_GENE_SYMBOL)).thenReturn(expectedGene);
         List<String> expectedAliases = new ArrayList<>();
         expectedAliases.add("alias");
         Mockito.when(geneRepository.getAliasesOfGeneByHugoGeneSymbol(HUGO_GENE_SYMBOL)).thenReturn(expectedAliases);
         List<String> result = geneService.getAliasesOfGene(HUGO_GENE_SYMBOL);
 
         Assert.assertEquals(expectedAliases, result);
+    }
+
+    @Test(expected = GeneNotFoundException.class)
+    public void getAliasesOfGeneByHugoGeneSymbolGeneNotFound() throws Exception {
+        
+        Mockito.when(geneRepository.getGeneByHugoGeneSymbol(HUGO_GENE_SYMBOL)).thenReturn(null);
+        geneService.getAliasesOfGene(HUGO_GENE_SYMBOL);
     }
 
     @Test

--- a/service/src/test/java/org/cbioportal/service/impl/GeneticProfileServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GeneticProfileServiceImplTest.java
@@ -1,9 +1,12 @@
 package org.cbioportal.service.impl;
 
 import org.cbioportal.model.GeneticProfile;
+import org.cbioportal.model.Sample;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.GeneticProfileRepository;
+import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.GeneticProfileNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,6 +26,8 @@ public class GeneticProfileServiceImplTest extends BaseServiceImplTest {
 
     @Mock
     private GeneticProfileRepository geneticProfileRepository;
+    @Mock
+    private StudyService studyService;
 
     @Test
     public void getAllGeneticProfiles() throws Exception {
@@ -89,6 +94,14 @@ public class GeneticProfileServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedGeneticProfileList, result);
     }
 
+    @Test(expected = StudyNotFoundException.class)
+    public void getAllGeneticProfilesInStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        geneticProfileService.getAllGeneticProfilesInStudy(STUDY_ID, PROJECTION,
+            PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+    }
+
     @Test
     public void getMetaGeneticProfilesInStudy() throws Exception {
 
@@ -99,5 +112,12 @@ public class GeneticProfileServiceImplTest extends BaseServiceImplTest {
         BaseMeta result = geneticProfileService.getMetaGeneticProfilesInStudy(STUDY_ID);
 
         Assert.assertEquals(expectedBaseMeta, result);
+    }
+
+    @Test(expected = StudyNotFoundException.class)
+    public void getMetaGeneticProfilesInStudyNotFound() throws Exception {
+
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        geneticProfileService.getMetaGeneticProfilesInStudy(STUDY_ID);
     }
 }

--- a/service/src/test/java/org/cbioportal/service/impl/MutationServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MutationServiceImplTest.java
@@ -3,6 +3,8 @@ package org.cbioportal.service.impl;
 import org.cbioportal.model.*;
 import org.cbioportal.model.meta.MutationMeta;
 import org.cbioportal.persistence.MutationRepository;
+import org.cbioportal.service.GeneticProfileService;
+import org.cbioportal.service.exception.GeneticProfileNotFoundException;
 import org.cbioportal.service.util.ChromosomeCalculator;
 import org.junit.Assert;
 import org.junit.Test;
@@ -25,10 +27,16 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
     @Mock
     private MutationRepository mutationRepository;
     @Mock
+    private GeneticProfileService geneticProfileService;
+    @Mock
     private ChromosomeCalculator chromosomeCalculator;
     
     @Test
     public void getMutationsInGeneticProfileBySampleListId() throws Exception {
+        
+        GeneticProfile geneticProfile = new GeneticProfile();
+        geneticProfile.setGeneticAlterationType(GeneticProfile.GeneticAlterationType.MUTATION_EXTENDED);
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenReturn(geneticProfile);
 
         List<Mutation> expectedMutationList = new ArrayList<>();
         Mutation mutation = new Mutation();
@@ -50,9 +58,22 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals("19", result.get(0).getGene().getChromosome());
     }
 
+    @Test(expected = GeneticProfileNotFoundException.class)
+    public void getMutationsInGeneticProfileBySampleListIdGeneticProfileNotFound() throws Exception {
+
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenThrow(
+            new GeneticProfileNotFoundException(GENETIC_PROFILE_ID));
+        mutationService.getMutationsInGeneticProfileBySampleListId(GENETIC_PROFILE_ID, SAMPLE_ID, PROJECTION, PAGE_SIZE, 
+            PAGE_NUMBER, SORT, DIRECTION);
+    }
+
     @Test
     public void getMetaMutationsInGeneticProfileBySampleListId() throws Exception {
 
+        GeneticProfile geneticProfile = new GeneticProfile();
+        geneticProfile.setGeneticAlterationType(GeneticProfile.GeneticAlterationType.MUTATION_EXTENDED);
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenReturn(geneticProfile);
+        
         MutationMeta expectedMutationMeta = new MutationMeta();
         Mockito.when(mutationRepository.getMetaMutationsInGeneticProfileBySampleListId(GENETIC_PROFILE_ID, SAMPLE_ID))
             .thenReturn(expectedMutationMeta);
@@ -62,8 +83,20 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedMutationMeta, result);
     }
 
+    @Test(expected = GeneticProfileNotFoundException.class)
+    public void getMetaMutationsInGeneticProfileBySampleListIdGeneticProfileNotFound() throws Exception {
+        
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenThrow(
+            new GeneticProfileNotFoundException(GENETIC_PROFILE_ID));
+        mutationService.getMetaMutationsInGeneticProfileBySampleListId(GENETIC_PROFILE_ID, SAMPLE_ID);
+    }
+
     @Test
     public void fetchMutationsInGeneticProfile() throws Exception {
+
+        GeneticProfile geneticProfile = new GeneticProfile();
+        geneticProfile.setGeneticAlterationType(GeneticProfile.GeneticAlterationType.MUTATION_EXTENDED);
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenReturn(geneticProfile);
 
         List<Mutation> expectedMutationList = new ArrayList<>();
         Mutation mutation = new Mutation();
@@ -85,8 +118,21 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals("19", result.get(0).getGene().getChromosome());
     }
 
+    @Test(expected = GeneticProfileNotFoundException.class)
+    public void fetchMutationsInGeneticProfileNotFound() throws Exception {
+        
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenThrow(
+            new GeneticProfileNotFoundException(GENETIC_PROFILE_ID));
+        mutationService.fetchMutationsInGeneticProfile(GENETIC_PROFILE_ID, Arrays.asList(SAMPLE_ID), PROJECTION, 
+            PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+    }
+
     @Test
     public void fetchMetaMutationsInGeneticProfile() throws Exception {
+
+        GeneticProfile geneticProfile = new GeneticProfile();
+        geneticProfile.setGeneticAlterationType(GeneticProfile.GeneticAlterationType.MUTATION_EXTENDED);
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenReturn(geneticProfile);
 
         MutationMeta expectedMutationMeta = new MutationMeta();
         Mockito.when(mutationRepository.fetchMetaMutationsInGeneticProfile(GENETIC_PROFILE_ID, 
@@ -97,8 +143,20 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedMutationMeta, result);
     }
 
+    @Test(expected = GeneticProfileNotFoundException.class)
+    public void fetchMetaMutationsInGeneticProfileNotFound() throws Exception {
+        
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenThrow(
+            new GeneticProfileNotFoundException(GENETIC_PROFILE_ID));
+        mutationService.fetchMetaMutationsInGeneticProfile(GENETIC_PROFILE_ID, Arrays.asList(SAMPLE_ID));
+    }
+
     @Test
     public void getSampleCountByEntrezGeneIds() throws Exception {
+
+        GeneticProfile geneticProfile = new GeneticProfile();
+        geneticProfile.setGeneticAlterationType(GeneticProfile.GeneticAlterationType.MUTATION_EXTENDED);
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenReturn(geneticProfile);
 
         List<MutationSampleCountByGene> expectedMutationSampleCountByGeneList = new ArrayList<>();
         MutationSampleCountByGene mutationSampleCountByGene = new MutationSampleCountByGene();
@@ -113,8 +171,20 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedMutationSampleCountByGeneList, result);
     }
 
+    @Test(expected = GeneticProfileNotFoundException.class)
+    public void getSampleCountByEntrezGeneIdsGeneticProfileNotFound() throws Exception {
+        
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenThrow(
+            new GeneticProfileNotFoundException(GENETIC_PROFILE_ID));
+        mutationService.getSampleCountByEntrezGeneIds(GENETIC_PROFILE_ID, Arrays.asList(ENTREZ_GENE_ID));
+    }
+
     @Test
     public void getSampleCountByKeywords() throws Exception {
+
+        GeneticProfile geneticProfile = new GeneticProfile();
+        geneticProfile.setGeneticAlterationType(GeneticProfile.GeneticAlterationType.MUTATION_EXTENDED);
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenReturn(geneticProfile);
 
         List<MutationSampleCountByKeyword> expectedmutationSampleCountByKeywordList = new ArrayList<>();
         MutationSampleCountByKeyword mutationSampleCountByKeyword = new MutationSampleCountByKeyword();
@@ -129,8 +199,20 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedmutationSampleCountByKeywordList, result);
     }
 
+    @Test(expected = GeneticProfileNotFoundException.class)
+    public void getSampleCountByKeywordsGeneticProfileNotFound() throws Exception {
+        
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenThrow(
+            new GeneticProfileNotFoundException(GENETIC_PROFILE_ID));
+        mutationService.getSampleCountByKeywords(GENETIC_PROFILE_ID, Arrays.asList(KEYWORD));
+    }
+
     @Test
     public void getMutationCountsInGeneticProfileBySampleListId() throws Exception {
+
+        GeneticProfile geneticProfile = new GeneticProfile();
+        geneticProfile.setGeneticAlterationType(GeneticProfile.GeneticAlterationType.MUTATION_EXTENDED);
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenReturn(geneticProfile);
         
         List<MutationCount> expectedMutationCountList = new ArrayList<>();
         MutationCount mutationCount = new MutationCount();
@@ -145,8 +227,20 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedMutationCountList, result);
     }
 
+    @Test(expected = GeneticProfileNotFoundException.class)
+    public void getMutationCountsInGeneticProfileBySampleListIdGeneticProfileNotFound() throws Exception {
+
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenThrow(
+            new GeneticProfileNotFoundException(GENETIC_PROFILE_ID));
+        mutationService.getMutationCountsInGeneticProfileBySampleListId(GENETIC_PROFILE_ID, SAMPLE_LIST_ID);
+    }
+
     @Test
     public void fetchMutationCountsInGeneticProfile() throws Exception {
+
+        GeneticProfile geneticProfile = new GeneticProfile();
+        geneticProfile.setGeneticAlterationType(GeneticProfile.GeneticAlterationType.MUTATION_EXTENDED);
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenReturn(geneticProfile);
 
         List<MutationCount> expectedMutationCountList = new ArrayList<>();
         MutationCount mutationCount = new MutationCount();
@@ -159,5 +253,13 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
             Arrays.asList(SAMPLE_LIST_ID));
 
         Assert.assertEquals(expectedMutationCountList, result);
+    }
+
+    @Test(expected = GeneticProfileNotFoundException.class)
+    public void fetchMutationCountsInGeneticProfileNotFound() throws Exception {
+        
+        Mockito.when(geneticProfileService.getGeneticProfile(GENETIC_PROFILE_ID)).thenThrow(
+            new GeneticProfileNotFoundException(GENETIC_PROFILE_ID));
+        mutationService.fetchMutationCountsInGeneticProfile(GENETIC_PROFILE_ID, Arrays.asList(SAMPLE_LIST_ID));
     }
 }

--- a/service/src/test/java/org/cbioportal/service/impl/PatientServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/PatientServiceImplTest.java
@@ -3,7 +3,9 @@ package org.cbioportal.service.impl;
 import org.cbioportal.model.Patient;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.PatientRepository;
+import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.PatientNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +26,8 @@ public class PatientServiceImplTest extends BaseServiceImplTest {
 
     @Mock
     private PatientRepository patientRepository;
+    @Mock
+    private StudyService studyService;
 
     @Test
     public void getAllPatientsInStudy() throws Exception {
@@ -40,6 +44,13 @@ public class PatientServiceImplTest extends BaseServiceImplTest {
 
         Assert.assertEquals(expectedPatientList, result);
     }
+    
+    @Test(expected = StudyNotFoundException.class)
+    public void getAllPatientsInStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        patientService.getAllPatientsInStudy(STUDY_ID, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+    }
 
     @Test
     public void getMetaPatientsInStudy() throws Exception {
@@ -51,10 +62,24 @@ public class PatientServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedBaseMeta, result);
     }
 
+    @Test(expected = StudyNotFoundException.class)
+    public void getMetaPatientsInStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        patientService.getMetaPatientsInStudy(STUDY_ID);
+    }
+
     @Test(expected = PatientNotFoundException.class)
-    public void getPatientInStudyNotFound() throws Exception {
+    public void getPatientInStudyPatientNotFound() throws Exception {
 
         Mockito.when(patientRepository.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenReturn(null);
+        patientService.getPatientInStudy(STUDY_ID, PATIENT_ID);
+    }
+
+    @Test(expected = StudyNotFoundException.class)
+    public void getPatientInStudyNotFound() throws Exception {
+
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
         patientService.getPatientInStudy(STUDY_ID, PATIENT_ID);
     }
 

--- a/service/src/test/java/org/cbioportal/service/impl/SampleListServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/SampleListServiceImplTest.java
@@ -4,7 +4,9 @@ import org.cbioportal.model.SampleList;
 import org.cbioportal.model.SampleListSampleCount;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.SampleListRepository;
+import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.SampleListNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +27,8 @@ public class SampleListServiceImplTest extends BaseServiceImplTest {
 
     @Mock
     private SampleListRepository sampleListRepository;
+    @Mock
+    private StudyService studyService;
 
     @Test
     public void getAllSampleLists() throws Exception {
@@ -112,11 +116,18 @@ public class SampleListServiceImplTest extends BaseServiceImplTest {
         Mockito.when(sampleListRepository.getAllSampleListsInStudy(STUDY_ID, "DETAILED", PAGE_SIZE, PAGE_NUMBER,
             SORT, DIRECTION)).thenReturn(expectedSampleLists);
 
-        List<SampleList> result = sampleListService.getAllSampleListsInStudy(STUDY_ID, "DETAILED",
-            PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+        List<SampleList> result = sampleListService.getAllSampleListsInStudy(STUDY_ID, "DETAILED", PAGE_SIZE, 
+            PAGE_NUMBER, SORT, DIRECTION);
 
         Assert.assertEquals(expectedSampleLists, result);
         Assert.assertEquals((Integer) 10, expectedSampleLists.get(0).getSampleCount());
+    }
+
+    @Test(expected = StudyNotFoundException.class)
+    public void getAllSampleListsInStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        sampleListService.getAllSampleListsInStudy(STUDY_ID, "DETAILED", PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
     }
 
     @Test
@@ -131,8 +142,27 @@ public class SampleListServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedBaseMeta, result);
     }
 
+    @Test(expected = StudyNotFoundException.class)
+    public void getMetaSampleListsInStudyNotFound() throws Exception {
+
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        sampleListService.getMetaSampleListsInStudy(STUDY_ID);
+    }
+
     @Test
     public void getAllSampleIdsInSampleList() throws Exception {
+
+        SampleList expectedSampleList = new SampleList();
+        expectedSampleList.setListId(1);
+
+        Mockito.when(sampleListRepository.getSampleList(SAMPLE_LIST_ID)).thenReturn(expectedSampleList);
+
+        List<SampleListSampleCount> expectedSampleListSampleCounts = new ArrayList<>();
+        SampleListSampleCount sampleListSampleCount = new SampleListSampleCount();
+        sampleListSampleCount.setSampleCount(10);
+        expectedSampleListSampleCounts.add(sampleListSampleCount);
+
+        Mockito.when(sampleListRepository.getSampleCounts(Arrays.asList(1))).thenReturn(expectedSampleListSampleCounts);
 
         List<String> expectedSampleIds = new ArrayList<>();
         expectedSampleIds.add(SAMPLE_ID);
@@ -140,5 +170,12 @@ public class SampleListServiceImplTest extends BaseServiceImplTest {
         List<String> result = sampleListService.getAllSampleIdsInSampleList(SAMPLE_LIST_ID);
 
         Assert.assertEquals(expectedSampleIds, result);
+    }
+
+    @Test(expected = SampleListNotFoundException.class)
+    public void getAllSampleIdsInSampleListNotFound() throws Exception {
+
+        Mockito.when(sampleListRepository.getSampleList(SAMPLE_LIST_ID)).thenReturn(null);
+        sampleListService.getAllSampleIdsInSampleList(SAMPLE_LIST_ID);
     }
 }

--- a/service/src/test/java/org/cbioportal/service/impl/SampleServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/SampleServiceImplTest.java
@@ -3,7 +3,11 @@ package org.cbioportal.service.impl;
 import org.cbioportal.model.Sample;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.SampleRepository;
+import org.cbioportal.service.PatientService;
+import org.cbioportal.service.StudyService;
+import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +28,10 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
 
     @Mock
     private SampleRepository sampleRepository;
+    @Mock
+    private StudyService studyService;
+    @Mock
+    private PatientService patientService;
 
     @Test
     public void getAllSamplesInStudy() throws Exception {
@@ -41,6 +49,13 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedSampleList, result);
     }
 
+    @Test(expected = StudyNotFoundException.class)
+    public void getAllSamplesInStudyNotFound() throws Exception {
+
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        sampleService.getAllSamplesInStudy(STUDY_ID, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+    }
+
     @Test
     public void getMetaSamplesInStudy() throws Exception {
 
@@ -51,10 +66,24 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedBaseMeta, result);
     }
 
+    @Test(expected = StudyNotFoundException.class)
+    public void getMetaSamplesInStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        sampleService.getMetaSamplesInStudy(STUDY_ID);
+    }
+
     @Test(expected = SampleNotFoundException.class)
-    public void getSampleInStudyNotFound() throws Exception {
+    public void getSampleInStudySampleNotFound() throws Exception {
 
         Mockito.when(sampleRepository.getSampleInStudy(STUDY_ID, SAMPLE_ID)).thenReturn(null);
+        sampleService.getSampleInStudy(STUDY_ID, SAMPLE_ID);
+    }
+
+    @Test(expected = StudyNotFoundException.class)
+    public void getSampleInStudyNotFound() throws Exception {
+
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
         sampleService.getSampleInStudy(STUDY_ID, SAMPLE_ID);
     }
 
@@ -84,14 +113,31 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(expectedSampleList, result);
     }
 
+    @Test(expected = PatientNotFoundException.class)
+    public void getAllSamplesOfPatientInStudyPatientNotFound() throws Exception {
+
+        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenThrow(new PatientNotFoundException(
+            STUDY_ID, PATIENT_ID));
+        sampleService.getAllSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, 
+            DIRECTION);
+    }
+
     @Test
     public void getMetaSamplesOfPatientInStudy() throws Exception {
 
         BaseMeta expectedBaseMeta = new BaseMeta();
-        Mockito.when(sampleRepository.getMetaSamplesOfPatientInStudy(STUDY_ID, SAMPLE_ID)).thenReturn(expectedBaseMeta);
-        BaseMeta result = sampleService.getMetaSamplesOfPatientInStudy(STUDY_ID, SAMPLE_ID);
+        Mockito.when(sampleRepository.getMetaSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID)).thenReturn(expectedBaseMeta);
+        BaseMeta result = sampleService.getMetaSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID);
 
         Assert.assertEquals(expectedBaseMeta, result);
+    }
+
+    @Test(expected = PatientNotFoundException.class)
+    public void getMetaSamplesOfPatientInStudyPatientNotFound() throws Exception {
+        
+        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenThrow(new PatientNotFoundException(
+            STUDY_ID, PATIENT_ID));
+        sampleService.getMetaSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID);
     }
 
     @Test

--- a/service/src/test/java/org/cbioportal/service/impl/SignificantCopyNumberRegionServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/SignificantCopyNumberRegionServiceImplTest.java
@@ -5,6 +5,8 @@ import org.cbioportal.model.Gistic;
 import org.cbioportal.model.GisticToGene;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.SignificantCopyNumberRegionRepository;
+import org.cbioportal.service.StudyService;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -24,6 +26,8 @@ public class SignificantCopyNumberRegionServiceImplTest extends BaseServiceImplT
     
     @Mock
     private SignificantCopyNumberRegionRepository significantCopyNumberRegionRepository;
+    @Mock
+    private StudyService studyService;
     
     @Test
     public void getSignificantCopyNumberRegions() throws Exception {
@@ -53,6 +57,14 @@ public class SignificantCopyNumberRegionServiceImplTest extends BaseServiceImplT
         Assert.assertEquals(gisticToGene, result.get(0).getGenes().get(0));
     }
 
+    @Test(expected = StudyNotFoundException.class)
+    public void getSignificantCopyNumberRegionsStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        significantCopyNumberRegionService.getSignificantCopyNumberRegions(STUDY_ID, PROJECTION, PAGE_SIZE, PAGE_NUMBER, 
+            SORT, DIRECTION);
+    }
+
     @Test
     public void getMetaSignificantCopyNumberRegions() throws Exception {
 
@@ -61,6 +73,13 @@ public class SignificantCopyNumberRegionServiceImplTest extends BaseServiceImplT
             .thenReturn(expectedBaseMeta);
         BaseMeta result = significantCopyNumberRegionService.getMetaSignificantCopyNumberRegions(STUDY_ID);
 
-        org.junit.Assert.assertEquals(expectedBaseMeta, result);
+        Assert.assertEquals(expectedBaseMeta, result);
+    }
+
+    @Test(expected = StudyNotFoundException.class)
+    public void getMetaSignificantCopyNumberRegionsStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        significantCopyNumberRegionService.getMetaSignificantCopyNumberRegions(STUDY_ID);
     }
 }

--- a/service/src/test/java/org/cbioportal/service/impl/SignificantlyMutatedGeneServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/SignificantlyMutatedGeneServiceImplTest.java
@@ -3,6 +3,8 @@ package org.cbioportal.service.impl;
 import org.cbioportal.model.MutSig;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.SignificantlyMutatedGeneRepository;
+import org.cbioportal.service.StudyService;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +24,8 @@ public class SignificantlyMutatedGeneServiceImplTest extends BaseServiceImplTest
 
     @Mock
     private SignificantlyMutatedGeneRepository significantlyMutatedGeneRepository;
+    @Mock
+    private StudyService studyService;
     
     @Test
     public void getSignificantlyMutatedGenes() throws Exception {
@@ -39,14 +43,29 @@ public class SignificantlyMutatedGeneServiceImplTest extends BaseServiceImplTest
         Assert.assertEquals(expectedMutSigList, result);
     }
 
+    @Test(expected = StudyNotFoundException.class)
+    public void getSignificantlyMutatedGenesStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        significantlyMutatedGeneService.getSignificantlyMutatedGenes(STUDY_ID, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, 
+            DIRECTION);
+    }
+
     @Test
     public void getMetaSignificantlyMutatedGenes() throws Exception {
 
         BaseMeta expectedBaseMeta = new BaseMeta();
-        Mockito.when(significantlyMutatedGeneRepository.getMetaSignificantlyMutatedGenes(GENETIC_PROFILE_ID))
+        Mockito.when(significantlyMutatedGeneRepository.getMetaSignificantlyMutatedGenes(STUDY_ID))
             .thenReturn(expectedBaseMeta);
-        BaseMeta result = significantlyMutatedGeneService.getMetaSignificantlyMutatedGenes(GENETIC_PROFILE_ID);
+        BaseMeta result = significantlyMutatedGeneService.getMetaSignificantlyMutatedGenes(STUDY_ID);
 
         Assert.assertEquals(expectedBaseMeta, result);
+    }
+
+    @Test(expected = StudyNotFoundException.class)
+    public void getMetaSignificantlyMutatedGenesStudyNotFound() throws Exception {
+        
+        Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
+        significantlyMutatedGeneService.getMetaSignificantlyMutatedGenes(STUDY_ID);
     }
 }

--- a/web/src/main/java/org/cbioportal/web/ClinicalAttributeController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalAttributeController.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.ClinicalAttribute;
 import org.cbioportal.service.ClinicalAttributeService;
 import org.cbioportal.service.exception.ClinicalAttributeNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -85,7 +86,7 @@ public class ClinicalAttributeController {
             @ApiParam("Name of the property that the result list is sorted by")
             @RequestParam(required = false) ClinicalAttributeSortBy sortBy,
             @ApiParam("Direction of the sort")
-            @RequestParam(defaultValue = "ASC") Direction direction) {
+            @RequestParam(defaultValue = "ASC") Direction direction) throws StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();
@@ -107,7 +108,7 @@ public class ClinicalAttributeController {
             @ApiParam(required = true, value = "Study ID e.g. acc_tcga")
             @PathVariable String studyId,
             @ApiParam(required = true, value= "Clinical Attribute ID e.g. CANCER_TYPE")
-            @PathVariable String clinicalAttributeId) throws ClinicalAttributeNotFoundException {
+            @PathVariable String clinicalAttributeId) throws ClinicalAttributeNotFoundException, StudyNotFoundException {
 
         return new ResponseEntity<>(clinicalAttributeService.getClinicalAttribute(studyId, clinicalAttributeId),
                 HttpStatus.OK);

--- a/web/src/main/java/org/cbioportal/web/ClinicalDataController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalDataController.java
@@ -4,6 +4,9 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.ClinicalData;
+import org.cbioportal.service.exception.PatientNotFoundException;
+import org.cbioportal.service.exception.SampleNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.ClinicalDataIdentifier;
 import org.cbioportal.service.ClinicalDataService;
@@ -63,7 +66,8 @@ public class ClinicalDataController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) ClinicalDataSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws SampleNotFoundException, 
+        StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();
@@ -100,7 +104,8 @@ public class ClinicalDataController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) ClinicalDataSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws PatientNotFoundException, 
+        StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();
@@ -137,7 +142,7 @@ public class ClinicalDataController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) ClinicalDataSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();

--- a/web/src/main/java/org/cbioportal/web/ClinicalEventController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalEventController.java
@@ -5,6 +5,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.ClinicalEvent;
 import org.cbioportal.service.ClinicalEventService;
+import org.cbioportal.service.exception.PatientNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -56,7 +58,8 @@ public class ClinicalEventController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) ClinicalEventSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws PatientNotFoundException, 
+        StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();

--- a/web/src/main/java/org/cbioportal/web/CopyNumberSegmentController.java
+++ b/web/src/main/java/org/cbioportal/web/CopyNumberSegmentController.java
@@ -5,6 +5,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.CopyNumberSeg;
 import org.cbioportal.service.CopyNumberSegmentService;
+import org.cbioportal.service.exception.SampleNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -63,7 +65,8 @@ public class CopyNumberSegmentController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) CopyNumberSegmentSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws SampleNotFoundException, 
+        StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();

--- a/web/src/main/java/org/cbioportal/web/GeneController.java
+++ b/web/src/main/java/org/cbioportal/web/GeneController.java
@@ -88,7 +88,7 @@ public class GeneController {
     @ApiOperation("Get aliases of a gene")
     public ResponseEntity<List<String>> getAliasesOfGene(
         @ApiParam(required = true, value = "Entrez Gene ID or Hugo Gene Symbol e.g. 1 or A1BG")
-        @PathVariable String geneId) {
+        @PathVariable String geneId) throws GeneNotFoundException {
 
         return new ResponseEntity<>(geneService.getAliasesOfGene(geneId), HttpStatus.OK);
     }

--- a/web/src/main/java/org/cbioportal/web/GeneticProfileController.java
+++ b/web/src/main/java/org/cbioportal/web/GeneticProfileController.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.GeneticProfile;
 import org.cbioportal.service.GeneticProfileService;
 import org.cbioportal.service.exception.GeneticProfileNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -95,7 +96,7 @@ public class GeneticProfileController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) GeneticProfileSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();

--- a/web/src/main/java/org/cbioportal/web/MutationController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationController.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.Mutation;
 import org.cbioportal.model.MutationCount;
 import org.cbioportal.service.MutationService;
+import org.cbioportal.service.exception.GeneticProfileNotFoundException;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
 import org.cbioportal.web.parameter.Direction;
@@ -64,7 +65,7 @@ public class MutationController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) MutationSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws GeneticProfileNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();
@@ -101,7 +102,7 @@ public class MutationController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) MutationSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws GeneticProfileNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();
@@ -122,7 +123,7 @@ public class MutationController {
         @ApiParam(required = true, value = "Genetic Profile ID e.g. acc_tcga_mutations")
         @PathVariable String geneticProfileId,
         @ApiParam(required = true, value = "Sample List ID e.g. acc_tcga_all")
-        @RequestParam String sampleListId) {
+        @RequestParam String sampleListId) throws GeneticProfileNotFoundException {
 
         return new ResponseEntity<>(mutationService.getMutationCountsInGeneticProfileBySampleListId(
             geneticProfileId, sampleListId), HttpStatus.OK);
@@ -136,7 +137,7 @@ public class MutationController {
         @PathVariable String geneticProfileId,
         @ApiParam(required = true, value = "List of Sample IDs")
         @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
-        @RequestBody List<String> sampleIds) {
+        @RequestBody List<String> sampleIds) throws GeneticProfileNotFoundException {
         
             return new ResponseEntity<>(mutationService.fetchMutationCountsInGeneticProfile(geneticProfileId, 
                 sampleIds), HttpStatus.OK);

--- a/web/src/main/java/org/cbioportal/web/PatientController.java
+++ b/web/src/main/java/org/cbioportal/web/PatientController.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.Patient;
 import org.cbioportal.service.PatientService;
 import org.cbioportal.service.exception.PatientNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.*;
 import org.cbioportal.web.parameter.sort.PatientSortBy;
@@ -55,7 +56,7 @@ public class PatientController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) PatientSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();
@@ -76,7 +77,7 @@ public class PatientController {
         @ApiParam(required = true, value = "Study ID e.g. acc_tcga")
         @PathVariable String studyId,
         @ApiParam(required = true, value = "Patient ID e.g. TCGA-OR-A5J2")
-        @PathVariable String patientId) throws PatientNotFoundException {
+        @PathVariable String patientId) throws PatientNotFoundException, StudyNotFoundException {
 
         return new ResponseEntity<>(patientService.getPatientInStudy(studyId, patientId), HttpStatus.OK);
     }

--- a/web/src/main/java/org/cbioportal/web/SampleController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleController.java
@@ -5,7 +5,9 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.Sample;
 import org.cbioportal.service.SampleService;
+import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.*;
 import org.cbioportal.web.parameter.sort.SampleSortBy;
@@ -55,7 +57,7 @@ public class SampleController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) SampleSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();
@@ -76,7 +78,7 @@ public class SampleController {
         @ApiParam(required = true, value = "Study ID e.g. acc_tcga")
         @PathVariable String studyId,
         @ApiParam(required = true, value = "Sample ID e.g. TCGA-OR-A5J2-01")
-        @PathVariable String sampleId) throws SampleNotFoundException {
+        @PathVariable String sampleId) throws SampleNotFoundException, StudyNotFoundException {
 
         return new ResponseEntity<>(sampleService.getSampleInStudy(studyId, sampleId), HttpStatus.OK);
     }
@@ -101,7 +103,8 @@ public class SampleController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) SampleSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws PatientNotFoundException, 
+        StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();

--- a/web/src/main/java/org/cbioportal/web/SampleListController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleListController.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.SampleList;
 import org.cbioportal.service.SampleListService;
 import org.cbioportal.service.exception.SampleListNotFoundException;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -95,7 +96,7 @@ public class SampleListController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) SampleListSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();
@@ -114,7 +115,7 @@ public class SampleListController {
     @ApiOperation("Get all sample IDs in a sample list")
     public ResponseEntity<List<String>> getAllSampleIdsInSampleList(
         @ApiParam(required = true, value = "Sample List ID e.g. acc_tcga_all")
-        @PathVariable String sampleListId) {
+        @PathVariable String sampleListId) throws SampleListNotFoundException {
 
         return new ResponseEntity<>(sampleListService.getAllSampleIdsInSampleList(sampleListId), HttpStatus.OK);
     }

--- a/web/src/main/java/org/cbioportal/web/SignificantCopyNumberRegionController.java
+++ b/web/src/main/java/org/cbioportal/web/SignificantCopyNumberRegionController.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.Gistic;
 import org.cbioportal.service.SignificantCopyNumberRegionService;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.web.config.annotation.InternalApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -54,7 +55,7 @@ public class SignificantCopyNumberRegionController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) SignificantCopyNumberRegionSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();

--- a/web/src/main/java/org/cbioportal/web/SignificantlyMutatedGenesController.java
+++ b/web/src/main/java/org/cbioportal/web/SignificantlyMutatedGenesController.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.MutSig;
 import org.cbioportal.service.SignificantlyMutatedGeneService;
+import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.web.config.annotation.InternalApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -54,7 +55,7 @@ public class SignificantlyMutatedGenesController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) SignificantlyMutatedGeneSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction) throws StudyNotFoundException {
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();


### PR DESCRIPTION
We were returning an empty list if a list-returning API has a path parameter and
that parameter can't be found in DB. Now we will return 404 in those cases.
This only applies to path parameters, nothing changed about query or body parameters.