### PR TITLE
WIP Font/text updates

### DIFF
--- a/portal/src/main/resources/content/about_us.markdown
+++ b/portal/src/main/resources/content/about_us.markdown
@@ -1,3 +1,5 @@
+# About cBioPortal
+
 The cBioPortal for Cancer Genomics is developed and maintained by the [Center for Molecular Oncology](http://www.mskcc.org/research/molecular-oncology) and the [Computational Biology Center](http://cbio.mskcc.org/) at [Memorial Sloan-Kettering Cancer Center](http://www.mskcc.org/).
 
 ## Team members (MSKCC)

--- a/portal/src/main/webapp/css/global_portal.css
+++ b/portal/src/main/webapp/css/global_portal.css
@@ -359,13 +359,13 @@ A:hover {
 }
 
 h1 {
-  /* margin:0px; */
-  font-family: verdana, arial, sans-serif;
+  font-family: helvetica, verdana, arial, sans-serif;
   font-size: 28px;
-  color:gray;
+  color: #333;
   letter-spacing: -1px;
   text-align: left;
-  padding-bottom:7px;
+  padding-bottom: 7px;
+  font-weight: 300;
 }
 
 .map h5 {
@@ -423,42 +423,44 @@ table td {
 }
 
 .markdown h1 {
-  font-family: verdana, arial, sans-serif;
-  font-size: 16px;
-  color:#555555;
-  background: #DDDDDD;
-  padding-left:5px;
-  padding-top:4px;
-  margin:0px;
-  padding-bottom:5px;
+  font-family: helvetica, verdana, arial, sans-serif;
+  font-size: 18px;
+  color: #555555;
+  margin: 15px 0px;
+  padding: 15px 0 5px 0px;
+  border-bottom: 1px solid #ccc;
+  font-weight: 600;
+  letter-spacing: 0;
 }
 
 .markdown h2 {
-  font-family: verdana, arial, sans-serif;
-  font-size: 12px;
-  color:#555555;
-  background: #EEEEEE;
-  padding-left:5px;
-  padding-top:4px;
-  padding-bottom:4px;
-  margin:0px;
-  margin-top:5px;
+  font-family: helvetica, verdana, arial, sans-serif;
+  font-size: 15px;
+  color: #555;
+  margin: 0px;
+  margin-top: 5px;
+  font-weight: 600;
 }
 
 .markdown h3 {
-  font-family: verdana, arial, sans-serif;
-  font-size: 12px !important;
-  padding-left:5px;
-  margin:0px;
-  margin-top:5px;
+  font-family: helvetica, verdana, arial, sans-serif;
+  font-size: 13px !important;
+  padding-left: 5px;
+  margin: 0px;
+  margin-top: 5px;
 }
 
 .markdown h4 {
-  font-family: verdana, arial, sans-serif;
-  font-size: 14px !important;
-  padding-left:5px;
-  margin:0px;
-  margin-top:5px;
+  font-family: helvetica, verdana, arial, sans-serif !important;
+  font-size: 13px !important;
+  padding-left: 5px;
+  margin: 0px;
+  margin-top: 5px;
+  color: #333;
+  padding: 0px;
+  margin: 5px 0px;
+  padding-top: 10px;
+  letter-spacing: 0 !important;
 }
 
 .markdown p {
@@ -937,13 +939,14 @@ html { min-height: 100%; margin-bottom: 1px; min-width: 100%; margin-right: 1px;
 
 
 #content h3 {
-  margin-top:5px; margin-bottom: 10px;
-  font-family: verdana, arial, sans-serif;
+  font-family: helvetica, verdana, arial, sans-serif;
   font-size: 17px;
   font-weight: bold;
-  letter-spacing: -1px;
+  letter-spacing: 0;
   line-height: 18px;
-  color: #2153AA;
+  text-transform: uppercase;
+  margin: 15px 0 0 0;
+  padding: 0px;
 }
 
 #content h4 {


### PR DESCRIPTION
This is a WIP for @alisman. The content pages (About/FAQ/Web APIs/etc.) needed some general cleaning up. Intended changes:

- [x] switch all fonts from Verdana to Helvetica. Ideally in the future, we'd use a nicer google/open font, but for now making this transition will at least bring the site out of the 90s a bit.
- [x] update the content headers to better denote hierarchy on the dense pages like Web APIs
- [ ] The Tutorials Page needs more proper styling on the copy -- right now there are multiple large h2s that should be brought down in size (Step-by-Step Guide and Tutorial 1 and 2 Headers) The copy and header styles for this page should match those on the Web APIs/FAQs/etc. The current changes in this PR target content that's wrapped in a `div` with a class of `markdown`, as that was the HTML for many of the pages. The Tutorials page does not wrap the content in a markdown div so the styles aren't catching on this page at the moment.
- [ ] Tools page buttons are misaligned for OncoPrinter and Mutation Mapper
- [x] About page should have an 'About' header/title - I've made this change, though I'm unsure of whether it should be made in the markdown file or the actual HTML/JSP file. (Are the corresponding markdown files being used to auto-generate these pages?)

I had been running into [this issue](https://github.com/cBioPortal/cbioportal/issues/2201) while working on this, but the problem seems to be intermittent/difficult to reproduce. Just keep an eye out for it while working on this.