### PR TITLE
Fix Distrece CNA error when alteration type is ALL

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/GeneticDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GeneticDataServiceImpl.java
@@ -127,10 +127,8 @@ public class GeneticDataServiceImpl implements GeneticDataService {
 
         GeneticProfile geneticProfile = geneticProfileService.getGeneticProfile(geneticProfileId);
 
-        if ((geneticProfile.getGeneticAlterationType().equals(GeneticAlterationType.COPY_NUMBER_ALTERATION) && 
-            geneticProfile.getDatatype().equals("DISCRETE")) || geneticProfile.getGeneticAlterationType()
-            .equals(GeneticAlterationType.MUTATION_EXTENDED) || geneticProfile.getGeneticAlterationType()
-            .equals(GeneticAlterationType.FUSION)) {
+        if (geneticProfile.getGeneticAlterationType().equals(GeneticAlterationType.MUTATION_EXTENDED) || 
+            geneticProfile.getGeneticAlterationType().equals(GeneticAlterationType.FUSION)) {
 
             throw new GeneticProfileNotFoundException(geneticProfileId);
         }


### PR DESCRIPTION
Removed the validation for CNA in GeneticDataService, because if alterationType=ALL,
Discrete CNA API is using that service.