### PR TITLE
Data download tab now prompts for file download

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/ShowData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/ShowData.java
@@ -106,6 +106,7 @@ public class ShowData extends HttpServlet {
                 DownloadLink downloadLink = downloadLinkList.get(i);
                 PrintWriter writer = response.getWriter();
                 response.setContentType("text/plain");
+                response.setHeader("Content-Disposition", "attachment;filename=cBioPortal_data.txt");
                 String transposeStr = request.getParameter(
                     QueryBuilder.CLIENT_TRANSPOSE_MATRIX);
                 boolean transpose = false;


### PR DESCRIPTION
# What? Why?
Fix #2727

Changes proposed in this pull request:
- Pressing the `Submit Query` button on the download tab now prompts for file download
- We need to create a separate PR on the front-end repo if we want to rename the button to `Download`

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.