### PR TITLE
Fix test data to allow for successful importing of gene panel data

### DIFF
--- a/core/src/test/scripts/test_data/study_es_0/data_gene_panel_matrix.txt
+++ b/core/src/test/scripts/test_data/study_es_0/data_gene_panel_matrix.txt
@@ -1,2 +1,5 @@
-SAMPLE_ID	study_es_0_mutations
+SAMPLE_ID	mutations
 TCGA-A1-A0SB-01	example_gene_panel_stable_id
+TEST-A2B8-01	example_gene_panel_stable_id
+TEST-A2FF-01	example_gene_panel_stable_id
+TCGA-GI-A2C8-01	example_gene_panel_stable_id

--- a/core/src/test/scripts/test_data/study_es_0/gene_panel_example.txt
+++ b/core/src/test/scripts/test_data/study_es_0/gene_panel_example.txt
@@ -1,3 +1,3 @@
 stable_id: example_gene_panel_stable_id
 description: Example gene panel meta file for testing purposes.
-gene_list:	AKT1	BRCA1	CDKN1A	EGFR	FOXP1	HRAS	KRAS	POLE	SMAD2	TP53
+gene_list: OR11H1	TMEM247	ABLIM1	ADAMTS20	CADM2	DTNB	KAT2A	MSH3	MYB	NPIPB15	OTOR	P2RY10	PIEZO1	ERBB2	FGFR3

--- a/core/src/test/scripts/test_data/study_es_0/meta_mutations_extended.txt
+++ b/core/src/test/scripts/test_data/study_es_0/meta_mutations_extended.txt
@@ -7,3 +7,4 @@ profile_description: Mutation data from whole exome sequencing.
 profile_name: Mutations
 data_filename: brca_tcga_pub.maf
 swissprot_identifier: name
+gene_panel: example_gene_panel_stable_id

--- a/core/src/test/scripts/test_data/study_es_0/result_report.html
+++ b/core/src/test/scripts/test_data/study_es_0/result_report.html
@@ -675,7 +675,7 @@
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
                 <td>&ndash;</td>
                 <td>&ndash;</td>
-                <td>Read 2 lines. Lines with warning: 0. Lines with error: 0</td>
+                <td>Read 5 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
               </tr>
             </tbody>


### PR DESCRIPTION
# What? Why?
This PR:
1. Fixes the importing of gene panels for study_es_0. The `gene_panel` property in `meta_mutations_extended.txt` is mandatory in this case.
2. Allow to test gene panels by replacing the genes for genes that are contained in the MAF and fusion file.