### PR TITLE
Fixed query gene returning "UNDEFINED" issue.

### DIFF
--- a/portal/src/main/webapp/js/src/dashboard/iviz.js
+++ b/portal/src/main/webapp/js/src/dashboard/iviz.js
@@ -192,7 +192,7 @@ function GeneValidator(geneAreaId, geneModel){
         $("#"+gene).change(function() {
             nrOfNotifications--;
             // replace the value in the text area
-            self.replaceAreaValue($(this).attr("name"), $(this).attr("value"));
+            self.replaceAreaValue($(this).attr("name"), $(this).val());
 
             // destroy the qtip if it's still there
             $(this).qtip("destroy");


### PR DESCRIPTION
# What? Why?
When users type gene or its alias in query panel, it returns "UNDEFINED"  since $(this).attr("value") returns "undefined".
Fix [#602](https://github.com/cBioPortal/iViz/issues/602) .
