### PR TITLE
Fix validation for IGR Variant Classification

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1361,19 +1361,24 @@ class MutationsExtendedValidator(Validator):
         entrez_id = '0'
         if 'Entrez_Gene_Id' in self.cols:
             entrez_id = data[self.cols.index('Entrez_Gene_Id')]
-        if hugo_symbol == 'Unknown' and entrez_id == '0' and variant_classification != 'IGR':
-            # the MAF specification documents the use of Unknown and 0 here
-            # for intergenic mutations, and since the Variant_Classification
-            # column is often invalid, cBioPortal interprets this combination
-            # (or just the symbol if the Entrez column is absent) as such,
-            # but with a warning:
-            self.logger.warning(
-                "Gene specification for this mutation implies "
-                "intergenic even though Variant_Classification is "
-                "not 'IGR'; this variant will be filtered out",
-                extra={'line_number': self.line_number,
-                       'cause': "Gene symbol 'Unknown', Entrez gene id 0"})
+        if hugo_symbol == 'Unknown' and entrez_id == '0':
             is_silent = True
+            if variant_classification == 'IGR':
+                self.logger.info("This variant (Gene symbol 'Unknown', Entrez gene ID 0) will be filtered out",
+                                 extra={'line_number': self.line_number,
+                                        'cause': variant_classification})
+            else:
+                # the MAF specification documents the use of Unknown and 0 here
+                # for intergenic mutations, and since the Variant_Classification
+                # column is often invalid, cBioPortal interprets this combination
+                # (or just the symbol if the Entrez column is absent) as such,
+                # but with a warning:
+                self.logger.warning(
+                                    "Gene specification (Gene symbol 'Unknown', Entrez gene ID 0) for this variant "
+                                    "implies intergenic even though Variant_Classification is "
+                                    "not 'IGR'; this variant will be filtered out",
+                                    extra={'line_number': self.line_number,
+                                           'cause': variant_classification})
         elif variant_classification in self.SKIP_VARIANT_TYPES:
             self.logger.info("Line will not be loaded due to the variant "
                              "classification filter. Filtered types: [%s]",

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -1102,22 +1102,25 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
         with a warning when Variant_Classification!='IGR'
         """
         # set level according to this test case:
-        self.logger.setLevel(logging.WARNING)
+        self.logger.setLevel(logging.INFO)
         record_list = self.validate('mutations/data_mutations_silent_alternative.maf',
                                     validateData.MutationsExtendedValidator,
                                     extra_meta_fields={
                                             'swissprot_identifier': 'name'})
-        # we expect 1 ERROR and 2 WARNINGs :
-        self.assertEqual(len(record_list), 3)
+        # we expect 1 ERROR, 2 WARNINGs and 5 INFO:
+        self.assertEqual(len(record_list), 8)
 
         # ERROR should be something like: "No Entrez id or gene symbol provided for gene"
-        self.assertIn("no entrez gene id or gene symbol provided", record_list[0].getMessage().lower())
-        self.assertEqual(record_list[0].levelno, logging.ERROR)
+        self.assertIn("no entrez gene id or gene symbol provided", record_list[1].getMessage().lower())
+        self.assertEqual(record_list[1].levelno, logging.ERROR)
         # WARNING should be something like: "Gene specification for this mutation implies intergenic..."
-        self.assertIn("implies intergenic", record_list[1].getMessage().lower())
-        self.assertEqual(record_list[1].levelno, logging.WARNING)
         self.assertIn("implies intergenic", record_list[2].getMessage().lower())
         self.assertEqual(record_list[2].levelno, logging.WARNING)
+        self.assertIn("implies intergenic", record_list[3].getMessage().lower())
+        self.assertEqual(record_list[3].levelno, logging.WARNING)
+        # INFO should be: "this variant (gene symbol 'unknown', entrez gene id 0) will be filtered out"
+        self.assertIn("this variant (gene symbol 'unknown', entrez gene id 0) will be filtered out", record_list[4].getMessage().lower())
+        self.assertEqual(record_list[4].levelno, logging.INFO)
 
     def test_customized_variants_skipped(self):
         


### PR DESCRIPTION
- Fix validation for IGR Variant Classification.
- Create new info message when IGR variant classifications are filtered out.

This issue originated from a recent feature that implemented the possibility to load variant classifications that were traditionally skipped, such as Silent or 5'Flank. Also IGR could be removed from the "Skip"-list, but IGR would still be rejected in the case there is no Entrez ID and no Symbol.

To summarize: If hugo_symbol == 'Unknown' and entrez_id == '0', the mutation will be filtered out, regardless of the settings in meta_mutation property variant_classification_filter and the SKIPPED_VARIANT_TYPES list.