### PR TITLE
Validator: Add cBio version to log and html-report

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -39,6 +39,7 @@ import csv
 import itertools
 import requests
 import json
+import xml.etree.ElementTree as ET
 
 import cbioportal_common
 
@@ -136,10 +137,11 @@ class Jinja2HtmlHandler(logging.handlers.BufferingHandler):
 
     """Logging handler that formats aggregated HTML reports using Jinja2."""
 
-    def __init__(self, study_dir, output_filename, *args, **kwargs):
+    def __init__(self, study_dir, output_filename, cbio_version, *args, **kwargs):
         """Set study directory name, output filename and buffer size."""
         self.study_dir = study_dir
         self.output_filename = output_filename
+        self.cbio_version = cbio_version
         self.max_level = logging.NOTSET
         self.closed = False
         # get the directory name of the currently running script,
@@ -175,6 +177,7 @@ class Jinja2HtmlHandler(logging.handlers.BufferingHandler):
         template = j_env.get_template('validation_report_template.html.jinja')
         doc = template.render(
             study_dir=self.study_dir,
+            cbio_version=self.cbio_version,
             record_list=self.buffer,
             max_level=logging.getLevelName(self.max_level))
         with open(self.output_filename, 'w') as f:
@@ -3065,6 +3068,14 @@ def validate_study(study_dir, portal_instance, logger, relaxed_mode):
     logger.info('Validation complete')
 
 
+def get_pom_path():
+    """
+    Get location of pom.xml. In system and integration test this is mocked.
+    """
+    pom_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))))) + "/pom.xml"
+    return pom_path
+
+
 def main_validate(args):
 
     """Main function: process parsed arguments and validate the study."""
@@ -3105,6 +3116,27 @@ def main_validate(args):
     collapsing_text_handler.setLevel(output_loglevel)
     logger.addHandler(collapsing_text_handler)
 
+    # set default to unknown because validator can be run independently from cBioPortal
+    cbio_version = "unknown"
+    
+    # get pom path to retrieve cBioPortal version
+    pom_path = get_pom_path()
+
+    try:
+        # parse xml
+        xml_root = ET.parse(pom_path).getroot()
+    except IOError:
+        logger.warning('Unable to read xml containing cBioPortal version.')
+    else:
+        for xml_child in xml_root:
+
+            # to circumvent the default namespace (possibly varying apache url) split on '}'
+            if xml_child.tag.split("}")[1] == "version":
+                cbio_version = xml_child.text
+
+                # output cBioPortal version
+                logger.info("Running validation from cBioPortal version %s" % cbio_version)
+
     collapsing_html_handler = None
     html_handler = None
     # add html table handler if applicable
@@ -3115,6 +3147,7 @@ def main_validate(args):
         html_handler = Jinja2HtmlHandler(
             study_dir,
             html_output_filename,
+            cbio_version = cbio_version,
             capacity=1e5)
         # TODO extend CollapsingLogMessageHandler to flush to multiple targets,
         # and get rid of the duplicated buffering of messages here

--- a/core/src/main/scripts/importer/validation_report_template.html.jinja
+++ b/core/src/main/scripts/importer/validation_report_template.html.jinja
@@ -48,6 +48,7 @@
         <h1>cBioPortal validation report</h1>
         <p>Study directory:<br />{{ study_dir }}</p>
         <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/blob/master/docs/File-Formats.md'>the documentation on file formats supported by cBioPortal</a></p>
+        <p>cBioPortal version {{ cbio_version }}</p>
       </div>
     </div>
 

--- a/core/src/test/scripts/system_tests_validate_data.py
+++ b/core/src/test/scripts/system_tests_validate_data.py
@@ -26,8 +26,17 @@ class ValidateDataSystemTester(unittest.TestCase):
     the html report when requested?", etc)
     '''
 
+    def setUp(self):
+        def dummy_get_pom_path():
+            return "test_data/test.xml"
+        self.orig_get_pom_path = validateData.get_pom_path
+        validateData.get_pom_path = dummy_get_pom_path
+
     def tearDown(self):
         """Close logging handlers after running validator and remove tmpdir."""
+        # restore original function
+        validateData.get_pom_path = self.orig_get_pom_path
+
         # get the logger used in validateData.main_validate()
         validator_logger = logging.getLogger(validateData.__name__)
         # flush and close all handlers of this logger

--- a/core/src/test/scripts/test_data/study_es_0/result_report.html
+++ b/core/src/test/scripts/test_data/study_es_0/result_report.html
@@ -48,6 +48,7 @@
         <h1>cBioPortal validation report</h1>
         <p>Study directory:<br />test_data/study_es_0/</p>
         <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/blob/master/docs/File-Formats.md'>the documentation on file formats supported by cBioPortal</a></p>
+        <p>cBioPortal version 1.5.1-SYSTEM-TEST</p>
       </div>
     </div>
 

--- a/core/src/test/scripts/test_data/study_quotes/result_report.html
+++ b/core/src/test/scripts/test_data/study_quotes/result_report.html
@@ -48,6 +48,7 @@
         <h1>cBioPortal validation report</h1>
         <p>Study directory:<br />test_data/study_quotes/</p>
         <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/blob/master/docs/File-Formats.md'>the documentation on file formats supported by cBioPortal</a></p>
+        <p>cBioPortal version 1.5.1-SYSTEM-TEST</p>
       </div>
     </div>
 

--- a/core/src/test/scripts/test_data/study_various_issues/result_report.html
+++ b/core/src/test/scripts/test_data/study_various_issues/result_report.html
@@ -48,6 +48,7 @@
         <h1>cBioPortal validation report</h1>
         <p>Study directory:<br />test_data/study_various_issues/</p>
         <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/blob/master/docs/File-Formats.md'>the documentation on file formats supported by cBioPortal</a></p>
+        <p>cBioPortal version 1.5.1-SYSTEM-TEST</p>
       </div>
     </div>
 

--- a/core/src/test/scripts/test_data/study_wr_clin/result_report.html
+++ b/core/src/test/scripts/test_data/study_wr_clin/result_report.html
@@ -48,6 +48,7 @@
         <h1>cBioPortal validation report</h1>
         <p>Study directory:<br />test_data/study_wr_clin/</p>
         <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/blob/master/docs/File-Formats.md'>the documentation on file formats supported by cBioPortal</a></p>
+        <p>cBioPortal version 1.5.1-SYSTEM-TEST</p>
       </div>
     </div>
 

--- a/core/src/test/scripts/test_data/test.xml
+++ b/core/src/test/scripts/test_data/test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!-- meta data -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.mskcc.cbio</groupId>
+  <artifactId>master</artifactId>
+  <packaging>pom</packaging>
+  <name>Portal Master</name>
+  <version>1.5.1-SYSTEM-TEST</version>
+  <description>master maven module</description>
+</project>


### PR DESCRIPTION
# What? Why?
Add cBioPortal version to log and html-report. This is useful when reviewing reports from older versions of cBioPortal, since many warnings/errors have changed in recent versions.

Changes proposed in this pull request:
- Add version to `logger.info` at start of validation:

```INFO: -: Running validation from cBioPortal version 1.5.2-SNAPSHOT```

- Add version to html report:

<img width="1151" alt="screen shot 2017-04-18 at 14 26 18" src="https://cloud.githubusercontent.com/assets/9624990/25130600/08a9b700-2443-11e7-986b-7133aa0b2d1c.png">

- Because the validator can be run independently from cBioPortal, the default value for this version is `unknown`.

- Modify unit tests to compare the new html-report, using a `test.xml` that includes a mock cBioPortal version