### PR TITLE
"No OQL" warning on plots, mutations, co expression tabs

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/co_expression.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/co_expression.jsp
@@ -91,6 +91,7 @@
 </style>
 
 <div class="section" id="coexp">
+    <jsp:include page="global/no_oql_warning.jsp" flush="true" />
     <p>
         <div id='coexp-profile-selector-dropdown' style="margin-top:10px;"></div>
         This table lists the genes with the highest expression correlation with the query genes. Click on a row to see the corresponding correlation plot. 

--- a/portal/src/main/webapp/WEB-INF/jsp/global/no_oql_warning.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/no_oql_warning.jsp
@@ -1,0 +1,43 @@
+<%--
+ - Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ -
+ - This library is distributed in the hope that it will be useful, but WITHOUT
+ - ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ - FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ - is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ - obligations to provide maintenance, support, updates, enhancements or
+ - modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ - liable to any party for direct, indirect, special, incidental or
+ - consequential damages, including lost profits, arising out of the use of this
+ - software and its documentation, even if Memorial Sloan-Kettering Cancer
+ - Center has been advised of the possibility of such damage.
+ --%>
+
+<%--
+ - This file is part of cBioPortal.
+ -
+ - cBioPortal is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+--%>
+<style>
+    .no-oql-warning {
+        color:#74bedb;
+        font-family: arial;
+        font-size:13px;
+        font-weight:bold;
+    }
+</style>
+<span class="no-oql-warning">
+    <i class="fa fa-info-circle fa-2"></i>
+    This tab does not reflect the OQL specification from your query.
+</span>

--- a/portal/src/main/webapp/WEB-INF/jsp/mutation_details.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/mutation_details.jsp
@@ -29,8 +29,12 @@
  - You should have received a copy of the GNU Affero General Public License
  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --%>
+
 <div class='section cbioportal-frontend' id='mutation_details'>
-    <img src='images/ajax-loader.gif' alt='loading'/>
+    <jsp:include page="global/no_oql_warning.jsp" flush="true" />
+    <div id="mutation_details_inner">
+        <img src='images/ajax-loader.gif' alt='loading'/>
+    </div>
 </div>
 
 <script type="text/javascript">
@@ -70,7 +74,7 @@
                     }
                 }
                 props.samplesSpecification = samplesSpecification;
-                window.renderMutationsTab(mutationsTab[0], props);
+                window.renderMutationsTab(mutationsTab.find('#mutation_details_inner')[0], props);
                 return true;
             }
             return false;

--- a/portal/src/main/webapp/WEB-INF/jsp/plots_tab.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/plots_tab.jsp
@@ -159,9 +159,16 @@
         margin-top: -30px;
         float: right;
     }
+    #plots .no-oql-warning {
+        margin-left: 10px;
+        margin-top: 10px;
+    }
 </style>
 
 <div class="section" id="plots">
+    <div class="no-oql-warning">
+        <jsp:include page="global/no_oql_warning.jsp" flush="true" />
+    </div>
     <table>
         <tr>
             <td>


### PR DESCRIPTION
The screenshots are a bit confusing in this regard, but to clarify: the message is the same size on each tab (its the same jsp injected), but it is not placed the same, i.e. with the same padding. I can change that, I wasn't sure what the cleanest way to handle that would be though (help me @alisman ?)

![image](https://user-images.githubusercontent.com/636232/33584301-ace66e5a-d92c-11e7-9f0f-6bb7535ee77f.png)

![image](https://user-images.githubusercontent.com/636232/33584293-a604fbd8-d92c-11e7-9ec7-059895c5e74d.png)

![image](https://user-images.githubusercontent.com/636232/33584309-b43cb6a0-d92c-11e7-8392-9c930de017cc.png)
