### PR TITLE
Documentation: Remove GRCh38 from documentation and improve mouse documentation

### DIFF
--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -516,6 +516,8 @@ AGRN<TAB>0.142<TAB>0.091<TAB>...
 The mutation data file extends the [Mutation Annotation Format](https://wiki.nci.nih.gov/display/TCGA/Mutation+Annotation+Format+%28MAF%29+Specification) (MAF) created as part of the [Cancer Genome Atlas](https://wiki.nci.nih.gov/display/TCGA/TCGA+Home) project, by adding *extra annotations* to each mutation record.  If your mutation data is already in [VCF](http://www.1000genomes.org/wiki/Analysis/Variant%20Call%20Format/vcf-variant-call-format-version-41) format (which by default most variant callers produce) you can use this  [vcf2maf](https://github.com/ckandoth/vcf2maf) converter.
 **Please note that all data should be mapped to UniProt canonical isoforms.** This can be done by calling the vcf2maf or maf2maf with the ```--custom-enst``` flag and the mapping file available [here](https://github.com/mskcc/vcf2maf/blob/master/data/isoform_overrides_uniprot). This will ensure the SWISSPROT column, which contains the UniProt canonical isoform, can be used correctly by cBioPortal.
 
+In mouse, the "chromosome plot" displayed in the Patient View is not fully supported ([see issue](https://github.com/cBioPortal/cbioportal-frontend/issues/410)).
+
 #### Meta file
 The mutation metadata file should contain the following fields:
 

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -574,7 +574,7 @@ The MAF format recognized by the portal (excluding the annotation columns alread
 1. **Hugo_Symbol (Required)**: A [HUGO](http://www.genenames.org/) gene symbol.
 2. **Entrez_Gene_Id (Optional, but desired)**: A [Entrez Gene](http://www.ncbi.nlm.nih.gov/gene) identifier.
 3. **Center (Optional)**: The sequencing center.
-4. **NCBI_Build (Optional)**: Must be "37".
+4. **NCBI_Build (Optional)**: Must be "GRCh37" for human, and "GRCm38" for mouse.
 5. **Chromosome (Optional)**: A chromosome number, e.g., "7".
 6. **Start_Position (Optional)**: Start position of event.
 7. **End_Position (Optional)**: End position of event.

--- a/docs/Import-the-Seed-Database.md
+++ b/docs/Import-the-Seed-Database.md
@@ -4,7 +4,7 @@ The next step is to populate your cBioPortal instance with all the required back
 
 ## Download the cBioPortal Seed Database
 
-A cBioPortal seed database can be found on [the datahub page](https://github.com/cbioportal/datahub/blob/master/seedDB/README.md).
+A cBioPortal seed database for human can be found on [the datahub page](https://github.com/cBioPortal/datahub/blob/84fd66daf8325ad9721895d1cc503653686de15e/seedDB/README.md). If you are looking for mouse, check [this link](https://github.com/cBioPortal/datahub/blob/b02ac7037c8febeb86d6635602fc98327fb77c50/seedDB_mouse/README.md).
 
 After download, the files can be unzipped by entering the following command:
 
@@ -20,13 +20,17 @@ After download, the files can be unzipped by entering the following command:
     mysql --user=cbio_user --password=somepassword cbioportal < cgds.sql
     ```
 
-2. Import the main part of the seed database:
+For human, then you should execute these two commands (the last command takes a bit longer to import PDB data that will enable the visualization of PDB structures in the mutation tab):
 
-    ```
-    mysql --user=cbio_user --password=somepassword cbioportal < seed-cbioportal_hg19_vX.Y.Z.sql
-    ```
+    > mysql --user=cbio_user --password=somepassword cbioportal  < seed-cbioportal_hg19_vX.Y.Z.sql
+    
+    > mysql --user=cbio_user --password=somepassword cbioportal  < seed-cbioportal_only-pdb.sql
+    
+For mouse, you just need to execute one command (PDB tables are not supported in mouse):
 
-    *Important:* Replace `seed-cbioportal_hg19_vX.Y.Z.sql` with the downloaded version of the seed database, such as `seed-cbioportal_hg19_v2.1.0.sql`.
+    > mysql --user=cbio_user --password=somepassword cbioportal  < seed-cbioportal_mm10_vX.Y.Z.sql
+
+*Important:* Replace `seed-cbioportal_hg19_vX.Y.Z.sql` with the downloaded version of the seed database, such as `seed-cbioportal_hg19_v2.1.0.sql` (human) or `seed-cbioportal_mm10_v2.1.0.sql` (mouse).
 
 3. Import the protein database (PDB) part of the seed database. This will enable the visualization of PDB structures in the mutation tab. Loading this file takes more time than loading the previous files, and is optional for users that do not require PDB structures.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ We also maintain an active [list of RFCs (Requests for Comments)](RFC-List.md) w
 
 ## 3. cBioPortal Maintenance
 * [Updating your cBioPortal Database Scheme](Updating-your-cBioPortal-installation.md)
+* [Update genes and gene aliases](Updating-gene-and-gene_alias-tables.md)
 
 ## 4. Development      
 * [cBioPortal Entity-relationship Diagram](cBioPortal-ER-Diagram.md)

--- a/docs/Updating-gene-and-gene_alias-tables.md
+++ b/docs/Updating-gene-and-gene_alias-tables.md
@@ -53,7 +53,7 @@ SELECT count(*) FROM cbioportal.gene_alias;
 
 8- Additionally, there are several other tables you may want to update now (only in human).
 
-1. Updating the pfam graphics if you want to see 3D structures, explained in [this document](https://github.com/oplantalech/cbioportal/blob/d74d7159ff6abba67739efa7f905e407b3961ed3/docs/Updating-pfam_graphics-table.md)
+1. Updating the pfam graphics if you want to see 3D structures, explained in [this document](Updating-pfam_graphics-table.md)
 
 2. Updating the COSMIC coding mutations, can be downloaded from [here](http://cancer.sanger.ac.uk/cosmic/download) and require the script `importCosmicData.pl`
 

--- a/docs/Updating-gene-and-gene_alias-tables.md
+++ b/docs/Updating-gene-and-gene_alias-tables.md
@@ -2,7 +2,7 @@ This manual is intended for users that have knowledge about the structure of the
 
 When loading studies into cBioPortal it is possible for warnings to occur that are caused by an outdated seed database. Gene symbols can be deprecated or be assigned to a different Entrez Gene in a new release. Also Entrez Gene IDs can be added. This markdown explains how to update the seed database, in order to use the most recent Entrez Gene IDs. 
 
-The cBioPortal scripts package provides a method to update the `gene` and `gene_alias` tables. This requires the latest version of the NCBI Gene Info: ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz.
+The cBioPortal scripts package provides a method to update the `gene` and `gene_alias` tables. This requires the latest version of the NCBI Gene Info: [click here for human](ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz) and [here for mouse](ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Mammalia/Mus_musculus.gene_info.gz).
 
 ## Updating the gene names and aliases
 
@@ -36,7 +36,7 @@ TRUNCATE TABLE gene;
 
 4- Restart cBioPortal (restart webserver) to clean-up any cached gene lists.
 
-5- You probably also want to update the gene lengths. This is dependent on the reference genome you want to use. Download .annotation.gtf.gz from the latest GENCODE release from http://www.gencodegenes.org/releases/current.html for hg38 / GRCh38. For the hg19 / GRCh37, click on 'Go to GRCh37 version of this release'.
+5- You probably also want to update the gene lengths. To do so, download .annotation.gtf.gz of the [latest GENCODE release for hg19 / GRCh37](http://www.gencodegenes.org/releases/26lift37.html) for human and [mm10 / GRCm38](http://www.gencodegenes.org/mouse_releases/current.html) for mouse.
 
 After downloading, go to your downloads directory, decompress the file and add it as an argument (--gtf) in the next step.
 
@@ -44,12 +44,12 @@ After downloading, go to your downloads directory, decompress the file and add i
 
 ```
  export PORTAL_HOME=<your_cbioportal_dir>
-./importGenes.pl --genes <Homo_sapiens_gene_info.txt> --gtf <gencode.v25.annotation.gtf>
+./importGenes.pl --genes <ncbi_gene_info.txt> --gtf <gencode.v25.annotation.gtf>
 ```
 
 7- :warning: Check the `gene` and `gene_alias` tables to verify that they are filled correctly.
 
-8- Additionally, there are several other tables you may want to update now.
+8- Additionally, there are several other tables you may want to update now (only in human).
 
 1. Updating the pfam graphics if you want to see 3D structures, explained in [this document](https://github.com/oplantalech/cbioportal/blob/d74d7159ff6abba67739efa7f905e407b3961ed3/docs/Updating-pfam_graphics-table.md)
 

--- a/docs/Using-the-dataset-validator.md
+++ b/docs/Using-the-dataset-validator.md
@@ -401,7 +401,14 @@ ncbi.build=37
 ucsc.build=hg19
 ```
 
-If your `portal.properties` has different settings for these variables, you should introduce a new parameter `-P` in your command. This parameter should point to either `portal.properties` or a file which contains the new global variables. 
+cBioPortal is gradually introducing support for mouse. If you want to load mouse studies and you have [set up your database for mouse](Import-the-Seed-Database.md#download-the-cbioportal-database), you should set the previous parameters to:
+```
+species=mouse
+ncbi.build=38
+ucsc.build=mm10
+```
+
+If your `portal.properties` does not have the default (human) settings, you should introduce a new parameter `-P` in your command. This parameter should point to either `portal.properties` or a file which contains the new global variables. 
 
 As an example, the command for the "Example 1" listed above incorporating the `-P` parameter is given:
 ```


### PR DESCRIPTION
I have completed the mouse documentation by explaining how to build a database with mouse information, and fix minor issues in other pages regarding mouse. Also, cBioPortal does not support GRCh38, so it needs to be removed from the documentation. 