### PR TITLE
Fix what's new default syntax error

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -155,12 +155,7 @@ public class GlobalProperties {
 
     // property for setting the news blurb in the right column
     public static final String SKIN_RIGHT_NAV_WHATS_NEW_BLURB = "skin.right_nav.whats_new_blurb";
-    public static final String DEFAULT_SKIN_WHATS_NEW_BLURB = 
-            "<form action=\"https://groups.google.com/group/cbioportal-news/boxsubscribe\"> &nbsp;&nbsp;&nbsp;&nbsp;" +
-            "<b>Sign up for low-volume email news alerts:</b></br> &nbsp;&nbsp;&nbsp;&nbsp;<input type=\"text\" " +
-            "name=\"email\" title=\"Subscribe to mailing list\"> <input type=\"submit\" name=\"sub\" value=\"Subscribe\"> " +
-            "</form> &nbsp;&nbsp;&nbsp;&nbsp;<b>Or follow us <a href=\"http://www.twitter.com/cbioportal\">" +
-            "<i>@cbioportal</i></a> on Twitter</b>\n";
+    public static final String DEFAULT_SKIN_WHATS_NEW_BLURB = ""; // default is in cbioportal-frontend repo
 
     // footer
     public static final String SKIN_FOOTER = "skin.footer";


### PR DESCRIPTION
The new line in the what's new blurb causes a syntax error. We can remove the default completely since the default is now stored in the frontend repo.