### PR TITLE
Oncoprint heatmap clustering improvements

### DIFF
--- a/OPEN-SOURCE-DOCUMENTATION
+++ b/OPEN-SOURCE-DOCUMENTATION
@@ -136,6 +136,7 @@ cbioportal@googlegroups.com.
 * FileSaver.min
 * Font Awesome (CSS)
 * Font Awesome (Fonts)
+* clusterfck.min.js
 
 
 ant-1.7.0
@@ -19686,3 +19687,30 @@ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
 DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
+
+clusterfck.min.js
+-----------------
+From: https://github.com/tayden/clusterfck
+
+Available under license:
+
+Copyright (c) 2011 Heather Arthur <fayearthur@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -1387,17 +1387,20 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 			//prepare input:
 			var cluster_input = {};
 			for (var i = 0; i < case_ids.length; i++) {
-				//case ids as key:
-				cluster_input[case_ids[i]] = {};
 				//iterate over genetic entities and get the sample data (heatmap data has genetic entityId as key):
 				for (var j = 0; j < heatmapData.length; j++) {
 					var entityId = heatmapData[j].gene;
+					var caseId = heatmapData[j].oncoprint_data[i].sample || heatmapData[j].oncoprint_data[i].patient;
 					//small validation/defensive programming:
 					if (!entityId) {
 						throw new Error("Unexpected error during getClusteringOrder: attribute 'gene' not found");
 					}
 					var value = heatmapData[j].oncoprint_data[i].profile_data;
-					cluster_input[case_ids[i]][entityId] = value;
+					if (!cluster_input[caseId]) {
+						//initialize with case ids as key:
+						cluster_input[caseId] = {};
+					}
+					cluster_input[caseId][entityId] = value;
 				}					
 			}
 			//do hierarchical clustering in background:

--- a/portal/src/main/webapp/js/src/clustering/clustering-worker.js
+++ b/portal/src/main/webapp/js/src/clustering/clustering-worker.js
@@ -65,20 +65,18 @@ var isAllNaNs = function(values) {
  *   
  */
 var preRankedSpearmanDist = function(item1, item2) {
-	//take the arrays from the preProcessedValueList:
-	var ranks1 = item1.preProcessedValueList;
-	var ranks2 = item2.preProcessedValueList;
-	var item1AllNaNs = isAllNaNs(item1.orderedValueList);
-	var item2AllNaNs = isAllNaNs(item2.orderedValueList);
 	//rules for NaN values:
-	if (item1AllNaNs && item2AllNaNs) {
+	if (item1.isAllNaNs && item2.isAllNaNs) {
 		//return distance 0
 		return 0;
 	}
-	else if (item1AllNaNs || item2AllNaNs) {
+	else if (item1.isAllNaNs || item2.isAllNaNs) {
 		//return large distance:
 		return 3;
 	}
+	//take the arrays from the preProcessedValueList:
+	var ranks1 = item1.preProcessedValueList;
+	var ranks2 = item2.preProcessedValueList;
 	//calculate spearman's rank correlation coefficient, using pearson's distance
 	//for correlation of the ranks:
 	var r = jStat.corrcoeff(ranks1, ranks2);
@@ -101,6 +99,11 @@ var _prepareForDistanceFunction = function(inputItems) {
 	//pre-calculate ranks and configure to use last step of SPEARMAN as distance function:
 	for (var i = 0; i < inputItems.length; i++) {
 		var inputItem = inputItems[i];
+		//check if all NaNs:
+		inputItem.isAllNaNs = isAllNaNs(inputItem.orderedValueList);
+		if (inputItem.isAllNaNs) {
+			continue;
+		}
 		//rank using fractional ranking:
 		var ranks = jStat.rank(inputItem.orderedValueList);
 		//calculate deviation:

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -1843,7 +1843,7 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 					var trackIdsInOriginalOrder = oncoprint.model.getTrackGroups()[heatmap_track_group_id];
 					State.trackIdsInOriginalOrder[heatmap_track_group_id] = trackIdsInOriginalOrder;
 					//get heatmap data:
-					var heatmap_data_deferred = State.using_sample_data ? getSampleHeatmapData(grp.genetic_profile_id, Object.keys(grp.gene_to_track_id)) : QuerySession.getPatientHeatmapData(grp.genetic_profile_id, Object.keys(grp.gene_to_track_id));
+					var heatmap_data_deferred = State.using_sample_data ? QuerySession.getSampleHeatmapData(grp.genetic_profile_id, Object.keys(grp.gene_to_track_id)) : QuerySession.getPatientHeatmapData(grp.genetic_profile_id, Object.keys(grp.gene_to_track_id));
 					var case_ids_deferred =  State.using_sample_data ? QuerySession.getSampleIds() : QuerySession.getPatientIds();
 					//process data, call clustering:
 					$.when(grp.gene_to_track_id, heatmap_data_deferred, case_ids_deferred).then(


### PR DESCRIPTION
# What? Why?
Improved clustering distance function to push samples with no data to outside. This solution should push samples that have no data to the outer edge of the resulting hierarchy (and of the resulting oncoprint heatmap). See screenshots.

**BEFORE**
![image](https://cloud.githubusercontent.com/assets/2900303/26349769/2a40bf42-3fb1-11e7-8cfc-7205e49dc898.png)


**NOW (with solution propose here)**
![image](https://cloud.githubusercontent.com/assets/2900303/26349692/d493546a-3fb0-11e7-8ee3-303c80f762e3.png)


Additional improvements:
- added missing LICENSE for clustering js library
- added support for clustering (sorting) on one track only (see screenshot below)

![image](https://cloud.githubusercontent.com/assets/2900303/26350051/245cf9fa-3fb2-11e7-9f5e-2de52f14c3b6.png)


