### PR TITLE
Fix #2609 hide uncalled mutations on study view

### DIFF
--- a/portal/src/main/webapp/js/src/dashboard/model/dataProxy.js
+++ b/portal/src/main/webapp/js/src/dashboard/model/dataProxy.js
@@ -1064,7 +1064,7 @@ window.DataManagerForIviz = (function($, _) {
             _.each(_profiles, function(_profile) {
               if (_profile.genetic_alteration_type === 'COPY_NUMBER_ALTERATION' && _profile.datatype === 'DISCRETE') {
                 self.cnaProfileIdsMap[_profile.study_id] = _profile.id;
-              } else if (_profile.genetic_alteration_type === 'MUTATION_EXTENDED') {
+              } else if (_profile.genetic_alteration_type === 'MUTATION_EXTENDED' && (_profile.study_id + '_mutations_uncalled' !== _profile.id)) {
                 self.mutationProfileIdsMap[_profile.study_id] = _profile.id;
               }
             });


### PR DESCRIPTION
Fix #2609 

Don't show uncalled mutations on study view e.g. BRCA1 in the mutated genes table of: http://triage.cbioportal.mskcc.org/study?id=poetic#summary

Also seems to fix another pretty serious bug. Locally i for instance see 7 cases with TP53, but none on Triage. Not sure why this is the case.
