### PR TITLE
Tell frontend what it will need for gene set Oncoprints

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
@@ -75,6 +75,7 @@ public class QueryBuilder extends HttpServlet {
     public static final String SET_OF_CASE_IDS = "set_of_case_ids";
     public static final String CLINICAL_PARAM_SELECTION = "clinical_param_selection";
     public static final String GENE_LIST = "gene_list";
+    public static final String GENESET_LIST = "geneset_list";
     public static final String ACTION_NAME = "Action";
     public static final String XDEBUG = "xdebug";
     public static final String ACTION_SUBMIT = "Submit";

--- a/portal/src/main/webapp/WEB-INF/jsp/global/server_vars.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/server_vars.jsp
@@ -23,6 +23,9 @@
     }
     oql = xssUtil.getCleanerInput(oql);
 
+    // List of queried gene sets
+    String genesetIds = request.getParameter(QueryBuilder.GENESET_LIST);
+
     String studySampleMapJson = (String)request.getAttribute("STUDY_SAMPLE_MAP");
     String sampleSetId = (String) request.getAttribute(QueryBuilder.CASE_SET_ID);
     String sampleSetName = request.getAttribute("case_set_name") != null ? (String) request.getAttribute("case_set_name") : "User-defined Patient List";
@@ -67,6 +70,7 @@
         dataPriority:jspToJs('<%=dataPriority%>', function(d) { return parseInt(d, 10); }),
         
         theQuery: jspToJs('<%=oql%>'.trim()) || "", 
+        genesetIds: jspToJs('<%=genesetIds%>'.trim()) || "",
         studySampleObj: jspToJs('<%=studySampleMapJson%>', JSON.parse)
        	
     };

--- a/service/src/main/java/org/cbioportal/service/impl/GenesetDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenesetDataServiceImpl.java
@@ -92,6 +92,8 @@ public class GenesetDataServiceImpl implements GenesetDataService {
                     GenesetMolecularData genesetData = new GenesetMolecularData();
                     genesetData.setMolecularProfileId(molecularProfileId);
                     genesetData.setSampleId(sample.getStableId());
+                    genesetData.setPatientId(sample.getPatientStableId());
+                    genesetData.setStudyId(sample.getCancerStudyIdentifier());
                     genesetData.setGenesetId(genesetAlteration.getGenesetId());
                     genesetData.setValue(genesetAlteration.getSplitValues()[indexOfSampleId]);
                     genesetDataList.add(genesetData);


### PR DESCRIPTION
I have been working to draw heatmaps of gene set scores in the Oncoprint if the user requests them via the query page fields added in cBioPortal/cbioportal-frontend/pull/742, but doing this in the style of the surrounding code needs these two modifications:
- provide the list of gene sets parsed from the query in the `serverVars` global
- provide correct unique cross-study keys for samples and patients in the web API to request gene set scores

In addition, as an added convenience that would take more work to leave out than in, the gene set score API annotates its records with their patient and study IDs in new separate JSON fields, as suggested by @ersinciftci.