### PR TITLE
Pass frontend config via window.frontendConfig

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -144,6 +144,10 @@ public class GlobalProperties {
     @Value("${session.service.url:}") // default is empty string
     public void setSessionServiceURL(String property) { sessionServiceURL = property; }
 
+    private static String frontendConfig;
+    @Value("${frontend.config:}") // default is empty string
+    public void setFrontendConfig(String property) { frontendConfig = property; }
+
     // properties for showing the right logo in the header_bar and default logo
     public static final String SKIN_RIGHT_LOGO = "skin.right_logo";
 
@@ -1058,26 +1062,40 @@ public class GlobalProperties {
 	String hidePassenger = properties.getProperty(HIDE_PASSENGER_MUTATIONS, "false");
 	return Boolean.parseBoolean(hidePassenger);
     }
+
+    public static String readFile(String fileName)
+    {
+        String result = new String();
+
+        if (fileName == null) {
+            result = null;
+        } else {
+            try {
+                BufferedReader br = new BufferedReader(new FileReader(ResourceUtils.getFile(fileName)));
+                for (String line = br.readLine(); line != null; line = br.readLine()) {
+                    line = line.trim();
+                    result = result + line;
+                }
+                br.close();
+            } catch (FileNotFoundException e) {
+                throw new RuntimeException("File not found: ", e);
+            } catch (IOException e) {
+                throw new RuntimeException("Line not found: ", e);
+            }
+        }
+        return result;
+    }
+
+    public static String getFrontendConfig() {
+        if (frontendConfig.length() > 0) {
+            return readFile(frontendConfig);
+        } else {
+            return null;
+        }
+    }
     
     public static String getQuerySetsOfGenes() {
-	String result = new String();
-	String fileName = properties.getProperty(SETSOFGENES_LOCATION, null);
-	if (fileName == null) {
-	    result = null;
-	} else {
-	    try {
-		BufferedReader br = new BufferedReader(new FileReader(ResourceUtils.getFile(fileName)));
-		for (String line = br.readLine();line != null;line = br.readLine()) {
-		    line = line.trim();
-		    result = result + line;
-		}
-		br.close();
-	    } catch (FileNotFoundException e) {
-		throw new RuntimeException("File not found: ", e);
-	    } catch (IOException e) {
-		throw new RuntimeException("Line not found: ", e);
-	    }
-	}
-	return result;
+        String fileName = properties.getProperty(SETSOFGENES_LOCATION, null);
+        return readFile(fileName);
     }
 }

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -107,7 +107,7 @@
                 <artifactItem>
                   <groupId>com.github.cbioportal</groupId>
                   <artifactId>cbioportal-frontend</artifactId>
-                  <version>c744e3765ce9e57dd9ce32b03b420bd8546bbe8e</version>
+                  <version>472f4d2c9262292f6e33f005c57ad2131dcb0d7b</version>
                   <type>jar</type>
                   <outputDirectory>.</outputDirectory>
                   <excludes>*index*</excludes>

--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -4,40 +4,39 @@
 
 <script type="text/javascript">
 
-window.frontendUrl = '<%=GlobalProperties.getFrontendUrl()%>';
-window.enableDarwin = <%=CheckDarwinAccessServlet.CheckDarwinAccess.existsDarwinProperties()%>;
-window.appVersion = '<%=GlobalProperties.getAppVersion()%>';
-window.maxTreeDepth = '<%=GlobalProperties.getMaxTreeDepth()%>';
-window.showOncoKB = <%=GlobalProperties.showOncoKB()%>;
-window.oncoKBApiUrl = '<%=GlobalProperties.getOncoKBPublicApiUrl()%>';
-window.genomeNexusApiUrl = '<%=GlobalProperties.getGenomeNexusApiUrl()%>';
-window.showCivic = <%=GlobalProperties.showCivic()%>;
-window.showHotspot = <%=GlobalProperties.showHotspot()%>;
-window.showMyCancerGenome = <%=GlobalProperties.showMyCancerGenomeUrl()%>;
-window.showGenomeNexus = <%=GlobalProperties.showGenomeNexus()%>;
-window.querySetsOfGenes = JSON.parse('<%=GlobalProperties.getQuerySetsOfGenes()%>');
+window.legacySupportFrontendConfig = {
+    enableDarwin : <%=CheckDarwinAccessServlet.CheckDarwinAccess.existsDarwinProperties()%>,
+    appVersion : '<%=GlobalProperties.getAppVersion()%>',
+    maxTreeDepth : '<%=GlobalProperties.getMaxTreeDepth()%>',
+    showOncoKB : <%=GlobalProperties.showOncoKB()%>,
+    oncoKBApiUrl : '<%=GlobalProperties.getOncoKBPublicApiUrl()%>',
+    genomeNexusApiUrl : '<%=GlobalProperties.getGenomeNexusApiUrl()%>',
+    showCivic : <%=GlobalProperties.showCivic()%>,
+    showHotspot : <%=GlobalProperties.showHotspot()%>,
+    showMyCancerGenome : <%=GlobalProperties.showMyCancerGenomeUrl()%>,
+    showGenomeNexus : <%=GlobalProperties.showGenomeNexus()%>,
+    querySetsOfGenes : JSON.parse('<%=GlobalProperties.getQuerySetsOfGenes()%>'),
+    skinBlurb : '<%=GlobalProperties.getBlurb()%>',
+    skinExampleStudyQueries : '<%=GlobalProperties.getExampleStudyQueries().replace("\n","\\n")%>'.split("\n"),
+    skinDatasetHeader : '<%=GlobalProperties.getDataSetsHeader()%>',
+    skinDatasetFooter : '<%=GlobalProperties.getDataSetsFooter()%>',
+    skinRightNavShowDatasets : <%=GlobalProperties.showRightNavDataSets()%>,
+    skinRightNavShowExamples : <%=GlobalProperties.showRightNavExamples()%>,
+    skinRightNavShowTestimonials : <%=GlobalProperties.showRightNavTestimonials()%>,
+    skinRightNavExamplesHTML : '<%=GlobalProperties.getExamplesRightColumnHtml()%>',
+    skinRightNavExamplesHTML : '<%=GlobalProperties.getExamplesRightColumnHtml()%>',
+    skinRightNavWhatsNewBlurb : '<%=GlobalProperties.getRightNavWhatsNewBlurb()%>',
+    priorityStudies : {}
+}
 
 // this prevents react router from messing with hash in a way that could is unecessary (static pages)
 // or could conflict
-window.historyType = 'memory';
-
-window.skinBlurb = '<%=GlobalProperties.getBlurb()%>';
-window.skinExampleStudyQueries = '<%=GlobalProperties.getExampleStudyQueries().replace("\n","\\n")%>'.split("\n");
-window.skinDatasetHeader = '<%=GlobalProperties.getDataSetsHeader()%>';
-window.skinDatasetFooter = '<%=GlobalProperties.getDataSetsFooter()%>';
-window.skinRightNavShowDatasets = <%=GlobalProperties.showRightNavDataSets()%>;
-window.skinRightNavShowExamples = <%=GlobalProperties.showRightNavExamples()%>;
-window.skinRightNavShowTestimonials = <%=GlobalProperties.showRightNavTestimonials()%>;
-window.skinRightNavExamplesHTML = '<%=GlobalProperties.getExamplesRightColumnHtml()%>';
-window.skinRightNavExamplesHTML = '<%=GlobalProperties.getExamplesRightColumnHtml()%>';
-window.skinRightNavWhatsNewBlurb = '<%=GlobalProperties.getRightNavWhatsNewBlurb()%>';
 // Prioritized studies for study selector
-window.priorityStudies = {};
 <%
 List<String[]> priorityStudies = GlobalProperties.getPriorityStudies();
 for (String[] group : priorityStudies) {
     if (group.length > 1) {
-        out.println("window.priorityStudies['"+group[0]+"'] = ");
+        out.println("window.legacySupportFrontendConfig.priorityStudies['"+group[0]+"'] = ");
         out.println("[");
         int i = 1;
         while (i < group.length) {
@@ -55,7 +54,23 @@ for (String[] group : priorityStudies) {
 String url = request.getRequestURL().toString();
 String baseURL = url.substring(0, url.length() - request.getRequestURI().length()) + request.getContextPath();
 baseURL = baseURL.replace("https://", "").replace("http://", "");
-
 %>
-__API_ROOT__ = '<%=baseURL%>';
+
+window.frontendConfig = JSON.parse('<%=GlobalProperties.getFrontendConfig()%>');
+if (window.frontendConfig) {
+    otherFrontendVariables = 'frontendUrl enableDarwin appVersion maxTreeDepth showOncoKB'
+    for (var prop in legacySupportFrontendConfig) {
+        // use old property if none is defined in frontendConfig
+        if (!window.frontendConfig.hasOwnProperty(prop)) {
+            window.frontendConfig[legacySupportFrontendConfig[prop]];
+        }
+    }
+} else {
+    window.frontendConfig = window.legacySupportFrontendConfig;
+}
+
+// frontend config that can't be changed by deployer
+window.frontendUrl = '<%=GlobalProperties.getFrontendUrl()%>',
+window.frontendConfig.apiRoot = '<%=baseURL%>';
+window.frontendConfig.historyType = 'memory';
 </script>


### PR DESCRIPTION
Pass frontend config in one object, instead of separate ones. Also allow user
to give path to frontendConfig file (property called frontend.config).