### PR TITLE
Oncoprinter fix

### DIFF
--- a/portal/src/main/webapp/js/src/oncoprint/setup-oncoprinter.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup-oncoprinter.js
@@ -118,7 +118,7 @@ $(document).ready(function () {
 	    gene_order = null;
 	}
 	
-	var sample_order = $('#sample_order').val().trim().split(/\s+/g);
+	var sample_order = $('#sample_order').val().trim().split(/[,\s]+/g);
 	if (sample_order.length === 0 || sample_order[0].length === 0) {
 	    sample_order = null;
 	}

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -2565,16 +2565,23 @@ window.CreateOncoprinterWithToolbar = function (ctr_selector, toolbar_selector) 
 		    if (data_by_gene.hasOwnProperty(gene)) {
 			var data = data_by_gene[gene];
 			for (var i=0; i<data.length; i++) {
-			    present_ids[data[i][id_key]] = true;
+			    present_ids[data[i][id_key]] = false;
 			}
 		    }
 		}
-		this.ids = Object.keys(present_ids);
+		id_order = id_order || Object.keys(present_ids);
+		for (var i=0; i<id_order.length; i++) {
+		    if (present_ids.hasOwnProperty(id_order[i])) {
+			present_ids[id_order[i]] = true;
+		    }
+		}
+		this.ids = Object.keys(present_ids).filter(function(x) { return !!present_ids[x]; });
 		
 		var altered_percentage_by_gene = {};
 		for (var gene in altered_ids_by_gene) {
 		    if (altered_ids_by_gene.hasOwnProperty(gene)) {
-			altered_percentage_by_gene[gene] = Math.round(100*altered_ids_by_gene[gene].length/this.ids.length);
+			var altered_id_count = altered_ids_by_gene[gene].filter(function(x) { return !!present_ids[x]; }).length;
+			altered_percentage_by_gene[gene] = Math.round(100*altered_id_count/this.ids.length);
 		    }
 		}
 		
@@ -2587,7 +2594,7 @@ window.CreateOncoprinterWithToolbar = function (ctr_selector, toolbar_selector) 
 			}
 		    }
 		}
-		this.altered_ids = Object.keys(altered_ids);
+		this.altered_ids = Object.keys(altered_ids).filter(function(x) { return !!present_ids[x]; });
 		
 		this.unaltered_ids = [];
 		for (var i=0; i<this.ids.length; i++) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
@@ -39,12 +39,16 @@ module.exports = function(array, target_key, keyFn, return_closest_if_not_found)
 	    lower_incl = middle + 1;
 	} else if (target_key < middle_key) {
 	    upper_excl = middle;
+	} else {
+	    // make sure we don't infinite loop in case anything's wrong
+	    //	so that those three cases don't cover everything
+	    return -1;
 	}
     }
     if (return_closest_if_not_found) {
 	return lower_incl-1;
     } else {
-	return null;
+	return -1;
     }
 }
 },{}],3:[function(require,module,exports){
@@ -4889,6 +4893,9 @@ var GradientRuleSet = (function () {
 	return function(t) {
 	    // 0 <= t <= 1
 	    var begin_interval_index = binarysearch(stop_points, t, function(x) { return x; }, true);
+	    if (begin_interval_index === -1) {
+		return "rgba(0,0,0,1)";
+	    }
 	    var end_interval_index = Math.min(colors.length - 1, begin_interval_index + 1);
 	    var spread = stop_points[end_interval_index] - stop_points[begin_interval_index];
 	    if (spread === 0) {
@@ -6733,9 +6740,6 @@ var OncoprintWebGLCellView = (function () {
 	return this.ctx !== null;
     }
     OncoprintWebGLCellView.prototype.removeTrack = function (model, track_id) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	delete this.identified_shape_list_list[track_id];
 	delete this.vertex_data[track_id];
 	delete this.vertex_column_array[track_id];
@@ -6744,13 +6748,14 @@ var OncoprintWebGLCellView = (function () {
 	clearTrackPositionAndColorBuffers(this, model, track_id);
 	clearTrackColumnBuffers(this, model, track_id);
 	
-	renderAllTracks(this, model);
+	if (!this.rendering_suppressed) {
+	    renderAllTracks(this, model);
+	};
     }
     OncoprintWebGLCellView.prototype.moveTrack = function (model) {
-	if (this.rendering_suppressed) {
-	    return;
+	if (!this.rendering_suppressed) {
+	    renderAllTracks(this, model);
 	};
-	renderAllTracks(this, model);
     }
     OncoprintWebGLCellView.prototype.setTrackGroupOrder = function(model) {
 	renderAllTracks(this, model);
@@ -6850,26 +6855,19 @@ var OncoprintWebGLCellView = (function () {
     }
     
     OncoprintWebGLCellView.prototype.setHorzScroll = function(model) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	this.setScroll(model);
     }
     
     OncoprintWebGLCellView.prototype.setVertScroll = function(model) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	this.setScroll(model);
     }
     
     OncoprintWebGLCellView.prototype.setScroll = function(model) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	this.scroll_x = model.getHorzScroll();
 	this.scroll_y = model.getVertScroll();
-	renderAllTracks(this, model, true);
+	if (!this.rendering_suppressed) {
+	    renderAllTracks(this, model, true);
+	};
     }
     
     var updateAntialiasSetting = function(view, model) {
@@ -6888,19 +6886,17 @@ var OncoprintWebGLCellView = (function () {
     };
     
     OncoprintWebGLCellView.prototype.setZoom = function(model) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	updateAntialiasSetting(this, model);
-	renderAllTracks(this, model);
+	if (!this.rendering_suppressed) {
+	    renderAllTracks(this, model);
+	};
     }
     
     OncoprintWebGLCellView.prototype.setHorzZoom = function(model) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	updateAntialiasSetting(this, model);
-	renderAllTracks(this, model);
+	if (!this.rendering_suppressed) {
+	    renderAllTracks(this, model);
+	};
     }
     
     OncoprintWebGLCellView.prototype.setVertZoom = function(model) {
@@ -6911,13 +6907,12 @@ var OncoprintWebGLCellView = (function () {
     }
     
     OncoprintWebGLCellView.prototype.setViewport = function(model) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	this.scroll_x = model.getHorzScroll();
 	this.scroll_y = model.getVertScroll();
 	updateAntialiasSetting(this, model);
-	renderAllTracks(this, model);
+	if (!this.rendering_suppressed) {
+	    renderAllTracks(this, model);
+	};
     }
     
     OncoprintWebGLCellView.prototype.getTotalWidth = function(model, base) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/binarysearch.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/binarysearch.js
@@ -11,11 +11,15 @@ module.exports = function(array, target_key, keyFn, return_closest_if_not_found)
 	    lower_incl = middle + 1;
 	} else if (target_key < middle_key) {
 	    upper_excl = middle;
+	} else {
+	    // make sure we don't infinite loop in case anything's wrong
+	    //	so that those three cases don't cover everything
+	    return -1;
 	}
     }
     if (return_closest_if_not_found) {
 	return lower_incl-1;
     } else {
-	return null;
+	return -1;
     }
 }

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintruleset.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintruleset.js
@@ -600,6 +600,9 @@ var GradientRuleSet = (function () {
 	return function(t) {
 	    // 0 <= t <= 1
 	    var begin_interval_index = binarysearch(stop_points, t, function(x) { return x; }, true);
+	    if (begin_interval_index === -1) {
+		return "rgba(0,0,0,1)";
+	    }
 	    var end_interval_index = Math.min(colors.length - 1, begin_interval_index + 1);
 	    var spread = stop_points[end_interval_index] - stop_points[begin_interval_index];
 	    if (spread === 0) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintwebglcellview.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintwebglcellview.js
@@ -674,9 +674,6 @@ var OncoprintWebGLCellView = (function () {
 	return this.ctx !== null;
     }
     OncoprintWebGLCellView.prototype.removeTrack = function (model, track_id) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	delete this.identified_shape_list_list[track_id];
 	delete this.vertex_data[track_id];
 	delete this.vertex_column_array[track_id];
@@ -685,16 +682,16 @@ var OncoprintWebGLCellView = (function () {
 	clearTrackPositionAndColorBuffers(this, model, track_id);
 	clearTrackColumnBuffers(this, model, track_id);
 	
-	renderAllTracks(this, model);
+	if (!this.rendering_suppressed) {
+	    renderAllTracks(this, model);
+	};
     }
     OncoprintWebGLCellView.prototype.moveTrack = function (model) {
-	if (this.rendering_suppressed) {
-	    return;
+	if (!this.rendering_suppressed) {
+	    renderAllTracks(this, model);
 	};
-	renderAllTracks(this, model);
     }
     OncoprintWebGLCellView.prototype.setTrackGroupOrder = function(model) {
-	clearZoneBuffers(this, model);
 	renderAllTracks(this, model);
     }
     
@@ -792,26 +789,19 @@ var OncoprintWebGLCellView = (function () {
     }
     
     OncoprintWebGLCellView.prototype.setHorzScroll = function(model) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	this.setScroll(model);
     }
     
     OncoprintWebGLCellView.prototype.setVertScroll = function(model) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	this.setScroll(model);
     }
     
     OncoprintWebGLCellView.prototype.setScroll = function(model) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	this.scroll_x = model.getHorzScroll();
 	this.scroll_y = model.getVertScroll();
-	renderAllTracks(this, model, true);
+	if (!this.rendering_suppressed) {
+	    renderAllTracks(this, model, true);
+	};
     }
     
     var updateAntialiasSetting = function(view, model) {
@@ -830,19 +820,17 @@ var OncoprintWebGLCellView = (function () {
     };
     
     OncoprintWebGLCellView.prototype.setZoom = function(model) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	updateAntialiasSetting(this, model);
-	renderAllTracks(this, model);
+	if (!this.rendering_suppressed) {
+	    renderAllTracks(this, model);
+	};
     }
     
     OncoprintWebGLCellView.prototype.setHorzZoom = function(model) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	updateAntialiasSetting(this, model);
-	renderAllTracks(this, model);
+	if (!this.rendering_suppressed) {
+	    renderAllTracks(this, model);
+	};
     }
     
     OncoprintWebGLCellView.prototype.setVertZoom = function(model) {
@@ -853,13 +841,12 @@ var OncoprintWebGLCellView = (function () {
     }
     
     OncoprintWebGLCellView.prototype.setViewport = function(model) {
-	if (this.rendering_suppressed) {
-	    return;
-	};
 	this.scroll_x = model.getHorzScroll();
 	this.scroll_y = model.getVertScroll();
 	updateAntialiasSetting(this, model);
-	renderAllTracks(this, model);
+	if (!this.rendering_suppressed) {
+	    renderAllTracks(this, model);
+	};
     }
     
     OncoprintWebGLCellView.prototype.getTotalWidth = function(model, base) {


### PR DESCRIPTION
Make oncoprint more robust to bad ids, and allow sample order delimiting with comma in oncoprinter

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.
