### PR TITLE
Hide download file links for multi-studies.

### DIFF
--- a/portal/src/main/webapp/js/src/data_download.js
+++ b/portal/src/main/webapp/js/src/data_download.js
@@ -219,15 +219,21 @@ var DataDownloadTab = (function() {
                     _processedProfiles.push(_p);
                 });
             }
-
-            $.each(_processedProfiles, function(index, val) {
-                var _str = "<li style=\"margin-bottom: 1em;\">" + val.name + ": ";
-                _formats.forEach(function(inner_obj) {
-                    _str += "<a href='#' onclick=\"DataDownloadTab.onClickDownload('"+val.profileIds+"','" +val.alterationType+"','" + inner_obj.value + "','" + val.fileName + "')\"> [ " + inner_obj.name + " ]</a>&nbsp;&nbsp;&nbsp;"
+            
+            // Hide download file links for multi-studies.
+            if (_processedProfiles.length > 1) {
+                $('#data_download_tab_links_li_div').css('display','none');
+                $('#data_download_tab_text_areas').css('margin-top','10px');
+            } else {
+                $.each(_processedProfiles, function(index, val) {
+                    var _str = "<li style=\"margin-bottom: 1em;\">" + val.name + ": ";
+                    _formats.forEach(function(inner_obj) {
+                        _str += "<a href='#' onclick=\"DataDownloadTab.onClickDownload('"+val.profileIds+"','" +val.alterationType+"','" + inner_obj.value + "','" + val.fileName + "')\"> [ " + inner_obj.name + " ]</a>&nbsp;&nbsp;&nbsp;"
+                    });
+                    _str += "</li>";
+                    $("#data_download_links_li").append(_str);
                 });
-                _str += "</li>";
-                $("#data_download_links_li").append(_str);
-            });
+            }
         });
 
         //configure the download link (link back to the home page download data tab)


### PR DESCRIPTION
# What? Why?
If a user select so many studies, the download files link will be too long. Therefore, we need to hire it.

![image](https://user-images.githubusercontent.com/14971266/30930334-6d28445a-a38f-11e7-88e2-47cc1a969911.png)

