### PR TITLE
Update The Hyve cBio team and fix UTF-8 decoding

### DIFF
--- a/docs/About-Us.md
+++ b/docs/About-Us.md
@@ -38,8 +38,12 @@ The cBioPortal for Cancer Genomics was originally developed at [Memorial Sloan K
 ## The Hyve
 * Pieter Lukasse
 * Fedde Schaeffer
+* Sander Tan
+* Oleguer Plantalech
+* Irina Pulyakhina
+* Piotr Zakrzewski
+* Peter Kok
 * Sjoerd van Hagen
-* Sander de Ridder
 * Kees van Bochove
 
 ## Bilkent University

--- a/web/src/main/java/org/mskcc/cbio/portal/documentation/ExternalPageController.java
+++ b/web/src/main/java/org/mskcc/cbio/portal/documentation/ExternalPageController.java
@@ -35,7 +35,7 @@ public class ExternalPageController {
         URLConnection connection = url.openConnection();
 
         // create a reader
-        BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream(), "UTF-8"));
 
         // read
         while ((decodedString = in.readLine()) != null) {


### PR DESCRIPTION
# What? Why?
- Update The Hyve cBioPortal team members on About-Us.md
- Fix UTF-8 decoding on the about page, which fixes the bug that causes "Marie-José" to be displayed incorrectly on About-Us.md:

![screen shot 2017-04-13 at 10 34 12](https://cloud.githubusercontent.com/assets/9624990/24996914/ff0bd30c-2034-11e7-86f3-e0748dfb60f9.png)