### PR TITLE
Fix #2963 Session persistence on app redeploy

### DIFF
--- a/portal/src/main/webapp/META-INF/context.xml
+++ b/portal/src/main/webapp/META-INF/context.xml
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Context antiJARLocking="true" path="/cbioportal"/>
+<Context antiJARLocking="true" path="/cbioportal">
+    <Manager pathname="${sessions.pathname:SESSIONS.ser}" />
+</Context>


### PR DESCRIPTION
Fix #2963 

This allows to set a location where the session is stored when redeploying an app. By default this is `SESSIONS.ser` in the root of the extracted war. This works fine when restarting tomcat, but is a problem when redeploying the app, since that folder gets overwritten. Simply specifying a folder outside of the app solves the issue. All we have have to do is update properties for each portal with authentication of where on the filesystem the session should be stored. For example for beta portal I specified this:

```
sessions.pathname=/srv/www/msk-tomcat/beta-SESSIONS.ser
```

See also: https://stackoverflow.com/questions/27938643/tomcat-deploy-war-without-losing-session