### PR TITLE
Oncoprint annotation improvement and fix

### DIFF
--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -210,8 +210,6 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	var oncogenic = {}; // See Out above
 	var cna_to_alteration = {
 	    '-2': 'deletion',
-	    '-1': 'loss',
-	    '1': 'gain',
 	    '2': 'amplification'
 	};
 	// Collect queries

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -154,6 +154,16 @@ var tooltip_utils = {
 		return ret;
 	    });
 	};
+	var listOfCNAToHTML = function(data) {
+	    return data.map(function(d) {
+		var ret = $('<span>');
+		ret.append('<b>'+d.cna+'</b>');
+		if (d.oncokb_oncogenic) {
+		    ret.append('<img src="images/oncokb-oncogenic-1.svg" title="'+d.oncokb_oncogenic+'" style="height:11px; width:11px;margin-left:3px"/>');
+		}
+		return ret;
+	    });
+	};
 	return function (d) {
 	    var ret = $('<div>');
 	    var mutations = [];
@@ -175,7 +185,13 @@ var tooltip_utils = {
 		} else if (datum.genetic_alteration_type === "COPY_NUMBER_ALTERATION") {
 		    var disp_cna = {'-2': 'HOMODELETED', '-1': 'HETLOSS', '1': 'GAIN', '2': 'AMPLIFIED'};
 		    if (disp_cna.hasOwnProperty(datum.profile_data)) {
-			cna.push(disp_cna[datum.profile_data]);
+			var tooltip_datum = {
+			    cna: disp_cna[datum.profile_data]
+			};
+			if (typeof datum.oncokb_oncogenic !== "undefined" && ["Likely Oncogenic", "Oncogenic"].indexOf(datum.oncokb_oncogenic) > -1) {
+			    tooltip_datum.oncokb_oncogenic = datum.oncokb_oncogenic;
+			}
+			cna.push(tooltip_datum);
 		    }
 		} else if (datum.genetic_alteration_type === "MRNA_EXPRESSION" || datum.genetic_alteration_type === "PROTEIN_LEVEL") {
 		    if (datum.oql_regulation_direction) {
@@ -207,7 +223,15 @@ var tooltip_utils = {
 		ret.append('<br>');
 	    }
 	    if (cna.length > 0) {
-		ret.append('Copy Number Alteration: <b>' + cna.join(", ") + '</b><br>');
+		ret.append('Copy Number Alteration: ');
+		cna = listOfCNAToHTML(cna);
+		for (var i = 0; i < cna.length; i++) {
+		    if (i > 0) {
+			ret.append(",");
+		    }
+		    ret.append(cna[i]);
+		}
+		ret.append('<br>');
 	    }
 	    if (mrna.length > 0) {
 		ret.append('MRNA: <b>' + mrna.join(", ") + '</b><br>');

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -703,7 +703,6 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			    var oncoprint_data_frame = oncoprint_data_by_line[track_line];
 			    var track_data = utils.deepCopyObject(oncoprint_data_frame.oncoprint_data);
 			    console.log("populating sample data for alteration track " + oncoprint_data_by_line[track_line].gene);
-			    track_data = State.colorby_knowledge ? annotateOncoprintDataWithRecurrence(State, track_data) : track_data;
 			    oncoprint.setTrackData(track_id, track_data, 'uid');
 			    var track_info;
 			    if (oncoprint_data_frame.sequenced_samples.length > 0) { 
@@ -783,7 +782,6 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			    var oncoprint_data_frame = oncoprint_data_by_line[track_line];
 			    var track_data = utils.deepCopyObject(oncoprint_data_frame.oncoprint_data);
 			    console.log("populating patient data for alteration track " + oncoprint_data_by_line[track_line].gene);
-			    track_data = State.colorby_knowledge ? annotateOncoprintDataWithRecurrence(State, track_data) : track_data;
 			    oncoprint.setTrackData(track_id, track_data, 'uid'); 
 			    var track_info;
 			    if (oncoprint_data_frame.sequenced_patients.length > 0) { 
@@ -911,42 +909,6 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			text += " ("+(state.using_sample_data ? QuerySession.getSampleIds().length : patients.length)+" total)";
 			$('#altered_value').text(text);
 	    });
-	};
-	
-	var annotateOncoprintDataWithRecurrence = function(state, list_of_oncoprint_data) {
-	    var known_mutation_settings = window.QuerySession.getKnownMutationSettings();
-	    var isRecurrent = function(d) {
-		return (known_mutation_settings.recognize_hotspot && d.cancer_hotspots_hotspot)
-			|| (known_mutation_settings.recognize_oncokb_oncogenic && (typeof d.oncokb_oncogenic !== "undefined") && (["likely oncogenic", "oncogenic"].indexOf(d.oncokb_oncogenic.toLowerCase()) > -1))
-			|| (known_mutation_settings.recognize_cbioportal_count && (typeof d.cbioportal_mutation_count !== "undefined") && d.cbioportal_mutation_count >= known_mutation_settings.cbioportal_count_thresh)
-			|| (known_mutation_settings.recognize_cosmic_count && (typeof d.cosmic_count !== "undefined") && d.cosmic_count >= known_mutation_settings.cosmic_count_thresh);
-	    };
-	    for (var i=0; i<list_of_oncoprint_data.length; i++) {
-		var oncoprint_datum = list_of_oncoprint_data[i];
-		if (typeof oncoprint_datum.disp_mut === "undefined") {
-		    continue;
-		}
-		var disp_mut = oncoprint_datum.disp_mut.toLowerCase();
-		var webservice_data = oncoprint_datum.data;
-		var has_known_disp_mut = false;
-		for (var j=0; j<webservice_data.length; j++) {
-		    var datum = webservice_data[j];
-		    if (datum.genetic_alteration_type !== "MUTATION_EXTENDED") {
-			continue;
-		    }
-		    var mutation_type = datum.oncoprint_mutation_type.toLowerCase();
-		    if (mutation_type === disp_mut) {
-			if (isRecurrent(datum)) {
-			    has_known_disp_mut = true;
-			    break;
-			}
-		    }
-		}
-		if (has_known_disp_mut) {
-		    oncoprint_datum.disp_mut += "_rec";
-		}
-	    }
-	    return list_of_oncoprint_data;
 	};
 	
 	var local_storage_minimap_var = "oncoprintState.is_minimap_shown";


### PR DESCRIPTION
(1) Annotate CNA changes (amplification, deletion) in oncoprint with oncoKB
(2) Fix mutation type rendering priority so that putative drivers dominate:
truncating (driver) > inframe (driver) > missense (driver) > truncating (passenger) > inframe (passenger) > missense (passenger)

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

![image](https://cloud.githubusercontent.com/assets/636232/25053304/7e19312c-2124-11e7-917f-d26e6a91c221.png)

When putative drivers on:
![image](https://cloud.githubusercontent.com/assets/636232/25055180/48d0a512-212f-11e7-9883-962649506d34.png)

When putative drivers on but settings modified so that the missense is not recognized:
![image](https://cloud.githubusercontent.com/assets/636232/25055190/51599266-212f-11e7-9c9e-725392952cfc.png)

When putative drivers off:
![image](https://cloud.githubusercontent.com/assets/636232/25055205/6762ea94-212f-11e7-83a1-0d3f6ad17164.png)


