### PR TITLE
Remove readOnly from mybatis

### DIFF
--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CancerTypeMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CancerTypeMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.CancerTypeMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="select">
         type_of_cancer.TYPE_OF_CANCER_ID AS "${prefix}typeOfCancerId"

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalAttributeMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalAttributeMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.ClinicalAttributeMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="select">
         clinical_attribute_meta.ATTR_ID AS "${prefix}attrId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalDataMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.ClinicalDataMapper">
-    <cache size="100000" readOnly="true"/>
+    <cache size="100000"/>
 
     <sql id="selectSample">
         clinical_sample.INTERNAL_ID AS "${prefix}internalId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalEventMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalEventMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.ClinicalEventMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="select">
         clinical_event.CLINICAL_EVENT_ID AS clinicalEventId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CopyNumberSegmentMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CopyNumberSegmentMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.CopyNumberSegmentMapper">
-    <cache size="20000" readOnly="true"/>
+    <cache size="20000"/>
     
     <sql id="select">
         copy_number_seg.SEG_ID AS segId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CosmicCountMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CosmicCountMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.CosmicCountMapper">
-    <cache size="50000" readOnly="true"/>
+    <cache size="50000"/>
 
     <select id="getCosmicCountsByKeywords" resultType="org.cbioportal.model.CosmicMutation">
         SELECT

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.DiscreteCopyNumberMapper">
-    <cache size="50000" readOnly="true"/>
+    <cache size="50000"/>
 
     <sql id="select">
         genetic_profile.STABLE_ID AS molecularProfileId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GeneMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GeneMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.GeneMapper">
-    <cache size="100000" readOnly="true"/>
+    <cache size="100000"/>
 
     <sql id="select">
         gene.ENTREZ_GENE_ID AS "${prefix}entrezGeneId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenePanelMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenePanelMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.GenePanelMapper">
-    <cache readOnly="true"/>
+    <cache/>
     
     <sql id="select">
         gene_panel.INTERNAL_ID AS internalId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetHierarchyMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetHierarchyMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.GenesetHierarchyMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="select">
         a.NODE_ID AS nodeId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.GenesetMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="select">
         geneset.ID AS "${prefix}internalId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.MolecularDataMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="whereInMultipleMolecularProfiles">
         <where>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularProfileMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularProfileMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.MolecularProfileMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="select">
         genetic_profile.GENETIC_PROFILE_ID AS "${prefix}molecularProfileId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.MutationMapper">
-    <cache size="100000" readOnly="true"/>
+    <cache size="100000"/>
 
     <sql id="select">
         genetic_profile.STABLE_ID AS molecularProfileId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/PatientMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/PatientMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.PatientMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="select">
         patient.INTERNAL_ID AS "${prefix}internalId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleListMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleListMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.SampleListMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="select">
         sample_list.LIST_ID AS "${prefix}listId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.SampleMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="select">
         sample.INTERNAL_ID AS "${prefix}internalId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SignificantCopyNumberRegionMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SignificantCopyNumberRegionMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.SignificantCopyNumberRegionMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="select">
         gistic.GISTIC_ROI_ID AS gisticRoiId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SignificantlyMutatedGeneMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SignificantlyMutatedGeneMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.SignificantlyMutatedGeneMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="select">
         mut_sig.ENTREZ_GENE_ID AS entrezGeneId

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.StudyMapper">
-    <cache readOnly="true"/>
+    <cache/>
 
     <sql id="select">
         cancer_study.CANCER_STUDY_ID AS "${prefix}cancerStudyId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/VariantCountMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/VariantCountMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.VariantCountMapper">
-    <cache readOnly="true"/>
+    <cache/>
     
     <select id="fetchVariantCounts" resultType="org.cbioportal.model.VariantCount">
         SELECT


### PR DESCRIPTION
This fixes the issue of not returning the right number of studies in the query selector. The endpoint returns different numbers for different users, which is why caching the results in a read only matter seems to mess things up. Not sure if removing readOnly is required for each endpoint, but I imagine that if we don't certain users might be able to pull the data they're not allowed access to?

We were able to reproduce this behavior on www.cbioportal.org/private. Good idea from @alisman and @jjgao. With this fix MyBatisGate seems to be solved