### PR TITLE
Fix broken institute logo in older Tomcat versions

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/global/header_bar.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/header_bar.jsp
@@ -32,6 +32,7 @@
 
 <%@ page import="org.mskcc.cbio.portal.util.GlobalProperties" %>
 <%@ taglib prefix='c' uri='http://java.sun.com/jsp/jstl/core' %>
+<%@ taglib prefix="s" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
 <%
     String principal = "";
@@ -45,7 +46,10 @@
     }
     pageContext.setAttribute("principal", principal);
 %>
-<c:set var="rightLogo" value="${GlobalProperties.getRightLogo()}"/>
+<%-- Calling static methods is not supported in all versions of EL without
+     explicitly defining a function in an external taglib XML file. Using
+     Spring's SpEL instead to keep it short for this one function call --%>
+<s:eval var="rightLogo" expression="T(org.mskcc.cbio.portal.util.GlobalProperties).getRightLogo()"/>
 
 <header>
         <div id="leftHeaderContent">


### PR DESCRIPTION
The JSP template for the header bar used an EL expression which called a
static Java method. This turned out not to work in Tomcat 7, causing the
template to insert a broken <img> tag no matter whether a logo was
enabled or not. The native JSP way to solve this would be to define the
static method as a function in a taglib, but as this is just a single
function call I decided to keep it short and evaluate a Spring SpEL
expression instead.

This should fix issue #3106.