### PR TITLE
Suppress db version on heroku attempt 2

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,7 +17,7 @@
     },
     "MAVEN_CUSTOM_OPTS": {
         "description":"set heroku profile for mvn",
-        "value":"-Pheroku,public -DskipTests -Dfinal.war.name=cbioportal -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.suppress_schema_version_mismatch_errors=true -Ddb.portal_db_name=public_test -Dtomcat.catalina.scope=runtime -Ddb.connection_string=jdbc:mysql://sm4sa6ozhn5ya6.cuooweljyhix.us-east-1.rds.amazonaws.com:3306/ -Ddb.host=sm4sa6ozhn5ya6.cuooweljyhix.us-east-1.rds.amazonaws.com"
+        "value":"-Pheroku,public -DskipTests -Dfinal.war.name=cbioportal -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test -Dtomcat.catalina.scope=runtime -Ddb.connection_string=jdbc:mysql://sm4sa6ozhn5ya6.cuooweljyhix.us-east-1.rds.amazonaws.com:3306/ -Ddb.host=sm4sa6ozhn5ya6.cuooweljyhix.us-east-1.rds.amazonaws.com"
     }
   },
   "buildpacks": [

--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -216,7 +216,9 @@ public class GlobalProperties {
     public static final String RECACHE_STUDY_AFTER_UPDATE = "recache_study_after_update";
     
     public static final String DB_VERSION = "db.version";
-    public static final String SUPPRESS_SCHEMA_VERSION_MISMATCH_ERRORS = "db.suppress_schema_version_mismatch_errors";
+    private static boolean suppressSchemaVersionMismatchErrors;
+    @Value("${db.suppress_schema_version_mismatch_errors:false}") // default is false
+    public void setSuppressSchemaVersionMismatchErrors(String property) { suppressSchemaVersionMismatchErrors = Boolean.parseBoolean(property); }
     
     public static final String DARWIN_AUTH_URL = "darwin.auth_url";
     public static final String DARWIN_RESPONSE_URL = "darwin.response_url";
@@ -851,8 +853,7 @@ public class GlobalProperties {
     }
     
     public static boolean isSuppressSchemaVersionMismatchErrors() {
-        String isSuppressSchemaVersionMismatchErrors = properties.getProperty(SUPPRESS_SCHEMA_VERSION_MISMATCH_ERRORS, "false");
-        return Boolean.parseBoolean(isSuppressSchemaVersionMismatchErrors);
+        return suppressSchemaVersionMismatchErrors;
     }
 
     public static String getDarwinAuthCheckUrl() {

--- a/heroku/Procfile
+++ b/heroku/Procfile
@@ -1,1 +1,1 @@
-web: java $JAVA_OPTS -Dsession.service.url=https://cbioportal-session-service.herokuapp.com/api/sessions/heroku_portal/ -Ddbconnector=dbcp -jar portal/target/dependency/webapp-runner.jar --enable-compression --expand-war --port $PORT portal/target/cbioportal.war
+web: java $JAVA_OPTS -Ddb.suppress_schema_version_mismatch_errors=true -Dsession.service.url=https://cbioportal-session-service.herokuapp.com/api/sessions/heroku_portal/ -Ddbconnector=dbcp -jar portal/target/dependency/webapp-runner.jar --enable-compression --expand-war --port $PORT portal/target/cbioportal.war


### PR DESCRIPTION
Suppress db version mismatch on heroku - Make the suppress_schema_version_mismatch_errors property overridable at runtime similar to `session_service`