### PR TITLE
Validator: Add 2 values allowed in Validation_Status column

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1193,7 +1193,7 @@ class MutationsExtendedValidator(Validator):
     def checkValidationStatus(self, value):
         # if value is not blank, then it should be one of these:
         if self.checkNotBlank(value) and value.lower() not in ('untested', 'inconclusive',
-                                 'valid', 'invalid', 'na'):
+                                 'valid', 'invalid', 'na', 'redacted', 'unknown'):
             return False
         return True
 


### PR DESCRIPTION
# What? Why?
Fix #2546 and https://github.com/cBioPortal/datahub/issues/72

Add 'Redacted' and 'Unknown' as valid values for `Validation_Status`. 

## Redacted
`Redacted` makes sure the mutation is not loaded in the database:
https://github.com/cBioPortal/cbioportal/blob/c628bfc06e0f7446b4c2a51892f7acc8b6087325/core/src/main/java/org/mskcc/cbio/portal/scripts/MutationFilter.java#L127

## Unknown
`Unknown` adds a 'U' icon:
![screen shot 2017-08-22 at 17 13 22](https://user-images.githubusercontent.com/9624990/29572667-40847bd8-875d-11e7-9c2c-e2bc4004ced2.png)
