### PR TITLE
Query Page: configurable list of sets of genes

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -37,9 +37,11 @@ import org.mskcc.cbio.portal.servlet.QueryBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ResourceUtils;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -233,6 +235,8 @@ public class GlobalProperties {
     public static final String DEFAULT_UCSC_BUILD = "hg19";
 
     public static final String ONCOPRINT_DEFAULTVIEW = "oncoprint.defaultview";
+    
+    public static final String SETSOFGENES_LOCATION = "querypage.setsofgenes.location";
 
     private static boolean showCivic;
     @Value("${show.civic:false}") // default is false
@@ -1053,5 +1057,22 @@ public class GlobalProperties {
     public static boolean hidePassengerMutations() {
 	String hidePassenger = properties.getProperty(HIDE_PASSENGER_MUTATIONS, "false");
 	return Boolean.parseBoolean(hidePassenger);
+    }
+    
+    public static String getQuerySetsOfGenes() {
+	String result = new String();
+	try {
+	    BufferedReader br = new BufferedReader(new FileReader(ResourceUtils.getFile(properties.getProperty(SETSOFGENES_LOCATION, "classpath:/setsofgenes.json"))));
+	    for (String line = br.readLine();line != null;line = br.readLine()) {
+		line = line.trim();
+		result = result + line;
+	    }
+	    br.close();
+	} catch (FileNotFoundException e) {
+	    throw new RuntimeException("File not found: ", e);
+	} catch (IOException e) {
+	    throw new RuntimeException("Line not found: ", e);
+	}
+	return result;
     }
 }

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -105,9 +105,9 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>com.github.cbioportal</groupId>
-                  <artifactId>cbioportal-frontend</artifactId>
-                  <version>2eb1f24a2a77c92cd8acd27c521802decb924873</version>
+                   <groupId>com.github.thehyve</groupId>
+                    <artifactId>cbioportal-frontend</artifactId>
+                    <version>bh_rc-SNAPSHOT</version>
                   <type>jar</type>
                   <outputDirectory>.</outputDirectory>
                   <excludes>*index*</excludes>

--- a/portal/src/main/resources/setsofgenes.json
+++ b/portal/src/main/resources/setsofgenes.json
@@ -1,0 +1,70 @@
+[{
+	"id": "Prostate Cancer: AR Signaling",
+	"genes": ["SOX9", "RAN", "TNK2", "EP300", "PXN", "NCOA2", "AR", "NRIP1", "NCOR1", "NCOR2"]
+}, {
+	"id": "Prostate Cancer: AR and steroid synthesis enzymes",
+	"genes": ["AKR1C3", "AR", "CYB5A", "CYP11A1", "CYP11B1", "CYP11B2", "CYP17A1", "CYP19A1", "CYP21A2", "HSD17B1", "HSD17B10", "HSD17B11", "HSD17B12", "HSD17B13", "HSD17B14", "HSD17B2", "HSD17B3", "HSD17B4", "HSD17B6", "HSD17B7", "HSD17B8", "HSD3B1", "HSD3B2", "HSD3B7", "RDH5", "SHBG", "SRD5A1", "SRD5A2", "SRD5A3", "STAR"]
+}, {
+	"id": "Prostate Cancer: Steroid inactivating genes",
+	"genes": ["AKR1C1", "AKR1C2", "AKR1C4", "CYP3A4", "CYP3A43", "CYP3A5", "CYP3A7", "UGT2B15", "UGT2B17", "UGT2B7"]
+}, {
+	"id": "Prostate Cancer: Down-regulated by androgen",
+	"genes": ["BCHE", "CDK8", "CTBP1", "ACKR3", "DDC", "DPH1", "FN1", "HES6", "MMP16", "MYC", "PEG3", "PIK3R3", "PRKD1", "SCNN1A", "SDC4", "SERPINI1", "SLC29A1", "ST7", "TULP4"]
+}, {
+	"id": "Glioblastoma: TP53 Pathway",
+	"genes": ["CDKN2A", "MDM2", "MDM4", "TP53"]
+}, {
+	"id": "Glioblastoma: RTK/Ras/PI3K/AKT Signaling",
+	"genes": ["EGFR", "ERBB2", "PDGFRA", "MET", "KRAS", "NRAS", "HRAS", "NF1", "SPRY2", "FOXO1", "FOXO3", "AKT1", "AKT2", "AKT3", "PIK3R1", "PIK3CA", "PTEN"]
+}, {
+	"id": "Glioblastoma: RB Pathway",
+	"genes": ["CDKN2A", "CDKN2B", "CDKN2C", "CDK4", "CDK6", "CCND2", "RB1"]
+}, {
+	"id": "Ovarian Cancer: Oncogenes associated with epithelial ovarian cancer",
+	"genes": ["RAB25", "MECOM", "EIF5A2", "PRKCI", "PIK3CA", "KIT", "FGF1", "MYC", "EGFR", "NOTCH3", "KRAS", "AKT1", "ERBB2", "PIK3R1", "CCNE1", "AKT2", "AURKA"]
+}, {
+	"id": "Ovarian Cancer: Putative tumor-suppressor genes in epithelial ovarian cancer",
+	"genes": ["DIRAS3", "RASSF1", "DLEC1", "SPARC", "DAB2", "PLAGL1", "RPS6KA2", "PTEN", "OPCML", "BRCA2", "ARL11", "WWOX", "TP53", "DPH1", "BRCA1", "PEG3"]
+}, {
+	"id": "General: Cell Cycle Control",
+	"genes": ["RB1", "RBL1", "RBL2", "CCNA1", "CCNB1", "CDK1", "CCNE1", "CDK2", "CDC25A", "CCND1", "CDK4", "CDK6", "CCND2", "CDKN2A", "CDKN2B", "MYC", "CDKN1A", "CDKN1B", "E2F1", "E2F2", "E2F3", "E2F4", "E2F5", "E2F6", "E2F7", "E2F8", "SRC", "JAK1", "JAK2", "STAT1", "STAT2", "STAT3", "STAT5A", "STAT5B"]
+}, {
+	"id": "General: p53 signaling",
+	"genes": ["TP53", "MDM2", "MDM4", "CDKN2A", "CDKN2B", "TP53BP1"]
+}, {
+	"id": "General: Notch signaling",
+	"genes": ["ADAM10", "ADAM17", "APH1A", "APH1B", "ARRDC1", "CIR1", "CTBP1", "CTBP2", "CUL1", "DLL1", "DLL3", "DLL4", "DTX1", "DTX2", "DTX3", "DTX3L", "DTX4", "EP300", "FBXW7", "HDAC1", "HDAC2", "HES1", "HES5", "HEYL", "ITCH", "JAG1", "JAG2", "KDM5A", "LFNG", "MAML1", "MAML2", "MAML3", "MFNG", "NCOR2", "NCSTN", "NOTCH1", "NOTCH2", "NOTCH3", "NOTCH4", "NRARP", "NUMB", "NUMBL", "PSEN1", "PSEN2", "PSENEN", "RBPJ", "RBPJL", "RFNG", "SNW1", "SPEN", "HES2", "HES4", "HES7", "HEY1", "HEY2"]
+}, {
+	"id": "General: DNA Damage Response",
+	"genes": ["CHEK1", "CHEK2", "RAD51", "BRCA1", "BRCA2", "MLH1", "MSH2", "ATM", "ATR", "MDC1", "PARP1", "FANCF"]
+}, {
+	"id": "General: Other growth / proliferation signaling",
+	"genes": ["CSF1", "CSF1R", "IGF1", "IGF1R", "FGF1", "FGFR1", "AURKA", "DLEC1", "PLAGL1", "OPCML", "DPH1"]
+}, {
+	"id": "General: Survival / cell death regulation signaling",
+	"genes": ["NFKB1", "NFKB2", "CHUK", "DIRAS3", "FAS", "HLA-G", "BAD", "BCL2", "BCL2L1", "APAF1", "CASP9", "CASP8", "CASP10", "CASP3", "CASP6", "CASP7", "GSK3B", "ARL11", "WWOX", "PEG3", "TGFB1", "TGFBR1", "TGFBR2"]
+}, {
+	"id": "General: Telomere maintenance",
+	"genes": ["TERC", "TERT"]
+}, {
+	"id": "General: RTK signaling family",
+	"genes": ["EGFR", "ERBB2", "ERBB3", "ERBB4", "PDGFA", "PDGFB", "PDGFRA", "PDGFRB", "KIT", "FGF1", "FGFR1", "IGF1", "IGF1R", "VEGFA", "VEGFB", "KDR"]
+}, {
+	"id": "General: PI3K-AKT-mTOR signaling",
+	"genes": ["PIK3CA", "PIK3R1", "PIK3R2", "PTEN", "PDPK1", "AKT1", "AKT2", "FOXO1", "FOXO3", "MTOR", "RICTOR", "TSC1", "TSC2", "RHEB", "AKT1S1", "RPTOR", "MLST8"]
+}, {
+	"id": "General: Ras-Raf-MEK-Erk/JNK signaling",
+	"genes": ["KRAS", "HRAS", "BRAF", "RAF1", "MAP3K1", "MAP3K2", "MAP3K3", "MAP3K4", "MAP3K5", "MAP2K1", "MAP2K2", "MAP2K3", "MAP2K4", "MAP2K5", "MAPK1", "MAPK3", "MAPK4", "MAPK6", "MAPK7", "MAPK8", "MAPK9", "MAPK12", "MAPK14", "DAB2", "RASSF1", "RAB25"]
+}, {
+	"id": "General: Regulation of ribosomal protein synthesis and cell growth",
+	"genes": ["RPS6KA1", "RPS6KA2", "RPS6KB1", "RPS6KB2", "EIF5A2", "EIF4E", "EIF4EBP1", "RPS6", "HIF1A"]
+}, {
+	"id": "General: Angiogenesis",
+	"genes": ["VEGFA", "VEGFB", "KDR", "CXCL8", "CXCR1", "CXCR2"]
+}, {
+	"id": "General: Folate transport",
+	"genes": ["SLC19A1", "FOLR1", "FOLR2", "FOLR3", "IZUMO1R"]
+}, {
+	"id": "General: Invasion and metastasis",
+	"genes": ["MMP1", "MMP2", "MMP3", "MMP7", "MMP9", "MMP10", "MMP11", "MMP12", "MMP13", "MMP14", "MMP15", "MMP16", "MMP17", "MMP19", "MMP21", "MMP23B", "MMP24", "MMP25", "MMP26", "MMP27", "MMP28", "ITGB3", "ITGAV", "PTK2", "CDH1", "SPARC", "WFDC2"]
+}]

--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -15,6 +15,7 @@ window.showCivic = <%=GlobalProperties.showCivic()%>;
 window.showHotspot = <%=GlobalProperties.showHotspot()%>;
 window.showMyCancerGenome = <%=GlobalProperties.showMyCancerGenomeUrl()%>;
 window.showGenomeNexus = <%=GlobalProperties.showGenomeNexus()%>;
+window.querySetsOfGenes = <%=GlobalProperties.getQuerySetsOfGenes()%>;
 
 // this prevents react router from messing with hash in a way that could is unecessary (static pages)
 // or could conflict
@@ -30,6 +31,7 @@ window.skinRightNavShowTestimonials = <%=GlobalProperties.showRightNavTestimonia
 window.skinRightNavExamplesHTML = '<%=GlobalProperties.getExamplesRightColumnHtml()%>';
 window.skinRightNavExamplesHTML = '<%=GlobalProperties.getExamplesRightColumnHtml()%>';
 window.skinRightNavWhatsNewBlurb = '<%=GlobalProperties.getRightNavWhatsNewBlurb()%>';
+
 // Prioritized studies for study selector
 window.priorityStudies = {};
 <%

--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -15,7 +15,7 @@ window.showCivic = <%=GlobalProperties.showCivic()%>;
 window.showHotspot = <%=GlobalProperties.showHotspot()%>;
 window.showMyCancerGenome = <%=GlobalProperties.showMyCancerGenomeUrl()%>;
 window.showGenomeNexus = <%=GlobalProperties.showGenomeNexus()%>;
-window.querySetsOfGenes = <%=GlobalProperties.getQuerySetsOfGenes()%>;
+window.querySetsOfGenes = JSON.parse('<%=GlobalProperties.getQuerySetsOfGenes()%>');
 
 // this prevents react router from messing with hash in a way that could is unecessary (static pages)
 // or could conflict

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -1581,6 +1581,23 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 	
 	return State.addAndPopulateClinicalTracks(attr);
     };
+    
+    var isAnyDriverLabellingDataSourceSelected = function() {
+	result = true;
+	var known_mutation_settings = QuerySession.getKnownMutationSettings();
+	    var tiers = false;
+	    Object.keys(known_mutation_settings.recognize_driver_tiers).forEach(function(tier) {
+		if (known_mutation_settings.recognize_driver_tiers[tier] === true) {
+		    tiers = true;
+		}
+	    });
+	    if (!known_mutation_settings.recognize_hotspot && !known_mutation_settings.recognize_cbioportal_count
+		    && !known_mutation_settings.recognize_cosmic_count && !known_mutation_settings.recognize_oncokb_oncogenic 
+		    && !known_mutation_settings.recognize_driver_filter && !tiers) {
+		result = false;
+	    }
+	return result;
+    };
 
     (/**
       * Initializes the OncoPrint tracks, populates them and scrolls back.
@@ -1597,10 +1614,7 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 	console.log("in initOncoprint, fetching genomic event data");
 	return QuerySession.getOncoprintSampleGenomicEventData()
 	.then(function (oncoprint_data) {
-	    var known_mutation_settings = QuerySession.getKnownMutationSettings();
-	    if (!known_mutation_settings.recognize_hotspot && !known_mutation_settings.recognize_cbioportal_count
-		    && !known_mutation_settings.recognize_cosmic_count && !known_mutation_settings.recognize_oncokb_oncogenic 
-		    && !known_mutation_settings.recognize_driver_filter) {
+	    if (!isAnyDriverLabellingDataSourceSelected()) {
 		// If no data sources selected, turn off driver/passenger labeling..
 		State.colorby_knowledge = false;
 		// .. and filtering
@@ -2060,11 +2074,7 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 		if (!external_data_status.oncokb) {
 		    $('#oncoprint_diagram_mutation_color').find('input[type="checkbox"][name="oncokb"]').attr("disabled", true);
 		}
-		
-		var known_mutation_settings = QuerySession.getKnownMutationSettings();
-		if (!known_mutation_settings.recognize_hotspot && !known_mutation_settings.recognize_cbioportal_count
-			    && !known_mutation_settings.recognize_cosmic_count && !known_mutation_settings.recognize_oncokb_oncogenic 
-			    && !known_mutation_settings.recognize_driver_filter) {
+		if (!isAnyDriverLabellingDataSourceSelected()) {
 		    // If no data sources selected, turn off driver/passenger labeling..
 		    State.colorby_knowledge = false;
 		    // .. and filtering

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -223,3 +223,6 @@ oncoprint.defaultview=patient
 
 # Set this to true if you want to check the "hide Putative Passenger Mutations" checkbox by default.
 # oncoprint.hide_passenger.default=true
+
+# Change this to custom file (e.g. file:/<path>) to have a custom set of genes in query page:
+querypage.setsofgenes.location = classpath:/setsofgenes.json


### PR DESCRIPTION
# What? Why?
We have created a property in portal.properties (`querypage.setsofgenes.location`) where the user can specify a different file that describes the list of sets of genes displayed in the query page. This file must be a JSON string.

This PR goes together with the PR cbioportal/cbioportal-frontend#689.
