### PR TITLE
Alter api-legacy model for DBStudy : pmid now String

### DIFF
--- a/business/src/main/java/org/mskcc/cbio/portal/model/DBStudy.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/model/DBStudy.java
@@ -18,7 +18,7 @@ public class DBStudy implements Serializable {
     public String name;
     public String short_name;
     public String description;
-    public Long pmid;
+    public String pmid;
     public String citation;
     public String groups;
     public Integer internal_id;

--- a/portal/src/main/webapp/js/api/doc
+++ b/portal/src/main/webapp/js/api/doc
@@ -173,7 +173,7 @@ getStudies
 	"name":"Breast Invasive Carcinoma (TCGA, Nature 2012)",
 	"short_name":"Breast (TCGA pub)",
 	"description":"<a href=\"http://cancergenome.nih.gov/\">The Cancer Genome Atlas (TCGA)</a> Breast Invasive Carcinoma project. 825 cases.<br><i>Nature 2012.</i> <a href=\"https://tcga-data.nci.nih.gov/docs/publications/brca_2012/\">Raw data via the TCGA Data Portal</a>.",
-	"pmid":23000897,
+	"pmid":"23000897",
 	"citation":"TCGA, Nature 2012",
 	"groups":"PUBLIC"
 }


### PR DESCRIPTION
# fix to allow non-numeric PMID output
Fix #1456 
Exceptions were observed when a study with a non-numeric PMID value in the database was part of the output of the api endpoint https://cbioportal.mskcc.org/api-legacy/studies.  The non-numeric PMID was accidentally entered, however nothing in the importer disallows the import of a non-numeric value.

Changes proposed in this pull request:
- Alter the model of the legacy Api-Controller to output PMID as a string instead of Long

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Notify reviewers
@cBioPortal/backend