### PR TITLE
Make OncoKB and CIViC asynchronous

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/patient_view/patient_view.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/patient_view/patient_view.jsp
@@ -475,6 +475,15 @@ function initOncoKB(instanceId, ids, mapData, type, indicatorCallback) {
                     indicatorCallback(instance);
                 }
             });
+            if (showCivic) {
+                instance.getCivicIndicator().then(function () {
+                    if(_.isFunction(indicatorCallback)) {
+                        indicatorCallback(instance);
+                    }
+                }).fail(function() {
+                    console.log('getCivicIndicator failed.');
+                });
+            }
         }
     }
     return instance;

--- a/portal/src/main/webapp/js/src/mutation/column/AnnotationColumn.js
+++ b/portal/src/main/webapp/js/src/mutation/column/AnnotationColumn.js
@@ -172,6 +172,29 @@ function AnnotationColumn(oncokbInstanceManager, showHotspot, enableMyCancerGeno
                     callback(params);
                 }
             });
+            if (showCivic) {
+                oncokbInstance.getCivicIndicator().done(function () {
+                    var tableData = dataTable.fnGetData();
+                    if (tableData.length > 0) {
+                        _.each(tableData, function (ele, i) {
+                            if (oncokbInstance.getVariant(ele[indexMap['datum']].mutation.get("mutationSid"))) {
+                                if (oncokbInstance.getVariant(ele[indexMap['datum']].mutation.get("mutationSid")).hasOwnProperty('evidence')) {
+                                    ele[indexMap["datum"]].oncokb = oncokbInstance.getVariant(ele[indexMap['datum']].mutation.get("mutationSid"));
+                                    ele[indexMap['datum']].mutation.set({oncokb: true});
+                                    //dataTable.fnUpdate(null, i, indexMap["annotation"], false, false);
+                                }
+                            }
+                        });
+                        //dataTable.fnUpdate(null, 0, indexMap['annotation']);
+                    }
+
+                    if (_.isFunction(callback)) {
+                        callback(params);
+                    }
+                }).fail(function() {
+                    console.log('getCivicIndicator failed.');
+                });
+            }
         }
     }
 


### PR DESCRIPTION
# What? Why?
Fix #2204. Note that it has been fixed for the mutation tab in the results, but I am not sure if they are completely asynchronous in the patient view, too (however, I believe this is less important since the patient view is going to be changed in the future).

# Notify reviewers
@zhx828 