### PR TITLE
Add schemes to the Swagger spec

### DIFF
--- a/web/src/main/java/org/cbioportal/web/config/SwaggerConfig.java
+++ b/web/src/main/java/org/cbioportal/web/config/SwaggerConfig.java
@@ -11,6 +11,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+import java.util.Arrays;
+import java.util.HashSet;
+
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig {
@@ -22,6 +25,7 @@ public class SwaggerConfig {
             .apis(RequestHandlerSelectors.withClassAnnotation(PublicApi.class))
             .build()
             .useDefaultResponseMessages(false)
+            .protocols(new HashSet<>(Arrays.asList("http", "https")))
             .apiInfo(apiInfo());
     }
 
@@ -32,6 +36,7 @@ public class SwaggerConfig {
             .apis(RequestHandlerSelectors.withClassAnnotation(InternalApi.class))
             .build()
             .useDefaultResponseMessages(false)
+            .protocols(new HashSet<>(Arrays.asList("http", "https")))
             .apiInfo(apiInfo());
     }
 
@@ -41,7 +46,7 @@ public class SwaggerConfig {
             "A web service for supplying JSON formatted data to cBioPortal clients. " +
                 "Please note that this API is currently in beta and subject to change.",
             "1.0 (beta)",
-            "www.cbioportal.org",
+            "http://www.cbioportal.org",
             new Contact("cBioPortal", "www.cbioportal.org", "cbioportal@googlegroups.com"),
             "License",
             "https://github.com/cBioPortal/cbioportal/blob/master/LICENSE");


### PR DESCRIPTION
After generating a Python client, it uses https by default if there is no schema defined
