### PR TITLE
Make auth options runtime configurable

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -71,8 +71,12 @@ public class GlobalProperties {
 	public static final String BROAD_BAM_CHECKING_URL = "broad.bam.checking.url";
 	public static final String IGV_BAM_LINKING = "igv.bam.linking";
 	public static final String IGV_BAM_LINKING_STUDIES = "igv.bam.linking.studies";
-    public static final String AUTHENTICATE = "authenticate";
-    public static final String AUTHORIZATION = "authorization";
+    private static String authenticate;
+    @Value("${authenticate:false}") // default is false
+    public void setAuthenticate(String property) { authenticate = property; }
+    private static String authorization;
+    @Value("${authorization:false}") // default is false
+    public void setAuthorization(String property) { authorization = property; }
     public static final String FILTER_GROUPS_BY_APPNAME = "filter_groups_by_appname";
     public static final String INCLUDE_NETWORKS = "include_networks";
     public static final String GOOGLE_ANALYTICS_PROFILE_ID = "google_analytics_profile_id";
@@ -103,8 +107,9 @@ public class GlobalProperties {
     public static final String SKIN_RIGHT_NAV_SHOW_DATA_SETS = "skin.right_nav.show_data_sets";
     public static final String SKIN_RIGHT_NAV_SHOW_EXAMPLES = "skin.right_nav.show_examples";
     public static final String SKIN_RIGHT_NAV_SHOW_TESTIMONIALS = "skin.right_nav.show_testimonials";
-    public static final String SKIN_AUTHORIZATION_MESSAGE = "skin.authorization_message";
-    public static final String DEFAULT_AUTHORIZATION_MESSAGE = "Access to this portal is only available to authorized users.";
+    private static String skinAuthorizationMessage;
+    @Value("${skin.authorization_message:Access to this portal is only available to authorized users.}")
+    public void setSkinAuthorizationMessage(String property) { skinAuthorizationMessage = property; }
     public static final String SKIN_EXAMPLE_STUDY_QUERIES = "skin.example_study_queries";
     public static final String DEFAULT_SKIN_EXAMPLE_STUDY_QUERIES =
             "tcga\n" +
@@ -396,13 +401,12 @@ public class GlobalProperties {
 
     public static boolean usersMustAuthenticate()
     {
-        String prop = properties.getProperty(AUTHENTICATE);
-        return (!prop.isEmpty() && !prop.equals("false"));
+        return (!authenticate.isEmpty() && !authenticate.equals("false"));
     }
 
     public static String authenticationMethod()
     {
-        return properties.getProperty(AUTHENTICATE);
+        return authenticate;
     }
 
     /**
@@ -420,7 +424,7 @@ public class GlobalProperties {
         }
     }
 	public static boolean usersMustBeAuthorized() {
-        return Boolean.parseBoolean(properties.getProperty(AUTHORIZATION));
+        return Boolean.parseBoolean(authorization);
 	}
 
     public static String getAppName()
@@ -652,8 +656,7 @@ public class GlobalProperties {
 
     public static String getAuthorizationMessage()
     {
-        String authMessage = properties.getProperty(SKIN_AUTHORIZATION_MESSAGE);
-        return authMessage == null ? DEFAULT_AUTHORIZATION_MESSAGE : authMessage;
+        return skinAuthorizationMessage;
     }
 
     public static String getExampleStudyQueries() {


### PR DESCRIPTION
To enable googleplus authorization on heroku, we need these properties to be
runtime configurable. One still needs to compile with googleplus enabled to
make this work, but at least now one doesn't need to set the properties in `portal.properties.EXAMPLE`.

See example: https://cbioportal-googleplus.herokuapp.com/

Log in with dummy gmail account cbiouser@gmail.com (contact me for pass, has only access to 1 study)

Ideally we would have two instances running for each PR, one password protected, one public. But for now we'll just have to put in the right configuration when deploying to get it working

After clicking on the `Deploy to Heroku link` add to MAVEN_CUSTOM_OPTS and JAVA_OPTS:
```
-Dauthenticate=googleplus
-Dauthorization=true 
-Dgoogleplus.consumer.key=xxx 
-Dgoogleplus.consumer.secret=yyy
```
Then there's one more issue that you need to specify the domain in the allowed redirect URLs to make the Google API work: https://stackoverflow.com/questions/14456821/how-to-deal-with-arbitrary-amount-of-redirect-uris. So you actually need to type in the specific heroku domain (wildcards not allowed). We might be able to automate that part, by automatically adding any URL that's an app owned by the cbioportal org

In short there's quite a few things necessary here for setup to make this work automatically on PRs. Completely automated solution is still a bit away. We could however just have this automatically deploy hotfix/rc branch etc, so we can at least test those easily. Similar to how we always have these reflect the latest code:

https://cbioportal.herokuapp.com (master)
https://cbioportal-hotfix.herokuapp.com (hotfix)
https://cbioportal-rc.herokuapp.com (rc)