### PR TITLE
Fix #2881 Make 301 redirect for old style URL

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/PatientView.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/PatientView.java
@@ -82,11 +82,32 @@ public class PatientView extends HttpServlet {
             throws ServletException, IOException {
         XDebug xdebug = new XDebug( request );
         request.setAttribute(QueryBuilder.XDEBUG_OBJECT, xdebug);
-                
-        request.setAttribute(QueryBuilder.HTML_TITLE, "Patient");
-        
-        RequestDispatcher dispatcher = getServletContext().getRequestDispatcher("/WEB-INF/jsp/patient_view/patient_view.jsp");
-        dispatcher.forward(request, response);
+
+        // Convert old URL parameters cancer_study_id and case_id/sample_id to new frontend
+        // hash style URL paramters #studyId=x&caseId=y
+        String cancerStudyId = (String) request.getParameter("cancer_study_id");
+        if (cancerStudyId != null) {
+            String hashUrl = "#/patient?studyId=" + cancerStudyId;
+            String caseId = (String) request.getParameter("case_id");
+            String sampleId = (String) request.getParameter("sample_id");
+            if (caseId != null) {
+                hashUrl += "&caseId=" + caseId;
+            } else if (sampleId != null) {
+                hashUrl += "&sampleId=" + sampleId;
+            } else {
+               response.sendError(HttpServletResponse.SC_NOT_FOUND); 
+               return;
+            }
+            
+            response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+            String oldUrl = ((HttpServletRequest)request).getRequestURL().toString();
+            response.setHeader("Location", oldUrl + hashUrl);
+        } else {
+            request.setAttribute(QueryBuilder.HTML_TITLE, "Patient");
+
+            RequestDispatcher dispatcher = getServletContext().getRequestDispatcher("/WEB-INF/jsp/patient_view/patient_view.jsp");
+            dispatcher.forward(request, response);
+        }
     }
 
     private static String getFullURL(HttpServletRequest request) {


### PR DESCRIPTION
Convert cancer_study_id & case_id/sample_id to new style hash parameters
patient?studyId=x&caseId=y using 301 redirect.

Tested curl & in browser
```
18:56 $ curl --verbose 'http://localhost:8080/case.do?cancer_study_id=lgg_ucsf_2014&case_id=P04#/patient?caseId=P04&studyId=lgg_ucsf_2014'
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /case.do?cancer_study_id=lgg_ucsf_2014&case_id=P04 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Server: Apache-Coyote/1.1
< Set-Cookie: JSESSIONID=39E80E58DCF8AC80195C548B189D60E2; Path=/; HttpOnly
< Location: http://localhost:8080/case.do#/patient?studyId=lgg_ucsf_2014&caseId=P04
< Content-Length: 0
< Date: Tue, 22 Aug 2017 22:47:06 GMT
<
* Connection #0 to host localhost left intact
```