### PR TITLE
jacoco for core and new api modules

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -440,22 +440,6 @@
           </execution>
         </executions>
       </plugin>
-        <!-- JaCoCo Test coverage plugin -->
-        <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>${jacoco-maven-plugin.version}</version>
-            <executions>
-                <execution>
-                    <goals><goal>prepare-agent</goal></goals>
-                </execution>
-                <execution>
-                    <id>report</id>
-                    <phase>prepare-package</phase>
-                    <goals><goal>report</goal></goals>
-                </execution>
-            </executions>
-        </plugin>
     </plugins>
 
     <!-- prevent some resources from getting into jar -->

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,50 @@
       </properties>
     <build>
     <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+             <version>${jacoco-maven-plugin.version}</version>
+             <executions>
+                <!--
+                    Prepares the property pointing to the JaCoCo runtime agent which
+                    is passed as VM argument when Maven the Surefire plugin is executed.
+                -->
+                <execution>
+                    <id>pre-unit-test</id>
+                    <phase>process-test-classes</phase>
+                    <goals>
+                        <goal>prepare-agent</goal>
+                    </goals>
+                    <configuration>
+                        <!-- Sets the path to the file which contains the execution data. -->
+                        <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
+                        <!--
+                            Sets the name of the property containing the settings
+                            for JaCoCo runtime agent.
+                        -->
+                        <propertyName>argLine</propertyName>
+                    </configuration>
+                </execution>
+                <!--
+                    Ensures that the code coverage report for unit tests is created after
+                    unit tests have been run.
+                -->
+                <execution>
+                    <id>post-unit-test</id>
+                    <phase>test</phase>
+                    <goals>
+                        <goal>report</goal>
+                    </goals>
+                    <configuration>
+                        <!-- Sets the path to the file which contains the execution data. -->
+                        <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
+                        <!-- Sets the output directory for the code coverage report. -->
+                        <outputDirectory>${project.build.directory}/coverage-reports/jacoco-ut</outputDirectory>
+                    </configuration>
+                </execution>
+             </executions>
+          </plugin>
           <!-- copy portal.properties.EXAMPLE and log4j.properties.EXAMPLE if they don't exist -->
           <plugin>
             <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
# What? Why?
Fixed Jacoco configuration to get it working for the new API modules like `web`, `service`, etc. and also for legacy `core` module.

Changes proposed in this pull request:
- centralized all jacoco configuration in root pom.xml
- `mvn test` will now produce jacoco coverage reports for  `web`, `service`, etc in `.../target/coverage-reports/jacoco-ut`
- `mvn integration-test` will now produce jacoco coverage reports for  `core` in `core/target/coverage-reports/jacoco-ut` (unclear where this report was previously located)


# Notify reviewers
@inodb @ersinciftci 