### PR TITLE
We don't want to show download tab in query selector when in modify-q…

### DIFF
--- a/portal/src/main/webapp/js/src/modifyQuery.js
+++ b/portal/src/main/webapp/js/src/modifyQuery.js
@@ -8,7 +8,7 @@ window.initModifyQueryComponent = function(modifyQueryButtonId, querySelectorId)
 
     $("#" + modifyQueryButtonId).click(function() {
         if (!selectorInitialized) {
-            window.renderQuerySelector(document.getElementById(querySelectorId));
+            window.renderQuerySelector(document.getElementById(querySelectorId), {showDownloadTab:false});
             selectorInitialized = true;
         }
 


### PR DESCRIPTION
When query selector is shown for purpose of modifying existing query on results page, we don't want to show the download tab.

![image](https://user-images.githubusercontent.com/186521/27594973-53a923e0-5b29-11e7-98f2-9c1c3a6bcf78.png)


# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend
@cBioPortal/backend
@cBioPortal/devops

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
