### PR TITLE
Clarification in documentation stable_id continuous RNA-seq

### DIFF
--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -414,6 +414,7 @@ The expression metadata file should contain the following fields:
 
 #### Supported stable_id values for MRNA_EXPRESSION
 For historical reasons, cBioPortal expects the `stable_id` to be one of those listed in the following static set.
+The stable_id for continous RNA-seq data has two options. These options were added to distinguish between two different TCGA pipelines. For custom datasets either one of these stable_id can be chosen.
 
 <table>
 <thead>

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -414,7 +414,7 @@ The expression metadata file should contain the following fields:
 
 #### Supported stable_id values for MRNA_EXPRESSION
 For historical reasons, cBioPortal expects the `stable_id` to be one of those listed in the following static set.
-The stable_id for continous RNA-seq data has two options. These options were added to distinguish between two different TCGA pipelines. For custom datasets either one of these stable_id can be chosen.
+The stable_id for continuous RNA-seq data has two options. These options were added to distinguish between two different TCGA pipelines. For custom datasets either one of these stable_id can be chosen.
 
 <table>
 <thead>

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -414,7 +414,7 @@ The expression metadata file should contain the following fields:
 
 #### Supported stable_id values for MRNA_EXPRESSION
 For historical reasons, cBioPortal expects the `stable_id` to be one of those listed in the following static set.
-The stable_id for continuous RNA-seq data has two options. These options were added to distinguish between two different TCGA pipelines. For custom datasets either one of these stable_id can be chosen.
+The stable_id for continuous RNA-seq data has two options: `rna_seq_mrna` or `rna_seq_v2_mrna`. These options were added to distinguish between two different TCGA pipelines, which perform different types of normalization (see [RNASeq](https://wiki.nci.nih.gov/display/TCGA/RNASeq) and [RNASeq version 2](https://wiki.nci.nih.gov/display/tcga/rnaseq+version+2)). However, for custom datasets either one of these `stable_id` can be chosen.
 
 <table>
 <thead>


### PR DESCRIPTION
Added clarification in documentation about stable_id of continuous RNA-seq data after question in google groups (https://groups.google.com/forum/#!topic/cbioportal/LPh5zBkdkHc). 