### PR TITLE
Updated modify query button behavior

### DIFF
--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -95,7 +95,7 @@
                 <artifactItem>
                   <groupId>com.github.cbioportal</groupId>
                   <artifactId>cbioportal-frontend</artifactId>
-                  <version>bb340360bc04366d8197f6768742f9d5511dd991</version>
+                  <version>71e2d4158042f4bbf8fa80adc0e7cfa4abee9392</version>
                   <type>jar</type>
                   <outputDirectory>.</outputDirectory>
                   <excludes>*index*</excludes>

--- a/portal/src/main/webapp/WEB-INF/jsp/cross_cancer_results.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/cross_cancer_results.jsp
@@ -80,11 +80,14 @@
 
 <jsp:include page="global/header.jsp" flush="true"/>
 
+<script type="text/javascript" src="js/src/modifyQuery.js?<%=GlobalProperties.getAppVersion()%>"></script>
 
 <script>
 window.appVersion = '<%=GlobalProperties.getAppVersion()%>';
     
 window.historyType = 'memory';
+
+window.maxTreeDepth = '<%=GlobalProperties.getMaxTreeDepth()%>';
 
 // Set API root variable for cbioportal-frontend repo
     <%
@@ -94,10 +97,10 @@ baseURL = baseURL.replace("https://", "").replace("http://", "");
 %>
 __API_ROOT__ = '<%=baseURL%>';
 
-window.loadReactApp({ defaultRoute: 'home' });
+window.loadReactApp({ defaultRoute: 'blank' });
     
 window.onReactAppReady(function(){
-    window.renderQuerySelectorInModal(document.getElementById("querySelector"));
+    window.initModifyQueryComponent("modifyQueryButton", "querySelector");
 });
     
 </script>
@@ -148,11 +151,6 @@ if (sessionError != null) {  %>
 </p>
 <% } %>
 
-<!-- Button trigger modal -->
-
-
-
-    
     <table>
     <tr>
         <td>
@@ -160,7 +158,8 @@ if (sessionError != null) {  %>
             <div id="results_container">
                 
                 <div id='modify_query'>
-                    <div id="querySelector" style="min-height:34px"></div>
+                    <button id="modifyQueryButton" class="btn btn-primary" style="display: none;">Modify Query</button>
+                    <div id="querySelector" class="cbioportal-frontend" style="min-height:34px"></div>
                     <div id="reactRoot" class="hidden"></div>
                     <div style="margin-left:5px;display:none;" id="query_form_on_results_page">
                         <%@ include file="query_form.jsp" %>

--- a/portal/src/main/webapp/WEB-INF/jsp/visualize.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/visualize.jsp
@@ -34,11 +34,14 @@
 <%@ include file="global/global_variables.jsp" %>
 <jsp:include page="global/header.jsp" flush="true" />
 
+<script type="text/javascript" src="js/src/modifyQuery.js?<%=GlobalProperties.getAppVersion()%>"></script>
 
 <script>
 window.appVersion = '<%=GlobalProperties.getAppVersion()%>';
 
 window.historyType = 'memory';
+
+window.maxTreeDepth = '<%=GlobalProperties.getMaxTreeDepth()%>';
 
 // Set API root variable for cbioportal-frontend repo
     <%
@@ -48,12 +51,10 @@ baseURL = baseURL.replace("https://", "").replace("http://", "");
 %>
 __API_ROOT__ = '<%=baseURL%>';
 
-window.loadReactApp({ defaultRoute: 'home' });
+window.loadReactApp({ defaultRoute: 'blank' });
 
-window.onReactAppReady(function(){
-    setTimeout(function(){
-        window.renderQuerySelectorInModal(document.getElementById("querySelector"));
-    },2000);
+window.onReactAppReady(function() {
+    window.initModifyQueryComponent("modifyQueryButton", "querySelector");
 });
 
 
@@ -82,12 +83,13 @@ window.onReactAppReady(function(){
         <table style='margin-left:0px;margin-top:-10px;margin-bottom:-5px;' >
             <tr>
                 <td>
-                    <div id="querySelector"></div>
+                    <button id="modifyQueryButton" class="btn btn-primary" style="display: none;">Modify Query</button>
                 </td>
                 <td><div id='main_smry_query_div' style='padding-left: 5px;'></div></td>
             </tr>
         </table>
     </div>
+    <div id="querySelector" class="cbioportal-frontend" style="margin-top: 10px"></div>
 </div>
 
 <div id="tabs">

--- a/portal/src/main/webapp/js/src/modifyQuery.js
+++ b/portal/src/main/webapp/js/src/modifyQuery.js
@@ -1,0 +1,25 @@
+window.initModifyQueryComponent = function(modifyQueryButtonId, querySelectorId) {
+    var selectorInitialized = false;
+    var selectorVisible = false;
+
+    setTimeout(function() {
+        $("#" + modifyQueryButtonId).show();
+    }, 2000);
+
+    $("#" + modifyQueryButtonId).click(function() {
+        if (!selectorInitialized) {
+            window.renderQuerySelector(document.getElementById(querySelectorId));
+            selectorInitialized = true;
+        }
+
+        // toggle visibility
+        selectorVisible = !selectorVisible;
+
+        if (selectorVisible) {
+            $("#" + querySelectorId).slideDown();
+        }
+        else {
+            $("#" + querySelectorId).slideUp();
+        }
+    });
+};


### PR DESCRIPTION
Upon clicking modify query button, showing the query selector on top of the page instead of inside a modal (fix issue #2534)

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.
