### PR TITLE
Fix to ImportGenePanel.java

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanel.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanel.java
@@ -79,6 +79,7 @@ public class ImportGenePanel extends ConsoleRunnable {
             }
 
             setFile(genePanel_f);
+            SpringUtil.initDataSource();
             importData();
         } catch (RuntimeException e) {
             throw e;


### PR DESCRIPTION
# What? Why?
Fix so that ImportGenePanel.java works directly from scripts jar.

Changes proposed in this pull request:
- Explicit call to SpringUtil.initDatSource() prior to call to importData().
