### PR TITLE
Fix duplicate columns in download file.

### DIFF
--- a/portal/src/main/webapp/js/src/dashboard/iviz.js
+++ b/portal/src/main/webapp/js/src/dashboard/iviz.js
@@ -1142,8 +1142,6 @@ var iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
         attr.study_id = 'Study ID';
         attr.patient_id = 'Patient ID';
         attr.sample_id = 'Sample ID';
-        attr.mutated_genes = 'With Mutation Data';
-        attr.cna_details = 'With CNA Data';
 
         var arr = [];
         var strA = [];


### PR DESCRIPTION
# What? Why?
With Mutation Data and With CNA data have duplicated columns. That's because we also add 2 attributes in attr array so that there are extra attributes in download file.

Fix [#578](https://github.com/cBioPortal/iViz/issues/578) .

