### PR TITLE
eliminate run time error when there's no cancerStudyList or cancerStu…

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/global/server_vars.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/server_vars.jsp
@@ -62,7 +62,6 @@
                 case_set_description: jspToJs('<%=sampleSetDescription%>')
             },
             
-        cohortIdsList : (cancerStudyIdList === 'null')? [cancerStudyId]: cancerStudyIdList.split(','),
         zScoreThreshold:jspToJs('<%=zScoreThreshold%>', parseFloat),
         rppaScoreThreshold:jspToJs('<%=rppaScoreThreshold%>', parseFloat),
         dataPriority:jspToJs('<%=dataPriority%>', function(d) { return parseInt(d, 10); }),
@@ -72,6 +71,13 @@
        	
     };
     
+    // yes "null" will be string
+    if (window.cancerStudyIdList && window.cancerStudyIdList !== "null") { 
+        window.serverVars.cohortIdsList = cancerStudyIdList.split(',');
+    } else if (window.cancerStudyId) {
+         window.serverVars.cohortIdsList = [cancerStudyId];
+    } 
+
     if (window.serverVars.studySampleObj) {
         window.serverVars.studySampleListMap = (function(){
                                           var ret = {};


### PR DESCRIPTION
ON homepage, there is never a cancerStudyId or cancerStudyIdList.  But the common servervars.jsp attempts to read it nontheless.  

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line can be automatically added by git if you run the `git-commit` command with the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging policy](../CONTRIBUTING.md#pull-request-merging-policy) and identify reviewer if you can.

If you are not part of the cBioPortal organization look at who worked on the file before you. Please use `git blame <filename>` to determine that and notify them here:
