### PR TITLE
Geneset functionality for the Oncoprint

### DIFF
--- a/OPEN-SOURCE-DOCUMENTATION
+++ b/OPEN-SOURCE-DOCUMENTATION
@@ -129,6 +129,7 @@ cbioportal@googlegroups.com.
 * underscore-min
 * dataTables.fixedColumns
 * dc
+* ColorBrewer scheme: PiYG
 * crossfilter
 * packery.pkgd.min
 * d3.layout.cloud
@@ -18615,6 +18616,47 @@ Apache License
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+ColorBrewer scheme: PiYG
+------------------------
+Available under license:
+
+    Apache-Style Software License for ColorBrewer software and
+    ColorBrewer Color Schemes
+
+    Copyright (c) 2002 Cynthia Brewer, Mark Harrower, and The
+    Pennsylvania State University.
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you
+    may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied. See the License for the specific language governing
+    permissions and limitations under the License.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions as source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    2. The end-user documentation included with the redistribution, if
+    any, must include the following acknowledgment:
+    "This product includes color specifications and designs developed by
+    Cynthia Brewer (http://colorbrewer.org/)."
+    Alternately, this acknowledgment may appear in the software itself,
+    if and wherever such third-party acknowledgments normally appear.
+    4. The name "ColorBrewer" must not be used to endorse or promote
+    products derived from this software without prior written
+    permission. For written permission, please contact Cynthia Brewer at
+    cbrewer@psu.edu.
+    5. Products derived from this software may not be called
+    "ColorBrewer", nor may "ColorBrewer" appear in their name, without
+    prior written permission of Cynthia Brewer.
 
 crossfilter
 -----------

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
@@ -74,6 +74,7 @@ public class QueryBuilder extends HttpServlet {
     public static final String SET_OF_CASE_IDS = "set_of_case_ids";
     public static final String CLINICAL_PARAM_SELECTION = "clinical_param_selection";
     public static final String GENE_LIST = "gene_list";
+    public static final String GENESET_LIST = "geneset_list";
     public static final String ACTION_NAME = "Action";
     public static final String XDEBUG = "xdebug";
     public static final String ACTION_SUBMIT = "Submit";

--- a/core/src/main/java/org/mskcc/cbio/portal/util/WebserviceParserUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/WebserviceParserUtils.java
@@ -34,6 +34,7 @@ package org.mskcc.cbio.portal.util;
 
 import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.*;
+import org.mskcc.cbio.portal.servlet.QueryBuilder;
 import org.mskcc.cbio.portal.servlet.WebService;
 import org.mskcc.cbio.portal.web_api.ProtocolException;
 
@@ -92,6 +93,15 @@ public final class WebserviceParserUtils {
         return sampleList;
     }
 
+    public static  String getGenesetIds(HttpServletRequest request) throws ProtocolException,
+    DaoException {
+
+        String genesetIds = request.getParameter(QueryBuilder.GENESET_LIST);
+        if (genesetIds != null) {
+            return genesetIds;
+        }
+        return "";
+    }
     /**
      * Given an HttpServletRequest, determine all cancer_study_ids associated with it.
      * cancer study identifiers can be inferred from profile_ids, case_list_ids, or case_ids.

--- a/portal/src/main/webapp/WEB-INF/jsp/global/global_variables.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/global_variables.jsp
@@ -175,9 +175,11 @@
     (function setUpQuerySession() {
         var oql_html_conversion_vessel = document.createElement("div");
         oql_html_conversion_vessel.innerHTML = '<%=oql%>'.trim();
+        var genesets = '<%=WebserviceParserUtils.getGenesetIds(request)%>'.trim();
         var converted_oql = oql_html_conversion_vessel.textContent.trim();
         window.QuerySession = window.initDatamanager('<%=geneticProfiles%>'.trim().split(/\s+/),
                                                             converted_oql,
+                                                            genesets,
                                                             ['<%=cancerStudyId%>'.trim()],
                                                             JSON.parse('<%=studySampleMapJson%>'),
                                                             parseFloat('<%=zScoreThreshold%>'),

--- a/portal/src/main/webapp/WEB-INF/jsp/global/global_variables.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/global_variables.jsp
@@ -228,21 +228,40 @@
     }
     
 $(document).ready(function() {
-    $.when(window.QuerySession.getAlteredSamples(), window.QuerySession.getPatientIds(), window.QuerySession.getCancerStudyNames()).then(function(altered_samples, patient_ids, cancer_study_names) {
+    var any_genes_queried = (window.QuerySession.getQueryGenes() !== null &&
+            window.QuerySession.getQueryGenes().length > 0);
+    var any_genesets_queried = (window.QuerySession.getQueryGenesets() !== null &&
+            window.QuerySession.getQueryGenesets().length > 0);
+    var altered_sample_promise;
+    if (any_genes_queried) {
+        altered_sample_promise = window.QuerySession.getAlteredSamples();
+    } else {
+        // not applicable, use a resolved promise
+        altered_sample_promise = $.when([]);
+    }
+    $.when(altered_sample_promise, window.QuerySession.getPatientIds(), window.QuerySession.getCancerStudyNames()).then(function(altered_samples, patient_ids, cancer_study_names) {
             var sample_ids = window.QuerySession.getSampleIds();
             
             var altered_samples_percentage = (100 * altered_samples.length / sample_ids.length).toFixed(1);
 
             //Configure the summary line of alteration statstics
-            var _stat_smry = "<h3 style='color:#686868;font-size:14px;'>Gene Set / Pathway is altered in <b>" + altered_samples.length + " (" + altered_samples_percentage + "%)" + "</b> of queried samples</h3>";
-            $("#main_smry_stat_div").append(_stat_smry);
+            if (any_genes_queried) {
+                var _stat_smry = "<h3 style='color:#686868;font-size:14px;'>Gene selection / Pathway is altered in <b>" + altered_samples.length + " (" + altered_samples_percentage + "%)" + "</b> of queried samples</h3>";
+                $("#main_smry_stat_div").append(_stat_smry);
+            }
 
             //Configure the summary line of query
             var _query_smry = "<h3 style='font-size:110%;'><a href='study?id=" + 
                 window.QuerySession.getCancerStudyIds()[0] + "' target='_blank'>" + 
                 cancer_study_names[0] + "</a><br>" + " " +  
-                "<small>" + window.QuerySession.getSampleSetName() + " (<b>" + sample_ids.length + "</b> samples)" + " / " + 
-                "<b>" + window.QuerySession.getQueryGenes().length + "</b>" + " Gene" + (window.QuerySession.getQueryGenes().length===1 ? "" : "s") + "<br></small></h3>"; 
+                "<small>" + window.QuerySession.getSampleSetName() + " (<b>" + sample_ids.length + "</b> samples)";
+            if (any_genes_queried) {
+                _query_smry += " / " + "<b>" + window.QuerySession.getQueryGenes().length + "</b>" + " Gene" + (window.QuerySession.getQueryGenes().length===1 ? "" : "s");
+            }
+            if (any_genesets_queried) {
+                _query_smry += " / " + "<b>" + window.QuerySession.getQueryGenesets().length + "</b>" + " Gene set" + (window.QuerySession.getQueryGenesets().length===1 ? "" : "s");
+            }
+            _query_smry += "<br /></small></h3>";
             $("#main_smry_query_div").append(_query_smry);
 
             //Append the modify query button

--- a/portal/src/main/webapp/WEB-INF/jsp/oncoprint/main.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/oncoprint/main.jsp
@@ -82,7 +82,7 @@
                        <textarea id="add_genes_input" rows="5" cols="100" wordwrap="true" placeholder="Type space- or comma-separated genes here, then click 'Add Genes to Heatmap'"></textarea><br>
                        <button id="add_genes_btn" style='font-size:13px; cursor:pointer'>Add Genes to Heatmap</button> <br/>
                        <button id="remove_heatmaps_btn" style='font-size:13px; cursor:pointer'>Remove Heatmap</button> <br/>
-                       <div class="checkbox"><label style='cursor:pointer'><input id="cluster_heatmap_chk" type="checkbox"/>Cluster Heatmap</label></div>
+                       <div class="checkbox"><label id="cluster_heatmap_chk_lbl" style="cursor:pointer"><input id="cluster_heatmap_chk" type="checkbox"/>Cluster Heatmap</label></div>
                    </form>
                </div>
             </div>

--- a/portal/src/main/webapp/js/api/cbioportal-client.js
+++ b/portal/src/main/webapp/js/api/cbioportal-client.js
@@ -64,6 +64,25 @@ window.cbioportal_client = (function() {
 					result.genesetIds = args.geneset_ids;
 					return result;
 				}
+			},
+			'GenesetCorrelations': {
+				endpoint: function (args) {
+					return 'api/genesets/' +
+						args.geneset_id +
+						'/expression-correlation/fetch?geneticProfileId=' +
+						args.genetic_profile_id +
+						'&correlationThreshold=' +
+						args.correlation_threshold +
+						(args.sample_list_id ?
+							'&sampleListId=' + args.sample_list_id : '');
+				},
+				args: function (args) {
+					var result = [];
+					if (!args.sample_list_id) {
+						result = args.sample_ids;
+					}
+					return result;
+				}
 			}
 		}
 		var ret = {};
@@ -527,6 +546,18 @@ window.cbioportal_client = (function() {
 				raw_service.getGenesetData,
 				[
 					['genetic_profile_id', 'geneset_ids', 'sample_list_id']
+				]),
+		getGenesetCorrelationsBySample: enforceRequiredArguments(
+				raw_service.getGenesetCorrelations,
+				[
+					['genetic_profile_id', 'correlation_threshold', 'geneset_id'],
+					['genetic_profile_id', 'correlation_threshold', 'geneset_id', 'sample_ids'],
+				]),
+		getGenesetCorrelationsBySampleList: enforceRequiredArguments(
+				raw_service.getGenesetCorrelations,
+				[
+					['genetic_profile_id', 'correlation_threshold', 'geneset_id'],
+					['genetic_profile_id', 'correlation_threshold', 'geneset_id', 'sample_list_id'],
 				]),
 
 		getSampleClinicalAttributes: enforceRequiredArguments(function(args) {

--- a/portal/src/main/webapp/js/api/cbioportal-client.js
+++ b/portal/src/main/webapp/js/api/cbioportal-client.js
@@ -83,11 +83,19 @@ window.cbioportal_client = (function() {
 					}
 					return result;
 				}
+			},
+			'GenesetMetadata': {
+				endpoint: function (args) {
+					return ('api/genesets/fetch/');
+				},
+				args: function (args) {
+					return args.geneset_ids;
+				},
 			}
-		}
-		var ret = {};
+		};
+		var ret = {}, fn_name;
 		//legacy API
-		for (var fn_name in functionNameToEndpointProperties) {
+		for (fn_name in functionNameToEndpointProperties) {
 			if (functionNameToEndpointProperties.hasOwnProperty(fn_name)) {
 				ret['get'+fn_name] = (function(props) {
 					return function(args) {
@@ -97,7 +105,7 @@ window.cbioportal_client = (function() {
 			}
 		}
 		//new API
-		for (var fn_name in newApiFunctionNameToEndpointProperties) {
+		for (fn_name in newApiFunctionNameToEndpointProperties) {
 			if (newApiFunctionNameToEndpointProperties.hasOwnProperty(fn_name)) {
 				ret['get'+fn_name] = (function(props) {
 					return function(args) {
@@ -516,6 +524,7 @@ window.cbioportal_client = (function() {
 		getGenes: enforceRequiredArguments(makeOneIndexService('hugo_gene_symbols', function(d) { return d.hugo_gene_symbol;}, 'getGenes'), [[],["hugo_gene_symbols"]]),
 		getStudies: enforceRequiredArguments(makeOneIndexService('study_ids', function(d) { return d.id;}, 'getStudies'), [[], ["study_ids"]]),
 		getGenePanelsByPanelId: enforceRequiredArguments(makeOneIndexService('panel_id', function(d) { return d.stableId;}, 'getGenePanels'), [["panel_id"]]),
+		getGenesetMetadataByIds: enforceRequiredArguments(makeOneIndexService('geneset_ids', function(d) { return d.genesetId;}, 'getGenesetMetadata'), [["geneset_ids"]]),
 		getGeneticProfiles: enforceRequiredArguments(makeTwoIndexService('study_id', function(d) { return d.study_id;}, false, 'genetic_profile_ids', function(d) {return d.id; }, true, 'getGeneticProfiles'), [["study_id"],["genetic_profile_ids"]]),
 		getSampleLists: enforceRequiredArguments(makeTwoIndexService('study_id', function(d) { return d.study_id;}, false, 'sample_list_ids', function(d) {return d.id; }, true, 'getSampleLists'), [["study_id"], ["sample_list_ids"]]),
 		getSampleClinicalData: enforceRequiredArguments(makeHierIndexService(['study_id', 'attribute_ids', 'sample_ids'], ['study_id', 'attr_id', 'sample_id'], 'getSampleClinicalData'), [["study_id","attribute_ids"], ["study_id","attribute_ids","sample_ids"]]),

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -1665,6 +1665,29 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 			fetch_promise.reject();
 		    });
 		}),
+	'getGenesetGeneCorrelations': function(geneset_id) {
+	    var self = this;
+	    return this.getSelectedGsvaProfile()
+	    .then(function(geneset_profile) {
+		var result, sample_list_id = self.getCaseSetId();
+		if (!sample_list_id || sample_list_id === "-1") {
+		    result = window.cbioportal_client.getGenesetCorrelationsBySample({
+			genetic_profile_id: [geneset_profile.id],
+			correlation_threshold: [0.3],
+			geneset_id: [geneset_id],
+			sample_id: self.getSampleIds
+		    });
+		} else {
+		    result = window.cbioportal_client.getGenesetCorrelationsBySampleList({
+			genetic_profile_id: [geneset_profile.id],
+			correlation_threshold: [0.3],
+			geneset_id: [geneset_id],
+			sample_list_id: [sample_list_id]
+		    });
+		}
+		return result;
+	    });
+	},
 	'getExternalDataStatus': makeCachedPromiseFunction(
 		function(self, fetch_promise) {
 		    self.getWebServiceGenomicEventData().then(function() {

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -1,4 +1,4 @@
-window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_ids, study_sample_map, z_score_threshold, rppa_score_threshold,
+window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, cancer_study_ids, study_sample_map, z_score_threshold, rppa_score_threshold,
 	case_set_properties, customDriverAnnotationsByDefault, showDriverAnnotation, hasDriverAnnotations, numTiers, enableOncoKBandHotspots,
 	showTierAnnotation, enableTiers, hidePassenger) {
 
@@ -1122,6 +1122,7 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	'cancer_study_ids': cancer_study_ids,
 	'study_sample_map': study_sample_map,
 	'genetic_profile_ids': genetic_profile_ids,
+	'geneset_ids': geneset_ids,
 	'mutation_counts': {},
 	'getKnownMutationSettings': function () {
 	    return deepCopyObject(this.known_mutation_settings);
@@ -1140,7 +1141,16 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 	    return this.oql_query;
 	},
 	'getQueryGenes': function () {
-	    return OQL.genes(this.oql_query);
+		if (this.oql_query.trim().length > 0) {
+		    return OQL.genes(this.oql_query);
+		} 
+		return null;
+	},
+	'getQueryGenesets': function () {
+		if (this.geneset_ids.trim().length > 0) {
+			return this.geneset_ids.split(" ");
+		}
+		return null;
 	},
 	'getGeneticProfileIds': function () {
 	    return this.genetic_profile_ids;
@@ -1543,18 +1553,20 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, cancer_study_
 		    }).fail(function () {
 			fetch_promise.reject();
 		    }).then(function () {
-			var genetic_profile_ids = self.getGeneticProfileIds();
-			var num_calls = genetic_profile_ids.length;
+		        var filtered_genetic_profile_ids = self.getGeneticProfileIds().filter(function(v) {
+                            return profile_types[v] !== "GENESET_SCORE";
+                        });
+			var num_calls = filtered_genetic_profile_ids.length;
 			var all_data = [];
-			for (var i = 0; i < self.getGeneticProfileIds().length; i++) {
+			for (var i = 0; i < filtered_genetic_profile_ids.length; i++) {
 			    (function (I) {
 				getGeneticProfileDataForQueryCases(self,
-				    [genetic_profile_ids[I]],
+				    [filtered_genetic_profile_ids[I]],
 				    self.getQueryGenes().map(function(x) { return x.toUpperCase();})
 				).fail(function () {
 				    fetch_promise.reject();
 				}).then(function (data) {
-				    var genetic_alteration_type = profile_types[genetic_profile_ids[I]];
+				    var genetic_alteration_type = profile_types[filtered_genetic_profile_ids[I]];
 				    if (genetic_alteration_type === "MUTATION_EXTENDED") {
 					for (var j = 0; j < data.length; j++) {
 					    data[j].simplified_mutation_type = getSimplifiedMutationType(data[j].mutation_type);

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -1669,6 +1669,24 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 			fetch_promise.reject();
 		    });
 		}),
+	'getGenesetLinkMap': makeCachedPromiseFunction(
+		function (self, fetch_promise) {
+		    cbioportal_client.getGenesetMetadataByIds(
+			    {geneset_ids: self.getQueryGenesets()})
+		    .done(function (geneset_metadata) {
+			fetch_promise.resolve(
+				geneset_metadata.reduce(
+					function (link_map, metadatum) {
+					    var map_entry = {}
+					    map_entry[metadatum.genesetId] = metadatum.refLink;
+					    return $.extend(link_map, metadatum.refLink ? map_entry : {});
+					},
+					{}));
+		    })
+		    .fail(function () {
+			fetch_promise.reject();
+		    });
+		}),
 	'getGenesetGeneCorrelations': function(geneset_id) {
 	    var self = this;
 	    return this.getSelectedGsvaProfile()

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -1079,7 +1079,8 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
      * @property {string} study - identifier of the study to which this sample belongs
      * @property {string} sample - identifier of the sample
      * @property {number} uid - cross-study identifier of this sample in the current Oncoprint
-     * @property {number} profile_data - score of the sample or patient for this gene set
+     * @property {(number|null)} profile_data - score of the sample for this gene set
+     * @property {boolean} na - whether the value for this cell is considered missing (null)
      */
     /**
      * One cell of patient-level gene set data for the Oncoprint
@@ -1089,7 +1090,8 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
      * @property {string} study - identifier of the study to which this patient belongs
      * @property {string} patient - identifier of the patient
      * @property {number} uid - cross-study identifier of this patient in the current Oncoprint
-     * @property {number} profile_data - score of the sample or patient for this gene set
+     * @property {(number|null)} profile_data - score of the patient for this gene set
+     * @property {boolean} na - whether the value for this cell is considered missing (null)
      */
     /**
      * One track of heatmap data for the Oncoprint
@@ -1106,7 +1108,7 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
      * @param {string} genetic_profile_id - identifier of the genetic profile to query
      * @param {string[]} geneset_ids - list of gene set identifiers for which to return data
      * @param {string} sample_or_patient - whether to return data per sample or aggregate to patient level
-     * @returns {Promise<OncoprintGenesetDataTrack[]>}
+     * @returns {JQueryPromise<OncoprintGenesetDataTrack[]>}
      */
     var getGenesetData = function (genetic_profile_id, geneset_ids, sample_or_patient) {
 	var def = new $.Deferred();
@@ -1161,6 +1163,7 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 		    // index the UID map by sample or patient as appropriate
 		    data_by_id[geneset_id][case_id].uid = case_uid_map[study_id][case_id];
 		    data_by_id[geneset_id][case_id].profile_data = null;
+		    data_by_id[geneset_id][case_id].na = true;
 		}
 	    }
 
@@ -1174,6 +1177,7 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 		if (data_by_id[geneset_id][case_id].profile_data === null) {
 		    // set the initial value for this sample or patient
 		    data_by_id[geneset_id][case_id].profile_data = sample_score;
+		    data_by_id[geneset_id][case_id].na = false;
 		} else if (sample_or_patient === "sample") {
 		    // this would be a programming error (unexpected output from getGeneticDataBySample)
 		    throw new Error("Unexpectedly received multiple gene set profile data for one sample");

--- a/portal/src/main/webapp/js/api/cbioportal-datamanager.js
+++ b/portal/src/main/webapp/js/api/cbioportal-datamanager.js
@@ -981,7 +981,7 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 		    interim_datum.profile_data = parseFloat(receive_datum.profile_data);
 		} else if (sample_or_patient === "sample") {
 		    // this would be a programming error (unexpected output from getGeneticProfileDataBySample)
-		    throw Error("Unexpectedly received multiple heatmap profile data for one sample");
+		    throw new Error("Unexpectedly received multiple heatmap profile data for one sample");
 		} else {
 		    // aggregate samples for this patient by selecting the highest absolute (Z-)score
 		    if (Math.abs(parseFloat(receive_datum.profile_data)) >
@@ -1070,7 +1070,144 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 	    return def.promise();
 	};
     })();
+    
+    /**
+     * One cell of sample-level gene set data for the Oncoprint
+     *
+     * @typedef {Object} OncoprintGenesetSampleDatum
+     * @property {string} geneset_id - gene set identifier for this track
+     * @property {string} study - identifier of the study to which this sample belongs
+     * @property {string} sample - identifier of the sample
+     * @property {number} uid - cross-study identifier of this sample in the current Oncoprint
+     * @property {number} profile_data - score of the sample or patient for this gene set
+     */
+    /**
+     * One cell of patient-level gene set data for the Oncoprint
+     *
+     * @typedef {Object} OncoprintGenesetPatientDatum
+     * @property {string} geneset_id - gene set identifier for this track
+     * @property {string} study - identifier of the study to which this patient belongs
+     * @property {string} patient - identifier of the patient
+     * @property {number} uid - cross-study identifier of this patient in the current Oncoprint
+     * @property {number} profile_data - score of the sample or patient for this gene set
+     */
+    /**
+     * One track of heatmap data for the Oncoprint
+     *
+     * @typedef {Object} OncoprintGenesetDataTrack
+     * @property {string} geneset_id - gene set identifier for this track
+     * @property {string} genetic_profile_id - identifier of the genetic profile used for this track
+     * @property {OncoprintGenesetSampleDatum[]|OncoprintGenesetPatientDatum[]} oncoprint_data -
+     * list of objects for individual samples or patients
+     */
+    /**
+     * Fetches Oncoprint heatmap data per gene track for the given profile per sample or patient.
+     *
+     * @param {string} genetic_profile_id - identifier of the genetic profile to query
+     * @param {string[]} geneset_ids - list of gene set identifiers for which to return data
+     * @param {string} sample_or_patient - whether to return data per sample or aggregate to patient level
+     * @returns {Promise<OncoprintGenesetDataTrack[]>}
+     */
+    var getGenesetData = function (genetic_profile_id, geneset_ids, sample_or_patient) {
+	var def = new $.Deferred();
+	// TODO: handle  more than one study
+	var study_id = this.getCancerStudyIds()[0];
+	var sample_ids = this.getSampleIds();
+	var deferred_case_ids = sample_or_patient === "sample" ? sample_ids : this.getPatientIds();
+	geneset_ids = geneset_ids || [];
+	sample_or_patient = sample_or_patient || "sample";
+	var deferred_profile_data, case_set_id = this.getCaseSetId();
+	if (!case_set_id || case_set_id === "-1") {
+	    deferred_profile_data = window.cbioportal_client.getGenesetDataBySample({
+		"genetic_profile_id": [genetic_profile_id],
+		"geneset_ids": geneset_ids,
+		"sample_ids": sample_ids
+	    });
+	} else {
+	    deferred_profile_data = new $.Deferred();
+	    window.cbioportal_client.getGenesetDataBySampleList({
+		"genetic_profile_id": [genetic_profile_id],
+		"geneset_ids": geneset_ids,
+		"sample_list_id": [case_set_id]
+	    }).then(function (data, textStatus, jqXHR) {
+		// the client function returns a jQuery jqXHR object
+		// which resolves with three arguments; the when below
+		// needs a promise that resolves with one
+		deferred_profile_data.resolve(data);
+	    });
+	}
+	$.when(
+	    deferred_profile_data,
+	    this.getPatientSampleIdMap(),
+	    deferred_case_ids,
+	    this.getCaseUIDMap()
+	).then(function (profile_data,
+		sample_to_patient_map,
+		case_ids,
+		case_uid_map) {
+	    var i, j;
+	    var geneset_id, case_id;
+	    // create an object for each sample or patient in each gene set
+	    var data_by_id = Object.create(null);
+	    for (i = 0; i < geneset_ids.length; i++) {
+		geneset_id = geneset_ids[i];
+		data_by_id[geneset_id] = Object.create(null);
+		for (j = 0; j < case_ids.length; j++) {
+		    case_id = case_ids[j];
+		    data_by_id[geneset_id][case_id] = {};
+		    data_by_id[geneset_id][case_id].geneset_id = geneset_id;
+		    data_by_id[geneset_id][case_id].study = study_id;
+		    data_by_id[geneset_id][case_id][sample_or_patient] = case_id;
+		    // index the UID map by sample or patient as appropriate
+		    data_by_id[geneset_id][case_id].uid = case_uid_map[study_id][case_id];
+		    data_by_id[geneset_id][case_id].profile_data = null;
+		}
+	    }
 
+	    // fill profile_data properties with scores
+	    var sample_id, sample_score;
+	    for (i = 0; i < profile_data.length; i++) {
+		geneset_id = profile_data[i].genesetId;
+		sample_id = profile_data[i].sampleId;
+		sample_score = parseFloat(profile_data[i].value);
+		case_id = (sample_or_patient === "sample" ? sample_id : sample_to_patient_map[sample_id]);
+		if (data_by_id[geneset_id][case_id].profile_data === null) {
+		    // set the initial value for this sample or patient
+		    data_by_id[geneset_id][case_id].profile_data = sample_score;
+		} else if (sample_or_patient === "sample") {
+		    // this would be a programming error (unexpected output from getGeneticDataBySample)
+		    throw new Error("Unexpectedly received multiple gene set profile data for one sample");
+		} else {
+		    // aggregate samples for this patient by selecting the highest absolute (GSVA-)score
+		    if (Math.abs(sample_score) > Math.abs(data_by_id[geneset_id][case_id].profile_data)) {
+			data_by_id[geneset_id][case_id].profile_data = sample_score;
+		    }
+		}
+	    }
+
+	    // construct the list to be returned
+	    var track_list = [];
+	    var track_data, oncoprint_data;
+	    for (i = 0; i < geneset_ids.length; i++) {
+		geneset_id = geneset_ids[i];
+		track_data = {};
+		track_data.geneset_id = geneset_id;
+		track_data.genetic_profile_id = genetic_profile_id;
+		oncoprint_data = [];
+		for (j = 0; j < case_ids.length; j++) {
+		    case_id = case_ids[j];
+		    oncoprint_data.push(data_by_id[geneset_id][case_id]);
+		}
+		track_data.oncoprint_data = oncoprint_data;
+		track_list.push(track_data);
+	    }
+	    def.resolve(track_list);
+	}).fail(function () {
+	    def.reject();
+	});
+	return def.promise();
+    };
+    
     function setKnownMutations (enableOncoKBandHotspots, showDriverAnnotation, hasDriverAnnotations,
 	                        showTierAnnotation, numTiers, enableTiers, hidePassenger){
 	    var oncoKBandHotspots = true;
@@ -1161,7 +1298,8 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 			    .then(function (profiles) {
 				fetch_promise.resolve(profiles.filter(function(profile) {
 				    return (profile.genetic_alteration_type === "MRNA_EXPRESSION" ||
-					    profile.genetic_alteration_type === "PROTEIN_LEVEL") &&
+					    profile.genetic_alteration_type === "PROTEIN_LEVEL" ||
+					    profile.genetic_alteration_type === "GENESET_SCORE") &&
 					    profile.show_profile_in_analysis_tab === "1";
 				}));
 		}).fail(function() {
@@ -1461,6 +1599,72 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 	'getPatientHeatmapData': function(genetic_profile_id, genes) {
 	    return getHeatmapDataCached(this, genetic_profile_id, genes, 'patient');
 	},
+	'getSelectedGsvaProfile': makeCachedPromiseFunction(
+		function (self, fetch_promise) {
+		    self.getGeneticProfiles()
+		    .then(function (geneticProfiles) {
+			var genesetProfile = null;
+			for (var i = 0; i < geneticProfiles.length; i++) {
+			    var profile = geneticProfiles[i];
+			    if (profile.genetic_alteration_type === "GENESET_SCORE" &&
+				    profile.datatype === "GSVA-SCORE") {
+				if (genesetProfile !== null) {
+				    throw new Error("Programming error: " +
+					    "multiple geneset score profiles " +
+					    "were selected in the Oncoprint");
+				}
+				genesetProfile = profile;
+			    }
+			}
+			fetch_promise.resolve(genesetProfile);
+		    }).fail(function () {
+			fetch_promise.reject();
+		    });
+		}),
+	/**
+	 * Fetches any sample-level GSVA data for the queried Oncoprint parameters.
+	 *
+	 * @returns {Promise<OncoprintGenesetDataTrack[]>}
+	 */
+	'getSampleGsvaData': makeCachedPromiseFunction(
+		function (self, fetch_promise) {
+		    self.getSelectedGsvaProfile()
+		    .then(function (gsvaProfile) {
+			console.log("fetching uncached sample-level GSVA data.");
+			var trackListPromise = [];
+			if (gsvaProfile !== null) {
+			    trackListPromise = getGenesetData.call(
+				    self, gsvaProfile.id, self.getQueryGenesets(), "sample");
+			}
+			return trackListPromise;
+		    }).done(function (trackList) {
+			fetch_promise.resolve(trackList);
+		    }).fail(function () {
+			fetch_promise.reject();
+		    });
+		}),
+	/**
+	 * Fetches any patient-level GSVA data for the queried Oncoprint parameters.
+	 *
+	 * @returns {Promise<OncoprintGenesetDataTrack[]>}
+	 */
+	'getPatientGsvaData': makeCachedPromiseFunction(
+		function (self, fetch_promise) {
+		    self.getSelectedGsvaProfile()
+		    .then(function (gsvaProfile) {
+			console.log("fetching uncached patient-level GSVA data.");
+			var trackListPromise = [];
+			if (gsvaProfile !== null) {
+			    trackListPromise = getGenesetData.call(
+				    self, gsvaProfile.id, self.getQueryGenesets(), "patient");
+			}
+			return trackListPromise;
+		    }).done(function (trackList) {
+			fetch_promise.resolve(trackList);
+		    }).fail(function () {
+			fetch_promise.reject();
+		    });
+		}),
 	'getExternalDataStatus': makeCachedPromiseFunction(
 		function(self, fetch_promise) {
 		    self.getWebServiceGenomicEventData().then(function() {
@@ -1477,11 +1681,11 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 			for (var i = 0; i < case_ids.length; i++) {
 				//iterate over genetic entities and get the sample data (heatmap data has genetic entityId as key):
 				for (var j = 0; j < heatmapData.length; j++) {
-					var entityId = heatmapData[j].gene;
+					var entityId = heatmapData[j].gene || heatmapData[j].geneset_id;
 					var caseId = heatmapData[j].oncoprint_data[i].sample || heatmapData[j].oncoprint_data[i].patient;
 					//small validation/defensive programming:
 					if (!entityId) {
-						throw new Error("Unexpected error during getClusteringOrder: attribute 'gene' not found");
+						throw new Error("Unexpected error during getClusteringOrder: attribute 'gene' or 'geneset_id' not found");
 					}
 					var value = heatmapData[j].oncoprint_data[i].profile_data;
 					if (!cluster_input[caseId]) {
@@ -1553,9 +1757,14 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 		    }).fail(function () {
 			fetch_promise.reject();
 		    }).then(function () {
-		        var filtered_genetic_profile_ids = self.getGeneticProfileIds().filter(function(v) {
-                            return profile_types[v] !== "GENESET_SCORE";
-                        });
+			if (self.getQueryGenes() === null || self.getQueryGenes().length === 0) {
+			    // no genetic alteration tracks to populate, return with a resolved promise
+			    fetch_promise.resolve([]);
+			    return;
+			}
+			var filtered_genetic_profile_ids = self.getGeneticProfileIds().filter(function(v) {
+			    return profile_types[v] !== "GENESET_SCORE";
+			});
 			var num_calls = filtered_genetic_profile_ids.length;
 			var all_data = [];
 			for (var i = 0; i < filtered_genetic_profile_ids.length; i++) {
@@ -1769,6 +1978,10 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 	}),
 	'getOncoprintSampleGenomicEventData': makeCachedPromiseFunctionWithSessionFilterOption(
 		function (self, fetch_promise, use_session_filters) {
+	    // if no genes were queried, resolve with an empty list
+	    if (self.getQueryGenes() === null || self.getQueryGenes() === 0) {
+		return fetch_promise.resolve([]).promise();
+	    }
 	    $.when((use_session_filters ? self.getSessionFilteredWebServiceGenomicEventData() : self.getWebServiceGenomicEventData()), 
 	    self.getStudySampleMap(), 
 	    self.getCaseUIDMap(),
@@ -1906,6 +2119,11 @@ window.initDatamanager = function (genetic_profile_ids, oql_query, geneset_ids, 
 	}),
 	'getOncoprintPatientGenomicEventData': makeCachedPromiseFunctionWithSessionFilterOption(
 		function (self, fetch_promise, use_session_filters) {
+	    // if no genes were queried, resolve with an empty list
+	    if (self.getQueryGenes() === null || self.getQueryGenes() === 0) {
+		fetch_promise.resolve([]);
+		return;
+	    }
 	    $.when((use_session_filters ? self.getSessionFilteredWebServiceGenomicEventData() : self.getWebServiceGenomicEventData()), 
 	    self.getStudyPatientMap(), 
 	    self.getPatientSampleIdMap(), 

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -1030,6 +1030,9 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			'target_group': set_track_group,
 			'expansion_of': set_track_id,
 			'removeCallback': makeRemoveExpTrackHandler(set_track_id),
+			'sort_direction_changeable': true,
+			'sortCmpFn': comparator_utils.heatmapComparator,
+			'init_sort_direction': 0,
 			'description': gene + ' data from ' + genetic_profile_id,
 		};
 		oncoprint.suppressRendering();
@@ -1416,6 +1419,9 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			'description': 'gene set scores from ' + genetic_profile_id,
 			'link_url': geneset_link_map[track_geneset_id],
 			'removeCallback': makeRemoveGenesetTrackHandler(track_geneset_id),
+			'sort_direction_changeable': true,
+			'sortCmpFn': comparator_utils.heatmapComparator,
+			'init_sort_direction': 0,
 			'expandCallback': makeGenesetExpandHandler(track_geneset_id),
 			'expandButtonTextGetter': function (is_expanded) {
 			    return (is_expanded ? 'More' : 'Show') + ' genes';

--- a/portal/src/main/webapp/js/src/oncoprint/setup.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup.js
@@ -925,6 +925,44 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 	    return done.promise();
 	};
 	
+	var HEATMAP_RULE_SET_PARAMS = {
+		'type': 'gradient',
+		'legend_label': "Expression heatmap",
+		'value_key': 'profile_data',
+		'value_range': [-3, 3],
+		'colors': [[0,0,255,1],[0,0,0,1],[255,0,0,1]],
+		'value_stop_points': [-3,0,3],
+		'null_color': 'rgba(224,224,224,1)'
+	};
+	
+	/**
+	 * Makes a track reuse the legend of any previous heatmap tracks.
+	 *
+	 * If any tracks previously given to this function still
+	 * exist, make the new track share the rule set and legend
+	 * of the existing ones.
+	 *
+	 * @param {number} track_id - ID of a track to use the shared legend
+	 */
+	var useExistingHeatmapRuleSet = (function() {
+	    var previous_hmtrack_ids = [];
+	    return function(track_id) {
+		var existing_track_ids = oncoprint.model.getTracks(),
+		    existing_hmtrack_ids;
+		// make an array of heatmap track handles that still exist
+		existing_hmtrack_ids = previous_hmtrack_ids.filter(
+		    function (track_id) {
+			return existing_track_ids.indexOf(track_id) !== -1;
+		    });
+		// reuse the ruleset of an existing track if any
+		if (existing_hmtrack_ids.length > 0) {
+		    oncoprint.shareRuleSet(existing_hmtrack_ids[0], track_id);
+		}
+		existing_hmtrack_ids.push(track_id);
+		previous_hmtrack_ids = existing_hmtrack_ids;
+	    };
+	})();
+	
 	var makeRemoveGenesetTrackHandler = function(geneset_id) {
 	    return function(track_id) {
 		delete State.geneset_to_track_id[geneset_id];
@@ -959,10 +997,127 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 		if (Object.keys(State.clinical_tracks).length === 0) {
 		    $(toolbar_selector + ' #oncoprint-diagram-showlegend-icon').hide();
 		}
-	    }
+	    };
 	};
 	var setSortOrder = function(order) {
 	    oncoprint.setSortConfig({'type':'order', 'order':order});
+	};
+	
+	var makeGenesetExpandHandler = function (geneset_id) {
+	    var gene_promise,
+		expansion_promise,
+		next_gene_index = 0,
+		num_expansion_tracks = 0;
+	    var makeRemoveExpTrackHandler = function (set_track_id) {
+		return function (track_id) {
+		    num_expansion_tracks--;
+		    // if this was the last expansion of the group track,
+		    // make it start from the first one when re-expanding
+		    if (num_expansion_tracks === 0) {
+			next_gene_index = 0;
+			oncoprint.model.enableTrackExpansion(set_track_id);
+		    }
+		};
+	    };
+	    var addExpansionTrack = function (genetic_profile_id, gene, correlation, set_track_id, set_track_group) {
+		var track_params = {
+			'rule_set_params': HEATMAP_RULE_SET_PARAMS,
+			'has_column_spacing': false,
+			'track_padding': 0,
+			'removable': true,
+			'label': gene,
+			'track_info': Number(correlation).toFixed(2),
+			'target_group': set_track_group,
+			'expansion_of': set_track_id,
+			'removeCallback': makeRemoveExpTrackHandler(set_track_id),
+			'description': gene + ' data from ' + genetic_profile_id,
+		};
+		oncoprint.suppressRendering();
+		var track_id = oncoprint.addTracks([track_params])[0];
+		num_expansion_tracks++;
+		useExistingHeatmapRuleSet(track_id);
+		oncoprint.releaseRendering();
+		return track_id;
+	    };
+	    var addExpansionTracksUnder = function (geneset_track_id, source_genes) {
+		// identify the track group the gene set track is in
+		var i, group_index = null, track_order_in_group = null, track_index = null;
+		var all_groups = oncoprint.model.getTrackGroups();
+		for (i = 0; i < all_groups.length; i++) {
+		    track_index = all_groups[i].indexOf(geneset_track_id);
+		    if (track_index !== -1) {
+			group_index = i;
+			track_order_in_group = all_groups[i].slice();
+			break;
+		    }
+		}
+		// find the index of the track after which to insert new track;
+		// this is the bottom-most expansion track if any are below the
+		// gene set track itself
+		for (i = track_order_in_group.length - 1; i > track_index; i--) {
+		    if (oncoprint.model.isExpansionOf(
+			    track_order_in_group[i], geneset_track_id)) {
+			track_index = i;
+			break;
+		    }
+		}
+		// add the gene tracks to the Oncoprint and the ordering
+		var symbol, correlation, profile_id, subtrack_id, promise_list = [];
+		oncoprint.suppressRendering();
+		for (i = 0; i < source_genes.length; i++) {
+		    symbol = source_genes[i].hugoGeneSymbol;
+		    profile_id = source_genes[i].zScoreGeneticProfileId;
+		    correlation = source_genes[i].correlationValue;
+		    subtrack_id = addExpansionTrack(
+			    profile_id, symbol, correlation, geneset_track_id, group_index);
+		    promise_list.push(populateHeatmapTrack(profile_id, symbol, subtrack_id));
+		    // insert subtrack id after existing track index
+		    track_order_in_group.splice(track_index + 1, 0, subtrack_id);
+		    track_index++;
+		}
+		// register a callback to set the order once all tracks
+		// are populated
+		return $.when.apply(null, promise_list)
+		.then(function() {
+		    oncoprint.setTrackGroupOrder(group_index, track_order_in_group);
+		}).then(function () {
+		    oncoprint.releaseRendering();
+		}, function() {
+		    oncoprint.releaseRendering();
+		}).promise();
+	    };
+	    return function (track_id) {
+		// request data if not already done so
+		if (gene_promise === undefined || gene_promise.state() === "rejected") {
+		    LoadingBar.msg('Fetching genes..');
+		    LoadingBar.update(0.1, 'yellow');
+		    LoadingBar.show();
+		    gene_promise = QuerySession.getGenesetGeneCorrelations(geneset_id);
+		}
+		// add gene tracks if not already waiting for them
+		if (expansion_promise === undefined || expansion_promise.state() !== "pending") {
+		    expansion_promise = gene_promise.then(function (correlated_genes) {
+			LoadingBar.msg('Expanding..');
+			LoadingBar.update(0.9, 'green');
+			LoadingBar.show();
+			// select the first 5 genes starting from the index,
+			// up to the end of the array
+			var genes_to_expand = correlated_genes.slice(
+				next_gene_index, next_gene_index + 5);
+			next_gene_index += genes_to_expand.length;
+			if (next_gene_index >= correlated_genes.length) {
+			    oncoprint.model.disableTrackExpansion(track_id);
+			}
+			return addExpansionTracksUnder(track_id, genes_to_expand);
+		    });
+		    expansion_promise.done(function () {
+			LoadingBar.hide();
+		    }).fail(function () {
+			LoadingBar.update(0.5, 'red');
+		    });
+		}
+		return expansion_promise;
+	    };
 	};
 	
 	var updateAlteredPercentIndicator = function(state) {
@@ -1040,20 +1195,7 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 	    
 	    'is_minimap_shown': false,
 	    
-	    'getAnyHeatmapTrackId': function() {
-		var ret = null;
-		var heatmap_profile_ids = Object.keys(this.heatmap_track_groups);
-		for (var i=0; i<heatmap_profile_ids.length; i++) {
-		    var gene_to_track_id = this.heatmap_track_groups[heatmap_profile_ids[i]].gene_to_track_id;
-		    var genes_with_tracks = Object.keys(gene_to_track_id);
-		    if (genes_with_tracks.length > 0) {
-			ret = gene_to_track_id[genes_with_tracks[0]];
-			break;
-		    }
-		}
-		return ret;
-	    },
-	    'getNewTrackGroupId': function() {
+	    'getNewTrackGroupId': function () {
 		// Return 1 more than the max heatmap track group id, minimum 2
 		var heatmap_genetic_profiles = Object.keys(this.heatmap_track_groups);
 		return Math.max(Math.max.apply(null, heatmap_genetic_profiles.map(function(id) { return State.heatmap_track_groups[id].track_group_id; })) + 1, 2);
@@ -1166,40 +1308,30 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 	    },
 	    'addHeatmapTrack': function (genetic_profile_id, gene) {
 		oncoprint.suppressRendering();
-		State.heatmap_track_groups[genetic_profile_id] = State.heatmap_track_groups[genetic_profile_id] || {
-		    genetic_profile_id: genetic_profile_id,
-		    track_group_id: State.getNewTrackGroupId(),
-		    gene_to_track_id: {}
-		};
 		var heatmap_track_group = State.heatmap_track_groups[genetic_profile_id];
-		    var track_params = {
-			'rule_set_params': {
-			    'type': 'gradient',
-			    'legend_label': "Heatmap",
-			    'value_key': 'profile_data',
-			    'value_range': [-3, 3],
-			    'colors': [[0,0,255,1],[0,0,0,1],[255,0,0,1]],
-			    'value_stop_points': [-3,0,3],
-			    'null_color': 'rgba(224,224,224,1)'
-			},
-			'has_column_spacing': false,
-			'track_padding': 0,
-			'label': gene,
-			'target_group': heatmap_track_group.track_group_id,
-			'removable': true,
-			'removeCallback': makeRemoveHeatmapHandler(genetic_profile_id, gene),
-			'sort_direction_changeable': true,
-			'sortCmpFn': comparator_utils.heatmapComparator,
-			'init_sort_direction': 0,
-			'description': gene + ' data from ' + genetic_profile_id,
-			//'track_group_header': genetic_profile_id
+		if (typeof heatmap_track_group === 'undefined') {
+		    heatmap_track_group = State.heatmap_track_groups[genetic_profile_id] = {
+			    genetic_profile_id: genetic_profile_id,
+			    track_group_id: State.getNewTrackGroupId(),
+			    gene_to_track_id: {}
 		    };
-		    var any_hm_id = State.getAnyHeatmapTrackId();
-		    var new_hm_id = oncoprint.addTracks([track_params])[0];
-		    heatmap_track_group.gene_to_track_id[gene] = new_hm_id;
-		    if (any_hm_id !== null) {
-			oncoprint.shareRuleSet(any_hm_id, new_hm_id);
-		    }
+		}
+		var track_params = {
+		    'rule_set_params': HEATMAP_RULE_SET_PARAMS,
+		    'has_column_spacing': false,
+		    'track_padding': 0,
+		    'label': gene,
+		    'target_group': heatmap_track_group.track_group_id,
+		    'removable': true,
+		    'removeCallback': makeRemoveHeatmapHandler(genetic_profile_id, gene),
+		    'sort_direction_changeable': true,
+		    'sortCmpFn': comparator_utils.heatmapComparator,
+		    'init_sort_direction': 0,
+		    'description': gene + ' data from ' + genetic_profile_id,
+		};
+		var new_hm_id = oncoprint.addTracks([track_params])[0];
+		useExistingHeatmapRuleSet(new_hm_id);
+		heatmap_track_group.gene_to_track_id[gene] = new_hm_id;
 		URL.update();
 		oncoprint.releaseRendering();
 		return new_hm_id;
@@ -1272,9 +1404,12 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 			'track_padding': 0,
 			'label': track_geneset_id,
 			'target_group': this.GENESET_HEATMAP_TRACK_GROUP_INDEX,
-			'removable': true,
 			'description': track_geneset_id + ' gene set scores from ' + genetic_profile_id,
 			'removeCallback': makeRemoveGenesetTrackHandler(track_geneset_id),
+			'expandCallback': makeGenesetExpandHandler(track_geneset_id),
+			'expandButtonTextGetter': function (is_expanded) {
+			    return (is_expanded ? 'More' : 'Show') + ' genes';
+			}
 		    };
 		    new_track_id = oncoprint.addTracks([track_params])[0];
 		    track_ids.push(new_track_id);
@@ -1912,6 +2047,8 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 		//reset all tracks of heatmaps that were clustered to their original order:
 		for (var clusteredHeatmapGroup in State.trackIdsInOriginalOrder) {
 			if (State.trackIdsInOriginalOrder.hasOwnProperty(clusteredHeatmapGroup)) {
+				// first remove any expansion tracks, as these are not part of the saved order
+				oncoprint.removeAllExpansionTracksInGroup(clusteredHeatmapGroup);
 				oncoprint.setTrackGroupOrder(clusteredHeatmapGroup, State.trackIdsInOriginalOrder[clusteredHeatmapGroup]);
 			}
 		}
@@ -2024,6 +2161,8 @@ window.CreateCBioPortalOncoprintWithToolbar = function (ctr_selector, toolbar_se
 					State.clustered_by_profile_id = genetic_profile_id;
 					//sort according to order found in the clustering results:
 					State.sorting_by_given_order = true;
+					// remove any expansion tracks, as these are not part of the clustering order
+					oncoprint.removeAllExpansionTracksInGroup(heatmap_track_group_id);
 					//store original order before clustering:
 					var trackIdsInOriginalOrder = oncoprint.model.getTrackGroups()[heatmap_track_group_id];
 					State.trackIdsInOriginalOrder[heatmap_track_group_id] = trackIdsInOriginalOrder;

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
@@ -1793,7 +1793,7 @@ var OncoprintLabelView = (function () {
 	    view.ctx.fillText(shortenLabelIfNecessary(view, view.labels[view.dragged_label_track_id]), 0, view.supersampling_ratio*view.drag_mouse_y);
 	    view.ctx.fillStyle = 'rgba(0,0,0,0.15)';
 	    var group = view.model.getContainingTrackGroup(view.dragged_label_track_id);
-	    var label_above_mouse = getLabelAboveMouseSpace(view, group, view.drag_mouse_y, null);
+	    var label_above_mouse = view.model.getLastExpansion(getLabelAboveMouseSpace(view, group, view.drag_mouse_y, null));
 	    var label_below_mouse = getLabelBelowMouseSpace(view, group, view.drag_mouse_y, null);
 	    var rect_y, rect_height;
 	    if (label_above_mouse === view.dragged_label_track_id || label_below_mouse === view.dragged_label_track_id) {
@@ -3263,6 +3263,7 @@ var OncoprintModel = (function () {
 	this.track_expand_callback = {}; // track id -> function that adds expansion tracks for its track if set
 	this.track_expand_button_getter = {}; // track id -> function from boolean to string if customized
 	this.track_expansion_tracks = {}; // track id -> array of track ids if applicable
+	this.track_expansion_parent = {}; // track id -> track id if applicable
 	
 	// Rule Set Properties
 	this.rule_sets = {}; // map from rule set id to rule set
@@ -3826,6 +3827,7 @@ var OncoprintModel = (function () {
 	    if (model.track_expansion_tracks[expansion_of].indexOf(track_id) !== -1) {
 		throw new Error('Illegal state: duplicate expansion track ID');
 	    }
+	    model.track_expansion_parent[track_id] = expansion_of;
 	    model.track_expansion_tracks[expansion_of].push(track_id);
 	}
 	if (typeof expandCallback !== 'undefined') {
@@ -3874,7 +3876,9 @@ var OncoprintModel = (function () {
 	model.setIdOrder(Object.keys(model.present_ids.get()));
     }
 
-    var _getContainingTrackGroup = function (oncoprint_model, track_id, return_reference) {
+    // get a reference to the array that stores the order of tracks in
+    // the same group
+    var _getMajorTrackGroup = function (oncoprint_model, track_id) {
 	var group;
 	track_id = parseInt(track_id);
 	for (var i = 0; i < oncoprint_model.track_groups.length; i++) {
@@ -3883,11 +3887,23 @@ var OncoprintModel = (function () {
 		break;
 	    }
 	}
-	if (group) {
-	    return (return_reference ? group : group.slice());
+	return group || null;
+    }
+    // get an array listing the track IDs that a track can move around
+    var _getEffectiveTrackGroup = function (oncoprint_model, track_id) {
+	var group,
+	    parent_id = oncoprint_model.track_expansion_parent[track_id];
+	if (parent_id === undefined) {
+	    group = (function(major_group) {
+		return (major_group === null ? null
+			: major_group.filter(function (sibling_id) {
+			    return oncoprint_model.track_expansion_parent[sibling_id] === undefined;
+			}));
+	    })(_getMajorTrackGroup(oncoprint_model, track_id));
 	} else {
-	    return null;
+	    group = oncoprint_model.track_expansion_tracks[parent_id];
 	}
+	return group ? group.slice() : null;
     }
 
     var isRuleSetUsed = function(model, rule_set_id) {
@@ -3931,21 +3947,17 @@ var OncoprintModel = (function () {
 	delete this.track_expand_button_getter[track_id];
 	delete this.track_expansion_tracks[track_id];
 
-	var containing_track_group = _getContainingTrackGroup(this, track_id, true);
+	var containing_track_group = _getMajorTrackGroup(this, track_id);
 	if (containing_track_group !== null) {
 	    containing_track_group.splice(
 		    containing_track_group.indexOf(track_id), 1);
 	}
-	// remove any listing of the track as the expansion of another track
-	var group_track, index_in_group;
-	for (group_track in this.track_expansion_tracks) {
-	    if (this.track_expansion_tracks.hasOwnProperty(group_track)) {
-		index_in_group = this.track_expansion_tracks[group_track].indexOf(track_id);
-		if (index_in_group !== -1) {
-		    this.track_expansion_tracks[group_track].splice(index_in_group, 1);
-		}
-	    }
+	// remove listing of the track as an expansion of its parent track
+	var expansion_group = this.track_expansion_tracks[this.track_expansion_parent[track_id]]
+	if (expansion_group) {
+	    expansion_group.splice(expansion_group.indexOf(track_id), 1);
 	}
+	delete this.track_expansion_parent[track_id];
 	this.track_tops.update();
 	this.track_present_ids.update(this, track_id);
 	this.track_id_to_datum.update(this, track_id);
@@ -4029,7 +4041,7 @@ var OncoprintModel = (function () {
     }
     
     OncoprintModel.prototype.getContainingTrackGroup = function (track_id) {
-	return _getContainingTrackGroup(this, track_id, false);
+	return _getEffectiveTrackGroup(this, track_id);
     }
 
     OncoprintModel.prototype.setTrackGroupHeader = function(track_group_id, text) {
@@ -4122,15 +4134,40 @@ var OncoprintModel = (function () {
 	return this.getOncoprintWidth();
     }
     OncoprintModel.prototype.moveTrack = function (track_id, new_previous_track) {
-	var track_group = _getContainingTrackGroup(this, track_id, true);
+
+	function moveContiguousValues(uniqArray, first_value, last_value, new_predecessor) {
+	    var old_start_index = uniqArray.indexOf(first_value),
+		old_end_index = uniqArray.indexOf(last_value);
+	    var values = uniqArray.slice(old_start_index, old_end_index + 1);
+	    uniqArray.splice(old_start_index, values.length);
+	    var new_position = (new_predecessor === null ? 0 : uniqArray.indexOf(new_predecessor)+1);
+	    uniqArray.splice.bind(uniqArray, new_position, 0).apply(null, values);
+	}
+
+	var track_group = _getMajorTrackGroup(this, track_id),
+	    expansion_parent = this.track_expansion_parent[track_id],
+	    flat_previous_track;
+
 	if (track_group !== null) {
-	    track_group.splice(track_group.indexOf(track_id), 1);
-	    var new_position = (new_previous_track === null ? 0 : track_group.indexOf(new_previous_track)+1);
-	    track_group.splice(new_position, 0, track_id);
+	    // if an expansion track moves above all other tracks it can,
+	    // place it directly below its expansion parent
+	    if (expansion_parent !== undefined && new_previous_track === null) {
+		flat_previous_track = expansion_parent;
+	    // otherwise, place the track under (the last expansion track of)
+	    // its sibling
+	    } else {
+		flat_previous_track = this.getLastExpansion(new_previous_track);
+	    }
+	    moveContiguousValues(track_group, track_id, this.getLastExpansion(track_id), flat_previous_track);
+	}
+
+	// keep the order of expansion siblings up-to-date as well
+	if (this.track_expansion_parent[track_id] !== undefined) {
+	    moveContiguousValues(this.track_expansion_tracks[expansion_parent], track_id, track_id, new_previous_track);
 	}
 	
 	this.track_tops.update();
-    }
+    };
 
     OncoprintModel.prototype.getTrackLabel = function (track_id) {
 	return this.track_label[track_id];
@@ -4216,6 +4253,21 @@ var OncoprintModel = (function () {
     OncoprintModel.prototype.isExpansionOf = function (expansion_track_id, set_track_id) {
 	return this.track_expansion_tracks.hasOwnProperty(set_track_id) &&
 	    this.track_expansion_tracks[set_track_id].indexOf(expansion_track_id) !== -1;
+    }
+    
+    /**
+     * Finds the bottom-most track in a track's expansion group
+     *
+     * @param track_id - the ID of the track to start from
+     * @returns the ID of its last expansion, or the unchanged param if none
+     */
+    OncoprintModel.prototype.getLastExpansion = function (track_id) {
+	var direct_children = this.track_expansion_tracks[track_id];
+	while (direct_children && direct_children.length) {
+	    track_id = direct_children[direct_children.length - 1];
+	    direct_children = this.track_expansion_tracks[track_id];
+	}
+	return track_id;
     }
     
     OncoprintModel.prototype.getRuleSet = function (track_id) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
@@ -1624,6 +1624,7 @@ var OncoprintLabelView = (function () {
 	this.label_middles_view_space = {};
 	this.labels = {};
 	this.label_colors = {};
+	this.track_link_urls = {};
 	this.track_descriptions = {};
 	this.tracks = [];
 	this.minimum_track_height = Number.POSITIVE_INFINITY;
@@ -1662,12 +1663,15 @@ var OncoprintLabelView = (function () {
 		    if (hovered_track !== null) {
 			var $tooltip_div = $('<div>');
 			var offset = view.$canvas.offset();   
-			if (isNecessaryToShortenLabel(view, view.labels[hovered_track])) {
-			    $tooltip_div.append($('<b>'+view.labels[hovered_track]+'</b>'));
+			if (isNecessaryToShortenLabel(view, view.labels[hovered_track])
+				|| view.track_link_urls[hovered_track]) {
+			    $tooltip_div.append(formatTooltipHeader(
+				    view.labels[hovered_track],
+				    view.track_link_urls[hovered_track]));
 			}
-			var track_description = view.track_descriptions[hovered_track].replace("<", "&lt;").replace(">", "&gt;");
+			var track_description = view.track_descriptions[hovered_track];
 			if (track_description.length > 0) {
-			    $tooltip_div.append(track_description + "<br>");
+			    $tooltip_div.append($('<div>').text(track_description));
 			}
 			if (model.getContainingTrackGroup(hovered_track).length > 1) {
 			    view.$canvas.css('cursor', 'move');
@@ -1687,7 +1691,7 @@ var OncoprintLabelView = (function () {
 		    var previous_track_id = getLabelAboveMouseSpace(view, track_group, evt.offsetY, view.dragged_label_track_id);
 		    stopDragging(view, previous_track_id);
 		}
-		view.tooltip.hide();
+		view.tooltip.hideIfNotAlreadyGoingTo(150);
 	    });
 	})(this);
 	
@@ -1748,6 +1752,18 @@ var OncoprintLabelView = (function () {
 	} else {
 	    return label;
 	}
+    };
+    var formatTooltipHeader = function (label, link_url) {
+	var header_contents;
+	if (link_url) {
+	    header_contents = (
+		    $('<a target="_blank" rel="noopener noreferrer">')
+		    .attr('href', link_url));
+	} else {
+	    header_contents = $('<span>');
+	}
+	header_contents.append(label.html_content || document.createTextNode(label));
+	return $('<b style="display: block;">').append(header_contents);
     };
     var renderAllLabels = function(view) {
 	if (view.rendering_suppressed) {
@@ -1888,6 +1904,7 @@ var OncoprintLabelView = (function () {
 	for (var i=0; i<track_ids.length; i++) {
 	    this.labels[track_ids[i]] = model.getTrackLabel(track_ids[i]);
 	    this.label_colors[track_ids[i]] = model.getTrackLabelColor(track_ids[i]);
+	    this.track_link_urls[track_ids[i]] = model.getTrackLinkUrl(track_ids[i]);
 	}
 	updateFromModel(this, model);
 	resizeAndClear(this, model);
@@ -3226,6 +3243,7 @@ var OncoprintModel = (function () {
 	// Track Properties
 	this.track_label = {};
 	this.track_label_color = {};
+	this.track_link_url = {};
 	this.track_description = {};
 	this.cell_height = {};
 	this.track_padding = {};
@@ -3771,7 +3789,7 @@ var OncoprintModel = (function () {
 	    var params = params_list[i];
 	    addTrack(this, params.track_id, params.target_group, params.track_group_header,
 		    params.cell_height, params.track_padding, params.has_column_spacing,
-		    params.data_id_key, params.tooltipFn,
+		    params.data_id_key, params.tooltipFn, params.link_url,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction,
 		    params.data, params.rule_set, params.track_label_color, params.expansion_of,
@@ -3782,13 +3800,14 @@ var OncoprintModel = (function () {
   
     var addTrack = function (model, track_id, target_group, track_group_header,
 	    cell_height, track_padding, has_column_spacing,
-	    data_id_key, tooltipFn,
+	    data_id_key, tooltipFn, link_url,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction,
 	    data, rule_set, track_label_color, expansion_of, expandCallback,
 	    expandButtonTextGetter) {
 	model.track_label[track_id] = ifndef(label, "Label");
 	model.track_label_color[track_id] = ifndef(track_label_color, "black");
+	model.track_link_url[track_id] = ifndef(link_url, null);
 	model.track_description[track_id] = ifndef(description, "");
 	model.cell_height[track_id] = ifndef(cell_height, 23);
 	model.track_padding[track_id] = ifndef(track_padding, 5);
@@ -3895,6 +3914,7 @@ var OncoprintModel = (function () {
 	delete this.track_data[track_id];
 	delete this.track_rule_set_id[track_id];
 	delete this.track_label[track_id];
+	delete this.track_link_url[track_id];
 	delete this.cell_height[track_id];
 	delete this.track_padding[track_id];
 	delete this.track_data_id_key[track_id];
@@ -4118,6 +4138,10 @@ var OncoprintModel = (function () {
     
     OncoprintModel.prototype.getTrackLabelColor = function (track_id) {
 	return this.track_label_color[track_id];
+    }
+    
+    OncoprintModel.prototype.getTrackLinkUrl = function (track_id) {
+	return this.track_link_url[track_id];
     }
     
     OncoprintModel.prototype.getTrackDescription = function(track_id) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
@@ -1653,7 +1653,8 @@ var OncoprintLabelView = (function () {
 	    view.$canvas.on("mousemove", function(evt) {
 		if (view.dragged_label_track_id !== null) {
 		    var track_group = model.getContainingTrackGroup(view.dragged_label_track_id);
-		    var max_drag_y = view.track_tops[track_group[track_group.length-1]] + model.getTrackHeight(track_group[track_group.length-1]) - view.scroll_y;
+		    var bottommost_track = model.getLastExpansion(track_group[track_group.length - 1]);
+		    var max_drag_y = view.track_tops[bottommost_track] + model.getTrackHeight(bottommost_track) - view.scroll_y;
 		    var min_drag_y = view.track_tops[track_group[0]] - 5 - view.scroll_y;
 		    view.drag_mouse_y = Math.min(evt.pageY - view.$canvas.offset().top, max_drag_y);
 		    view.drag_mouse_y = Math.max(view.drag_mouse_y, min_drag_y);
@@ -1806,7 +1807,7 @@ var OncoprintLabelView = (function () {
 		rect_y = view.cell_tops_view_space[group[0]] - view.ctx.measureText("m").width;
 		rect_height = view.ctx.measureText("m").width;
 	    } else if (label_below_mouse === null) {
-		rect_y = view.cell_tops_view_space[group[group.length-1]] + view.cell_heights_view_space[group[group.length-1]];
+		rect_y = view.cell_tops_view_space[label_above_mouse] + view.cell_heights_view_space[label_above_mouse];
 		rect_height = view.ctx.measureText("m").width;
 	    }
 	    

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
@@ -1600,6 +1600,7 @@ var OncoprintLabelView = (function () {
 	this.cell_heights_view_space = {};
 	this.label_middles_view_space = {};
 	this.labels = {};
+	this.label_colors = {};
 	this.track_descriptions = {};
 	this.tracks = [];
 	this.minimum_track_height = Number.POSITIVE_INFINITY;
@@ -1742,6 +1743,10 @@ var OncoprintLabelView = (function () {
 	view.ctx.fillStyle = 'black';
 	var tracks = view.tracks;
 	for (var i=0; i<tracks.length; i++) {
+	    if (view.label_colors && view.label_colors[tracks[i]]) {
+		//override color, if set:
+		view.ctx.fillStyle = view.label_colors[tracks[i]];
+	    }
 	    view.ctx.fillText(shortenLabelIfNecessary(view, view.labels[tracks[i]]), 0, view.label_middles_view_space[tracks[i]]);
 	}
 	if (view.dragged_label_track_id !== null) {
@@ -1859,6 +1864,7 @@ var OncoprintLabelView = (function () {
     OncoprintLabelView.prototype.addTracks = function (model, track_ids) {
 	for (var i=0; i<track_ids.length; i++) {
 	    this.labels[track_ids[i]] = model.getTrackLabel(track_ids[i]);
+	    this.label_colors[track_ids[i]] = model.getTrackLabelColor(track_ids[i]);
 	}
 	updateFromModel(this, model);
 	resizeAndClear(this, model);
@@ -3195,6 +3201,7 @@ var OncoprintModel = (function () {
 	
 	// Track Properties
 	this.track_label = {};
+	this.track_label_color = {};
 	this.track_description = {};
 	this.cell_height = {};
 	this.track_padding = {};
@@ -3739,7 +3746,7 @@ var OncoprintModel = (function () {
 		    params.data_id_key, params.tooltipFn,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction,
-		    params.data, params.rule_set);
+		    params.data, params.rule_set, params.track_label_color);
 	}
 	this.track_tops.update();
     }
@@ -3749,8 +3756,9 @@ var OncoprintModel = (function () {
 	    data_id_key, tooltipFn,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction,
-	    data, rule_set) {
+	    data, rule_set, track_label_color) {
 	model.track_label[track_id] = ifndef(label, "Label");
+	model.track_label_color[track_id] = ifndef(track_label_color, "black");
 	model.track_description[track_id] = ifndef(description, "");
 	model.cell_height[track_id] = ifndef(cell_height, 23);
 	model.track_padding[track_id] = ifndef(track_padding, 5);
@@ -4045,6 +4053,10 @@ var OncoprintModel = (function () {
 
     OncoprintModel.prototype.getTrackLabel = function (track_id) {
 	return this.track_label[track_id];
+    }
+    
+    OncoprintModel.prototype.getTrackLabelColor = function (track_id) {
+	return this.track_label_color[track_id];
     }
     
     OncoprintModel.prototype.getTrackDescription = function(track_id) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/dist/oncoprint-bundle.js
@@ -880,7 +880,7 @@ var Oncoprint = (function () {
 	}*/
 	
 	this.track_options_view = new OncoprintTrackOptionsView($track_options_div,
-								function(track_id) { 
+								function (track_id) {
 								    // move up
 								    var tracks = self.model.getContainingTrackGroup(track_id);
 								    var index = tracks.indexOf(track_id);
@@ -892,7 +892,7 @@ var Oncoprint = (function () {
 									self.moveTrack(track_id, new_previous_track);
 								    }
 								},
-								function(track_id) {
+								function (track_id) {
 								    // move down
 								    var tracks = self.model.getContainingTrackGroup(track_id);
 								    var index = tracks.indexOf(track_id);
@@ -900,8 +900,9 @@ var Oncoprint = (function () {
 									self.moveTrack(track_id, tracks[index+1]);
 								    }
 								},
-								function(track_id) { self.removeTrack(track_id); }, 
-								function(track_id, dir) { self.setTrackSortDirection(track_id, dir); });
+								function (track_id) { self.removeTrack(track_id); },
+								function (track_id, dir) { self.setTrackSortDirection(track_id, dir); },
+								function (track_id) { self.removeExpansionTracksFor(track_id); });
 	this.track_info_view = new OncoprintTrackInfoView($track_info_div);
 								
 	//this.track_info_view = new OncoprintTrackInfoView($track_info_div);
@@ -1151,6 +1152,28 @@ var Oncoprint = (function () {
     Oncoprint.prototype.removeAllTracks = function() {
 	var track_ids = this.model.getTracks();
 	this.removeTracks(track_ids);
+    }
+
+    Oncoprint.prototype.removeExpansionTracksFor = function (track_id) {
+	// remove all expansion tracks for this track
+	this.removeTracks(this.model.track_expansion_tracks[track_id].slice());
+    }
+
+    Oncoprint.prototype.removeAllExpansionTracksInGroup = function (index) {
+	var tracks_in_group = this.model.getTrackGroups()[index],
+	    expanded_tracks = [],
+	    i;
+	for (i = 0; i < tracks_in_group.length ; i++) {
+	    if (this.model.isTrackExpanded(tracks_in_group[i])) {
+		expanded_tracks.push(tracks_in_group[i]);
+	    }
+	}
+	this.suppressRendering();
+	for (i = 0; i < expanded_tracks.length; i++) {
+	    // assume that the expanded tracks are not themselves removed here
+	    this.removeExpansionTracksFor(expanded_tracks[i]);
+	}
+	this.releaseRendering();
     }
 
     Oncoprint.prototype.setHorzZoomToFit = function(ids) {
@@ -3071,6 +3094,7 @@ var OncoprintMinimapView = (function () {
 
 module.exports = OncoprintMinimapView;
 },{"./oncoprintzoomslider.js":21,"gl-matrix":24}],12:[function(require,module,exports){
+/* jshint browserify: true, asi: true */
 var binarysearch = require('./binarysearch.js');
 var hasElementsInInterval = require('./haselementsininterval.js');
 var CachedProperty = require('./CachedProperty.js');
@@ -3217,6 +3241,10 @@ var OncoprintModel = (function () {
 	this.track_active_rules = {}; // from track id to active rule map (map with rule ids as keys)
 	this.track_info = {};
 	this.track_has_column_spacing = {}; // track id -> boolean
+	this.track_expansion_enabled = {}; // track id -> boolean or undefined
+	this.track_expand_callback = {}; // track id -> function that adds expansion tracks for its track if set
+	this.track_expand_button_getter = {}; // track id -> function from boolean to string if customized
+	this.track_expansion_tracks = {}; // track id -> array of track ids if applicable
 	
 	// Rule Set Properties
 	this.rule_sets = {}; // map from rule set id to rule set
@@ -3746,7 +3774,8 @@ var OncoprintModel = (function () {
 		    params.data_id_key, params.tooltipFn,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction,
-		    params.data, params.rule_set, params.track_label_color);
+		    params.data, params.rule_set, params.track_label_color, params.expansion_of,
+		    params.expandCallback, params.expandButtonTextGetter);
 	}
 	this.track_tops.update();
     }
@@ -3756,7 +3785,8 @@ var OncoprintModel = (function () {
 	    data_id_key, tooltipFn,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction,
-	    data, rule_set, track_label_color) {
+	    data, rule_set, track_label_color, expansion_of, expandCallback,
+	    expandButtonTextGetter) {
 	model.track_label[track_id] = ifndef(label, "Label");
 	model.track_label_color[track_id] = ifndef(track_label_color, "black");
 	model.track_description[track_id] = ifndef(description, "");
@@ -3769,6 +3799,23 @@ var OncoprintModel = (function () {
 	});
 	model.track_removable[track_id] = ifndef(removable, false);
 	model.track_remove_callback[track_id] = ifndef(removeCallback, function() {});
+	
+	if (typeof expansion_of !== 'undefined') {
+	    if (!model.track_expansion_tracks.hasOwnProperty(expansion_of)) {
+		model.track_expansion_tracks[expansion_of] = [];
+	    }
+	    if (model.track_expansion_tracks[expansion_of].indexOf(track_id) !== -1) {
+		throw new Error('Illegal state: duplicate expansion track ID');
+	    }
+	    model.track_expansion_tracks[expansion_of].push(track_id);
+	}
+	if (typeof expandCallback !== 'undefined') {
+	    model.track_expand_callback[track_id] = expandCallback;
+	    model.track_expansion_enabled[track_id] = true;
+	}
+	if (typeof expandButtonTextGetter !== 'undefined') {
+	    model.track_expand_button_getter[track_id] = expandButtonTextGetter;
+	}
 	
 	model.track_sort_cmp_fn[track_id] = ifndef(sortCmpFn, function () {
 	    return 0;
@@ -3859,11 +3906,25 @@ var OncoprintModel = (function () {
 	delete this.track_sort_direction[track_id];
 	delete this.track_info[track_id];
 	delete this.track_has_column_spacing[track_id];
+	delete this.track_expansion_enabled[track_id];
+	delete this.track_expand_callback[track_id];
+	delete this.track_expand_button_getter[track_id];
+	delete this.track_expansion_tracks[track_id];
 
 	var containing_track_group = _getContainingTrackGroup(this, track_id, true);
 	if (containing_track_group !== null) {
 	    containing_track_group.splice(
 		    containing_track_group.indexOf(track_id), 1);
+	}
+	// remove any listing of the track as the expansion of another track
+	var group_track, index_in_group;
+	for (group_track in this.track_expansion_tracks) {
+	    if (this.track_expansion_tracks.hasOwnProperty(group_track)) {
+		index_in_group = this.track_expansion_tracks[group_track].indexOf(track_id);
+		if (index_in_group !== -1) {
+		    this.track_expansion_tracks[group_track].splice(index_in_group, 1);
+		}
+	    }
 	}
 	this.track_tops.update();
 	this.track_present_ids.update(this, track_id);
@@ -3874,7 +3935,7 @@ var OncoprintModel = (function () {
 	if (!rule_set_used) {
 	    removeRuleSet(this, rule_set_id);
 	}
-    }
+    };
     
     OncoprintModel.prototype.getOverlappingCell = function(x,y) {
 	// First, see if it's in a column
@@ -4085,7 +4146,54 @@ var OncoprintModel = (function () {
     OncoprintModel.prototype.isTrackSortDirectionChangeable = function (track_id) {
 	return this.track_sort_direction_changeable[track_id];
     }
+    
+    OncoprintModel.prototype.isTrackExpandable = function (track_id) {
+	// return true if the flag is defined and true
+	return Boolean(this.track_expansion_enabled[track_id]);
+    }
+    
+    OncoprintModel.prototype.expandTrack = function (track_id) {
+	return this.track_expand_callback[track_id](track_id);
+    }
+    
+    OncoprintModel.prototype.disableTrackExpansion = function (track_id) {
+	this.track_expansion_enabled[track_id] = false;
+    }
 
+    OncoprintModel.prototype.enableTrackExpansion = function (track_id) {
+	if (!this.track_expand_callback.hasOwnProperty(track_id)) {
+	    throw new Error("Track '" + track_id +"' has no expandCallback");
+	}
+	this.track_expansion_enabled[track_id] = true;
+    }
+    
+    OncoprintModel.prototype.isTrackExpanded = function (track_id) {
+	return this.track_expansion_tracks.hasOwnProperty(track_id) &&
+		this.track_expansion_tracks[track_id].length > 0;
+    }
+    
+    OncoprintModel.prototype.getExpandButtonText = function (track_id) {
+	var self = this;
+	var getExpandButtonFunction = function (track_id) {
+	    return (self.track_expand_button_getter[track_id] ||
+		    function (is_expanded) {
+			return is_expanded ? 'Expand more' : 'Expand';
+		    });
+	};
+	return getExpandButtonFunction(track_id)(this.isTrackExpanded(track_id));
+    }
+    
+    /**
+     * Checks if one track is the expansion of another
+     *
+     * @param {number} expansion_track_id - the ID of the track to check
+     * @param {number} set_track_id - the ID of the track it may be an expansion of
+     */
+    OncoprintModel.prototype.isExpansionOf = function (expansion_track_id, set_track_id) {
+	return this.track_expansion_tracks.hasOwnProperty(set_track_id) &&
+	    this.track_expansion_tracks[set_track_id].indexOf(expansion_track_id) !== -1;
+    }
+    
     OncoprintModel.prototype.getRuleSet = function (track_id) {
 	return this.rule_sets[this.track_rule_set_id[track_id]];
     }
@@ -5898,7 +6006,7 @@ var OncoprintTrackInfoView = (function () {
 module.exports = OncoprintTrackInfoView;
 },{"./svgfactory.js":23}],19:[function(require,module,exports){
 var OncoprintTrackOptionsView = (function () {
-    function OncoprintTrackOptionsView($div, moveUpCallback, moveDownCallback, removeCallback, sortChangeCallback) {
+    function OncoprintTrackOptionsView($div, moveUpCallback, moveDownCallback, removeCallback, sortChangeCallback, unexpandCallback) {
 	// removeCallback: function(track_id)
 	var position = $div.css('position');
 	if (position !== 'absolute' && position !== 'relative') {
@@ -5909,6 +6017,7 @@ var OncoprintTrackOptionsView = (function () {
 	this.moveDownCallback = moveDownCallback;
 	this.removeCallback = removeCallback; // function(track_id) { ... }
 	this.sortChangeCallback = sortChangeCallback; // function(track_id, dir) { ... }
+	this.unexpandCallback = unexpandCallback; // function(track_id)
 
 	this.$div = $div;
 	this.$ctr = $('<div></div>').css({'position': 'absolute', 'overflow-y':'hidden', 'overflow-x':'hidden'}).appendTo(this.$div);
@@ -6107,6 +6216,27 @@ var OncoprintTrackOptionsView = (function () {
 	    $dropdown.append($sort_inc_li);
 	    $dropdown.append($sort_dec_li);
 	    $dropdown.append($dont_sort_li);
+	}
+	if (model.isTrackExpandable(track_id)) {
+	    $dropdown.append($makeDropdownOption(
+		    model.getExpandButtonText(track_id),
+		    'normal',
+		    function (evt) {
+			evt.stopPropagation();
+			// close the menu to discourage clicking again, as it
+			// may take a moment to finish expanding
+			renderAllOptions(view, model);
+			model.expandTrack(track_id);
+		    }));
+	}
+	if (model.isTrackExpanded(track_id)) {
+	    $dropdown.append($makeDropdownOption(
+		    'Remove expansion',
+		    'normal',
+		    function (evt) {
+			evt.stopPropagation();
+			view.unexpandCallback(track_id);
+		    }));
 	}
     };
 

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprint.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprint.js
@@ -208,7 +208,7 @@ var Oncoprint = (function () {
 	}*/
 	
 	this.track_options_view = new OncoprintTrackOptionsView($track_options_div,
-								function(track_id) { 
+								function (track_id) {
 								    // move up
 								    var tracks = self.model.getContainingTrackGroup(track_id);
 								    var index = tracks.indexOf(track_id);
@@ -220,7 +220,7 @@ var Oncoprint = (function () {
 									self.moveTrack(track_id, new_previous_track);
 								    }
 								},
-								function(track_id) {
+								function (track_id) {
 								    // move down
 								    var tracks = self.model.getContainingTrackGroup(track_id);
 								    var index = tracks.indexOf(track_id);
@@ -228,8 +228,9 @@ var Oncoprint = (function () {
 									self.moveTrack(track_id, tracks[index+1]);
 								    }
 								},
-								function(track_id) { self.removeTrack(track_id); }, 
-								function(track_id, dir) { self.setTrackSortDirection(track_id, dir); });
+								function (track_id) { self.removeTrack(track_id); },
+								function (track_id, dir) { self.setTrackSortDirection(track_id, dir); },
+								function (track_id) { self.removeExpansionTracksFor(track_id); });
 	this.track_info_view = new OncoprintTrackInfoView($track_info_div);
 								
 	//this.track_info_view = new OncoprintTrackInfoView($track_info_div);
@@ -479,6 +480,28 @@ var Oncoprint = (function () {
     Oncoprint.prototype.removeAllTracks = function() {
 	var track_ids = this.model.getTracks();
 	this.removeTracks(track_ids);
+    }
+
+    Oncoprint.prototype.removeExpansionTracksFor = function (track_id) {
+	// remove all expansion tracks for this track
+	this.removeTracks(this.model.track_expansion_tracks[track_id].slice());
+    }
+
+    Oncoprint.prototype.removeAllExpansionTracksInGroup = function (index) {
+	var tracks_in_group = this.model.getTrackGroups()[index],
+	    expanded_tracks = [],
+	    i;
+	for (i = 0; i < tracks_in_group.length ; i++) {
+	    if (this.model.isTrackExpanded(tracks_in_group[i])) {
+		expanded_tracks.push(tracks_in_group[i]);
+	    }
+	}
+	this.suppressRendering();
+	for (i = 0; i < expanded_tracks.length; i++) {
+	    // assume that the expanded tracks are not themselves removed here
+	    this.removeExpansionTracksFor(expanded_tracks[i]);
+	}
+	this.releaseRendering();
     }
 
     Oncoprint.prototype.setHorzZoomToFit = function(ids) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
@@ -188,7 +188,7 @@ var OncoprintLabelView = (function () {
 	    view.ctx.fillText(shortenLabelIfNecessary(view, view.labels[view.dragged_label_track_id]), 0, view.supersampling_ratio*view.drag_mouse_y);
 	    view.ctx.fillStyle = 'rgba(0,0,0,0.15)';
 	    var group = view.model.getContainingTrackGroup(view.dragged_label_track_id);
-	    var label_above_mouse = getLabelAboveMouseSpace(view, group, view.drag_mouse_y, null);
+	    var label_above_mouse = view.model.getLastExpansion(getLabelAboveMouseSpace(view, group, view.drag_mouse_y, null));
 	    var label_below_mouse = getLabelBelowMouseSpace(view, group, view.drag_mouse_y, null);
 	    var rect_y, rect_height;
 	    if (label_above_mouse === view.dragged_label_track_id || label_below_mouse === view.dragged_label_track_id) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
@@ -48,7 +48,8 @@ var OncoprintLabelView = (function () {
 	    view.$canvas.on("mousemove", function(evt) {
 		if (view.dragged_label_track_id !== null) {
 		    var track_group = model.getContainingTrackGroup(view.dragged_label_track_id);
-		    var max_drag_y = view.track_tops[track_group[track_group.length-1]] + model.getTrackHeight(track_group[track_group.length-1]) - view.scroll_y;
+		    var bottommost_track = model.getLastExpansion(track_group[track_group.length - 1]);
+		    var max_drag_y = view.track_tops[bottommost_track] + model.getTrackHeight(bottommost_track) - view.scroll_y;
 		    var min_drag_y = view.track_tops[track_group[0]] - 5 - view.scroll_y;
 		    view.drag_mouse_y = Math.min(evt.pageY - view.$canvas.offset().top, max_drag_y);
 		    view.drag_mouse_y = Math.max(view.drag_mouse_y, min_drag_y);
@@ -201,7 +202,7 @@ var OncoprintLabelView = (function () {
 		rect_y = view.cell_tops_view_space[group[0]] - view.ctx.measureText("m").width;
 		rect_height = view.ctx.measureText("m").width;
 	    } else if (label_below_mouse === null) {
-		rect_y = view.cell_tops_view_space[group[group.length-1]] + view.cell_heights_view_space[group[group.length-1]];
+		rect_y = view.cell_tops_view_space[label_above_mouse] + view.cell_heights_view_space[label_above_mouse];
 		rect_height = view.ctx.measureText("m").width;
 	    }
 	    

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
@@ -19,6 +19,7 @@ var OncoprintLabelView = (function () {
 	this.label_middles_view_space = {};
 	this.labels = {};
 	this.label_colors = {};
+	this.track_link_urls = {};
 	this.track_descriptions = {};
 	this.tracks = [];
 	this.minimum_track_height = Number.POSITIVE_INFINITY;
@@ -57,12 +58,15 @@ var OncoprintLabelView = (function () {
 		    if (hovered_track !== null) {
 			var $tooltip_div = $('<div>');
 			var offset = view.$canvas.offset();   
-			if (isNecessaryToShortenLabel(view, view.labels[hovered_track])) {
-			    $tooltip_div.append($('<b>'+view.labels[hovered_track]+'</b>'));
+			if (isNecessaryToShortenLabel(view, view.labels[hovered_track])
+				|| view.track_link_urls[hovered_track]) {
+			    $tooltip_div.append(formatTooltipHeader(
+				    view.labels[hovered_track],
+				    view.track_link_urls[hovered_track]));
 			}
-			var track_description = view.track_descriptions[hovered_track].replace("<", "&lt;").replace(">", "&gt;");
+			var track_description = view.track_descriptions[hovered_track];
 			if (track_description.length > 0) {
-			    $tooltip_div.append(track_description + "<br>");
+			    $tooltip_div.append($('<div>').text(track_description));
 			}
 			if (model.getContainingTrackGroup(hovered_track).length > 1) {
 			    view.$canvas.css('cursor', 'move');
@@ -82,7 +86,7 @@ var OncoprintLabelView = (function () {
 		    var previous_track_id = getLabelAboveMouseSpace(view, track_group, evt.offsetY, view.dragged_label_track_id);
 		    stopDragging(view, previous_track_id);
 		}
-		view.tooltip.hide();
+		view.tooltip.hideIfNotAlreadyGoingTo(150);
 	    });
 	})(this);
 	
@@ -143,6 +147,18 @@ var OncoprintLabelView = (function () {
 	} else {
 	    return label;
 	}
+    };
+    var formatTooltipHeader = function (label, link_url) {
+	var header_contents;
+	if (link_url) {
+	    header_contents = (
+		    $('<a target="_blank" rel="noopener noreferrer">')
+		    .attr('href', link_url));
+	} else {
+	    header_contents = $('<span>');
+	}
+	header_contents.append(label.html_content || document.createTextNode(label));
+	return $('<b style="display: block;">').append(header_contents);
     };
     var renderAllLabels = function(view) {
 	if (view.rendering_suppressed) {
@@ -283,6 +299,7 @@ var OncoprintLabelView = (function () {
 	for (var i=0; i<track_ids.length; i++) {
 	    this.labels[track_ids[i]] = model.getTrackLabel(track_ids[i]);
 	    this.label_colors[track_ids[i]] = model.getTrackLabelColor(track_ids[i]);
+	    this.track_link_urls[track_ids[i]] = model.getTrackLinkUrl(track_ids[i]);
 	}
 	updateFromModel(this, model);
 	resizeAndClear(this, model);

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintlabelview.js
@@ -18,6 +18,7 @@ var OncoprintLabelView = (function () {
 	this.cell_heights_view_space = {};
 	this.label_middles_view_space = {};
 	this.labels = {};
+	this.label_colors = {};
 	this.track_descriptions = {};
 	this.tracks = [];
 	this.minimum_track_height = Number.POSITIVE_INFINITY;
@@ -160,6 +161,10 @@ var OncoprintLabelView = (function () {
 	view.ctx.fillStyle = 'black';
 	var tracks = view.tracks;
 	for (var i=0; i<tracks.length; i++) {
+	    if (view.label_colors && view.label_colors[tracks[i]]) {
+		//override color, if set:
+		view.ctx.fillStyle = view.label_colors[tracks[i]];
+	    }
 	    view.ctx.fillText(shortenLabelIfNecessary(view, view.labels[tracks[i]]), 0, view.label_middles_view_space[tracks[i]]);
 	}
 	if (view.dragged_label_track_id !== null) {
@@ -277,6 +282,7 @@ var OncoprintLabelView = (function () {
     OncoprintLabelView.prototype.addTracks = function (model, track_ids) {
 	for (var i=0; i<track_ids.length; i++) {
 	    this.labels[track_ids[i]] = model.getTrackLabel(track_ids[i]);
+	    this.label_colors[track_ids[i]] = model.getTrackLabelColor(track_ids[i]);
 	}
 	updateFromModel(this, model);
 	resizeAndClear(this, model);

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintmodel.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintmodel.js
@@ -130,6 +130,7 @@ var OncoprintModel = (function () {
 	// Track Properties
 	this.track_label = {};
 	this.track_label_color = {};
+	this.track_link_url = {};
 	this.track_description = {};
 	this.cell_height = {};
 	this.track_padding = {};
@@ -675,7 +676,7 @@ var OncoprintModel = (function () {
 	    var params = params_list[i];
 	    addTrack(this, params.track_id, params.target_group, params.track_group_header,
 		    params.cell_height, params.track_padding, params.has_column_spacing,
-		    params.data_id_key, params.tooltipFn,
+		    params.data_id_key, params.tooltipFn, params.link_url,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction,
 		    params.data, params.rule_set, params.track_label_color, params.expansion_of,
@@ -686,13 +687,14 @@ var OncoprintModel = (function () {
   
     var addTrack = function (model, track_id, target_group, track_group_header,
 	    cell_height, track_padding, has_column_spacing,
-	    data_id_key, tooltipFn,
+	    data_id_key, tooltipFn, link_url,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction,
 	    data, rule_set, track_label_color, expansion_of, expandCallback,
 	    expandButtonTextGetter) {
 	model.track_label[track_id] = ifndef(label, "Label");
 	model.track_label_color[track_id] = ifndef(track_label_color, "black");
+	model.track_link_url[track_id] = ifndef(link_url, null);
 	model.track_description[track_id] = ifndef(description, "");
 	model.cell_height[track_id] = ifndef(cell_height, 23);
 	model.track_padding[track_id] = ifndef(track_padding, 5);
@@ -799,6 +801,7 @@ var OncoprintModel = (function () {
 	delete this.track_data[track_id];
 	delete this.track_rule_set_id[track_id];
 	delete this.track_label[track_id];
+	delete this.track_link_url[track_id];
 	delete this.cell_height[track_id];
 	delete this.track_padding[track_id];
 	delete this.track_data_id_key[track_id];
@@ -1022,6 +1025,10 @@ var OncoprintModel = (function () {
     
     OncoprintModel.prototype.getTrackLabelColor = function (track_id) {
 	return this.track_label_color[track_id];
+    }
+    
+    OncoprintModel.prototype.getTrackLinkUrl = function (track_id) {
+	return this.track_link_url[track_id];
     }
     
     OncoprintModel.prototype.getTrackDescription = function(track_id) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintmodel.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintmodel.js
@@ -128,6 +128,7 @@ var OncoprintModel = (function () {
 	
 	// Track Properties
 	this.track_label = {};
+	this.track_label_color = {};
 	this.track_description = {};
 	this.cell_height = {};
 	this.track_padding = {};
@@ -672,7 +673,7 @@ var OncoprintModel = (function () {
 		    params.data_id_key, params.tooltipFn,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction,
-		    params.data, params.rule_set);
+		    params.data, params.rule_set, params.track_label_color);
 	}
 	this.track_tops.update();
     }
@@ -682,8 +683,9 @@ var OncoprintModel = (function () {
 	    data_id_key, tooltipFn,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction,
-	    data, rule_set) {
+	    data, rule_set, track_label_color) {
 	model.track_label[track_id] = ifndef(label, "Label");
+	model.track_label_color[track_id] = ifndef(track_label_color, "black");
 	model.track_description[track_id] = ifndef(description, "");
 	model.cell_height[track_id] = ifndef(cell_height, 23);
 	model.track_padding[track_id] = ifndef(track_padding, 5);
@@ -978,6 +980,10 @@ var OncoprintModel = (function () {
 
     OncoprintModel.prototype.getTrackLabel = function (track_id) {
 	return this.track_label[track_id];
+    }
+    
+    OncoprintModel.prototype.getTrackLabelColor = function (track_id) {
+	return this.track_label_color[track_id];
     }
     
     OncoprintModel.prototype.getTrackDescription = function(track_id) {

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintmodel.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprintmodel.js
@@ -1,3 +1,4 @@
+/* jshint browserify: true, asi: true */
 var binarysearch = require('./binarysearch.js');
 var hasElementsInInterval = require('./haselementsininterval.js');
 var CachedProperty = require('./CachedProperty.js');
@@ -144,6 +145,10 @@ var OncoprintModel = (function () {
 	this.track_active_rules = {}; // from track id to active rule map (map with rule ids as keys)
 	this.track_info = {};
 	this.track_has_column_spacing = {}; // track id -> boolean
+	this.track_expansion_enabled = {}; // track id -> boolean or undefined
+	this.track_expand_callback = {}; // track id -> function that adds expansion tracks for its track if set
+	this.track_expand_button_getter = {}; // track id -> function from boolean to string if customized
+	this.track_expansion_tracks = {}; // track id -> array of track ids if applicable
 	
 	// Rule Set Properties
 	this.rule_sets = {}; // map from rule set id to rule set
@@ -673,7 +678,8 @@ var OncoprintModel = (function () {
 		    params.data_id_key, params.tooltipFn,
 		    params.removable, params.removeCallback, params.label, params.description, params.track_info,
 		    params.sortCmpFn, params.sort_direction_changeable, params.init_sort_direction,
-		    params.data, params.rule_set, params.track_label_color);
+		    params.data, params.rule_set, params.track_label_color, params.expansion_of,
+		    params.expandCallback, params.expandButtonTextGetter);
 	}
 	this.track_tops.update();
     }
@@ -683,7 +689,8 @@ var OncoprintModel = (function () {
 	    data_id_key, tooltipFn,
 	    removable, removeCallback, label, description, track_info,
 	    sortCmpFn, sort_direction_changeable, init_sort_direction,
-	    data, rule_set, track_label_color) {
+	    data, rule_set, track_label_color, expansion_of, expandCallback,
+	    expandButtonTextGetter) {
 	model.track_label[track_id] = ifndef(label, "Label");
 	model.track_label_color[track_id] = ifndef(track_label_color, "black");
 	model.track_description[track_id] = ifndef(description, "");
@@ -696,6 +703,23 @@ var OncoprintModel = (function () {
 	});
 	model.track_removable[track_id] = ifndef(removable, false);
 	model.track_remove_callback[track_id] = ifndef(removeCallback, function() {});
+	
+	if (typeof expansion_of !== 'undefined') {
+	    if (!model.track_expansion_tracks.hasOwnProperty(expansion_of)) {
+		model.track_expansion_tracks[expansion_of] = [];
+	    }
+	    if (model.track_expansion_tracks[expansion_of].indexOf(track_id) !== -1) {
+		throw new Error('Illegal state: duplicate expansion track ID');
+	    }
+	    model.track_expansion_tracks[expansion_of].push(track_id);
+	}
+	if (typeof expandCallback !== 'undefined') {
+	    model.track_expand_callback[track_id] = expandCallback;
+	    model.track_expansion_enabled[track_id] = true;
+	}
+	if (typeof expandButtonTextGetter !== 'undefined') {
+	    model.track_expand_button_getter[track_id] = expandButtonTextGetter;
+	}
 	
 	model.track_sort_cmp_fn[track_id] = ifndef(sortCmpFn, function () {
 	    return 0;
@@ -786,11 +810,25 @@ var OncoprintModel = (function () {
 	delete this.track_sort_direction[track_id];
 	delete this.track_info[track_id];
 	delete this.track_has_column_spacing[track_id];
+	delete this.track_expansion_enabled[track_id];
+	delete this.track_expand_callback[track_id];
+	delete this.track_expand_button_getter[track_id];
+	delete this.track_expansion_tracks[track_id];
 
 	var containing_track_group = _getContainingTrackGroup(this, track_id, true);
 	if (containing_track_group !== null) {
 	    containing_track_group.splice(
 		    containing_track_group.indexOf(track_id), 1);
+	}
+	// remove any listing of the track as the expansion of another track
+	var group_track, index_in_group;
+	for (group_track in this.track_expansion_tracks) {
+	    if (this.track_expansion_tracks.hasOwnProperty(group_track)) {
+		index_in_group = this.track_expansion_tracks[group_track].indexOf(track_id);
+		if (index_in_group !== -1) {
+		    this.track_expansion_tracks[group_track].splice(index_in_group, 1);
+		}
+	    }
 	}
 	this.track_tops.update();
 	this.track_present_ids.update(this, track_id);
@@ -801,7 +839,7 @@ var OncoprintModel = (function () {
 	if (!rule_set_used) {
 	    removeRuleSet(this, rule_set_id);
 	}
-    }
+    };
     
     OncoprintModel.prototype.getOverlappingCell = function(x,y) {
 	// First, see if it's in a column
@@ -1012,7 +1050,54 @@ var OncoprintModel = (function () {
     OncoprintModel.prototype.isTrackSortDirectionChangeable = function (track_id) {
 	return this.track_sort_direction_changeable[track_id];
     }
+    
+    OncoprintModel.prototype.isTrackExpandable = function (track_id) {
+	// return true if the flag is defined and true
+	return Boolean(this.track_expansion_enabled[track_id]);
+    }
+    
+    OncoprintModel.prototype.expandTrack = function (track_id) {
+	return this.track_expand_callback[track_id](track_id);
+    }
+    
+    OncoprintModel.prototype.disableTrackExpansion = function (track_id) {
+	this.track_expansion_enabled[track_id] = false;
+    }
 
+    OncoprintModel.prototype.enableTrackExpansion = function (track_id) {
+	if (!this.track_expand_callback.hasOwnProperty(track_id)) {
+	    throw new Error("Track '" + track_id +"' has no expandCallback");
+	}
+	this.track_expansion_enabled[track_id] = true;
+    }
+    
+    OncoprintModel.prototype.isTrackExpanded = function (track_id) {
+	return this.track_expansion_tracks.hasOwnProperty(track_id) &&
+		this.track_expansion_tracks[track_id].length > 0;
+    }
+    
+    OncoprintModel.prototype.getExpandButtonText = function (track_id) {
+	var self = this;
+	var getExpandButtonFunction = function (track_id) {
+	    return (self.track_expand_button_getter[track_id] ||
+		    function (is_expanded) {
+			return is_expanded ? 'Expand more' : 'Expand';
+		    });
+	};
+	return getExpandButtonFunction(track_id)(this.isTrackExpanded(track_id));
+    }
+    
+    /**
+     * Checks if one track is the expansion of another
+     *
+     * @param {number} expansion_track_id - the ID of the track to check
+     * @param {number} set_track_id - the ID of the track it may be an expansion of
+     */
+    OncoprintModel.prototype.isExpansionOf = function (expansion_track_id, set_track_id) {
+	return this.track_expansion_tracks.hasOwnProperty(set_track_id) &&
+	    this.track_expansion_tracks[set_track_id].indexOf(expansion_track_id) !== -1;
+    }
+    
     OncoprintModel.prototype.getRuleSet = function (track_id) {
 	return this.rule_sets[this.track_rule_set_id[track_id]];
     }

--- a/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprinttrackoptionsview.js
+++ b/portal/src/main/webapp/js/src/oncoprint/webgl/src/js/oncoprinttrackoptionsview.js
@@ -1,5 +1,5 @@
 var OncoprintTrackOptionsView = (function () {
-    function OncoprintTrackOptionsView($div, moveUpCallback, moveDownCallback, removeCallback, sortChangeCallback) {
+    function OncoprintTrackOptionsView($div, moveUpCallback, moveDownCallback, removeCallback, sortChangeCallback, unexpandCallback) {
 	// removeCallback: function(track_id)
 	var position = $div.css('position');
 	if (position !== 'absolute' && position !== 'relative') {
@@ -10,6 +10,7 @@ var OncoprintTrackOptionsView = (function () {
 	this.moveDownCallback = moveDownCallback;
 	this.removeCallback = removeCallback; // function(track_id) { ... }
 	this.sortChangeCallback = sortChangeCallback; // function(track_id, dir) { ... }
+	this.unexpandCallback = unexpandCallback; // function(track_id)
 
 	this.$div = $div;
 	this.$ctr = $('<div></div>').css({'position': 'absolute', 'overflow-y':'hidden', 'overflow-x':'hidden'}).appendTo(this.$div);
@@ -208,6 +209,27 @@ var OncoprintTrackOptionsView = (function () {
 	    $dropdown.append($sort_inc_li);
 	    $dropdown.append($sort_dec_li);
 	    $dropdown.append($dont_sort_li);
+	}
+	if (model.isTrackExpandable(track_id)) {
+	    $dropdown.append($makeDropdownOption(
+		    model.getExpandButtonText(track_id),
+		    'normal',
+		    function (evt) {
+			evt.stopPropagation();
+			// close the menu to discourage clicking again, as it
+			// may take a moment to finish expanding
+			renderAllOptions(view, model);
+			model.expandTrack(track_id);
+		    }));
+	}
+	if (model.isTrackExpanded(track_id)) {
+	    $dropdown.append($makeDropdownOption(
+		    'Remove expansion',
+		    'normal',
+		    function (evt) {
+			evt.stopPropagation();
+			view.unexpandCallback(track_id);
+		    }));
 	}
     };
 

--- a/service/src/main/java/org/cbioportal/service/GenesetService.java
+++ b/service/src/main/java/org/cbioportal/service/GenesetService.java
@@ -14,8 +14,10 @@ public interface GenesetService {
     BaseMeta getMetaGenesets();
 
     Geneset getGeneset(String genesetId) throws GenesetNotFoundException;
-    
+
     List<Gene> getGenesByGenesetId(String genesetId) throws GenesetNotFoundException;
+
+    List<Geneset> fetchGenesets(List<String> genesetIds);
 
 }
 

--- a/service/src/main/java/org/cbioportal/service/impl/GenesetServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenesetServiceImpl.java
@@ -47,4 +47,10 @@ public class GenesetServiceImpl implements GenesetService {
 	    this.getGeneset(genesetId);
 		return genesetRepository.getGenesByGenesetId(genesetId);
 	}
+
+    @Override
+    public List<Geneset> fetchGenesets(List<String> genesetIds) {
+        return genesetRepository.fetchGenesets(genesetIds);
+    }
+
 }

--- a/web/src/main/java/org/cbioportal/web/GenesetController.java
+++ b/web/src/main/java/org/cbioportal/web/GenesetController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
 
 import org.cbioportal.model.Geneset;
 import org.cbioportal.service.GenesetService;
@@ -19,6 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -70,5 +72,16 @@ public class GenesetController {
         return new ResponseEntity<>(genesetService.getGeneset(genesetId), HttpStatus.OK);
     }
 
+    @RequestMapping(value = "/genesets/fetch", method = RequestMethod.POST,
+            consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Fetch gene sets by ID")
+    public ResponseEntity<List<Geneset>> fetchGenesets(
+            @ApiParam(required = true, value = "List of gene set IDs")
+            @Size(min = 1)
+            @RequestBody List<String> genesetIds) {
+        return new ResponseEntity<>(
+                genesetService.fetchGenesets(genesetIds),
+                HttpStatus.OK);
+    }
 
 }


### PR DESCRIPTION
This adds support for visualising gene set scores, already supported in the
data loading pipeline and backend as per pull request #2470, to the Oncoprint.
The functionality for querying such an Oncoprint is currently being developed
by @oplantalech, and he will later present it as a pull request to the new
frontend project.

## Screenshot ##
![Screenshot of an Oncoprint showing gene set heatmaps and no genes, also demonstrating the sorting and NA label features new in the current rc branch](https://user-images.githubusercontent.com/4929431/32490427-78bd079e-c3b3-11e7-864e-8d513e798d09.png)

## Relation to other pull requests ##
This pull request ports several previously reviewed but unmerged pull
requests to the current state of the `rc` branch, as reflected in the
included merge commits.  Please take care to preserve these merge
commits if a rebase is necessary.

The first few of the changesets were previously proposed for merging in pull
request #2476, which was stalled due to merge conflicts with the frontend
refactoring effort.

<details>
<summary>This log illustrates the origin of the rebased commits.</summary>

```
* f5eef29f1 Fix track dragging below bottommost expansion
* fd8dde6d0 Enable sort buttons for GSVA heatmap tracks
*   487f38637 Forward-port pull request thehyve/cbioportal#21
|\
| * 83e21fa49 Keep tracks from moving in/out of expansion groups
| * bbb3eed7d Move a track's expansion tracks along with it
|/
*   ac50517c4 Forward-port pull request thehyve/cbioportal#19
|\
| * fb99f6bf0 Insert word breaks in gene set tooltip titles
| * f0f580df6 Allow HTML versions of track names
| * 53142d415 Include gene set links in Oncoprint tooltips
| * c61b2a5d4 Add web service to request gs metadata by ID list
| * 1dab26f8e Allow annotating Oncoprint tracks with a hyperlink
| * c533c86f0 Make Oncoprint label view tooltips mouse-navigable
| * 032886987 Prevent HTML injection in Oncoprint track tooltips
|/
*   1db20ab9d Forward-port pull request thehyve/cbioportal#18
|\
| * a10418d99 Explain NA gene set scores in the Oncoprint legend
|/
*   b57795f5e Forward-port pull request cBioPortal/cbioportal#2190
|\
| * fc77be199 Make gene set tracks in Oncoprints non-removable
| * adeabab1c Remove expansion tracks before clustering
| * 24e5dca22 Enable expansion functionality for gene set tracks
| * cff32d467 Generalise rule sets for heatmap track groups
| * 9668d5807 Add track expansion support to  Oncoprint classes
|/
*   1d1a4a337 Forward-port pull request cBioPortal/cbioportal#2186
|\
| * 28cc45d0b Enable Oncoprint queries with only gene sets
| * 1ff7a2e3e Integrate clustering option for gene set heatmaps
| * dd736823b Add gene set score heatmap tracks to the Oncoprint
| * ddb356273 Convert geneset data to an Oncoprint-usable format
| * 6593d78a6 Integrate frontend with geneset data endpoint
|/
*   cdd84ce39 Select from pull request cBioPortal/cbioportal#2164
|\
| * 8ceddb5a1 Add gene set score support to the legacy frontend
|/
*
```
</details>  

