### PR TITLE
Fix dot in variable names in URL issue

### DIFF
--- a/web/src/main/resources/applicationContext-web.xml
+++ b/web/src/main/resources/applicationContext-web.xml
@@ -40,7 +40,12 @@
     <mvc:resources mapping="/swf/**" location="/swf/"/>
     <mvc:view-controller path="/api" view-name="redirect:/api/swagger-ui.html"/>
 
-    <mvc:annotation-driven>
+    <bean id="contentNegotiationManager" class="org.springframework.web.accept.ContentNegotiationManagerFactoryBean">
+        <property name="favorPathExtension" value="false" />
+    </bean>
+
+    <mvc:annotation-driven content-negotiation-manager="contentNegotiationManager">
+        <mvc:path-matching suffix-pattern="false" />
         <mvc:message-converters>
             <bean class="org.springframework.http.converter.json.MappingJackson2HttpMessageConverter">
                 <property name="objectMapper">


### PR DESCRIPTION
For example http://www.cbioportal.org/api/genes/H3.X was truncating after the dot,
now it shouldn't.