### PR TITLE
piwik support

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -71,6 +71,8 @@ public class GlobalProperties {
     public static final String FILTER_GROUPS_BY_APPNAME = "filter_groups_by_appname";
     public static final String INCLUDE_NETWORKS = "include_networks";
     public static final String GOOGLE_ANALYTICS_PROFILE_ID = "google_analytics_profile_id";
+    public static final String PIWIK_SITE_ID = "piwik.site_id";
+    public static final String PIWIK_SERVER_URL = "piwik.server_url";
     public static final String GENOMESPACE = "genomespace";
 
     public static final String APP_NAME = "app.name";
@@ -504,6 +506,17 @@ public class GlobalProperties {
         return properties.getProperty(GOOGLE_ANALYTICS_PROFILE_ID);
     }
 
+    public static String getPiwikSiteId()
+    {
+        return properties.getProperty(PIWIK_SITE_ID);
+    }
+
+    public static String getPiwikServerUrl()
+    {
+        return properties.getProperty(PIWIK_SERVER_URL);
+    }
+
+    
     public static boolean genomespaceEnabled()
     {
         return Boolean.parseBoolean(properties.getProperty(GENOMESPACE));

--- a/portal/src/main/webapp/WEB-INF/jsp/global/js_include_analytics_and_email.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/js_include_analytics_and_email.jsp
@@ -51,6 +51,37 @@ if (googleAnalyticsProfileId!=null && !googleAnalyticsProfileId.isEmpty()) {
 </script>
 <% } %>
 
+<%
+String piwikSiteId = GlobalProperties.getPiwikSiteId();
+String piwikServerUrl = GlobalProperties.getPiwikServerUrl();
+if (piwikSiteId!=null && !piwikSiteId.isEmpty() && piwikServerUrl!=null && !piwikServerUrl.isEmpty()) {
+    org.springframework.security.core.Authentication auth = org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication();
+    String username = "";
+    if (auth != null)
+        username =((org.cbioportal.security.spring.authentication.PortalUserDetails)auth.getPrincipal()).getName(); 
+%>
+<!-- Piwik open source tracking -->
+<script type="text/javascript">
+  var _paq = _paq || [];
+  var username = '<%=username%>';
+  if (username != '') {
+    _paq.push(['setUserId', username])
+  }
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  //cbioportal URLs can get too long for GET
+  _paq.push(['setRequestMethod', 'POST']);
+  (function() {
+    var u="//<%=piwikServerUrl%>/";
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', '<%=piwikSiteId%>']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Piwik Code -->
+<% } %>
+
 <!-- De-obfuscate All Email Addresses -->
 <script type="text/javascript">
     <!-- When the document is ready, de-obfuscate the email addresses -->

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -172,6 +172,10 @@ bitly.url=http://api.bit.ly/shorten?login=[bitly.user]&apiKey=[bitly.apiKey]&
 # google analytics
 google_analytics_profile_id=
 
+#piwik tracking
+piwik.site_id=
+piwik.server_url=
+
 # genomespace linking
 genomespace=true
 


### PR DESCRIPTION
# What? Why?
This pull requests adds support for open source Google Analytics alternative called Piwik (https://piwik.org, https://github.com/piwik). It can be self hosted thus providing more privacy.

Changes proposed in this pull request:

basic support - administrators can see titles and URLs of the visited pages
username tracking - when user is logged in the username is added to the request so that administrators can see which user executed which action. I put it in a separate commit.

Fixes #2554

# Checks
- [ ] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@inodb I've fixed the problems with the old PR and rebased and squashed it, could you have a look at it?
