### PR TITLE
Use StableIdUtil in ImportSampleList.

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportSampleList.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportSampleList.java
@@ -91,6 +91,7 @@ public class ImportSampleList extends ConsoleRunnable {
       ArrayList<String> sampleIDsList = new ArrayList<String>();
       String[] sampleIds = sampleListStr.split("\t");
       for (String sampleId : sampleIds) {
+         sampleId = StableIdUtil.getSampleId(sampleId);
          Sample s = DaoSample.getSampleByCancerStudyAndSampleId(theCancerStudy.getInternalId(), sampleId);
          if (s==null) {
              String warningMessage = "Error: could not find sample "+sampleId;


### PR DESCRIPTION
# What? Why?
Some TCGA case lists from provisional or public sources do not contain the truncated sample id form. This change is to ensure that we always use the standardized form of sample stable ids. 

Ideally this would be fixed in the data itself but these issues are not always caught. @pieterlukasse maybe this is an error that we can flag in the validator?

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/backend

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>
