### PR TITLE
Add sentry for error logging

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -92,6 +92,11 @@
           <artifactId>javax.el</artifactId>
           <version>2.2.4</version>
       </dependency>
+      <dependency>
+          <groupId>io.sentry</groupId>
+          <artifactId>sentry-spring</artifactId>
+          <version>1.6.1</version>
+      </dependency>
   </dependencies>
 
 </project>

--- a/web/src/main/resources/applicationContext-web.xml
+++ b/web/src/main/resources/applicationContext-web.xml
@@ -46,6 +46,8 @@
         <property name="favorPathExtension" value="false" />
     </bean>
 
+    <bean class="io.sentry.spring.SentryExceptionResolver"/>
+
     <mvc:annotation-driven content-negotiation-manager="contentNegotiationManager">
         <mvc:path-matching suffix-pattern="false" />
         <mvc:message-converters>


### PR DESCRIPTION
Add error logging for sentry. Only enabled when key is given. Only used in public portal