### PR TITLE
Remove special case for SAML institute logo URL

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/global/header_bar.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/header_bar.jsp
@@ -43,12 +43,9 @@
     else if (authenticationMethod.equals("googleplus") || authenticationMethod.equals("saml") || authenticationMethod.equals("ad")) {
         principal = "principal.username";
     }
-
-    // retrieve right-logo from global properties. Based on the tagLineImage code.
-    String rightLogo = (authenticationMethod.equals("saml")) ?
-            "/" + GlobalProperties.getRightLogo() : GlobalProperties.getRightLogo();
-    pageContext.setAttribute("rightLogo", rightLogo);
+    pageContext.setAttribute("principal", principal);
 %>
+<c:set var="rightLogo" value="${GlobalProperties.getRightLogo()}"/>
 
 <header>
         <div id="leftHeaderContent">
@@ -127,12 +124,12 @@
         </div>
 
         <div id="rightHeaderContent">
-        <!-- Display Sign Out Button for Real (Non-Anonymous) User -->
+        <%-- Display Sign Out Button for Real (Non-Anonymous) User --%>
         <sec:authorize access="!hasRole('ROLE_ANONYMOUS')">
             <div class="userControls">
             <span class="username"><i class="fa fa-cog" aria-hidden="true"></i></span>&nbsp;
                 
-                <div class="identity">Logged in as <sec:authentication property='<%=principal%>' />&nbsp;|&nbsp;
+                <div class="identity">Logged in as <sec:authentication property="${principal}" />&nbsp;|&nbsp;
                 <% if (authenticationMethod.equals("saml")) { %>
                     <a href="<c:url value="/saml/logout?local=true"/>">Sign out</a>
                 <%} else { %>
@@ -143,15 +140,10 @@
                 </div>
             </div>
         </sec:authorize>
-    
-    
-            <% if (rightLogo != "") { %>
-            <img id="institute-logo" src="<c:url value="${rightLogo}"/>" alt="Institute Logo" />
-            <% } %>
-    
-        </div>
-    
-    
 
+        <c:if test="${rightLogo != ''}">
+            <img id="institute-logo" src="<c:url value="${rightLogo}"/>" alt="Institute Logo" />
+        </c:if>
+        </div>
 
     </header>


### PR DESCRIPTION
The template logic for the header bar contained a special case in which
the institute logo was be prepended with a slash when using SAML
authentication, which caused issues when no logo was applicable
(signalled by an empty string). The logo seems to display just fine
without the special case, and removing it both solves the issue and
gets rid of some non-templating logic in a JSP scriptlet.

## Screenshots
### Before:
The top-right corner showed the alternative text of the logo (the literal words ‘Institute logo’) next to the account actions icon, when no logo was applicable to a SAML-authenticated portal.
![Screenshot showing the literal words 'Institute logo' next to the account action icon in the top right](https://user-images.githubusercontent.com/4929431/29073693-dab38ae4-7c4c-11e7-8ec6-e4f19fb7d264.png)

### After:
The top-right corner does not show anything there in those circumstances, exactly as it does when SAML authentication is not enabled.
![Screenshot showing only the account action icon in the top right without any logo](https://user-images.githubusercontent.com/4929431/29073969-f4b6cacc-7c4d-11e7-9a39-66fcae9546d1.png)


