### PR TITLE
Fix allowing priority=0 to hide attribute

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1603,11 +1603,12 @@ class ClinicalValidator(Validator):
                         invalid_values = True
                 elif self.METADATA_LINES[line_index] == 'priority':
                     try:
-                        if int(value) < 1:
+                        if int(value) < 0:
                             raise ValueError()
                     except ValueError:
                         self.logger.error(
-                            'Priority definition is not a positive integer',
+                            'Priority definition should be an integer, and should be '
+                            'greater than or equal to zero',
                             extra={'line_number': line_index + 1,
                                    'column_number': col_index + 1,
                                    'cause': value})


### PR DESCRIPTION
# What? Why?
Fixes the issue reported at https://groups.google.com/forum/#!topic/cbioportal/rs1VgJhYcEI where priority 0 gives an error in the validation report:
```
"ERROR: data_patients.txt: line 4: columns [2, 3, 4, (2 more)]: Priority 
definition is not a positive integer; value encountered: '0' 
ERROR: data_patients.txt: Invalid header comments, file cannot be parsed" 
```
Now the value 0 is allowed (value 0 is used by study view to hide a clinical attribute).

Changes proposed in this pull request:
- allow 0 in clinical "priority" header line for clinical data, according to https://github.com/cBioPortal/cbioportal/blob/master/docs/Study-View.md#priorities

# Notify reviewers
@zhx828 