### PR TITLE
Fix #2613 filter uncalled

### DIFF
--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -119,7 +119,7 @@
                 <artifactItem>
                   <groupId>com.github.cbioportal</groupId>
                   <artifactId>cbioportal-frontend</artifactId>
-                  <version>d43bd40e130b269cfafe9d843066b0271beb190f</version>
+                  <version>349b7c070e60462aeb47b70cccae841f07046988</version>
                   <type>jar</type>
                   <outputDirectory>.</outputDirectory>
                   <excludes>*index*</excludes>


### PR DESCRIPTION
Fix #2613
Only show uncalled mutations on patient view if they are called in at least one sample of the same patient

Fixes showing of uncalled mutations in:
http://triage.cbioportal.mskcc.org/case.do#/patient?caseId=P01-00001&navCaseIds=P01-00001&studyId=poetic
