### PR TITLE
Fix for mutation_event comparison / mutation data loading script

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/model/ExtendedMutation.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/model/ExtendedMutation.java
@@ -307,17 +307,19 @@ public final class ExtendedMutation
             this.canonicalTranscript = canonicalTranscript;
         }
 
-        // the fields used here have to be the same as in sql file.
+        // The fields used here have to be the same as in sql file.
+        // The comparison has to be case insensitive, since this is how MYSQL will
+        // look at the values for the UQ constraint in DB.
         @Override
         public int hashCode() {
             int hash = 3;
             hash = 37 * hash + (this.gene != null ? this.gene.hashCode() : 0);
-            hash = 37 * hash + (this.chr != null ? this.chr.hashCode() : 0);
+            hash = 37 * hash + (this.chr != null ? this.chr.toUpperCase().hashCode() : 0);
             hash = 37 * hash + (int) (this.startPosition ^ (this.startPosition >>> 32));
             hash = 37 * hash + (int) (this.endPosition ^ (this.endPosition >>> 32));
-            hash = 37 * hash + (this.proteinChange != null ? this.proteinChange.hashCode() : 0);
-            hash = 37 * hash + (this.tumorSeqAllele != null ? this.tumorSeqAllele.hashCode() : 0);
-            hash = 37 * hash + (this.mutationType != null ? this.mutationType.hashCode() : 0);
+            hash = 37 * hash + (this.proteinChange != null ? this.proteinChange.toUpperCase().hashCode() : 0);
+            hash = 37 * hash + (this.tumorSeqAllele != null ? this.tumorSeqAllele.toUpperCase().hashCode() : 0);
+            hash = 37 * hash + (this.mutationType != null ? this.mutationType.toUpperCase().hashCode() : 0);
             return hash;
         }
 
@@ -333,7 +335,7 @@ public final class ExtendedMutation
             if (this.gene != other.gene && (this.gene == null || !this.gene.equals(other.gene))) {
                 return false;
             }
-            if ((this.chr == null) ? (other.chr != null) : !this.chr.equals(other.chr)) {
+            if ((this.chr == null) ? (other.chr != null) : !this.chr.equalsIgnoreCase(other.chr)) {
                 return false;
             }
             if (this.startPosition != other.startPosition) {
@@ -342,13 +344,13 @@ public final class ExtendedMutation
             if (this.endPosition != other.endPosition) {
                 return false;
             }
-            if ((this.proteinChange == null) ? (other.proteinChange != null) : !this.proteinChange.equals(other.proteinChange)) {
+            if ((this.proteinChange == null) ? (other.proteinChange != null) : !this.proteinChange.equalsIgnoreCase(other.proteinChange)) {
                 return false;
             }
-            if ((this.tumorSeqAllele == null) ? (other.tumorSeqAllele != null) : !this.tumorSeqAllele.equals(other.tumorSeqAllele)) {
+            if ((this.tumorSeqAllele == null) ? (other.tumorSeqAllele != null) : !this.tumorSeqAllele.equalsIgnoreCase(other.tumorSeqAllele)) {
                 return false;
             }
-            if ((this.mutationType == null) ? (other.mutationType != null) : !this.mutationType.equals(other.mutationType)) {
+            if ((this.mutationType == null) ? (other.mutationType != null) : !this.mutationType.equalsIgnoreCase(other.mutationType)) {
                 return false;
             }
             return true;


### PR DESCRIPTION
# What? Why?
Fix for issue with UQ constraint violation in `mutation_event` table when importing mutation data. It turns out MySQL is not case sensitive when it comes to UQ constraints. However, the java code that determines whether a new `mutation_event` record should be added or not was comparing values with `.equals()` which is case sensitive. This was leading to constraint violations, e.g.:

```
ABORTED! java.lang.RuntimeException: org.mskcc.cbio.portal.dao.DaoException: 
DB Error: only 1043 of the 1044 records were inserted in `mutation_event`. 
More error/warning details: Duplicate 
entry '15-41796352-41796353-NA-62524-E813*-stop_gained' for key 'CHR' 
See tmp file for more details: /tmp/mutation_event....tempTable
```


Changes proposed in this pull request:
- Changed java code to be case insensitive when comparing mutation event objects

