### PR TITLE
Set the width of the Annotation column in cross-cancer queries to 100px

### DIFF
--- a/portal/src/main/webapp/js/src/crosscancer.js
+++ b/portal/src/main/webapp/js/src/crosscancer.js
@@ -1274,7 +1274,8 @@
                                                 sTitle: "Annotation",
                                                 tip: "",
                                                 sType: "sort-icons",
-                                                sClass: "left-align-td"
+                                                sClass: "left-align-td",
+                                                sWidth: "100px"
                                             }
                                         },
                                         columnOrder: columnOrder,


### PR DESCRIPTION
# What? Why?
Fix #2205 by fixing the width of the Annotation column.