### PR TITLE
Improve oncokb icon status handling

### DIFF
--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -95,7 +95,7 @@
                 <artifactItem>
                   <groupId>com.github.cbioportal</groupId>
                   <artifactId>cbioportal-frontend</artifactId>
-                  <version>9ba9c62f83c52eac3d6d02480fb0fa8eba6befda</version>
+                  <version>d7f6d0904b0b196a80e1ec85a61de244e07315a1</version>
                   <type>jar</type>
                   <outputDirectory>.</outputDirectory>
                   <excludes>*index*</excludes>


### PR DESCRIPTION
Improve oncokb icon status handling. Use CANCER_TYPE from study if none is available on sample's clinical data.

Fixes errors for:

http://www.cbioportal.org/case.do?#/patient?studyId=brca_tcga&caseId=TCGA-3C-AAAU

![screen shot 2017-07-07 at 1 28 41 pm](https://user-images.githubusercontent.com/1334004/27969258-2c78781a-6318-11e7-9ba9-0b9c37089ac3.png)

Fixed in:
http://cbioportal-pr-2710.herokuapp.com/case.do?#/patient?studyId=brca_tcga&caseId=TCGA-3C-AAAU
