### PR TITLE
cancer type summary first when  more than one study queried

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/pancancer_study_summary.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/pancancer_study_summary.jsp
@@ -67,7 +67,9 @@
     	function tabsUpdate() {
 	        if ($("#pancancer_study_summary").is(":visible")) {
 		    	if (tab_init === false) {
-                    window.renderCancerTypeSummary(document.getElementById('pancancer_study_summary'));
+                   window.onReactAppReady(function(){
+                                           window.renderCancerTypeSummary(document.getElementById('pancancer_study_summary'));
+                                       });
                     tab_init = true;
 		    		<%--var pancancerStudySummary = new PancancerStudySummary();--%>
                     <%--pancancerStudySummary.init();--%>

--- a/portal/src/main/webapp/js/src/cgx_jquery.js
+++ b/portal/src/main/webapp/js/src/cgx_jquery.js
@@ -45,9 +45,10 @@ $(document).ready(function(){
 function setUpTabs() {
      // generate tabs for results page; set cookies to preserve
     // state of tabs when user navigates away from page and back
-    $('#tabs').tabs({cookie:{expires:1, name:("results-tab-" + 
-                    (typeof cancer_study_id_selected === 'undefined'? "" : cancer_study_id_selected))}});
-    $('#tabs').show();
+     var summaryIsDefault = (window.isVirtualStudy && QuerySession.getQueryGenes().length === 1);
+     var activeIndex = summaryIsDefault ? 1 : 0;
+     $('#tabs').tabs({ active:activeIndex});
+     $('#tabs').show();
 }
 
 /*

--- a/portal/src/main/webapp/js/src/oncoprint/setup-main.js
+++ b/portal/src/main/webapp/js/src/oncoprint/setup-main.js
@@ -1,3 +1,23 @@
 $(document).ready(function () {
-    CreateCBioPortalOncoprintWithToolbar('#oncoprint #everything', '#oncoprint #oncoprint-diagram-toolbar-buttons');
+
+    //whether this tab has already been initialized or not:
+    var tab_init = false;
+    //function that will listen to tab changes and init this one when applicable:
+    function tabsUpdate() {
+        if ($("#summary").is(":visible")) {
+            if (tab_init === false) {
+                tab_init = true;
+                CreateCBioPortalOncoprintWithToolbar('#oncoprint #everything', '#oncoprint #oncoprint-diagram-toolbar-buttons');
+            }
+            $(window).trigger("resize");
+        }
+    }
+    //this is for the scenario where the tab is open by default (as part of URL >> #tab_name at the end of URL):
+    tabsUpdate();
+    //this is for the scenario where the user navigates to this tab:
+    $("#tabs").bind("tabsactivate", function(event, ui) {
+        tabsUpdate();
+    });
+
+
 });


### PR DESCRIPTION
When there is more than one study in a query, open cancer type summary tab by default instead of oncoprint

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend
@cBioPortal/backend
@cBioPortal/devops

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
