### PR TITLE
enrichments and plots tab need to initialize querysession before init…

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/co_expression.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/co_expression.jsp
@@ -113,7 +113,9 @@
         }
         $("#tabs").bind("tabsactivate", function(event, ui) {
             if (ui.newTab.text().trim().toLowerCase() === "co-expression") {
+
                 if (coexp_tab_init === false) {
+                    fireQuerySession();
                     CoExpView.init();
                     coexp_tab_init = true;
                     $(window).trigger("resize");

--- a/portal/src/main/webapp/WEB-INF/jsp/plots_tab.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/plots_tab.jsp
@@ -208,10 +208,14 @@
     	//function that will listen to tab changes and init this one when applicable:
     	function tabsUpdate() {
 	        if ($("#plots").is(":visible")) {
-		    	if (tab_init === false) {
-		        	plotsTab.init();
-		            tab_init = true;
-		        }
+	            
+		        if (tab_init === false) {
+		            fireQuerySession();
+                    plotsTab.init();
+                    tab_init = true;
+                } 
+		        
+		        
 		        $(window).trigger("resize");
 	    	}
     	}


### PR DESCRIPTION
…ializing themselves

# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line
  can be automatically added by git if you run the `git-commit` command with
  the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to
  hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). If you are part of the
cBioPortal organization, notify the approprate team (remove inappropriate):

@cBioPortal/frontend
@cBioPortal/backend
@cBioPortal/devops

If you are not part of the cBioPortal organization look at who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them here:
