### PR TITLE
Fixed NullPointerException in AccessControlImpl.getUserDetails()

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/internal/AccessControlImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/internal/AccessControlImpl.java
@@ -133,6 +133,12 @@ public class AccessControlImpl implements AccessControl {
     {
         if (GlobalProperties.usersMustBeAuthorized()) {
             Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth == null) {
+                String errorMessage = "Possible configuration error detected: authorization=true but no authentication found. "
+                        + "If authentication is turned off, authorization should be set to false";
+                log.error(errorMessage);
+                throw new RuntimeException(errorMessage);
+            }
             return !(auth instanceof AnonymousAuthenticationToken) ? (UserDetails)auth.getPrincipal() : null;
         }
         return null;


### PR DESCRIPTION
# What? Why?
It is possible to configure `portal.properties` in a wrong way, leaving `authorization=true` while `authenticate=false`. This would lead to a NullPointerException (see screenshot below). 
![image](https://cloud.githubusercontent.com/assets/2900303/26398199/113c1186-4079-11e7-8407-f2f6b463bb21.png)


With this fix, the NullPointerException is replaced by a clear exception message and an ERROR entry in the log (see screenshot below):

![image](https://cloud.githubusercontent.com/assets/2900303/26398227/205d49a0-4079-11e7-99fb-363dc8bbc9a4.png)


Changes proposed in this pull request:
- fix in `AccessControlImpl.java` to avoid NullPointerException and give clear error message
