### PR TITLE
Gene set importer improvements

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenesetData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenesetData.java
@@ -245,11 +245,15 @@ public class ImportGenesetData extends ConsoleRunnable {
             // Add a new gene
         	} else {
         		ProgressMonitor.setCurrentMessage("Adding gene set: " + geneset.getExternalId());
-                DaoGeneset.addGeneset(geneset);            
+                Geneset newGeneset = DaoGeneset.addGeneset(geneset);
+                // add geneset genes (adding to bulkloader for performance reasons):
+                DaoGeneset.addGenesetGenesToBulkLoader(newGeneset);
         	}
 
             line = buf.readLine();
         }
+        //flush bulkloader to commit geneset genes:
+        MySQLbulkLoader.flushAll();
         // close file
         reader.close();
 

--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -700,19 +700,15 @@ def parse_metadata_file(filename,
                 extra={'filename_': filename,
                        'cause': metaDictionary['swissprot_identifier']})
             meta_file_type = None
-    
-    """
-    Save information regarding `source_stable_id`, so that after all meta files are validated, 
-    we can validate fields between meta files in validate_dependencies() in validateData.py
-    """
-    global expression_stable_ids
+
+    #Save information regarding `source_stable_id`, so that after all meta files are validated,
+    #we can validate fields between meta files in validate_dependencies() in validateData.py
     global gsva_scores_stable_id
-    global expression_zscores_source_stable_ids
     global gsva_scores_source_stable_id
     global gsva_pvalues_source_stable_id
     global gsva_scores_filename
     global gsva_pvalues_filename
-    
+
     # save all expression `stable_id` in list
     if meta_file_type is MetaFileTypes.EXPRESSION:
         if 'stable_id' in metaDictionary:


### PR DESCRIPTION
# What? Why?
Fix bug with study importer and improved perforance of importing geneset

Changes proposed in this pull request:
- In study importer, z-score expression is now always imported after expression. This is important because the `source_stable_id` of the z-score expression file is the `stable_id` of the expression file.
- Improved performance of gene set importer by using the bulk loader (18x faster).