### PR TITLE
Use dao/bulk loader for gene panel matrix import

### DIFF
--- a/business/src/main/java/org/mskcc/cbio/portal/repository/GenePanelMyBatisRepository.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/repository/GenePanelMyBatisRepository.java
@@ -69,11 +69,6 @@ public class GenePanelMyBatisRepository implements GenePanelRepository {
     }
 
     @Override
-    public Sample getSampleByStableIdAndStudyId(String stableId, String studyId) {
-        return genePanelMapper.getSampleByStableIdAndStudyId(stableId, studyId);
-    }
-
-    @Override
     public GeneticProfile getGeneticProfileByStableId(String stableId) {
         return genePanelMapper.getGeneticProfileByStableId(stableId);
     }
@@ -136,11 +131,6 @@ public class GenePanelMyBatisRepository implements GenePanelRepository {
     @Override
     public void insertGenePanelListByHugo(Map<String, Object> map) {
         genePanelMapper.insertGenePanelListByHugo(map);
-    }
-
-    @Override
-    public void insertGenePanelSampleProfileMap(Map<String, Object> map) {
-        genePanelMapper.insertGenePanelSampleProfileMap(map);
     }
 
     public void setGenePanelMapper(GenePanelMapper genePanelMapper) {

--- a/business/src/main/java/org/mskcc/cbio/portal/repository/GenePanelRepository.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/repository/GenePanelRepository.java
@@ -50,7 +50,6 @@ public interface GenePanelRepository {
         // removed once a proper import solution is put in place.
         List<GenePanel> getGenePanelByStableId(String stableId);
         List<GenePanel> getGenePanels();
-        Sample getSampleByStableIdAndStudyId(String stableId, String studyId);
         GeneticProfile getGeneticProfileByStableId(String stableId);
         Gene getGeneByEntrezGeneId(Integer geneId);
         Gene getGeneByHugoSymbol(String symbol);
@@ -64,5 +63,4 @@ public interface GenePanelRepository {
         void deleteSampleProfileMappingByPanel(Integer panelId);
         void insertGenePanelList(Map<String, Object> map);
         void insertGenePanelListByHugo(Map<String, Object> map);
-        void insertGenePanelSampleProfileMap(Map<String, Object> map);
 }

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/GenePanelMapper.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/GenePanelMapper.xml
@@ -148,43 +148,6 @@
         from gene_panel
     </select>
 
-    <select id="getSampleByStableIdAndStudyId" resultMap="sampleResultMap">
-        select
-            sample.INTERNAL_ID,
-            sample.STABLE_ID,
-            sample.SAMPLE_TYPE,
-            sample.PATIENT_ID,
-            patient.INTERNAL_ID,
-            patient.STABLE_ID,
-            patient.CANCER_STUDY_ID,
-            sample.TYPE_OF_CANCER_ID,
-            type_of_cancer.TYPE_OF_CANCER_ID,
-            type_of_cancer.NAME,
-            type_of_cancer.CLINICAL_TRIAL_KEYWORDS,
-            type_of_cancer.DEDICATED_COLOR,
-            type_of_cancer.SHORT_NAME,
-            type_of_cancer.PARENT,
-            cancer_study.CANCER_STUDY_ID,
-            cancer_study.CANCER_STUDY_IDENTIFIER,
-            cancer_study.TYPE_OF_CANCER_ID,
-            cancer_study.NAME,
-            cancer_study.SHORT_NAME,
-            cancer_study.DESCRIPTION,
-            cancer_study.PUBLIC,
-            cancer_study.PMID,
-            cancer_study.CITATION,
-            cancer_study.GROUPS,
-            cancer_study.STATUS
-        from sample
-            inner join patient on sample.PATIENT_ID = patient.INTERNAL_ID
-            inner join type_of_cancer on sample.TYPE_OF_CANCER_ID = type_of_cancer.TYPE_OF_CANCER_ID
-            inner join cancer_study on patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
-        where
-            sample.STABLE_ID = #{stableId}
-            and
-            cancer_study.CANCER_STUDY_IDENTIFIER=#{studyId}
-    </select>
-
 <select id="getGeneByHugoSymbol" resultMap="geneResultMap">
         select
             gene.ENTREZ_GENE_ID,
@@ -312,9 +275,5 @@
         <foreach item="gene" index="index" collection="genes" separator=",">
             (#{panelId}, (select ENTREZ_GENE_ID from gene where HUGO_GENE_SYMBOL = #{gene}))
         </foreach>
-    </insert>
-
-    <insert id="insertGenePanelSampleProfileMap" parameterType="map" useGeneratedKeys="false">
-        update sample_profile set PANEL_ID = #{panelId} where SAMPLE_ID = #{sampleId} and GENETIC_PROFILE_ID = #{profileId}
     </insert>
 </mapper>

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGenePanel.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGenePanel.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cbio.portal.dao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+import org.mskcc.cbio.portal.model.CancerStudy;
+import org.mskcc.cbio.portal.model.GenePanel;
+
+/**
+ *
+ * @author heinsz
+ */
+public class DaoGenePanel {
+    private static Map<String, GenePanel> genePanelMap = initMap();
+
+    public static GenePanel getGenePanelByStableId(String stableId) {
+        return genePanelMap.get(stableId);
+    }
+
+    private static Map<String, GenePanel> initMap() {
+        Map<String, GenePanel> genePanelMap = null;
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try {
+            con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
+            pstmt = con.prepareStatement("SELECT * FROM gene_panel");
+            rs = pstmt.executeQuery();
+            genePanelMap = extractGenePanelMap(rs);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            JdbcUtil.closeAll(DaoCancerStudy.class, con, pstmt, rs);
+        }
+        return genePanelMap;
+    }
+
+    private static Map<String, GenePanel> extractGenePanelMap(ResultSet rs) throws SQLException {
+        Map<String, GenePanel> genePanelMap = new HashMap<>();
+        while(rs.next()) {
+            GenePanel gp = new GenePanel();
+            gp.setInternalId(rs.getInt("INTERNAL_ID"));
+            gp.setStableId(rs.getString("STABLE_ID"));
+            gp.setDescription(rs.getString("DESCRIPTION"));
+            genePanelMap.put(gp.getStableId(), gp);
+        }
+        return genePanelMap;
+    }
+
+}

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoSampleProfile.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoSampleProfile.java
@@ -44,10 +44,24 @@ import java.util.*;
  */
 public final class DaoSampleProfile {
     private DaoSampleProfile() {}
-   
-    private static final int NO_SUCH_PROFILE_ID = -1;
 
-    public static int addSampleProfile(int sampleId, int geneticProfileId, Integer panelId) throws DaoException {
+    private static final int NO_SUCH_PROFILE_ID = -1;
+    private static final String TABLE_NAME = "sample_profile";
+
+    public static int addSampleProfile(Integer sampleId, Integer geneticProfileId, Integer panelId) throws DaoException {        
+        if (MySQLbulkLoader.isBulkLoad()) {
+            if (panelId != null) {
+                MySQLbulkLoader.getMySQLbulkLoader(TABLE_NAME).insertRecord(Integer.toString(sampleId),
+                    Integer.toString(geneticProfileId),
+                    Integer.toString(panelId));            
+            }
+            else {
+                MySQLbulkLoader.getMySQLbulkLoader(TABLE_NAME).insertRecord(Integer.toString(sampleId),
+                    Integer.toString(geneticProfileId), null);     
+            }
+
+            return 1;
+        }
 
         Connection con = null;
         PreparedStatement pstmt = null;
@@ -65,7 +79,7 @@ public final class DaoSampleProfile {
                     pstmt.setInt(3, panelId);
                 }
                 else {
-                    pstmt.setNull(3, java.sql.Types.INTEGER);                    
+                    pstmt.setNull(3, java.sql.Types.INTEGER);
                 }
                 return pstmt.executeUpdate();
             } else {
@@ -102,7 +116,7 @@ public final class DaoSampleProfile {
             JdbcUtil.closeAll(DaoSampleProfile.class, con, pstmt, rs);
         }
     }
-    
+
     public static int countSamplesInProfile(int geneticProfileId) throws DaoException {
         Connection con = null;
         PreparedStatement pstmt = null;
@@ -258,8 +272,8 @@ public final class DaoSampleProfile {
         } finally {
             JdbcUtil.closeAll(DaoMutation.class, con, pstmt, rs);
         }
-        
-	return data;
+
+    return data;
     }
 
     public static void deleteAllRecords() throws DaoException {
@@ -270,6 +284,25 @@ public final class DaoSampleProfile {
             con = JdbcUtil.getDbConnection(DaoSampleProfile.class);
             pstmt = con.prepareStatement("TRUNCATE TABLE sample_profile");
             pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        } finally {
+            JdbcUtil.closeAll(DaoSampleProfile.class, con, pstmt, rs);
+        }
+    }
+
+    public static void deleteRecords(List<Integer> sampleIds, List<Integer> profileIds) throws DaoException {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try {
+            con = JdbcUtil.getDbConnection(DaoSampleProfile.class);
+            for (int i = 0; i < sampleIds.size(); i++) {
+                pstmt = con.prepareCall("DELETE FROM sample_profile WHERE sample_id = ? and genetic_profile_id = ?");
+                pstmt.setInt(1, sampleIds.get(i));
+                pstmt.setInt(2, profileIds.get(i));
+                pstmt.executeUpdate();
+            }
         } catch (SQLException e) {
             throw new DaoException(e);
         } finally {

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
@@ -58,29 +58,29 @@ import java.util.*;
  */
 public class ImportExtendedMutationData{
 
-	private File mutationFile;
-	private int geneticProfileId;
-	private boolean swissprotIsAccession;
-	private MutationFilter myMutationFilter;
-	private int entriesSkipped = 0;
-	private int samplesSkipped = 0;
-	private Set<String> sampleSet = new HashSet<String>();
-	private Set<String> geneSet = new HashSet<String>();
+    private File mutationFile;
+    private int geneticProfileId;
+    private boolean swissprotIsAccession;
+    private MutationFilter myMutationFilter;
+    private int entriesSkipped = 0;
+    private int samplesSkipped = 0;
+    private Set<String> sampleSet = new HashSet<String>();
+    private Set<String> geneSet = new HashSet<String>();
                      private String genePanel;
 
-	/**
-	 * construct an ImportExtendedMutationData.
-	 * Filter mutations according to the no argument MutationFilter().
-	 */
-	public ImportExtendedMutationData(File mutationFile, int geneticProfileId, String genePanel) {
-		this.mutationFile = mutationFile;
-		this.geneticProfileId = geneticProfileId;
-		this.swissprotIsAccession = false;
-		this.genePanel = genePanel;
+    /**
+     * construct an ImportExtendedMutationData.
+     * Filter mutations according to the no argument MutationFilter().
+     */
+    public ImportExtendedMutationData(File mutationFile, int geneticProfileId, String genePanel) {
+        this.mutationFile = mutationFile;
+        this.geneticProfileId = geneticProfileId;
+        this.swissprotIsAccession = false;
+        this.genePanel = genePanel;
 
-		// create default MutationFilter
-		myMutationFilter = new MutationFilter( );
-	}
+        // create default MutationFilter
+        myMutationFilter = new MutationFilter( );
+    }
 
     /**
      * Turns parsing the SWISSPROT column as an accession on or off again.
@@ -93,183 +93,174 @@ public class ImportExtendedMutationData{
         this.swissprotIsAccession = swissprotIsAccession;
     }
 
-	public void importData() throws IOException, DaoException {
-		MySQLbulkLoader.bulkLoadOn();
+    public void importData() throws IOException, DaoException {
+        MySQLbulkLoader.bulkLoadOn();
 
-		HashSet <String> sequencedCaseSet = new HashSet<String>();
-                
+        HashSet <String> sequencedCaseSet = new HashSet<String>();
+
                 Map<MutationEvent,MutationEvent> existingEvents = new HashMap<MutationEvent,MutationEvent>();
                 Set<MutationEvent> newEvents = new HashSet<MutationEvent>();
-                
+
                 Map<ExtendedMutation,ExtendedMutation> mutations = new HashMap<ExtendedMutation,ExtendedMutation>();
-                
+
                 long mutationEventId = DaoMutation.getLargestMutationEventId();
 
-		FileReader reader = new FileReader(mutationFile);
-		BufferedReader buf = new BufferedReader(reader);
+        FileReader reader = new FileReader(mutationFile);
+        BufferedReader buf = new BufferedReader(reader);
 
-		DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
+        DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
 
-		//  The MAF File Changes fairly frequently, and we cannot use column index constants.
-		String line = buf.readLine();
+        //  The MAF File Changes fairly frequently, and we cannot use column index constants.
+        String line = buf.readLine();
                 while (line.startsWith("#")) {
                     line = buf.readLine(); // skip comments/meta info
                 }
-                
-		line = line.trim();
 
-		MafUtil mafUtil = new MafUtil(line);
+        line = line.trim();
 
-		boolean fileHasOMAData = false;
+        MafUtil mafUtil = new MafUtil(line);
 
-		if (mafUtil.getMaFImpactIndex() >= 0) {
-			// fail gracefully if a non-essential column is missing
-			// e.g. if there is no MA_link.var column, we assume that the value is NA and insert it as such
-			fileHasOMAData = true;
-			ProgressMonitor.setCurrentMessage(" --> OMA Scores Column Number:  "
-			                           + mafUtil.getMaFImpactIndex());
-		} 
-		else {
-			fileHasOMAData = false;
-		}
+        boolean fileHasOMAData = false;
+
+        if (mafUtil.getMaFImpactIndex() >= 0) {
+            // fail gracefully if a non-essential column is missing
+            // e.g. if there is no MA_link.var column, we assume that the value is NA and insert it as such
+            fileHasOMAData = true;
+            ProgressMonitor.setCurrentMessage(" --> OMA Scores Column Number:  "
+                                       + mafUtil.getMaFImpactIndex());
+        }
+        else {
+            fileHasOMAData = false;
+        }
 
         GeneticProfile geneticProfile = DaoGeneticProfile.getGeneticProfileById(geneticProfileId);
-		while((line=buf.readLine()) != null)
-		{
+        while((line=buf.readLine()) != null)
+        {
             ProgressMonitor.incrementCurValue();
             ConsoleUtil.showProgress();
-                        
-			if( !line.startsWith("#") && line.trim().length() > 0)
-			{
-				String[] parts = line.split("\t", -1 ); // the -1 keeps trailing empty strings; see JavaDoc for String
-				MafRecord record = mafUtil.parseRecord(line);
 
-				// process case id
-				String barCode = record.getTumorSampleID();
-				// backwards compatible part (i.e. in the new process, the sample should already be there. TODO - replace this workaround later with an exception:
-				Sample sample = DaoSample.getSampleByCancerStudyAndSampleId(geneticProfile.getCancerStudyId(),
+            if( !line.startsWith("#") && line.trim().length() > 0)
+            {
+                String[] parts = line.split("\t", -1 ); // the -1 keeps trailing empty strings; see JavaDoc for String
+                MafRecord record = mafUtil.parseRecord(line);
+
+                // process case id
+                String barCode = record.getTumorSampleID();
+                // backwards compatible part (i.e. in the new process, the sample should already be there. TODO - replace this workaround later with an exception:
+                Sample sample = DaoSample.getSampleByCancerStudyAndSampleId(geneticProfile.getCancerStudyId(),
                         StableIdUtil.getSampleId(barCode));
-				if (sample == null ) {
-					ImportDataUtil.addPatients(new String[] { barCode }, geneticProfileId);
-	                // add the sample (except if it is a 'normal' sample):
-					ImportDataUtil.addSamples(new String[] { barCode }, geneticProfileId);
-				}
-		        // check again (repeated because of workaround above):
-				sample = DaoSample.getSampleByCancerStudyAndSampleId(geneticProfile.getCancerStudyId(),
+                if (sample == null ) {
+                    ImportDataUtil.addPatients(new String[] { barCode }, geneticProfileId);
+                    // add the sample (except if it is a 'normal' sample):
+                    ImportDataUtil.addSamples(new String[] { barCode }, geneticProfileId);
+                }
+                // check again (repeated because of workaround above):
+                sample = DaoSample.getSampleByCancerStudyAndSampleId(geneticProfile.getCancerStudyId(),
                                                                             StableIdUtil.getSampleId(barCode));
-		        // can be null in case of 'normal' sample:
-				if (sample == null) {
-		        	assert StableIdUtil.isNormal(barCode);
-		        	//if new sample:
-		        	if (sampleSet.add(barCode))
-		        		samplesSkipped++;
-		        	continue;
-		        }
-		        
-				if( !DaoSampleProfile.sampleExistsInGeneticProfile(sample.getInternalId(), geneticProfileId)) {					
-                                                                                                            if (genePanel != null) {
-                                                                                                                DaoSampleProfile.addSampleProfile(sample.getInternalId(), geneticProfileId, GeneticProfileUtil.getGenePanelId(genePanel));
-                                                                                                            }
-                                                                                                            else {
-                                                                                                                DaoSampleProfile.addSampleProfile(sample.getInternalId(), geneticProfileId, null);
-                                                                                                            }
-				}
+                // can be null in case of 'normal' sample:
+                if (sample == null) {
+                    assert StableIdUtil.isNormal(barCode);
+                    //if new sample:
+                    if (sampleSet.add(barCode))
+                        samplesSkipped++;
+                    continue;
+                }
 
-				String validationStatus = record.getValidationStatus();
+                String validationStatus = record.getValidationStatus();
 
-				if (validationStatus == null ||
-				    validationStatus.equalsIgnoreCase("Wildtype"))
-				{
-					ProgressMonitor.logWarning("Skipping entry with Validation_Status: Wildtype");
-					entriesSkipped++;
-					continue;
-				}
+                if (validationStatus == null ||
+                    validationStatus.equalsIgnoreCase("Wildtype"))
+                {
+                    ProgressMonitor.logWarning("Skipping entry with Validation_Status: Wildtype");
+                    entriesSkipped++;
+                    continue;
+                }
 
-				String chr = DaoGeneOptimized.normalizeChr(record.getChr().toUpperCase());
-				if (chr==null) {
-					ProgressMonitor.logWarning("Skipping entry with chromosome value: " + record.getChr());
-					entriesSkipped++;
-					continue;
-				}
-				record.setChr(chr);
+                String chr = DaoGeneOptimized.normalizeChr(record.getChr().toUpperCase());
+                if (chr==null) {
+                    ProgressMonitor.logWarning("Skipping entry with chromosome value: " + record.getChr());
+                    entriesSkipped++;
+                    continue;
+                }
+                record.setChr(chr);
 
-				if (record.getStartPosition() < 0)
-					record.setStartPosition(0);
+                if (record.getStartPosition() < 0)
+                    record.setStartPosition(0);
 
-				if (record.getEndPosition() < 0)
-					record.setEndPosition(0);
+                if (record.getEndPosition() < 0)
+                    record.setEndPosition(0);
 
-				String functionalImpactScore = "";
-				// using -1 is not safe, FIS can be a negative value
-				Float fisValue = Float.MIN_VALUE;
-				String linkXVar = "";
-				String linkMsa = "";
-				String linkPdb = "";
+                String functionalImpactScore = "";
+                // using -1 is not safe, FIS can be a negative value
+                Float fisValue = Float.MIN_VALUE;
+                String linkXVar = "";
+                String linkMsa = "";
+                String linkPdb = "";
 
-				if (fileHasOMAData)
-				{
-//					functionalImpactScore = getField(parts, "MA:FImpact" );
-//					fisValue = getField(parts, "MA:FIS");
-//					linkXVar = getField(parts, "MA:link.var" );
-//					linkMsa = getField(parts, "MA:link.MSA" );
-//					linkPdb = getField(parts, "MA:link.PDB" );
+                if (fileHasOMAData)
+                {
+//                    functionalImpactScore = getField(parts, "MA:FImpact" );
+//                    fisValue = getField(parts, "MA:FIS");
+//                    linkXVar = getField(parts, "MA:link.var" );
+//                    linkMsa = getField(parts, "MA:link.MSA" );
+//                    linkPdb = getField(parts, "MA:link.PDB" );
 
-					functionalImpactScore = record.getMaFuncImpact();
-					fisValue = record.getMaFIS();
-					linkXVar = record.getMaLinkVar();
-					linkMsa = record.getMaLinkMsa();
-					linkPdb = record.getMaLinkPdb();
+                    functionalImpactScore = record.getMaFuncImpact();
+                    fisValue = record.getMaFIS();
+                    linkXVar = record.getMaLinkVar();
+                    linkMsa = record.getMaLinkMsa();
+                    linkPdb = record.getMaLinkPdb();
 
-					functionalImpactScore = transformOMAScore(functionalImpactScore);
-					linkXVar = linkXVar.replace("\"", "");
-				}
+                    functionalImpactScore = transformOMAScore(functionalImpactScore);
+                    linkXVar = linkXVar.replace("\"", "");
+                }
 
-				String mutationType,
-					proteinChange,
-					aaChange,
-					codonChange,
-					refseqMrnaId,
-					uniprotAccession;
+                String mutationType,
+                    proteinChange,
+                    aaChange,
+                    codonChange,
+                    refseqMrnaId,
+                    uniprotAccession;
 
-				int proteinPosStart,
-					proteinPosEnd;
+                int proteinPosStart,
+                    proteinPosEnd;
 
-				// determine whether to use canonical or best effect transcript
+                // determine whether to use canonical or best effect transcript
 
-				// try canonical first
-				if (ExtendedMutationUtil.isAcceptableMutation(record.getVariantClassification()))
-				{
-					mutationType = record.getVariantClassification();
-				}
-				// if not acceptable either, use the default value
-				else
-				{
-					mutationType = ExtendedMutationUtil.getMutationType(record);
-				}
+                // try canonical first
+                if (ExtendedMutationUtil.isAcceptableMutation(record.getVariantClassification()))
+                {
+                    mutationType = record.getVariantClassification();
+                }
+                // if not acceptable either, use the default value
+                else
+                {
+                    mutationType = ExtendedMutationUtil.getMutationType(record);
+                }
 
-				// skip RNA mutations
-				if (mutationType != null && mutationType.equalsIgnoreCase("rna"))
-				{
-					ProgressMonitor.logWarning("Skipping entry with mutation type: RNA");
-					entriesSkipped++;
-					continue;
-				}
+                // skip RNA mutations
+                if (mutationType != null && mutationType.equalsIgnoreCase("rna"))
+                {
+                    ProgressMonitor.logWarning("Skipping entry with mutation type: RNA");
+                    entriesSkipped++;
+                    continue;
+                }
 
-				proteinChange = ExtendedMutationUtil.getProteinChange(parts, record);
-				//proteinChange = record.getProteinChange();
-				aaChange = record.getAminoAcidChange();
-				codonChange = record.getCodons();
-				refseqMrnaId = record.getRefSeq();
+                proteinChange = ExtendedMutationUtil.getProteinChange(parts, record);
+                //proteinChange = record.getProteinChange();
+                aaChange = record.getAminoAcidChange();
+                codonChange = record.getCodons();
+                refseqMrnaId = record.getRefSeq();
                 if (this.swissprotIsAccession) {
                     uniprotAccession = record.getSwissprot();
                 } else {
                     String uniprotName = record.getSwissprot();
                     uniprotAccession = DaoUniProtIdMapping.mapFromUniprotIdToAccession(uniprotName);
                 }
-				proteinPosStart = ExtendedMutationUtil.getProteinPosStart(
-						record.getProteinPosition(), proteinChange);
-				proteinPosEnd = ExtendedMutationUtil.getProteinPosEnd(
-						record.getProteinPosition(), proteinChange);
+                proteinPosStart = ExtendedMutationUtil.getProteinPosStart(
+                        record.getProteinPosition(), proteinChange);
+                proteinPosEnd = ExtendedMutationUtil.getProteinPosEnd(
+                        record.getProteinPosition(), proteinChange);
 
                 //  Assume we are dealing with Entrez Gene Ids (this is the best / most stable option)
                 String geneSymbol = record.getHugoGeneSymbol();
@@ -312,20 +303,20 @@ public class ImportExtendedMutationData{
                     gene = daoGene.getNonAmbiguousGene(geneSymbol, chr);
                 }
 
-                // assume symbol=Unknown and entrez=0 (or missing Entrez column) to imply an 
+                // assume symbol=Unknown and entrez=0 (or missing Entrez column) to imply an
                 // intergenic, irrespective of what the column Variant_Classification says
                 if (geneSymbol.equals("Unknown") &&
-                        (entrezIdString.equals("0") || mafUtil.getEntrezGeneIdIndex() == -1)) { 
-                	// give extra warning if mutationType is something different from IGR:
-                	if (mutationType != null &&
-                			!mutationType.equalsIgnoreCase("IGR")) { 
-                		ProgressMonitor.logWarning(
+                        (entrezIdString.equals("0") || mafUtil.getEntrezGeneIdIndex() == -1)) {
+                    // give extra warning if mutationType is something different from IGR:
+                    if (mutationType != null &&
+                            !mutationType.equalsIgnoreCase("IGR")) {
+                        ProgressMonitor.logWarning(
                             "Treating mutation with gene symbol 'Unknown' " +
                             (mafUtil.getEntrezGeneIdIndex() == -1 ? "" : "and Entrez gene ID 0") + " as intergenic ('IGR') " +
                             "instead of '" + mutationType + "'. Entry filtered/skipped.");
-                	}
-                	// treat as IGR:
-                	myMutationFilter.decisions++;
+                    }
+                    // treat as IGR:
+                    myMutationFilter.decisions++;
                     myMutationFilter.igrRejects++;
                     // skip entry:
                     entriesSkipped++;
@@ -341,65 +332,65 @@ public class ImportExtendedMutationData{
                             "and all mutation data associated with it!");
                     entriesSkipped++;
                     continue;
-				} else {
-					ExtendedMutation mutation = new ExtendedMutation();
+                } else {
+                    ExtendedMutation mutation = new ExtendedMutation();
 
-					mutation.setGeneticProfileId(geneticProfileId);
-					mutation.setSampleId(sample.getInternalId());
-					mutation.setGene(gene);
-					mutation.setSequencingCenter(record.getCenter());
-					mutation.setSequencer(record.getSequencer());
-					mutation.setProteinChange(proteinChange);
-					mutation.setAminoAcidChange(aaChange);
-					mutation.setMutationType(mutationType);
-					mutation.setChr(record.getChr());
-					mutation.setStartPosition(record.getStartPosition());
-					mutation.setEndPosition(record.getEndPosition());
-					mutation.setValidationStatus(record.getValidationStatus());
-					mutation.setMutationStatus(record.getMutationStatus());
-					mutation.setFunctionalImpactScore(functionalImpactScore);
-					mutation.setFisValue(fisValue);
-					mutation.setLinkXVar(linkXVar);
-					mutation.setLinkPdb(linkPdb);
-					mutation.setLinkMsa(linkMsa);
-					mutation.setNcbiBuild(record.getNcbiBuild());
-					mutation.setStrand(record.getStrand());
-					mutation.setVariantType(record.getVariantType());
+                    mutation.setGeneticProfileId(geneticProfileId);
+                    mutation.setSampleId(sample.getInternalId());
+                    mutation.setGene(gene);
+                    mutation.setSequencingCenter(record.getCenter());
+                    mutation.setSequencer(record.getSequencer());
+                    mutation.setProteinChange(proteinChange);
+                    mutation.setAminoAcidChange(aaChange);
+                    mutation.setMutationType(mutationType);
+                    mutation.setChr(record.getChr());
+                    mutation.setStartPosition(record.getStartPosition());
+                    mutation.setEndPosition(record.getEndPosition());
+                    mutation.setValidationStatus(record.getValidationStatus());
+                    mutation.setMutationStatus(record.getMutationStatus());
+                    mutation.setFunctionalImpactScore(functionalImpactScore);
+                    mutation.setFisValue(fisValue);
+                    mutation.setLinkXVar(linkXVar);
+                    mutation.setLinkPdb(linkPdb);
+                    mutation.setLinkMsa(linkMsa);
+                    mutation.setNcbiBuild(record.getNcbiBuild());
+                    mutation.setStrand(record.getStrand());
+                    mutation.setVariantType(record.getVariantType());
                                         mutation.setAllele(record.getTumorSeqAllele1(), record.getTumorSeqAllele2(), record.getReferenceAllele());
-					mutation.setDbSnpRs(record.getDbSNP_RS());
-					mutation.setDbSnpValStatus(record.getDbSnpValStatus());
-					mutation.setMatchedNormSampleBarcode(record.getMatchedNormSampleBarcode());
-					mutation.setMatchNormSeqAllele1(record.getMatchNormSeqAllele1());
-					mutation.setMatchNormSeqAllele2(record.getMatchNormSeqAllele2());
-					mutation.setTumorValidationAllele1(record.getTumorValidationAllele1());
-					mutation.setTumorValidationAllele2(record.getTumorValidationAllele2());
-					mutation.setMatchNormValidationAllele1(record.getMatchNormValidationAllele1());
-					mutation.setMatchNormValidationAllele2(record.getMatchNormValidationAllele2());
-					mutation.setVerificationStatus(record.getVerificationStatus());
-					mutation.setSequencingPhase(record.getSequencingPhase());
-					mutation.setSequenceSource(record.getSequenceSource());
-					mutation.setValidationMethod(record.getValidationMethod());
-					mutation.setScore(record.getScore());
-					mutation.setBamFile(record.getBamFile());
+                    mutation.setDbSnpRs(record.getDbSNP_RS());
+                    mutation.setDbSnpValStatus(record.getDbSnpValStatus());
+                    mutation.setMatchedNormSampleBarcode(record.getMatchedNormSampleBarcode());
+                    mutation.setMatchNormSeqAllele1(record.getMatchNormSeqAllele1());
+                    mutation.setMatchNormSeqAllele2(record.getMatchNormSeqAllele2());
+                    mutation.setTumorValidationAllele1(record.getTumorValidationAllele1());
+                    mutation.setTumorValidationAllele2(record.getTumorValidationAllele2());
+                    mutation.setMatchNormValidationAllele1(record.getMatchNormValidationAllele1());
+                    mutation.setMatchNormValidationAllele2(record.getMatchNormValidationAllele2());
+                    mutation.setVerificationStatus(record.getVerificationStatus());
+                    mutation.setSequencingPhase(record.getSequencingPhase());
+                    mutation.setSequenceSource(record.getSequenceSource());
+                    mutation.setValidationMethod(record.getValidationMethod());
+                    mutation.setScore(record.getScore());
+                    mutation.setBamFile(record.getBamFile());
                     mutation.setTumorAltCount(ExtendedMutationUtil.getTumorAltCount(record));
                     mutation.setTumorRefCount(ExtendedMutationUtil.getTumorRefCount(record));
-					mutation.setNormalAltCount(ExtendedMutationUtil.getNormalAltCount(record));
-					mutation.setNormalRefCount(ExtendedMutationUtil.getNormalRefCount(record));
+                    mutation.setNormalAltCount(ExtendedMutationUtil.getNormalAltCount(record));
+                    mutation.setNormalRefCount(ExtendedMutationUtil.getNormalRefCount(record));
 
-					// TODO rename the oncotator column names (remove "oncotator")
-					mutation.setOncotatorCodonChange(codonChange);
-					mutation.setOncotatorRefseqMrnaId(refseqMrnaId);
-					mutation.setOncotatorUniprotAccession(uniprotAccession);
-					mutation.setOncotatorProteinPosStart(proteinPosStart);
-					mutation.setOncotatorProteinPosEnd(proteinPosEnd);
+                    // TODO rename the oncotator column names (remove "oncotator")
+                    mutation.setOncotatorCodonChange(codonChange);
+                    mutation.setOncotatorRefseqMrnaId(refseqMrnaId);
+                    mutation.setOncotatorUniprotAccession(uniprotAccession);
+                    mutation.setOncotatorProteinPosStart(proteinPosStart);
+                    mutation.setOncotatorProteinPosEnd(proteinPosEnd);
 
-					// TODO we don't use this info right now...
-					mutation.setCanonicalTranscript(true);
+                    // TODO we don't use this info right now...
+                    mutation.setCanonicalTranscript(true);
 
-					sequencedCaseSet.add(sample.getStableId());
+                    sequencedCaseSet.add(sample.getStableId());
 
-					//  Filter out Mutations
-					if( myMutationFilter.acceptMutation( mutation )) {
+                    //  Filter out Mutations
+                    if( myMutationFilter.acceptMutation( mutation )) {
                                                 MutationEvent event =
                                                     existingEvents.containsKey(mutation.getEvent()) ?
                                                     existingEvents.get(mutation.getEvent()) :
@@ -419,17 +410,25 @@ public class ImportExtendedMutationData{
                                                 } else {
                                                     mutations.put(mutation,mutation);
                                                 }
+                                                if( !DaoSampleProfile.sampleExistsInGeneticProfile(sample.getInternalId(), geneticProfileId) && !sampleSet.contains(sample.getStableId())) {
+                                                    if (genePanel != null) {
+                                                        DaoSampleProfile.addSampleProfile(sample.getInternalId(), geneticProfileId, GeneticProfileUtil.getGenePanelId(genePanel));
+                                                    }
+                                                    else {
+                                                        DaoSampleProfile.addSampleProfile(sample.getInternalId(), geneticProfileId, null);
+                                                    }
+                                                }
                                                 //keep track:
-                                                sampleSet.add(barCode);
+                                                sampleSet.add(sample.getStableId());
                                                 geneSet.add(mutation.getEntrezGeneId()+"");
-					}
-					else {
-						entriesSkipped++;
-					}
-				}
-			}
-		}
-                
+                    }
+                    else {
+                        entriesSkipped++;
+                    }
+                }
+            }
+        }
+
                 for (MutationEvent event : newEvents) {
                     try {
                         DaoMutation.addMutationEvent(event);
@@ -437,7 +436,7 @@ public class ImportExtendedMutationData{
                         throw ex;
                     }
                 }
-                
+
                 for (ExtendedMutation mutation : mutations.values()) {
                     try {
                         DaoMutation.addMutation(mutation,false);
@@ -445,31 +444,31 @@ public class ImportExtendedMutationData{
                         throw ex;
                     }
                 }
-                
-		if( MySQLbulkLoader.isBulkLoad()) {
-			MySQLbulkLoader.flushAll();
-		}
-                
+
+        if( MySQLbulkLoader.isBulkLoad()) {
+            MySQLbulkLoader.flushAll();
+        }
+
                 // calculate mutation count for every sample
                 DaoMutation.calculateMutationCount(geneticProfileId);
                 DaoMutation.calculateMutationCountByKeyword(geneticProfileId);
-		
+
                 if (entriesSkipped > 0) {
-                	ProgressMonitor.setCurrentMessage(" --> total number of data entries skipped (see table below):  " + entriesSkipped);
+                    ProgressMonitor.setCurrentMessage(" --> total number of data entries skipped (see table below):  " + entriesSkipped);
                 }
                 ProgressMonitor.setCurrentMessage(" --> total number of samples: " + sampleSet.size());
                 if (samplesSkipped > 0) {
-                	ProgressMonitor.setCurrentMessage(" --> total number of samples skipped (normal samples): " + samplesSkipped);
+                    ProgressMonitor.setCurrentMessage(" --> total number of samples skipped (normal samples): " + samplesSkipped);
                 }
                 ProgressMonitor.setCurrentMessage(" --> total number of genes for which one or more mutation events were stored:  " + geneSet.size());
-                
+
                 ProgressMonitor.setCurrentMessage("Filtering table:\n-----------------");
                 ProgressMonitor.setCurrentMessage(myMutationFilter.getStatistics() );
-	}
+    }
 
-	/**
+    /**
          * merge the current mutation
-         * @return 
+         * @return
          */
         private ExtendedMutation mergeMutationData(ExtendedMutation mut1, ExtendedMutation mut2) {
             ExtendedMutation ret = mut1;
@@ -504,26 +503,26 @@ public class ImportExtendedMutationData{
                 }
                 ret.setSequencingCenter(StringUtils.join(centers, ";"));
             }
-            
+
             return ret;
         }
 
-	private String transformOMAScore( String omaScore) {
-		if( omaScore == null || omaScore.length() ==0) {
-			return omaScore;
-		}
-		if( omaScore.equalsIgnoreCase("H") || omaScore.equalsIgnoreCase("high")) {
-			return "H";
-		} else if( omaScore.equalsIgnoreCase("M") || omaScore.equalsIgnoreCase("medium")) {
-			return "M";
-		} else if( omaScore.equalsIgnoreCase("L") || omaScore.equalsIgnoreCase("low")) {
-			return "L";
-		} else if( omaScore.equalsIgnoreCase("N") || omaScore.equalsIgnoreCase("neutral")) {
-			return "N";
-		} else if( omaScore.equalsIgnoreCase("[sent]")) {
-			return ExtendedMutationUtil.NOT_AVAILABLE; // TODO temp workaround for invalid sent values
-		} else {
-			return omaScore;
-		}
-	}
+    private String transformOMAScore( String omaScore) {
+        if( omaScore == null || omaScore.length() ==0) {
+            return omaScore;
+        }
+        if( omaScore.equalsIgnoreCase("H") || omaScore.equalsIgnoreCase("high")) {
+            return "H";
+        } else if( omaScore.equalsIgnoreCase("M") || omaScore.equalsIgnoreCase("medium")) {
+            return "M";
+        } else if( omaScore.equalsIgnoreCase("L") || omaScore.equalsIgnoreCase("low")) {
+            return "L";
+        } else if( omaScore.equalsIgnoreCase("N") || omaScore.equalsIgnoreCase("neutral")) {
+            return "N";
+        } else if( omaScore.equalsIgnoreCase("[sent]")) {
+            return ExtendedMutationUtil.NOT_AVAILABLE; // TODO temp workaround for invalid sent values
+        } else {
+            return omaScore;
+        }
+    }
 }

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportFusionData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportFusionData.java
@@ -52,6 +52,7 @@ public class ImportFusionData {
     private File fusionFile;
     private int geneticProfileId;
     private String genePanel;
+    private Set<String> sampleSet  = new HashSet<>();
 
     public ImportFusionData(File fusionFile, int geneticProfileId, String genePanel) {
         this.fusionFile = fusionFile;
@@ -98,13 +99,6 @@ public class ImportFusionData {
                     line = buf.readLine();
                     continue;
                 }
-                if (!DaoSampleProfile.sampleExistsInGeneticProfile(sample.getInternalId(), geneticProfileId)) {
-                    if (genePanel != null) {
-                        DaoSampleProfile.addSampleProfile(sample.getInternalId(), geneticProfileId, GeneticProfileUtil.getGenePanelId(genePanel));
-                    } else {
-                        DaoSampleProfile.addSampleProfile(sample.getInternalId(), geneticProfileId, null);
-                    }
-                }
                 //  Assume we are dealing with Entrez Gene Ids (this is the best / most stable option)
                 String geneSymbol = record.getHugoGeneSymbol();
                 long entrezGeneId = record.getEntrezGeneId();
@@ -145,6 +139,14 @@ public class ImportFusionData {
                     }
                     // add fusion (as a mutation)
                     DaoMutation.addMutation(mutation, addEvent);
+                    if (!DaoSampleProfile.sampleExistsInGeneticProfile(sample.getInternalId(), geneticProfileId) && !sampleSet.contains(sample.getStableId())) {
+                        if (genePanel != null) {
+                            DaoSampleProfile.addSampleProfile(sample.getInternalId(), geneticProfileId, GeneticProfileUtil.getGenePanelId(genePanel));
+                        } else {
+                            DaoSampleProfile.addSampleProfile(sample.getInternalId(), geneticProfileId, null);
+                        }
+                    }                    
+                    sampleSet.add(sample.getStableId());
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: zheins <zackheins@gmail.com>

# What? Why?
Imports of gene panel matrix files is horribly slow due to not using the Dao classes with cached records and the mysql bulk loader. For our internal clinical datasets, just importing this one datatype can take upwards of 20 minutes, and it's only going to get worse as the data sets grow.

By making these changes, the time of import of this datatype for one of our largest studies was decreased from ~20m to ~1m.

Changes proposed in this pull request:
- Use the Dao classes for looking up records
- Use the mysql bulk loader for loading sample profile records.

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@n1zea144 @sheridancbio @angelicaochoa 
