### PR TITLE
When no mutation data is available an empty list is returned

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoSampleProfile.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoSampleProfile.java
@@ -237,6 +237,12 @@ public final class DaoSampleProfile {
         ResultSet rs = null;
 
         List<Map<String, Object>> data = new ArrayList<Map<String, Object>>();
+        
+        // fixes issue #2576: prevent the query below from failing due to an empty join
+        if(id2MutationProfile.size()==0){
+            return data;
+        }
+        
         try {
             con = JdbcUtil.getDbConnection(DaoMutation.class);
 


### PR DESCRIPTION
# What? Why?
fixes #2576 

Changes proposed in this pull request:
- return empty list if there no mutations

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@ersinciftci 
