### PR TITLE
Update cBioPortal-ER-Diagram.md

### DIFF
--- a/docs/cBioPortal-ER-Diagram.md
+++ b/docs/cBioPortal-ER-Diagram.md
@@ -1,4 +1,4 @@
 # cBioPortal ER Diagram
-[cBioPortal ER Diagram - PDF Version](https://github.com/cBioPortal/cbioportal/blob/master/core/src/main/resources/db/cbioportal-er-diagram.pdf)
+[cBioPortal ER Diagram - PDF Version](https://github.com/cBioPortal/cbioportal/blob/master/db-scripts/src/main/resources/cbioportal-er-diagram.pdf)
 
-![cBioPortal ER Diagram](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/core/src/main/resources/db/cbioportal-er-diagram.png)
+![cBioPortal ER Diagram](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/db-scripts/src/main/resources/cbioportal-er-diagram.png)


### PR DESCRIPTION
Repair broken link to entity-relationship diagram.
Files were moved from core/src/main/resources/db to db-scripts/src/main/resources

Fix for issue #3110 

# Notify reviewers
@cBioPortal/frontend
@cBioPortal/backend

