### PR TITLE
use replaceState instead of pushState, so that new history states are…

### DIFF
--- a/portal/src/main/webapp/js/src/cgx_jquery.js
+++ b/portal/src/main/webapp/js/src/cgx_jquery.js
@@ -238,7 +238,7 @@ to be saved as a JSON string
 */
 function changeURLToSessionServiceURL(fullURL, pageTitle, sessionJSON) {
     getSessionServiceBookmark(fullURL, sessionJSON, function(bookmark) {
-        window.history.pushState({ "html": fullURL, "pageTitle": pageTitle }, "", bookmark);
+        window.history.replaceState({ "html": fullURL, "pageTitle": pageTitle }, "", bookmark);
     });
 }
 

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -619,7 +619,7 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 		new_url = changeURLParam(HEATMAP_TRACK_GROUPS_PARAM,
 					encodeURIComponent(getHeatmapParamValue(State.heatmap_track_groups)),
 					new_url);
-		window.history.pushState({"html":window.location.html,"pageTitle":window.location.pageTitle},"", new_url);
+		window.history.replaceState({"html":window.location.html,"pageTitle":window.location.pageTitle},"", new_url);
 	    },
 	    'getInitDataType': function() {
 		if (init_show_samples === null) {


### PR DESCRIPTION
Fix browser back button behavior by using history.replaceState instead of pushState method

https://github.com/cBioPortal/cbioportal/issues/2962

# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend
@cBioPortal/backend
@cBioPortal/devops

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
