### PR TITLE
Make the Perl layer use the Scripts JAR

### DIFF
--- a/core/src/main/scripts/env.pl
+++ b/core/src/main/scripts/env.pl
@@ -35,11 +35,11 @@ if ($portalDataHome eq "") {
 	die "PORTAL_DATA_HOME Environment Variable is not set.  Please set, and try again.\n";
 }
 
-# Set up Classpath to use all JAR files in lib dir.
-$cp="$portalHome/portal/target/portal/WEB-INF/classes";
-@jar_files = glob ("$portalHome/portal/target/portal/WEB-INF/lib/*.jar");
-foreach my $jar (@jar_files) {
-  $cp="$cp$pathDelim$jar"
+# Set up Classpath to use the scripts jar
+@jar_files = glob("$portalHome/scripts/target/scripts-*.jar");
+if (scalar @jar_files != 1) {
+	die "Expected to find 1 scripts-*.jar, but found: " . scalar @jar_files;
 }
+$cp = pop @jar_files;
 
 return 1;

--- a/core/src/main/scripts/envSimple.pl
+++ b/core/src/main/scripts/envSimple.pl
@@ -30,11 +30,11 @@ if ($portalHome eq "") {
 	die "PORTAL_HOME Environment Variable is not set.  Please set, and try again.\n";
 }
 
-# Set up Classpath to use all JAR files in lib dir.
-$cp="$portalHome/portal/target/portal/WEB-INF/classes";
-@jar_files = glob ("$portalHome/portal/target/portal/WEB-INF/lib/*.jar");
-foreach my $jar (@jar_files) {
-  $cp="$cp$pathDelim$jar"
+# Set up Classpath to use the scripts jar
+@jar_files = glob("$portalHome/scripts/target/scripts-*.jar");
+if (scalar @jar_files != 1) {
+	die "Expected to find 1 scripts-*.jar, but found: " . scalar @jar_files;
 }
+$cp = pop @jar_files;
 
 return 1;


### PR DESCRIPTION
Commit dd095170a47521735bce51d83094ee4a794b0410 (pull request #1517)
introduced a fat JAR file with all dependencies used for (import)
scripts, as a second build product in addition to the WAR that is
used to deploy the webapp. Commit c594d70676fe136fba85ae8172307ef53a3353ac
(#1753) adjusted the Python layer to use this JAR. The Perl layer
(used for side data shared by multiple studies, such as gene symbols)
still referred to various other intermediate build products, and
would break if these had been cleaned up. This patch changes the
Perl layer for consistency with the Python layer.