### PR TITLE
Correct data type names containing underscores

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/model/GeneticAlterationType.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/model/GeneticAlterationType.java
@@ -32,7 +32,7 @@
 
 package org.mskcc.cbio.portal.model;
 
-// Copied to org.cbioportal.model.GeneticProfile.GeneticAlterationType, if you alter this,
+// Copied to org.cbioportal.model.MolecularProfile.GeneticAlterationType, if you alter this,
 // don't forget to change the other one too
 public enum GeneticAlterationType {
     MUTATION_EXTENDED,

--- a/service/src/main/java/org/cbioportal/service/impl/GenesetCorrelationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenesetCorrelationServiceImpl.java
@@ -150,7 +150,7 @@ public class GenesetCorrelationServiceImpl implements GenesetCorrelationService 
 		MolecularProfile zscoresProfile = null;
 		for (MolecularProfile referringProfile : referringProfiles) {
 			//use the first z-score profile we can find in this list of referring profiles (normally there should be only 1 anyway):
-			if (referringProfile.getDatatype().equals("Z_SCORE")) {
+			if (referringProfile.getDatatype().equals("Z-SCORE")) {
 				zscoresProfile = referringProfile;
 				break;
 			}

--- a/service/src/main/java/org/cbioportal/service/impl/GenesetHierarchyServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenesetHierarchyServiceImpl.java
@@ -91,8 +91,8 @@ public class GenesetHierarchyServiceImpl implements GenesetHierarchyService {
 		//validate: 
 		MolecularProfile geneticProfile = geneticProfileService.getMolecularProfile(geneticProfileId);
 		//also validate if profile is of geneset_score type:
-		if (!geneticProfile.getDatatype().equals("GSVA_SCORE")) {
-			throw new IllegalArgumentException("Genetic profile should be of DATA_TYPE = GSVA_SCORE, but found: " +
+		if (!geneticProfile.getDatatype().equals("GSVA-SCORE")) {
+			throw new IllegalArgumentException("Genetic profile should be of DATA_TYPE = GSVA-SCORE, but found: " +
 					geneticProfile.getDatatype());
 		}
 		
@@ -120,8 +120,8 @@ public class GenesetHierarchyServiceImpl implements GenesetHierarchyService {
 			throw new RuntimeException("The given gene set profile [" + scoresGeneticProfileId + "] should have (at least) 1 and only 1 linked p-values profile in DB");
 		}
 		//validate if profile is of pvalue type:
-		if (!pvaluesGeneticProfiles.get(0).getDatatype().equals("P_VALUE")) {
-			throw new IllegalArgumentException("Genetic profile should be of DATA_TYPE = P_VALUE");
+		if (!pvaluesGeneticProfiles.get(0).getDatatype().equals("P-VALUE")) {
+			throw new IllegalArgumentException("Genetic profile should be of DATA_TYPE = P-VALUE");
 		}
 
 		List<GenesetMolecularData> genesetPvalues = genesetDataService.fetchGenesetData(pvaluesGeneticProfiles.get(0).getStableId(), sampleIds, null);  

--- a/service/src/test/java/org/cbioportal/service/impl/GenesetCorrelationServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenesetCorrelationServiceImplTest.java
@@ -79,7 +79,7 @@ public class GenesetCorrelationServiceImplTest extends BaseServiceImplTest {
             .thenReturn(Arrays.asList(geneticProfile));
         MolecularProfile zscoreGeneticProfile = new MolecularProfile();
         zscoreGeneticProfile.setStableId(MOLECULAR_PROFILE_ID);
-        zscoreGeneticProfile.setDatatype("Z_SCORE");
+        zscoreGeneticProfile.setDatatype("Z-SCORE");
         Mockito.when(geneticProfileService.getMolecularProfilesReferringTo(MOLECULAR_PROFILE_ID))
             .thenReturn(Arrays.asList(zscoreGeneticProfile));
         

--- a/service/src/test/java/org/cbioportal/service/impl/GenesetHierarchyServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenesetHierarchyServiceImplTest.java
@@ -56,7 +56,7 @@ public class GenesetHierarchyServiceImplTest extends BaseServiceImplTest {
 
         MolecularProfile geneticProfile = new MolecularProfile();
         geneticProfile.setCancerStudyIdentifier(STUDY_ID);
-        geneticProfile.setDatatype("GSVA_SCORE");
+        geneticProfile.setDatatype("GSVA-SCORE");
         Mockito.when(geneticProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(geneticProfile);
         
         //stub for geneset scores:
@@ -74,7 +74,7 @@ public class GenesetHierarchyServiceImplTest extends BaseServiceImplTest {
         //stubs for related p-values:
         MolecularProfile pvalueGeneticProfile = new MolecularProfile();
         pvalueGeneticProfile.setStableId(PVALUE_GENETIC_PROFILE_ID);
-        pvalueGeneticProfile.setDatatype("P_VALUE");
+        pvalueGeneticProfile.setDatatype("P-VALUE");
         Mockito.when(geneticProfileService.getMolecularProfilesReferringTo(MOLECULAR_PROFILE_ID))
             .thenReturn(Arrays.asList(pvalueGeneticProfile));
 


### PR DESCRIPTION
Pull request #2544 replaced the central enum of supported profile data types in
the web service backend by per-case string literals, but inadvertantly replaced
all hyphens by underscores in the process, breaking compatiblity with the data
validation/loading pipeline for gene set data. Correctly using hyphens in the
inserted string literals should restore this.

In addition, adjust a comment referring to a renamed class resulting from pull
request #3043.