### PR TITLE
Query Page: configurable list of sets of genes

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -37,9 +37,11 @@ import org.mskcc.cbio.portal.servlet.QueryBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ResourceUtils;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -233,6 +235,8 @@ public class GlobalProperties {
     public static final String DEFAULT_UCSC_BUILD = "hg19";
 
     public static final String ONCOPRINT_DEFAULTVIEW = "oncoprint.defaultview";
+    
+    public static final String SETSOFGENES_LOCATION = "querypage.setsofgenes.location";
 
     private static boolean showCivic;
     @Value("${show.civic:false}") // default is false
@@ -1053,5 +1057,27 @@ public class GlobalProperties {
     public static boolean hidePassengerMutations() {
 	String hidePassenger = properties.getProperty(HIDE_PASSENGER_MUTATIONS, "false");
 	return Boolean.parseBoolean(hidePassenger);
+    }
+    
+    public static String getQuerySetsOfGenes() {
+	String result = new String();
+	String fileName = properties.getProperty(SETSOFGENES_LOCATION, null);
+	if (fileName == null) {
+	    result = null;
+	} else {
+	    try {
+		BufferedReader br = new BufferedReader(new FileReader(ResourceUtils.getFile(fileName)));
+		for (String line = br.readLine();line != null;line = br.readLine()) {
+		    line = line.trim();
+		    result = result + line;
+		}
+		br.close();
+	    } catch (FileNotFoundException e) {
+		throw new RuntimeException("File not found: ", e);
+	    } catch (IOException e) {
+		throw new RuntimeException("Line not found: ", e);
+	    }
+	}
+	return result;
     }
 }

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -107,7 +107,7 @@
                 <artifactItem>
                   <groupId>com.github.cbioportal</groupId>
                   <artifactId>cbioportal-frontend</artifactId>
-                  <version>2eb1f24a2a77c92cd8acd27c521802decb924873</version>
+                  <version>a0c61b4a26ce66435c82058cf953836344395e91</version>
                   <type>jar</type>
                   <outputDirectory>.</outputDirectory>
                   <excludes>*index*</excludes>

--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -15,6 +15,7 @@ window.showCivic = <%=GlobalProperties.showCivic()%>;
 window.showHotspot = <%=GlobalProperties.showHotspot()%>;
 window.showMyCancerGenome = <%=GlobalProperties.showMyCancerGenomeUrl()%>;
 window.showGenomeNexus = <%=GlobalProperties.showGenomeNexus()%>;
+window.querySetsOfGenes = JSON.parse('<%=GlobalProperties.getQuerySetsOfGenes()%>');
 
 // this prevents react router from messing with hash in a way that could is unecessary (static pages)
 // or could conflict

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -223,3 +223,6 @@ oncoprint.defaultview=patient
 
 # Set this to true if you want to check the "hide Putative Passenger Mutations" checkbox by default.
 # oncoprint.hide_passenger.default=true
+
+# Change this to custom file (e.g. file:/<path>) to have a custom set of genes in query page:
+# querypage.setsofgenes.location =


### PR DESCRIPTION
# What? Why?
We have created a property in portal.properties (`querypage.setsofgenes.location`) where the user can specify a different file that describes the list of sets of genes displayed in the query page. This file must be a JSON string.

This PR goes together with the PR cbioportal/cbioportal-frontend#690.