### PR TITLE
Upgrade apache commons dbcp to dbcp2 and refactor mutations lookup

### DIFF
--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -72,14 +72,14 @@
     <beans profile="dbcp">
         <!-- business data source -->
         <!-- setting minIdle/maxIdle to 1 doesn't limit the number of active -->
-        <bean id="businessDataSource" destroy-method="close" class="org.apache.commons.dbcp.BasicDataSource">
+        <bean id="businessDataSource" destroy-method="close" class="org.apache.commons.dbcp2.BasicDataSource">
             <property name="driverClassName" value="${db.driver}"/>
             <property name="url" value="${db.connection_string}${db.portal_db_name}?zeroDateTimeBehavior=convertToNull"/>
             <property name="username" value="${db.user}"/>
             <property name="password" value="${db.password}"/>
             <property name="minIdle" value="0"/>
             <property name="maxIdle" value="10"/>
-            <property name="maxActive" value="100"/>
+            <property name="maxTotal" value="100"/>
             <property name="poolPreparedStatements" value="true"/>
         </bean>
         <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -57,9 +57,9 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-        <groupId>commons-dbcp</groupId>
-        <artifactId>commons-dbcp</artifactId>
-        <version>1.4</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-dbcp2</artifactId>
+        <version>2.1.1</version>
     </dependency>
     <dependency>
       <groupId>commons-fileupload</groupId>

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
@@ -571,6 +571,44 @@ public final class DaoMutation {
         return events;
     }
 
+    /*
+     * Returns an existing MutationEvent record from the database or null.
+     */
+    public static ExtendedMutation.MutationEvent getMutationEvent(ExtendedMutation.MutationEvent event) throws DaoException {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try {
+            con = JdbcUtil.getDbConnection(DaoMutation.class);
+            pstmt = con.prepareStatement("SELECT * from mutation_event WHERE" +
+                                         " `ENTREZ_GENE_ID`=?" +
+                                         " AND `CHR`=?" +
+                                         " AND `START_POSITION`=?" +
+                                         " AND `END_POSITION`=?" +
+                                         " AND `TUMOR_SEQ_ALLELE`=?" +
+                                         " AND `PROTEIN_CHANGE`=?" +
+                                         " AND `MUTATION_TYPE`=?");
+            pstmt.setLong(1, event.getGene().getEntrezGeneId());
+            pstmt.setString(2, event.getChr());
+            pstmt.setLong(3, event.getStartPosition());
+            pstmt.setLong(4, event.getEndPosition());
+            pstmt.setString(5, event.getTumorSeqAllele());
+            pstmt.setString(6, event.getProteinChange());
+            pstmt.setString(7, event.getMutationType());
+            rs = pstmt.executeQuery();
+            if (rs.next()) {
+                return extractMutationEvent(rs);
+            }
+            else {
+                return null;
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        } finally {
+            JdbcUtil.closeAll(DaoMutation.class, con, pstmt, rs);
+        }
+    }
+
     public static long getLargestMutationEventId() throws DaoException {
         Connection con = null;
         PreparedStatement pstmt = null;

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
@@ -35,7 +35,7 @@ package org.mskcc.cbio.portal.dao;
 import java.sql.*;
 import java.util.*;
 import javax.sql.DataSource;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.logging.*;
 import org.mskcc.cbio.portal.util.*;
 
@@ -86,7 +86,7 @@ public class JdbcUtil {
         dataSource.setUrl(url);
         //  By pooling/reusing PreparedStatements, we get a major performance gain
         dataSource.setPoolPreparedStatements(true);
-        dataSource.setMaxActive(100);
+        dataSource.setMaxTotal(100);
         activeConnectionCount = new HashMap<String,Integer>();
         return dataSource;
     }

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
@@ -99,9 +99,6 @@ public class ImportExtendedMutationData{
 		HashSet <String> sequencedCaseSet = new HashSet<String>();
                 
                 Map<MutationEvent,MutationEvent> existingEvents = new HashMap<MutationEvent,MutationEvent>();
-                for (MutationEvent event : DaoMutation.getAllMutationEvents()) {
-                    existingEvents.put(event, event);
-                }
                 Set<MutationEvent> newEvents = new HashSet<MutationEvent>();
                 
                 Map<ExtendedMutation,ExtendedMutation> mutations = new HashMap<ExtendedMutation,ExtendedMutation>();
@@ -403,8 +400,10 @@ public class ImportExtendedMutationData{
 
 					//  Filter out Mutations
 					if( myMutationFilter.acceptMutation( mutation )) {
-                                                MutationEvent event = existingEvents.get(mutation.getEvent());
-
+                                                MutationEvent event =
+                                                    existingEvents.containsKey(mutation.getEvent()) ?
+                                                    existingEvents.get(mutation.getEvent()) :
+                                                    DaoMutation.getMutationEvent(mutation.getEvent());
                                                 if (event!=null) {
                                                     mutation.setEvent(event);
                                                 } else {

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportFusionData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportFusionData.java
@@ -37,6 +37,7 @@ import java.util.*;
 import org.mskcc.cbio.maf.*;
 import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.*;
+import org.mskcc.cbio.portal.model.ExtendedMutation.MutationEvent;
 import org.mskcc.cbio.portal.util.*;
 
 /**
@@ -59,11 +60,8 @@ public class ImportFusionData {
     }
 
     public void importData() throws IOException, DaoException {
-        Map<ExtendedMutation.MutationEvent, ExtendedMutation.MutationEvent> existingEvents =
-                new HashMap<ExtendedMutation.MutationEvent, ExtendedMutation.MutationEvent>();
-        for (ExtendedMutation.MutationEvent event : DaoMutation.getAllMutationEvents()) {
-            existingEvents.put(event, event);
-        }
+        Map<MutationEvent, MutationEvent> existingEvents =
+                new HashMap<MutationEvent, MutationEvent>();
         long mutationEventId = DaoMutation.getLargestMutationEventId();
         FileReader reader = new FileReader(this.fusionFile);
         BufferedReader buf = new BufferedReader(reader);
@@ -133,7 +131,10 @@ public class ImportFusionData {
                     // TODO we may need get mutation type from the file
                     // instead of defining a constant
                     mutation.setMutationType(FUSION);
-                    ExtendedMutation.MutationEvent event = existingEvents.get(mutation.getEvent());
+                    MutationEvent event =
+                        existingEvents.containsKey(mutation.getEvent()) ?
+                        existingEvents.get(mutation.getEvent()) :
+                        DaoMutation.getMutationEvent(mutation.getEvent());
                     if (event != null) {
                         mutation.setEvent(event);
                         addEvent = false;

--- a/core/src/test/resources/applicationContext-dao.xml
+++ b/core/src/test/resources/applicationContext-dao.xml
@@ -44,14 +44,14 @@
 	</bean>
 	
 	<!-- Values are for testing only, so need to correspond to the cgds in the pom.xml -->
-	<bean id="dbcpDataSource" destroy-method="close" class="org.apache.commons.dbcp.BasicDataSource">
+	<bean id="dbcpDataSource" destroy-method="close" class="org.apache.commons.dbcp2.BasicDataSource">
 		<property name="driverClassName" value="com.mysql.jdbc.Driver" />
 		<property name="url" value="jdbc:mysql://localhost:3306/cgds_test" />
 		<property name="username" value="${db.user}" />
 		<property name="password" value="${db.password}" />
 		<property name="minIdle" value="0" />
 		<property name="maxIdle" value="10" />
-		<property name="maxActive" value="100" />
+		<property name="maxTotal" value="100" />
 		<property name="poolPreparedStatements" value="true" />
 	</bean>
 	

--- a/persistence/persistence-mybatis/pom.xml
+++ b/persistence/persistence-mybatis/pom.xml
@@ -42,9 +42,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
-            <version>1.4</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <version>2.1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -204,9 +204,9 @@
       <version>1.1</version>
     </dependency>
     <dependency>
-      <groupId>commons-dbcp</groupId>
-      <artifactId>commons-dbcp</artifactId>
-      <version>1.4</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+      <version>2.1.1</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>

--- a/src/main/etc/jetty-cbioportal.xml
+++ b/src/main/etc/jetty-cbioportal.xml
@@ -174,7 +174,7 @@
 	        <Arg><Ref refid="webapp"/></Arg>
 	        <Arg>jdbc/cbioportal</Arg>
 	        <Arg>
-	            <New class="org.apache.commons.dbcp.BasicDataSource">
+	            <New class="org.apache.commons.dbcp2.BasicDataSource">
 	                <Set name="driverClassName">com.mysql.jdbc.Driver</Set>
 	                <Set name="url">jdbc:mysql://localhost/cbioportal</Set>
 	                <Set name="username">cbioportal</Set>


### PR DESCRIPTION
# What? Why?
The version of apache commons dbcp has become incompatible with Java 8 - certain methods no longer work and throw exceptions (the isClosed() method being an example in the JdbcUtil class).

The way in which mutations were being looked up from the database was causing performance/timeout issues as well. These changes instead look them up on an as needed basis to prevent this and improve overall performance for large databases.

Changes proposed in this pull request:
- Upgrade dbcp to dbcp2
- Look up mutation events on as needed basis

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@n1zea144 @sheridancbio 