### PR TITLE
Add an API enpoint to shorten URLs using bit.ly

### DIFF
--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -173,6 +173,20 @@
     </servlet-mapping>
 
     <servlet>
+        <servlet-name>url_shortener</servlet-name>
+        <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+        <init-param>
+            <param-name>contextConfigLocation</param-name>
+            <param-value>classpath:applicationContext-url-shortener.xml</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>url_shortener</servlet-name>
+        <url-pattern>/api/url-shortener</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
         <servlet-name>api</servlet-name>
         <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
         <init-param>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -167,6 +167,8 @@ pathway_commons.url=http://www.pathwaycommons.org/pc2
 
 # bitly, please use your bitly user and apiKey
 bitly.url=http://api.bit.ly/shorten?login=[bitly.user]&apiKey=[bitly.apiKey]&
+# the new API uses the v3 of bitly API, and a java library to make the API call, so you only need to provide the access token  
+bitly.access.token=
 
 # google analytics
 google_analytics_profile_id=

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -92,6 +92,16 @@
           <artifactId>javax.el</artifactId>
           <version>2.2.4</version>
       </dependency>
+      <dependency>
+          <groupId>com.github.romain-warnan</groupId>
+          <artifactId>simple-java-bitly</artifactId>
+          <version>1.1</version>
+      </dependency>
+      <dependency>
+          <groupId>commons-validator</groupId>
+          <artifactId>commons-validator</artifactId>
+          <version>1.6</version>
+      </dependency>
   </dependencies>
 
 </project>

--- a/web/src/main/java/org/cbioportal/url_shortener/URLShortenerController.java
+++ b/web/src/main/java/org/cbioportal/url_shortener/URLShortenerController.java
@@ -1,0 +1,36 @@
+package org.cbioportal.url_shortener;
+
+import fr.plaisance.bitly.Bit;
+import fr.plaisance.bitly.Bitly;
+import org.apache.commons.validator.routines.UrlValidator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class URLShortenerController {
+
+    @Value("${bitly.access.token}")
+    private String bitlyAccessToken;
+    
+    private Bitly bitly ;
+    private UrlValidator urlValidator = new UrlValidator();
+    
+    @RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<URLShortenerResponse> urlShortener(@RequestParam String url) {
+        
+        if (urlValidator.isValid(url)) {
+            if (bitly == null) {
+                bitly = Bit.ly(bitlyAccessToken);
+            }
+            return new ResponseEntity<>(new URLShortenerResponse(bitly.shorten(url), null), HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(new URLShortenerResponse(null, "Invalid URL"), HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/web/src/main/java/org/cbioportal/url_shortener/URLShortenerResponse.java
+++ b/web/src/main/java/org/cbioportal/url_shortener/URLShortenerResponse.java
@@ -1,0 +1,28 @@
+package org.cbioportal.url_shortener;
+
+public class URLShortenerResponse {
+    
+    private String shortURL;
+    private String error;
+
+    public URLShortenerResponse(String shortURL, String error) {
+        this.shortURL = shortURL;
+        this.error = error;
+    }
+
+    public String getShortURL() {
+        return shortURL;
+    }
+
+    public void setShortURL(String shortURL) {
+        this.shortURL = shortURL;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+}

--- a/web/src/main/resources/applicationContext-url-shortener.xml
+++ b/web/src/main/resources/applicationContext-url-shortener.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+     http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+     http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+     http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+
+    <bean id="propertyPlaceholderConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE" />
+        <property name="searchSystemEnvironment" value="true" />
+        <property name="ignoreResourceNotFound" value="true" />
+        <property name="ignoreUnresolvablePlaceholders" value="true" />
+        <property name="locations">
+            <list>
+                <value>file:///${PORTAL_HOME}/portal.properties</value>
+                <value>classpath:portal.properties</value>
+            </list>
+        </property>
+    </bean>
+    
+    <context:component-scan base-package="org.cbioportal.url_shortener" />
+
+    <mvc:annotation-driven/>
+</beans>


### PR DESCRIPTION
http://cbioportal.org/api/url-shortener?url=http://google.com

This PR adds a new property in portal.properties called `bitly.access.token`. No need to use the old `bitly.url`, `bitly.user` and `bitly.apiKey` with this new API.