### PR TITLE
Fix #2306 add _uncalled genetic mutations profile

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/model/GeneticAlterationType.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/model/GeneticAlterationType.java
@@ -36,6 +36,7 @@ package org.mskcc.cbio.portal.model;
 // don't forget to change the other one too
 public enum GeneticAlterationType {
     MUTATION_EXTENDED,
+    MUTATION_EXTENDED_UNCALLED, // uncalled mutations for cfDNA
     FUSION,
     STRUCTURAL_VARIANT,
     COPY_NUMBER_ALTERATION,

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportProfileData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportProfileData.java
@@ -33,6 +33,7 @@
 package org.mskcc.cbio.portal.scripts;
 
 import java.io.*;
+import java.util.Arrays;
 import java.util.Date;
 import joptsimple.*;
 import org.mskcc.cbio.portal.model.*;
@@ -70,7 +71,7 @@ public class ImportProfileData extends ConsoleRunnable {
                     "\n --> profile name:  " + geneticProfile.getProfileName() +
                     "\n --> genetic alteration type:  " + geneticProfile.getGeneticAlterationType().name());
             ProgressMonitor.setMaxValue(numLines);
-            if (geneticProfile.getGeneticAlterationType() == GeneticAlterationType.MUTATION_EXTENDED) {
+            if (Arrays.asList(GeneticAlterationType.MUTATION_EXTENDED, GeneticAlterationType.MUTATION_EXTENDED_UNCALLED).contains(geneticProfile.getGeneticAlterationType())) {
                 ImportExtendedMutationData importer = new ImportExtendedMutationData(dataFile, geneticProfile.getGeneticProfileId(), genePanel);
                 String swissprotIdType = geneticProfile.getOtherMetaDataField("swissprot_identifier");
                 if (swissprotIdType != null && swissprotIdType.equals("accession")) {


### PR DESCRIPTION
Fix #2306. Allow import of uncalled mutations for uncalled mutations in ctDNA. This allows
import of genetic profiles postfixed with `_uncalled`.

Looking for some suggestions here i.e. whether it is necessary to create the `MUTATION_EXTENDED_UNCALLED` genetic data type or if it would be better to use `MUTATION_EXTENDED`. The idea is that we want to show uncalled mutations in the patient view, so we can show the number of supporting reads in the sequencing data, even though we can't call the mutation with confidence. At the moment we only want to show these on the patient view, everywhere else the mutations should be ignored.