### PR TITLE
duplication of codes leads to problem with network loading. networkGr…

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/visualize.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/visualize.jsp
@@ -297,10 +297,6 @@ window.onReactAppReady(function() {
             <%@ include file="mutation_details.jsp" %>
         <% } %>
 
-        <% if (includeNetworks) { %>
-            <%@ include file="networks.jsp" %>
-        <% } %>
-
             <% if (includeNetworks) { %>
         <%@ include file="networks.jsp" %>
             <% } %>


### PR DESCRIPTION
# What? Why?

There are double loading in all tabs, with the second one going on infinitely. This is due to the duplication of 3 lines of codes (including "networks.jsp")

Action = removing these three lines of codes.


