### PR TITLE
Change Gene Panel API to return sequenced and whole exome information

### DIFF
--- a/model/src/main/java/org/cbioportal/model/GenePanelData.java
+++ b/model/src/main/java/org/cbioportal/model/GenePanelData.java
@@ -1,7 +1,5 @@
 package org.cbioportal.model;
 
-import java.util.List;
-
 public class GenePanelData extends UniqueKeyBase {
     
     private String molecularProfileId;
@@ -9,7 +7,9 @@ public class GenePanelData extends UniqueKeyBase {
     private String patientId;
     private String studyId;
     private String genePanelId;
-    private List<Integer> entrezGeneIds;
+    private Integer entrezGeneId;
+    private Boolean sequenced;
+    private Boolean wholeExomeSequenced;
 
     public String getMolecularProfileId() {
         return molecularProfileId;
@@ -51,11 +51,27 @@ public class GenePanelData extends UniqueKeyBase {
         this.genePanelId = genePanelId;
     }
 
-    public List<Integer> getEntrezGeneIds() {
-        return entrezGeneIds;
-    }
+	public Integer getEntrezGeneId() {
+		return entrezGeneId;
+	}
 
-    public void setEntrezGeneIds(List<Integer> entrezGeneIds) {
-        this.entrezGeneIds = entrezGeneIds;
-    }
+	public void setEntrezGeneId(Integer entrezGeneId) {
+		this.entrezGeneId = entrezGeneId;
+	}
+
+	public Boolean getSequenced() {
+		return sequenced;
+	}
+
+	public void setSequenced(Boolean sequenced) {
+		this.sequenced = sequenced;
+	}
+
+	public Boolean getWholeExomeSequenced() {
+		return wholeExomeSequenced;
+	}
+
+	public void setWholeExomeSequenced(Boolean wholeExomeSequenced) {
+		this.wholeExomeSequenced = wholeExomeSequenced;
+	}
 }

--- a/model/src/main/java/org/cbioportal/model/Sample.java
+++ b/model/src/main/java/org/cbioportal/model/Sample.java
@@ -115,7 +115,7 @@ public class Sample extends UniqueKeyBase {
         this.cancerStudyIdentifier = cancerStudyIdentifier;
     }
 
-    public Boolean isSequenced() {
+    public Boolean getSequenced() {
         return sequenced;
     }
 
@@ -123,7 +123,7 @@ public class Sample extends UniqueKeyBase {
         this.sequenced = sequenced;
     }
 
-    public Boolean isCopyNumberSegmentPresent() {
+    public Boolean getCopyNumberSegmentPresent() {
         return copyNumberSegmentPresent;
     }
 

--- a/service/src/main/java/org/cbioportal/service/impl/GenePanelServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenePanelServiceImpl.java
@@ -1,20 +1,30 @@
 package org.cbioportal.service.impl;
 
+import org.cbioportal.model.Gene;
 import org.cbioportal.model.GenePanel;
 import org.cbioportal.model.GenePanelData;
 import org.cbioportal.model.GenePanelToGene;
+import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.Sample;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.GenePanelRepository;
+import org.cbioportal.persistence.SampleListRepository;
 import org.cbioportal.service.GenePanelService;
+import org.cbioportal.service.GeneService;
 import org.cbioportal.service.MolecularProfileService;
+import org.cbioportal.service.SampleService;
 import org.cbioportal.service.exception.GenePanelNotFoundException;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,6 +34,12 @@ public class GenePanelServiceImpl implements GenePanelService {
     private GenePanelRepository genePanelRepository;
     @Autowired
     private MolecularProfileService molecularProfileService;
+    @Autowired
+    private SampleListRepository sampleListRepository;
+    @Autowired
+    private SampleService sampleService;
+    @Autowired
+    private GeneService geneService;
 
     @Override
     public List<GenePanel> getAllGenePanels(String projection, Integer pageSize, Integer pageNumber, String sortBy, 
@@ -68,11 +84,12 @@ public class GenePanelServiceImpl implements GenePanelService {
                                                 List<Integer> entrezGeneIds) throws MolecularProfileNotFoundException {
 
         molecularProfileService.getMolecularProfile(molecularProfileId);
+        List<String> sampleIds = sampleListRepository.getAllSampleIdsInSampleList(sampleListId);
+        List<String> molecularProfileIds = new ArrayList<>();
+        sampleIds.forEach(s -> molecularProfileIds.add(molecularProfileId));
         
-        List<GenePanelData> genePanelDataList = genePanelRepository.getGenePanelData(molecularProfileId, sampleListId);
-        assignGenesOfPanels(genePanelDataList, entrezGeneIds);
-        
-        return genePanelDataList;
+        return createGenePanelData(genePanelRepository.getGenePanelData(molecularProfileId, sampleListId), 
+            molecularProfileIds, sampleIds, entrezGeneIds);
     }
 
     @Override
@@ -81,11 +98,11 @@ public class GenePanelServiceImpl implements GenePanelService {
                                                   List<Integer> entrezGeneIds) throws MolecularProfileNotFoundException {
 
         molecularProfileService.getMolecularProfile(molecularProfileId);
+        List<String> molecularProfileIds = new ArrayList<>();
+        sampleIds.forEach(s -> molecularProfileIds.add(molecularProfileId));
 
-        List<GenePanelData> genePanelDataList = genePanelRepository.fetchGenePanelData(molecularProfileId, sampleIds);
-        assignGenesOfPanels(genePanelDataList, entrezGeneIds);
-
-        return genePanelDataList;
+        return createGenePanelData(genePanelRepository.fetchGenePanelData(molecularProfileId, sampleIds), 
+            molecularProfileIds, sampleIds, entrezGeneIds);
     }
 
     @Override
@@ -93,20 +110,59 @@ public class GenePanelServiceImpl implements GenePanelService {
 	public List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<String> molecularProfileIds,
 			List<String> sampleIds, List<Integer> entrezGeneIds) {
         
-        List<GenePanelData> genePanelDataList = genePanelRepository.fetchGenePanelDataInMultipleMolecularProfiles(
-            molecularProfileIds, sampleIds);
-        assignGenesOfPanels(genePanelDataList, entrezGeneIds);
-        
-        return genePanelDataList;
+        return createGenePanelData(genePanelRepository.fetchGenePanelDataInMultipleMolecularProfiles(
+            molecularProfileIds, sampleIds), molecularProfileIds, sampleIds, entrezGeneIds);
 	}
 
-    private void assignGenesOfPanels(List<GenePanelData> genePanelDataList, List<Integer> entrezGeneIds) {
-        
+    private List<GenePanelData> createGenePanelData(List<GenePanelData> genePanelDataList, List<String> molecularProfileIds,
+        List<String> sampleIds, List<Integer> entrezGeneIds) {
+
+        List<Gene> genes = geneService.fetchGenes(entrezGeneIds.stream().map(e -> String.valueOf(e)).collect(Collectors.toList()), 
+            "ENTREZ_GENE_ID", "ID");
+
+        Map<String, MolecularProfile> molecularProfileMap = molecularProfileService.getMolecularProfiles(
+            molecularProfileIds, "SUMMARY").stream().collect(Collectors.toMap(MolecularProfile::getStableId, Function.identity()));
+        List<String> studyIds = new ArrayList<>();
+        molecularProfileIds.forEach(m -> studyIds.add(molecularProfileMap.get(m).getCancerStudyIdentifier()));
+        List<Sample> samples = sampleService.fetchSamples(studyIds, sampleIds, "ID");
+
         List<GenePanelToGene> genePanelToGeneList = genePanelRepository.getGenesOfPanels(genePanelDataList.stream()
             .map(GenePanelData::getGenePanelId).collect(Collectors.toList()));
 
-        genePanelDataList.forEach(g1 -> g1.setEntrezGeneIds(genePanelToGeneList.stream().filter(g2 ->
-            g2.getGenePanelId().equals(g1.getGenePanelId())).filter(g2 -> entrezGeneIds.contains(g2.getEntrezGeneId()))
-            .map(GenePanelToGene::getEntrezGeneId).collect(Collectors.toList())));
+        List<GenePanelData> resultGenePanelDataList = new ArrayList<>();
+
+        for(int i = 0; i < sampleIds.size(); i++) {
+            String sampleId = sampleIds.get(i);
+            String molecularProfileId = molecularProfileIds.get(i);
+            for (Gene gene : genes) {
+                Integer entrezGeneId = gene.getEntrezGeneId();
+                GenePanelData resultGenePanelData = new GenePanelData();
+                Optional<GenePanelData> genePanelData = genePanelDataList.stream().filter(g -> g.getMolecularProfileId().equals(
+                    molecularProfileId) && g.getSampleId().equals(sampleId)).findFirst();
+                if (genePanelData.isPresent()) {
+                    String genePanelId = genePanelData.get().getGenePanelId();
+                    resultGenePanelData.setGenePanelId(genePanelId);
+                    resultGenePanelData.setSequenced(genePanelToGeneList.stream().anyMatch(g -> 
+                        g.getGenePanelId().equals(genePanelId) && g.getEntrezGeneId().equals(entrezGeneId)));
+                    resultGenePanelData.setWholeExomeSequenced(false);
+                } else {
+                    resultGenePanelData.setWholeExomeSequenced(true);
+                    resultGenePanelData.setSequenced(true);
+                }
+                resultGenePanelData.setEntrezGeneId(entrezGeneId);
+                resultGenePanelData.setMolecularProfileId(molecularProfileId);
+                resultGenePanelData.setSampleId(sampleId);
+                String studyId = molecularProfileMap.get(molecularProfileId).getCancerStudyIdentifier();
+                resultGenePanelData.setStudyId(studyId);
+                Optional<Sample> sample = samples.stream().filter(s -> s.getStableId().equals(sampleId) && 
+                    s.getCancerStudyIdentifier().equals(studyId)).findFirst();
+                if (sample.isPresent()) {
+                    resultGenePanelData.setPatientId(sample.get().getPatientStableId());
+                    resultGenePanelDataList.add(resultGenePanelData);
+                }
+            }
+        }
+
+        return resultGenePanelDataList;
     }
 }

--- a/service/src/test/java/org/cbioportal/service/impl/BaseServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/BaseServiceImplTest.java
@@ -12,11 +12,14 @@ public class BaseServiceImplTest {
     public static final String SAMPLE_ID1 = "sample_id1";
     public static final String SAMPLE_ID2 = "sample_id2";
     public static final String SAMPLE_ID3 = "sample_id3";
-    public static final String PATIENT_ID = "patient_id";
+    public static final String PATIENT_ID_1 = "patient_id1";
+    public static final String PATIENT_ID_2 = "patient_id2";
+    public static final String PATIENT_ID_3 = "patient_id3";
     public static final String CLINICAL_ATTRIBUTE_ID = "attributeId";
     public static final String CANCER_TYPE_ID = "cancer_type_id";
     public static final String CLINICAL_DATA_TYPE = "clinical_data_type";
-    public static final Integer ENTREZ_GENE_ID = 1;
+    public static final Integer ENTREZ_GENE_ID_1 = 1;
+    public static final Integer ENTREZ_GENE_ID_2 = 2;
     public static final String GENESET_ID1 = "geneset_id1";
     public static final String GENESET_ID2 = "geneset_id2";
     public static final String HUGO_GENE_SYMBOL = "hugo_gene_symbol";

--- a/service/src/test/java/org/cbioportal/service/impl/ClinicalDataServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ClinicalDataServiceImplTest.java
@@ -90,11 +90,11 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
         ClinicalData patientClinicalData = new ClinicalData();
         expectedPatientClinicalDataList.add(patientClinicalData);
 
-        Mockito.when(clinicalDataRepository.getAllClinicalDataOfPatientInStudy(STUDY_ID, PATIENT_ID, 
+        Mockito.when(clinicalDataRepository.getAllClinicalDataOfPatientInStudy(STUDY_ID, PATIENT_ID_1, 
             CLINICAL_ATTRIBUTE_ID, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION))
             .thenReturn(expectedPatientClinicalDataList);
 
-        List<ClinicalData> result = clinicalDataService.getAllClinicalDataOfPatientInStudy(STUDY_ID, PATIENT_ID,
+        List<ClinicalData> result = clinicalDataService.getAllClinicalDataOfPatientInStudy(STUDY_ID, PATIENT_ID_1,
             CLINICAL_ATTRIBUTE_ID, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
 
         Assert.assertEquals(expectedPatientClinicalDataList, result);
@@ -103,9 +103,9 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
     @Test(expected = PatientNotFoundException.class)
     public void getAllClinicalDataOfPatientInStudyPatientNotFound() throws Exception {
         
-        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenThrow(new PatientNotFoundException(
-            STUDY_ID, PATIENT_ID));
-        clinicalDataService.getAllClinicalDataOfPatientInStudy(STUDY_ID, PATIENT_ID, CLINICAL_ATTRIBUTE_ID, PROJECTION, 
+        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID_1)).thenThrow(new PatientNotFoundException(
+            STUDY_ID, PATIENT_ID_1));
+        clinicalDataService.getAllClinicalDataOfPatientInStudy(STUDY_ID, PATIENT_ID_1, CLINICAL_ATTRIBUTE_ID, PROJECTION, 
             PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
     }
 
@@ -114,10 +114,10 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
 
         BaseMeta expectedBaseMeta = new BaseMeta();
 
-        Mockito.when(clinicalDataRepository.getMetaPatientClinicalData(STUDY_ID, PATIENT_ID, CLINICAL_ATTRIBUTE_ID))
+        Mockito.when(clinicalDataRepository.getMetaPatientClinicalData(STUDY_ID, PATIENT_ID_1, CLINICAL_ATTRIBUTE_ID))
                 .thenReturn(expectedBaseMeta);
 
-        BaseMeta result = clinicalDataService.getMetaPatientClinicalData(STUDY_ID, PATIENT_ID, CLINICAL_ATTRIBUTE_ID);
+        BaseMeta result = clinicalDataService.getMetaPatientClinicalData(STUDY_ID, PATIENT_ID_1, CLINICAL_ATTRIBUTE_ID);
 
         Assert.assertEquals(expectedBaseMeta, result);
     }
@@ -125,9 +125,9 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
     @Test(expected = PatientNotFoundException.class)
     public void getMetaPatientClinicalDataPatientNotFound() throws Exception {
 
-        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenThrow(new PatientNotFoundException(
-            STUDY_ID, PATIENT_ID));
-        clinicalDataService.getMetaPatientClinicalData(STUDY_ID, PATIENT_ID, CLINICAL_ATTRIBUTE_ID);
+        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID_1)).thenThrow(new PatientNotFoundException(
+            STUDY_ID, PATIENT_ID_1));
+        clinicalDataService.getMetaPatientClinicalData(STUDY_ID, PATIENT_ID_1, CLINICAL_ATTRIBUTE_ID);
     }
 
     @Test
@@ -184,7 +184,7 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
         List<String> studyIds = new ArrayList<>();
         studyIds.add(STUDY_ID);
         List<String> patientIds = new ArrayList<>();
-        patientIds.add(PATIENT_ID);
+        patientIds.add(PATIENT_ID_1);
 
         List<ClinicalData> expectedPatientClinicalDataList = new ArrayList<>();
         ClinicalData patientClinicalData = new ClinicalData();
@@ -206,7 +206,7 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
         List<String> studyIds = new ArrayList<>();
         studyIds.add(STUDY_ID);
         List<String> patientIds = new ArrayList<>();
-        patientIds.add(PATIENT_ID);
+        patientIds.add(PATIENT_ID_1);
 
         BaseMeta expectedBaseMeta = new BaseMeta();
         expectedBaseMeta.setTotalCount(5);

--- a/service/src/test/java/org/cbioportal/service/impl/ClinicalEventServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ClinicalEventServiceImplTest.java
@@ -37,7 +37,7 @@ public class ClinicalEventServiceImplTest extends BaseServiceImplTest {
         clinicalEvent.setClinicalEventId(CLINICAL_EVENT_ID);
         expectedClinicalEventList.add(clinicalEvent);
 
-        Mockito.when(clinicalEventRepository.getAllClinicalEventsOfPatientInStudy(STUDY_ID, PATIENT_ID, PROJECTION,
+        Mockito.when(clinicalEventRepository.getAllClinicalEventsOfPatientInStudy(STUDY_ID, PATIENT_ID_1, PROJECTION,
             PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION)).thenReturn(expectedClinicalEventList);
 
         List<ClinicalEventData> expectedClinicalEventDataList = new ArrayList<>();
@@ -48,7 +48,7 @@ public class ClinicalEventServiceImplTest extends BaseServiceImplTest {
         Mockito.when(clinicalEventRepository.getDataOfClinicalEvents(Arrays.asList(CLINICAL_EVENT_ID)))
             .thenReturn(expectedClinicalEventDataList);
 
-        List<ClinicalEvent> result = clinicalEventService.getAllClinicalEventsOfPatientInStudy(STUDY_ID, PATIENT_ID,
+        List<ClinicalEvent> result = clinicalEventService.getAllClinicalEventsOfPatientInStudy(STUDY_ID, PATIENT_ID_1,
             PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
 
         Assert.assertEquals(1, result.size());
@@ -60,9 +60,9 @@ public class ClinicalEventServiceImplTest extends BaseServiceImplTest {
     @Test(expected = PatientNotFoundException.class)
     public void getAllClinicalEventsOfPatientInStudyPatientNotFound() throws Exception {
 
-        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenThrow(new PatientNotFoundException(
-            STUDY_ID, PATIENT_ID));
-        clinicalEventService.getAllClinicalEventsOfPatientInStudy(STUDY_ID, PATIENT_ID, PROJECTION, PAGE_SIZE, 
+        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID_1)).thenThrow(new PatientNotFoundException(
+            STUDY_ID, PATIENT_ID_1));
+        clinicalEventService.getAllClinicalEventsOfPatientInStudy(STUDY_ID, PATIENT_ID_1, PROJECTION, PAGE_SIZE, 
             PAGE_NUMBER, SORT, DIRECTION);
     }
 
@@ -70,9 +70,9 @@ public class ClinicalEventServiceImplTest extends BaseServiceImplTest {
     public void getMetaPatientClinicalEvents() throws Exception {
 
         BaseMeta expectedBaseMeta = new BaseMeta();
-        Mockito.when(clinicalEventRepository.getMetaPatientClinicalEvents(STUDY_ID, PATIENT_ID))
+        Mockito.when(clinicalEventRepository.getMetaPatientClinicalEvents(STUDY_ID, PATIENT_ID_1))
             .thenReturn(expectedBaseMeta);
-        BaseMeta result = clinicalEventService.getMetaPatientClinicalEvents(STUDY_ID, PATIENT_ID);
+        BaseMeta result = clinicalEventService.getMetaPatientClinicalEvents(STUDY_ID, PATIENT_ID_1);
 
         Assert.assertEquals(expectedBaseMeta, result);
     }
@@ -80,8 +80,8 @@ public class ClinicalEventServiceImplTest extends BaseServiceImplTest {
     @Test(expected = PatientNotFoundException.class)
     public void getMetaPatientClinicalEventsPatientNotFound() throws Exception {
         
-        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenThrow(new PatientNotFoundException(
-            STUDY_ID, PATIENT_ID));
-        clinicalEventService.getMetaPatientClinicalEvents(STUDY_ID, PATIENT_ID);
+        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID_1)).thenThrow(new PatientNotFoundException(
+            STUDY_ID, PATIENT_ID_1));
+        clinicalEventService.getMetaPatientClinicalEvents(STUDY_ID, PATIENT_ID_1);
     }
 }

--- a/service/src/test/java/org/cbioportal/service/impl/CoExpressionServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/CoExpressionServiceImplTest.java
@@ -44,7 +44,7 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
             .thenReturn(genes);
 
         List<CoExpression> result = coExpressionService.getCoExpressions(MOLECULAR_PROFILE_ID,
-            SAMPLE_LIST_ID, ENTREZ_GENE_ID, THRESHOLD);
+            SAMPLE_LIST_ID, ENTREZ_GENE_ID_1, THRESHOLD);
 
         Assert.assertEquals(2, result.size());
         CoExpression coExpression1 = result.get(0);
@@ -74,7 +74,7 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
             .thenReturn(genes);
 
         List<CoExpression> result = coExpressionService.fetchCoExpressions(MOLECULAR_PROFILE_ID,
-            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), ENTREZ_GENE_ID, THRESHOLD);
+            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), ENTREZ_GENE_ID_1, THRESHOLD);
 
         Assert.assertEquals(2, result.size());
         CoExpression coExpression1 = result.get(0);
@@ -94,15 +94,15 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
     private List<GeneMolecularData> createGeneMolecularData() {
         List<GeneMolecularData> molecularDataList = new ArrayList<>();
         GeneMolecularData geneMolecularData1 = new GeneMolecularData();
-        geneMolecularData1.setEntrezGeneId(ENTREZ_GENE_ID);
+        geneMolecularData1.setEntrezGeneId(ENTREZ_GENE_ID_1);
         geneMolecularData1.setValue("2.1");
         molecularDataList.add(geneMolecularData1);
         GeneMolecularData geneMolecularData2 = new GeneMolecularData();
-        geneMolecularData2.setEntrezGeneId(ENTREZ_GENE_ID);
+        geneMolecularData2.setEntrezGeneId(ENTREZ_GENE_ID_1);
         geneMolecularData2.setValue("3");
         molecularDataList.add(geneMolecularData2);
         GeneMolecularData geneMolecularData3 = new GeneMolecularData();
-        geneMolecularData3.setEntrezGeneId(ENTREZ_GENE_ID);
+        geneMolecularData3.setEntrezGeneId(ENTREZ_GENE_ID_1);
         geneMolecularData3.setValue("3");
         molecularDataList.add(geneMolecularData3);
         GeneMolecularData geneMolecularData4 = new GeneMolecularData();

--- a/service/src/test/java/org/cbioportal/service/impl/CopyNumberSegmentServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/CopyNumberSegmentServiceImplTest.java
@@ -82,10 +82,10 @@ public class CopyNumberSegmentServiceImplTest extends BaseServiceImplTest {
         expectedCopyNumberSegList.add(copyNumberSeg);
 
         Mockito.when(copyNumberSegmentRepository.fetchCopyNumberSegments(Arrays.asList(STUDY_ID), 
-            Arrays.asList(PATIENT_ID), PROJECTION)).thenReturn(expectedCopyNumberSegList);
+            Arrays.asList(PATIENT_ID_1), PROJECTION)).thenReturn(expectedCopyNumberSegList);
 
         List<CopyNumberSeg> result = copyNumberSegmentService.fetchCopyNumberSegments(Arrays.asList(STUDY_ID),
-            Arrays.asList(PATIENT_ID), PROJECTION);
+            Arrays.asList(PATIENT_ID_1), PROJECTION);
 
         Assert.assertEquals(expectedCopyNumberSegList, result);
     }
@@ -95,9 +95,9 @@ public class CopyNumberSegmentServiceImplTest extends BaseServiceImplTest {
 
         BaseMeta expectedBaseMeta = new BaseMeta();
         Mockito.when(copyNumberSegmentRepository.fetchMetaCopyNumberSegments(Arrays.asList(STUDY_ID), 
-            Arrays.asList(PATIENT_ID))).thenReturn(expectedBaseMeta);
+            Arrays.asList(PATIENT_ID_1))).thenReturn(expectedBaseMeta);
         BaseMeta result = copyNumberSegmentService.fetchMetaCopyNumberSegments(Arrays.asList(STUDY_ID), 
-            Arrays.asList(PATIENT_ID));
+            Arrays.asList(PATIENT_ID_1));
 
         Assert.assertEquals(expectedBaseMeta, result);
     }

--- a/service/src/test/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImplTest.java
@@ -49,12 +49,12 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
         alterationTypes.add(-2);
         
         Mockito.when(discreteCopyNumberRepository.getDiscreteCopyNumbersInMolecularProfileBySampleListId(
-            MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID), alterationTypes, PROJECTION))
+            MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID_1), alterationTypes, PROJECTION))
             .thenReturn(expectedDiscreteCopyNumberDataList);
         
         List<DiscreteCopyNumberData> result = discreteCopyNumberService
             .getDiscreteCopyNumbersInMolecularProfileBySampleListId(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, 
-                Arrays.asList(ENTREZ_GENE_ID), alterationTypes, PROJECTION);
+                Arrays.asList(ENTREZ_GENE_ID_1), alterationTypes, PROJECTION);
 
         Assert.assertEquals(expectedDiscreteCopyNumberDataList, result);
     }
@@ -69,27 +69,27 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
         molecularData.setValue("-1");
         molecularData.setMolecularProfileId(MOLECULAR_PROFILE_ID);
         molecularData.setSampleId(SAMPLE_ID1);
-        molecularData.setEntrezGeneId(ENTREZ_GENE_ID);
+        molecularData.setEntrezGeneId(ENTREZ_GENE_ID_1);
         Gene gene = new Gene(); 
         molecularData.setGene(gene);
         expectedMolecularDataList.add(molecularData);
         
         Mockito.when(molecularDataService.getMolecularData(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, 
-            Arrays.asList(ENTREZ_GENE_ID), PROJECTION)).thenReturn(expectedMolecularDataList);
+            Arrays.asList(ENTREZ_GENE_ID_1), PROJECTION)).thenReturn(expectedMolecularDataList);
 
         List<Integer> alterationTypes = new ArrayList<>();
         alterationTypes.add(-1);
         
         List<DiscreteCopyNumberData> result = discreteCopyNumberService
             .getDiscreteCopyNumbersInMolecularProfileBySampleListId(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, 
-                Arrays.asList(ENTREZ_GENE_ID), alterationTypes, PROJECTION);
+                Arrays.asList(ENTREZ_GENE_ID_1), alterationTypes, PROJECTION);
         
         Assert.assertEquals(1, result.size());
         DiscreteCopyNumberData discreteCopyNumberData = result.get(0);
         Assert.assertEquals((Integer) (-1), discreteCopyNumberData.getAlteration());
         Assert.assertEquals(MOLECULAR_PROFILE_ID, discreteCopyNumberData.getMolecularProfileId());
         Assert.assertEquals(SAMPLE_ID1, discreteCopyNumberData.getSampleId());
-        Assert.assertEquals(ENTREZ_GENE_ID, discreteCopyNumberData.getEntrezGeneId());
+        Assert.assertEquals(ENTREZ_GENE_ID_1, discreteCopyNumberData.getEntrezGeneId());
         Assert.assertEquals(gene, discreteCopyNumberData.getGene());
     }
 
@@ -103,11 +103,11 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
 
         BaseMeta expectedBaseMeta = new BaseMeta();
         Mockito.when(discreteCopyNumberRepository.getMetaDiscreteCopyNumbersInMolecularProfileBySampleListId(
-            MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID), alterationTypes))
+            MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID_1), alterationTypes))
             .thenReturn(expectedBaseMeta);
 
         BaseMeta result = discreteCopyNumberService.getMetaDiscreteCopyNumbersInMolecularProfileBySampleListId(
-            MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID), alterationTypes);
+            MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID_1), alterationTypes);
         
         Assert.assertEquals(expectedBaseMeta, result);
     }
@@ -123,13 +123,13 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
         expectedMolecularDataList.add(molecularData);
 
         Mockito.when(molecularDataService.getMolecularData(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, 
-            Arrays.asList(ENTREZ_GENE_ID), "ID")).thenReturn(expectedMolecularDataList);
+            Arrays.asList(ENTREZ_GENE_ID_1), "ID")).thenReturn(expectedMolecularDataList);
 
         List<Integer> alterationTypes = new ArrayList<>();
         alterationTypes.add(-1);
 
         BaseMeta result = discreteCopyNumberService.getMetaDiscreteCopyNumbersInMolecularProfileBySampleListId(
-            MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID), alterationTypes);
+            MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID_1), alterationTypes);
         
         Assert.assertEquals((Integer) 1, result.getTotalCount());
     }
@@ -147,11 +147,11 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
         alterationTypes.add(-2);
 
         Mockito.when(discreteCopyNumberRepository.fetchDiscreteCopyNumbersInMolecularProfile(MOLECULAR_PROFILE_ID, 
-            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID), alterationTypes, PROJECTION))
+            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), alterationTypes, PROJECTION))
             .thenReturn(expectedDiscreteCopyNumberDataList);
 
         List<DiscreteCopyNumberData> result = discreteCopyNumberService.fetchDiscreteCopyNumbersInMolecularProfile(
-            MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID), alterationTypes, PROJECTION);
+            MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), alterationTypes, PROJECTION);
 
         Assert.assertEquals(expectedDiscreteCopyNumberDataList, result);
     }
@@ -166,26 +166,26 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
         molecularData.setValue("-1");
         molecularData.setMolecularProfileId(MOLECULAR_PROFILE_ID);
         molecularData.setSampleId(SAMPLE_ID1);
-        molecularData.setEntrezGeneId(ENTREZ_GENE_ID);
+        molecularData.setEntrezGeneId(ENTREZ_GENE_ID_1);
         Gene gene = new Gene();
         molecularData.setGene(gene);
         expectedMolecularDataList.add(molecularData);
 
         Mockito.when(molecularDataService.fetchMolecularData(MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1), 
-            Arrays.asList(ENTREZ_GENE_ID), PROJECTION)).thenReturn(expectedMolecularDataList);
+            Arrays.asList(ENTREZ_GENE_ID_1), PROJECTION)).thenReturn(expectedMolecularDataList);
 
         List<Integer> alterationTypes = new ArrayList<>();
         alterationTypes.add(-1);
 
         List<DiscreteCopyNumberData> result = discreteCopyNumberService.fetchDiscreteCopyNumbersInMolecularProfile(
-            MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID), alterationTypes, PROJECTION);
+            MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), alterationTypes, PROJECTION);
 
         Assert.assertEquals(1, result.size());
         DiscreteCopyNumberData discreteCopyNumberData = result.get(0);
         Assert.assertEquals((Integer) (-1), discreteCopyNumberData.getAlteration());
         Assert.assertEquals(MOLECULAR_PROFILE_ID, discreteCopyNumberData.getMolecularProfileId());
         Assert.assertEquals(SAMPLE_ID1, discreteCopyNumberData.getSampleId());
-        Assert.assertEquals(ENTREZ_GENE_ID, discreteCopyNumberData.getEntrezGeneId());
+        Assert.assertEquals(ENTREZ_GENE_ID_1, discreteCopyNumberData.getEntrezGeneId());
         Assert.assertEquals(gene, discreteCopyNumberData.getGene());
     }
 
@@ -199,10 +199,10 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
 
         BaseMeta expectedBaseMeta = new BaseMeta();
         Mockito.when(discreteCopyNumberRepository.fetchMetaDiscreteCopyNumbersInMolecularProfile(MOLECULAR_PROFILE_ID,
-            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID), alterationTypes)).thenReturn(expectedBaseMeta);
+            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), alterationTypes)).thenReturn(expectedBaseMeta);
 
         BaseMeta result = discreteCopyNumberService.fetchMetaDiscreteCopyNumbersInMolecularProfile(
-            MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID), alterationTypes);
+            MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), alterationTypes);
 
         Assert.assertEquals(expectedBaseMeta, result);
     }
@@ -218,13 +218,13 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
         expectedMolecularDataList.add(molecularData);
 
         Mockito.when(molecularDataService.fetchMolecularData(MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1), 
-            Arrays.asList(ENTREZ_GENE_ID), "ID")).thenReturn(expectedMolecularDataList);
+            Arrays.asList(ENTREZ_GENE_ID_1), "ID")).thenReturn(expectedMolecularDataList);
 
         List<Integer> alterationTypes = new ArrayList<>();
         alterationTypes.add(-1);
 
         BaseMeta result = discreteCopyNumberService.fetchMetaDiscreteCopyNumbersInMolecularProfile(
-            MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID), alterationTypes);
+            MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), alterationTypes);
 
         Assert.assertEquals((Integer) 1, result.getTotalCount());
     }
@@ -236,11 +236,11 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
         expectedCopyNumberSampleCountByGeneList.add(new CopyNumberCountByGene());
 
         Mockito.when(discreteCopyNumberRepository.getSampleCountByGeneAndAlterationAndSampleIds(MOLECULAR_PROFILE_ID, 
-            null, Arrays.asList(ENTREZ_GENE_ID), Arrays.asList(-2)))
+            null, Arrays.asList(ENTREZ_GENE_ID_1), Arrays.asList(-2)))
             .thenReturn(expectedCopyNumberSampleCountByGeneList);
         
         List<CopyNumberCountByGene> result = discreteCopyNumberService
-            .getSampleCountByGeneAndAlterationAndSampleIds(MOLECULAR_PROFILE_ID, null, Arrays.asList(ENTREZ_GENE_ID), 
+            .getSampleCountByGeneAndAlterationAndSampleIds(MOLECULAR_PROFILE_ID, null, Arrays.asList(ENTREZ_GENE_ID_1), 
                 Arrays.asList(-2));
         
         Assert.assertEquals(expectedCopyNumberSampleCountByGeneList, result);
@@ -253,11 +253,11 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
         expectedCopyNumberSampleCountByGeneList.add(new CopyNumberCountByGene());
 
         Mockito.when(discreteCopyNumberRepository.getPatientCountByGeneAndAlterationAndPatientIds(MOLECULAR_PROFILE_ID, 
-            null, Arrays.asList(ENTREZ_GENE_ID), Arrays.asList(-2)))
+            null, Arrays.asList(ENTREZ_GENE_ID_1), Arrays.asList(-2)))
             .thenReturn(expectedCopyNumberSampleCountByGeneList);
         
         List<CopyNumberCountByGene> result = discreteCopyNumberService
-            .getPatientCountByGeneAndAlterationAndPatientIds(MOLECULAR_PROFILE_ID, null, Arrays.asList(ENTREZ_GENE_ID), 
+            .getPatientCountByGeneAndAlterationAndPatientIds(MOLECULAR_PROFILE_ID, null, Arrays.asList(ENTREZ_GENE_ID_1), 
                 Arrays.asList(-2));
         
         Assert.assertEquals(expectedCopyNumberSampleCountByGeneList, result);
@@ -268,7 +268,7 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
 
         List<CopyNumberCountByGene> copyNumberSampleCountByGeneList = new ArrayList<>();
         CopyNumberCountByGene copyNumberSampleCountByGene = new CopyNumberCountByGene();
-        copyNumberSampleCountByGene.setEntrezGeneId(ENTREZ_GENE_ID);
+        copyNumberSampleCountByGene.setEntrezGeneId(ENTREZ_GENE_ID_1);
         copyNumberSampleCountByGene.setAlteration(-2);
         copyNumberSampleCountByGene.setCount(1);
         copyNumberSampleCountByGeneList.add(copyNumberSampleCountByGene);
@@ -281,15 +281,15 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
         Mockito.when(molecularDataService.getNumberOfSamplesInMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(2);
 
         Mockito.when(discreteCopyNumberService.getSampleCountByGeneAndAlterationAndSampleIds(MOLECULAR_PROFILE_ID, null,
-            Arrays.asList(ENTREZ_GENE_ID), Arrays.asList(-2))).thenReturn(copyNumberSampleCountByGeneList);
+            Arrays.asList(ENTREZ_GENE_ID_1), Arrays.asList(-2))).thenReturn(copyNumberSampleCountByGeneList);
 
         List<CopyNumberCount> result = discreteCopyNumberService.fetchCopyNumberCounts(MOLECULAR_PROFILE_ID,
-            Arrays.asList(ENTREZ_GENE_ID), Arrays.asList(-2));
+            Arrays.asList(ENTREZ_GENE_ID_1), Arrays.asList(-2));
 
         Assert.assertEquals(1, result.size());
         CopyNumberCount copyNumberCount = result.get(0);
         Assert.assertEquals(MOLECULAR_PROFILE_ID, copyNumberCount.getMolecularProfileId());
-        Assert.assertEquals(ENTREZ_GENE_ID, copyNumberCount.getEntrezGeneId());
+        Assert.assertEquals(ENTREZ_GENE_ID_1, copyNumberCount.getEntrezGeneId());
         Assert.assertEquals((Integer) (-2), copyNumberCount.getAlteration());
         Assert.assertEquals((Integer) 2, copyNumberCount.getNumberOfSamples());
         Assert.assertEquals((Integer) 1, copyNumberCount.getNumberOfSamplesWithAlterationInGene());

--- a/service/src/test/java/org/cbioportal/service/impl/GenePanelServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenePanelServiceImplTest.java
@@ -1,12 +1,17 @@
 package org.cbioportal.service.impl;
 
+import org.cbioportal.model.Gene;
 import org.cbioportal.model.GenePanel;
 import org.cbioportal.model.GenePanelData;
 import org.cbioportal.model.GenePanelToGene;
 import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.Sample;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.GenePanelRepository;
+import org.cbioportal.persistence.SampleListRepository;
+import org.cbioportal.service.GeneService;
 import org.cbioportal.service.MolecularProfileService;
+import org.cbioportal.service.SampleService;
 import org.cbioportal.service.exception.GenePanelNotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,6 +35,12 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
     private GenePanelRepository genePanelRepository;
     @Mock
     private MolecularProfileService molecularProfileService;
+    @Mock
+    private SampleListRepository sampleListRepository;
+    @Mock
+    private SampleService sampleService;
+    @Mock
+    private GeneService geneService;
     
     @Test
     public void getAllGenePanelsSummaryProjection() throws Exception {
@@ -116,93 +127,262 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
     @Test
     public void getGenePanelData() throws Exception {
         
-        List<GenePanelData> expectedGenePanelDataList = new ArrayList<>();
+        List<GenePanelData> genePanelDataList = new ArrayList<>();
         GenePanelData genePanelData = new GenePanelData();
         genePanelData.setGenePanelId(GENE_PANEL_ID);
-        expectedGenePanelDataList.add(genePanelData);
-        List<GenePanelToGene> expectedGenePanelToGeneList = new ArrayList<>();
+        genePanelData.setMolecularProfileId(MOLECULAR_PROFILE_ID);
+        genePanelData.setSampleId(SAMPLE_ID1);
+        genePanelDataList.add(genePanelData);
+
+        List<GenePanelToGene> genePanelToGeneList = new ArrayList<>();
         GenePanelToGene genePanelToGene = new GenePanelToGene();
         genePanelToGene.setGenePanelId(GENE_PANEL_ID);
-        genePanelToGene.setEntrezGeneId(ENTREZ_GENE_ID);
-        expectedGenePanelToGeneList.add(genePanelToGene);
+        genePanelToGene.setEntrezGeneId(ENTREZ_GENE_ID_1);
+        genePanelToGeneList.add(genePanelToGene);
+
+        List<Gene> genes = new ArrayList<>();
+        Gene gene1 = new Gene();
+        gene1.setEntrezGeneId(ENTREZ_GENE_ID_1);
+        genes.add(gene1);
+        Gene gene2 = new Gene();
+        gene2.setEntrezGeneId(ENTREZ_GENE_ID_2);
+        genes.add(gene2);
+
+        List<MolecularProfile> molecularProfiles = new ArrayList<>();
+        MolecularProfile molecularProfile = new MolecularProfile();
+        molecularProfile.setStableId(MOLECULAR_PROFILE_ID);
+        molecularProfile.setCancerStudyIdentifier(STUDY_ID);
+        molecularProfiles.add(molecularProfile);
+
+        List<Sample> samples = new ArrayList<>();
+        Sample sample1 = new Sample();
+        sample1.setStableId(SAMPLE_ID1);
+        sample1.setPatientStableId(PATIENT_ID_1);
+        sample1.setCancerStudyIdentifier(STUDY_ID);
+        samples.add(sample1);
+        Sample sample2 = new Sample();
+        sample2.setStableId(SAMPLE_ID2);
+        sample2.setPatientStableId(PATIENT_ID_2);
+        sample2.setCancerStudyIdentifier(STUDY_ID);
+        samples.add(sample2);
         
-        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(new MolecularProfile());
+        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
+
+        Mockito.when(sampleListRepository.getAllSampleIdsInSampleList(SAMPLE_LIST_ID))
+            .thenReturn(Arrays.asList(SAMPLE_ID1, SAMPLE_ID2));
+
+        Mockito.when(geneService.fetchGenes(Arrays.asList(String.valueOf(ENTREZ_GENE_ID_1), 
+            String.valueOf(ENTREZ_GENE_ID_2)), "ENTREZ_GENE_ID", "ID")).thenReturn(genes);
+
+        Mockito.when(molecularProfileService.getMolecularProfiles(
+            Arrays.asList(MOLECULAR_PROFILE_ID, MOLECULAR_PROFILE_ID), "SUMMARY")).thenReturn(molecularProfiles);
+
+        Mockito.when(sampleService.fetchSamples(Arrays.asList(STUDY_ID, STUDY_ID), 
+            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), "ID")).thenReturn(samples);
         
         Mockito.when(genePanelRepository.getGenePanelData(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID))
-            .thenReturn(expectedGenePanelDataList);
+            .thenReturn(genePanelDataList);
 
         Mockito.when(genePanelRepository.getGenesOfPanels(Arrays.asList(GENE_PANEL_ID)))
-            .thenReturn(expectedGenePanelToGeneList);
+            .thenReturn(genePanelToGeneList);
         
         List<GenePanelData> result = genePanelService.getGenePanelData(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, 
-            Arrays.asList(ENTREZ_GENE_ID));
+            Arrays.asList(ENTREZ_GENE_ID_1, ENTREZ_GENE_ID_2));
         
-        Assert.assertEquals(expectedGenePanelDataList, result);
-        Assert.assertEquals(1, result.size());
-        Assert.assertEquals(genePanelData, result.get(0));
-        Assert.assertEquals(1, result.get(0).getEntrezGeneIds().size());
-        Assert.assertEquals(ENTREZ_GENE_ID, result.get(0).getEntrezGeneIds().get(0));
+        Assert.assertEquals(4, result.size());
+        GenePanelData resultGenePanelData1 = result.get(0);
+        Assert.assertEquals(SAMPLE_ID1, resultGenePanelData1.getSampleId());
+        Assert.assertEquals(ENTREZ_GENE_ID_1, resultGenePanelData1.getEntrezGeneId());
+        Assert.assertEquals(GENE_PANEL_ID, resultGenePanelData1.getGenePanelId());
+        Assert.assertEquals(MOLECULAR_PROFILE_ID, resultGenePanelData1.getMolecularProfileId());
+        Assert.assertEquals(PATIENT_ID_1, resultGenePanelData1.getPatientId());
+        Assert.assertEquals(STUDY_ID, resultGenePanelData1.getStudyId());
+        Assert.assertEquals(true, resultGenePanelData1.getSequenced());
+        Assert.assertEquals(false, resultGenePanelData1.getWholeExomeSequenced());
+        GenePanelData resultGenePanelData2 = result.get(1);
+        Assert.assertEquals(SAMPLE_ID1, resultGenePanelData2.getSampleId());
+        Assert.assertEquals(ENTREZ_GENE_ID_2, resultGenePanelData2.getEntrezGeneId());
+        Assert.assertEquals(GENE_PANEL_ID, resultGenePanelData2.getGenePanelId());
+        Assert.assertEquals(MOLECULAR_PROFILE_ID, resultGenePanelData2.getMolecularProfileId());
+        Assert.assertEquals(PATIENT_ID_1, resultGenePanelData2.getPatientId());
+        Assert.assertEquals(STUDY_ID, resultGenePanelData2.getStudyId());
+        Assert.assertEquals(false, resultGenePanelData2.getSequenced());
+        Assert.assertEquals(false, resultGenePanelData2.getWholeExomeSequenced());
+        GenePanelData resultGenePanelData3 = result.get(2);
+        Assert.assertEquals(SAMPLE_ID2, resultGenePanelData3.getSampleId());
+        Assert.assertEquals(ENTREZ_GENE_ID_1, resultGenePanelData3.getEntrezGeneId());
+        Assert.assertNull(resultGenePanelData3.getGenePanelId());
+        Assert.assertEquals(MOLECULAR_PROFILE_ID, resultGenePanelData3.getMolecularProfileId());
+        Assert.assertEquals(PATIENT_ID_2, resultGenePanelData3.getPatientId());
+        Assert.assertEquals(STUDY_ID, resultGenePanelData3.getStudyId());
+        Assert.assertEquals(true, resultGenePanelData3.getSequenced());
+        Assert.assertEquals(true, resultGenePanelData3.getWholeExomeSequenced());
+        GenePanelData resultGenePanelData4 = result.get(3);
+        Assert.assertEquals(SAMPLE_ID2, resultGenePanelData4.getSampleId());
+        Assert.assertEquals(ENTREZ_GENE_ID_2, resultGenePanelData4.getEntrezGeneId());
+        Assert.assertNull(resultGenePanelData4.getGenePanelId());
+        Assert.assertEquals(MOLECULAR_PROFILE_ID, resultGenePanelData4.getMolecularProfileId());
+        Assert.assertEquals(PATIENT_ID_2, resultGenePanelData4.getPatientId());
+        Assert.assertEquals(STUDY_ID, resultGenePanelData4.getStudyId());
+        Assert.assertEquals(true, resultGenePanelData4.getSequenced());
+        Assert.assertEquals(true, resultGenePanelData4.getWholeExomeSequenced());
     }
 
     @Test
     public void fetchGenePanelData() throws Exception {
 
-        List<GenePanelData> expectedGenePanelDataList = new ArrayList<>();
+        List<GenePanelData> genePanelDataList = new ArrayList<>();
         GenePanelData genePanelData = new GenePanelData();
         genePanelData.setGenePanelId(GENE_PANEL_ID);
-        expectedGenePanelDataList.add(genePanelData);
-        List<GenePanelToGene> expectedGenePanelToGeneList = new ArrayList<>();
+        genePanelData.setMolecularProfileId(MOLECULAR_PROFILE_ID);
+        genePanelData.setSampleId(SAMPLE_ID1);
+        genePanelDataList.add(genePanelData);
+
+        List<GenePanelToGene> genePanelToGeneList = new ArrayList<>();
         GenePanelToGene genePanelToGene = new GenePanelToGene();
         genePanelToGene.setGenePanelId(GENE_PANEL_ID);
-        genePanelToGene.setEntrezGeneId(ENTREZ_GENE_ID);
-        expectedGenePanelToGeneList.add(genePanelToGene);
+        genePanelToGene.setEntrezGeneId(ENTREZ_GENE_ID_1);
+        genePanelToGeneList.add(genePanelToGene);
 
-        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(new MolecularProfile());
+        List<Gene> genes = new ArrayList<>();
+        Gene gene1 = new Gene();
+        gene1.setEntrezGeneId(ENTREZ_GENE_ID_1);
+        genes.add(gene1);
+        Gene gene2 = new Gene();
+        gene2.setEntrezGeneId(ENTREZ_GENE_ID_2);
+        genes.add(gene2);
 
+        List<MolecularProfile> molecularProfiles = new ArrayList<>();
+        MolecularProfile molecularProfile = new MolecularProfile();
+        molecularProfile.setStableId(MOLECULAR_PROFILE_ID);
+        molecularProfile.setCancerStudyIdentifier(STUDY_ID);
+        molecularProfiles.add(molecularProfile);
+
+        List<Sample> samples = new ArrayList<>();
+        Sample sample1 = new Sample();
+        sample1.setStableId(SAMPLE_ID1);
+        sample1.setPatientStableId(PATIENT_ID_1);
+        sample1.setCancerStudyIdentifier(STUDY_ID);
+        samples.add(sample1);
+        
+        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
+
+        Mockito.when(geneService.fetchGenes(Arrays.asList(String.valueOf(ENTREZ_GENE_ID_1), 
+            String.valueOf(ENTREZ_GENE_ID_2)), "ENTREZ_GENE_ID", "ID")).thenReturn(genes);
+
+        Mockito.when(molecularProfileService.getMolecularProfiles(
+            Arrays.asList(MOLECULAR_PROFILE_ID, MOLECULAR_PROFILE_ID), "SUMMARY")).thenReturn(molecularProfiles);
+
+        Mockito.when(sampleService.fetchSamples(Arrays.asList(STUDY_ID, STUDY_ID), 
+            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), "ID")).thenReturn(samples);
+        
         Mockito.when(genePanelRepository.fetchGenePanelData(MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1, SAMPLE_ID2)))
-            .thenReturn(expectedGenePanelDataList);
+            .thenReturn(genePanelDataList);
 
         Mockito.when(genePanelRepository.getGenesOfPanels(Arrays.asList(GENE_PANEL_ID)))
-            .thenReturn(expectedGenePanelToGeneList);
-
-        List<GenePanelData> result = genePanelService.fetchGenePanelData(MOLECULAR_PROFILE_ID,
-            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), Arrays.asList(ENTREZ_GENE_ID));
-
-        Assert.assertEquals(expectedGenePanelDataList, result);
-        Assert.assertEquals(1, result.size());
-        Assert.assertEquals(genePanelData, result.get(0));
-        Assert.assertEquals(1, result.get(0).getEntrezGeneIds().size());
-        Assert.assertEquals(ENTREZ_GENE_ID, result.get(0).getEntrezGeneIds().get(0));
+            .thenReturn(genePanelToGeneList);
+        
+        List<GenePanelData> result = genePanelService.fetchGenePanelData(MOLECULAR_PROFILE_ID, 
+            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), Arrays.asList(ENTREZ_GENE_ID_1, ENTREZ_GENE_ID_2));
+        
+        Assert.assertEquals(2, result.size());
+        GenePanelData resultGenePanelData1 = result.get(0);
+        Assert.assertEquals(SAMPLE_ID1, resultGenePanelData1.getSampleId());
+        Assert.assertEquals(ENTREZ_GENE_ID_1, resultGenePanelData1.getEntrezGeneId());
+        Assert.assertEquals(GENE_PANEL_ID, resultGenePanelData1.getGenePanelId());
+        Assert.assertEquals(MOLECULAR_PROFILE_ID, resultGenePanelData1.getMolecularProfileId());
+        Assert.assertEquals(PATIENT_ID_1, resultGenePanelData1.getPatientId());
+        Assert.assertEquals(STUDY_ID, resultGenePanelData1.getStudyId());
+        Assert.assertEquals(true, resultGenePanelData1.getSequenced());
+        Assert.assertEquals(false, resultGenePanelData1.getWholeExomeSequenced());
+        GenePanelData resultGenePanelData2 = result.get(1);
+        Assert.assertEquals(SAMPLE_ID1, resultGenePanelData2.getSampleId());
+        Assert.assertEquals(ENTREZ_GENE_ID_2, resultGenePanelData2.getEntrezGeneId());
+        Assert.assertEquals(GENE_PANEL_ID, resultGenePanelData2.getGenePanelId());
+        Assert.assertEquals(MOLECULAR_PROFILE_ID, resultGenePanelData2.getMolecularProfileId());
+        Assert.assertEquals(PATIENT_ID_1, resultGenePanelData2.getPatientId());
+        Assert.assertEquals(STUDY_ID, resultGenePanelData2.getStudyId());
+        Assert.assertEquals(false, resultGenePanelData2.getSequenced());
+        Assert.assertEquals(false, resultGenePanelData2.getWholeExomeSequenced());
     }
 
     @Test
     public void fetchGenePanelDataInMultipleMolecularProfiles() throws Exception {
 
-        List<GenePanelData> expectedGenePanelDataList = new ArrayList<>();
+        List<GenePanelData> genePanelDataList = new ArrayList<>();
         GenePanelData genePanelData = new GenePanelData();
         genePanelData.setGenePanelId(GENE_PANEL_ID);
-        expectedGenePanelDataList.add(genePanelData);
-        List<GenePanelToGene> expectedGenePanelToGeneList = new ArrayList<>();
+        genePanelData.setMolecularProfileId(MOLECULAR_PROFILE_ID);
+        genePanelData.setSampleId(SAMPLE_ID1);
+        genePanelDataList.add(genePanelData);
+
+        List<GenePanelToGene> genePanelToGeneList = new ArrayList<>();
         GenePanelToGene genePanelToGene = new GenePanelToGene();
         genePanelToGene.setGenePanelId(GENE_PANEL_ID);
-        genePanelToGene.setEntrezGeneId(ENTREZ_GENE_ID);
-        expectedGenePanelToGeneList.add(genePanelToGene);
+        genePanelToGene.setEntrezGeneId(ENTREZ_GENE_ID_1);
+        genePanelToGeneList.add(genePanelToGene);
 
-        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(new MolecularProfile());
+        List<Gene> genes = new ArrayList<>();
+        Gene gene = new Gene();
+        gene.setEntrezGeneId(ENTREZ_GENE_ID_1);
+        genes.add(gene);
 
+        List<MolecularProfile> molecularProfiles = new ArrayList<>();
+        MolecularProfile molecularProfile = new MolecularProfile();
+        molecularProfile.setStableId(MOLECULAR_PROFILE_ID);
+        molecularProfile.setCancerStudyIdentifier(STUDY_ID);
+        molecularProfiles.add(molecularProfile);
+
+        List<Sample> samples = new ArrayList<>();
+        Sample sample1 = new Sample();
+        sample1.setStableId(SAMPLE_ID1);
+        sample1.setPatientStableId(PATIENT_ID_1);
+        sample1.setCancerStudyIdentifier(STUDY_ID);
+        samples.add(sample1);
+        Sample sample2 = new Sample();
+        sample2.setStableId(SAMPLE_ID2);
+        sample2.setPatientStableId(PATIENT_ID_2);
+        sample2.setCancerStudyIdentifier(STUDY_ID);
+        samples.add(sample2);
+
+        Mockito.when(geneService.fetchGenes(Arrays.asList(String.valueOf(ENTREZ_GENE_ID_1), "3"), "ENTREZ_GENE_ID", 
+            "ID")).thenReturn(genes);
+
+        Mockito.when(molecularProfileService.getMolecularProfiles(
+            Arrays.asList(MOLECULAR_PROFILE_ID, MOLECULAR_PROFILE_ID), "SUMMARY")).thenReturn(molecularProfiles);
+
+        Mockito.when(sampleService.fetchSamples(Arrays.asList(STUDY_ID, STUDY_ID), 
+            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), "ID")).thenReturn(samples);
+        
         Mockito.when(genePanelRepository.fetchGenePanelDataInMultipleMolecularProfiles(
-            Arrays.asList(MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1, SAMPLE_ID2))).thenReturn(expectedGenePanelDataList);
+            Arrays.asList(MOLECULAR_PROFILE_ID, MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1, SAMPLE_ID2)))
+            .thenReturn(genePanelDataList);
 
         Mockito.when(genePanelRepository.getGenesOfPanels(Arrays.asList(GENE_PANEL_ID)))
-            .thenReturn(expectedGenePanelToGeneList);
-
+            .thenReturn(genePanelToGeneList);
+        
         List<GenePanelData> result = genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(
-            Arrays.asList(MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), Arrays.asList(ENTREZ_GENE_ID));
-
-        Assert.assertEquals(expectedGenePanelDataList, result);
-        Assert.assertEquals(1, result.size());
-        Assert.assertEquals(genePanelData, result.get(0));
-        Assert.assertEquals(1, result.get(0).getEntrezGeneIds().size());
-        Assert.assertEquals(ENTREZ_GENE_ID, result.get(0).getEntrezGeneIds().get(0));
+            Arrays.asList(MOLECULAR_PROFILE_ID, MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), 
+            Arrays.asList(ENTREZ_GENE_ID_1, 3));
+        
+        Assert.assertEquals(2, result.size());
+        GenePanelData resultGenePanelData1 = result.get(0);
+        Assert.assertEquals(SAMPLE_ID1, resultGenePanelData1.getSampleId());
+        Assert.assertEquals(ENTREZ_GENE_ID_1, resultGenePanelData1.getEntrezGeneId());
+        Assert.assertEquals(GENE_PANEL_ID, resultGenePanelData1.getGenePanelId());
+        Assert.assertEquals(MOLECULAR_PROFILE_ID, resultGenePanelData1.getMolecularProfileId());
+        Assert.assertEquals(PATIENT_ID_1, resultGenePanelData1.getPatientId());
+        Assert.assertEquals(STUDY_ID, resultGenePanelData1.getStudyId());
+        Assert.assertEquals(true, resultGenePanelData1.getSequenced());
+        Assert.assertEquals(false, resultGenePanelData1.getWholeExomeSequenced());
+        GenePanelData resultGenePanelData2 = result.get(1);
+        Assert.assertEquals(SAMPLE_ID2, resultGenePanelData2.getSampleId());
+        Assert.assertEquals(ENTREZ_GENE_ID_1, resultGenePanelData2.getEntrezGeneId());
+        Assert.assertNull(resultGenePanelData2.getGenePanelId());
+        Assert.assertEquals(MOLECULAR_PROFILE_ID, resultGenePanelData2.getMolecularProfileId());
+        Assert.assertEquals(PATIENT_ID_2, resultGenePanelData2.getPatientId());
+        Assert.assertEquals(STUDY_ID, resultGenePanelData2.getStudyId());
+        Assert.assertEquals(true, resultGenePanelData2.getSequenced());
+        Assert.assertEquals(true, resultGenePanelData2.getWholeExomeSequenced());
     }
 }

--- a/service/src/test/java/org/cbioportal/service/impl/GeneServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GeneServiceImplTest.java
@@ -61,22 +61,22 @@ public class GeneServiceImplTest extends BaseServiceImplTest {
     @Test(expected = GeneNotFoundException.class)
     public void getGeneByEntrezGeneIdNotFound() throws Exception {
 
-        Mockito.when(geneRepository.getGeneByEntrezGeneId(ENTREZ_GENE_ID)).thenReturn(null);
+        Mockito.when(geneRepository.getGeneByEntrezGeneId(ENTREZ_GENE_ID_1)).thenReturn(null);
 
-        geneService.getGene(ENTREZ_GENE_ID.toString());
+        geneService.getGene(ENTREZ_GENE_ID_1.toString());
     }
 
     @Test
     public void getGeneByEntrezGeneId() throws Exception {
 
         Gene expectedGene = new Gene();
-        Mockito.when(geneRepository.getGeneByEntrezGeneId(ENTREZ_GENE_ID)).thenReturn(expectedGene);
+        Mockito.when(geneRepository.getGeneByEntrezGeneId(ENTREZ_GENE_ID_1)).thenReturn(expectedGene);
         Mockito.doAnswer(invocationOnMock -> {
             ((Gene) invocationOnMock.getArguments()[0]).setChromosome("X");
             return null;
         }).when(chromosomeCalculator).setChromosome(expectedGene);
         
-        Gene result = geneService.getGene(ENTREZ_GENE_ID.toString());
+        Gene result = geneService.getGene(ENTREZ_GENE_ID_1.toString());
 
         Assert.assertEquals(expectedGene, result);
         Assert.assertEquals("X", result.getChromosome());
@@ -110,11 +110,11 @@ public class GeneServiceImplTest extends BaseServiceImplTest {
     public void getAliasesOfGeneByEntrezGeneId() throws Exception {
 
         Gene expectedGene = new Gene();
-        Mockito.when(geneRepository.getGeneByEntrezGeneId(ENTREZ_GENE_ID)).thenReturn(expectedGene);
+        Mockito.when(geneRepository.getGeneByEntrezGeneId(ENTREZ_GENE_ID_1)).thenReturn(expectedGene);
         List<String> expectedAliases = new ArrayList<>();
         expectedAliases.add("alias");
-        Mockito.when(geneRepository.getAliasesOfGeneByEntrezGeneId(ENTREZ_GENE_ID)).thenReturn(expectedAliases);
-        List<String> result = geneService.getAliasesOfGene(ENTREZ_GENE_ID.toString());
+        Mockito.when(geneRepository.getAliasesOfGeneByEntrezGeneId(ENTREZ_GENE_ID_1)).thenReturn(expectedAliases);
+        List<String> result = geneService.getAliasesOfGene(ENTREZ_GENE_ID_1.toString());
 
         Assert.assertEquals(expectedAliases, result);
     }
@@ -122,8 +122,8 @@ public class GeneServiceImplTest extends BaseServiceImplTest {
     @Test(expected = GeneNotFoundException.class)
     public void getAliasesOfGeneByEntrezGeneIdGeneNotFound() throws Exception {
         
-        Mockito.when(geneRepository.getGeneByEntrezGeneId(ENTREZ_GENE_ID)).thenReturn(null);
-        geneService.getAliasesOfGene(ENTREZ_GENE_ID.toString());
+        Mockito.when(geneRepository.getGeneByEntrezGeneId(ENTREZ_GENE_ID_1)).thenReturn(null);
+        geneService.getAliasesOfGene(ENTREZ_GENE_ID_1.toString());
     }
 
     @Test

--- a/service/src/test/java/org/cbioportal/service/impl/GenesetDataServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenesetDataServiceImplTest.java
@@ -76,7 +76,7 @@ public class GenesetDataServiceImplTest extends BaseServiceImplTest {
         genesetGeneticAlterationList.add(genesetGeneticAlteration);
 
         List<Integer> entrezGeneIds = new ArrayList<>();
-        entrezGeneIds.add(ENTREZ_GENE_ID);
+        entrezGeneIds.add(ENTREZ_GENE_ID_1);
         Mockito.when(geneticDataRepository.getGenesetMolecularAlterations(MOLECULAR_PROFILE_ID, Arrays.asList(GENESET_ID1, GENESET_ID2), "SUMMARY"))
             .thenReturn(genesetGeneticAlterationList);
     }

--- a/service/src/test/java/org/cbioportal/service/impl/MolecularDataServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MolecularDataServiceImplTest.java
@@ -60,12 +60,12 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
 
         List<GeneMolecularAlteration> molecularAlterationList = new ArrayList<>();
         GeneMolecularAlteration molecularAlteration = new GeneMolecularAlteration();
-        molecularAlteration.setEntrezGeneId(ENTREZ_GENE_ID);
+        molecularAlteration.setEntrezGeneId(ENTREZ_GENE_ID_1);
         molecularAlteration.setValues("0.4674,-0.3456");
         molecularAlterationList.add(molecularAlteration);
 
         List<Integer> entrezGeneIds = new ArrayList<>();
-        entrezGeneIds.add(ENTREZ_GENE_ID);
+        entrezGeneIds.add(ENTREZ_GENE_ID_1);
         Mockito.when(molecularDataRepository.getGeneMolecularAlterations(MOLECULAR_PROFILE_ID, entrezGeneIds, 
             PROJECTION)).thenReturn(molecularAlterationList);
 
@@ -74,7 +74,7 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
 
         Assert.assertEquals(1, result.size());
         GeneMolecularData molecularData = result.get(0);
-        Assert.assertEquals(ENTREZ_GENE_ID, molecularData.getEntrezGeneId());
+        Assert.assertEquals(ENTREZ_GENE_ID_1, molecularData.getEntrezGeneId());
         Assert.assertEquals(MOLECULAR_PROFILE_ID, molecularData.getMolecularProfileId());
         Assert.assertEquals(SAMPLE_ID1, molecularData.getSampleId());
         Assert.assertEquals("0.4674", molecularData.getValue());
@@ -104,12 +104,12 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
 
         List<GeneMolecularAlteration> molecularAlterationList = new ArrayList<>();
         GeneMolecularAlteration molecularAlteration = new GeneMolecularAlteration();
-        molecularAlteration.setEntrezGeneId(ENTREZ_GENE_ID);
+        molecularAlteration.setEntrezGeneId(ENTREZ_GENE_ID_1);
         molecularAlteration.setValues("0.4674,-0.3456");
         molecularAlterationList.add(molecularAlteration);
 
         List<Integer> entrezGeneIds = new ArrayList<>();
-        entrezGeneIds.add(ENTREZ_GENE_ID);
+        entrezGeneIds.add(ENTREZ_GENE_ID_1);
         Mockito.when(molecularDataRepository.getGeneMolecularAlterations(MOLECULAR_PROFILE_ID, entrezGeneIds, "ID"))
             .thenReturn(molecularAlterationList);
 
@@ -131,12 +131,12 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
 
         List<GeneMolecularAlteration> molecularAlterationList = new ArrayList<>();
         GeneMolecularAlteration molecularAlteration = new GeneMolecularAlteration();
-        molecularAlteration.setEntrezGeneId(ENTREZ_GENE_ID);
+        molecularAlteration.setEntrezGeneId(ENTREZ_GENE_ID_1);
         molecularAlteration.setValues("0.4674,-0.3456");
         molecularAlterationList.add(molecularAlteration);
 
         List<Integer> entrezGeneIds = new ArrayList<>();
-        entrezGeneIds.add(ENTREZ_GENE_ID);
+        entrezGeneIds.add(ENTREZ_GENE_ID_1);
         Mockito.when(molecularDataRepository.getGeneMolecularAlterations(MOLECULAR_PROFILE_ID, entrezGeneIds, 
             PROJECTION)).thenReturn(molecularAlterationList);
         
@@ -160,12 +160,12 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
 
         Assert.assertEquals(2, result.size());
         GeneMolecularData molecularData1 = result.get(0);
-        Assert.assertEquals(ENTREZ_GENE_ID, molecularData1.getEntrezGeneId());
+        Assert.assertEquals(ENTREZ_GENE_ID_1, molecularData1.getEntrezGeneId());
         Assert.assertEquals(MOLECULAR_PROFILE_ID, molecularData1.getMolecularProfileId());
         Assert.assertEquals(SAMPLE_ID1, molecularData1.getSampleId());
         Assert.assertEquals("0.4674", molecularData1.getValue());
         GeneMolecularData molecularData2 = result.get(1);
-        Assert.assertEquals(ENTREZ_GENE_ID, molecularData2.getEntrezGeneId());
+        Assert.assertEquals(ENTREZ_GENE_ID_1, molecularData2.getEntrezGeneId());
         Assert.assertEquals(MOLECULAR_PROFILE_ID, molecularData2.getMolecularProfileId());
         Assert.assertEquals("sample_id_2", molecularData2.getSampleId());
         Assert.assertEquals("-0.3456", molecularData2.getValue());
@@ -183,12 +183,12 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
 
         List<GeneMolecularAlteration> molecularAlterationList = new ArrayList<>();
         GeneMolecularAlteration molecularAlteration = new GeneMolecularAlteration();
-        molecularAlteration.setEntrezGeneId(ENTREZ_GENE_ID);
+        molecularAlteration.setEntrezGeneId(ENTREZ_GENE_ID_1);
         molecularAlteration.setValues("0.4674,-0.3456");
         molecularAlterationList.add(molecularAlteration);
 
         List<Integer> entrezGeneIds = new ArrayList<>();
-        entrezGeneIds.add(ENTREZ_GENE_ID);
+        entrezGeneIds.add(ENTREZ_GENE_ID_1);
         Mockito.when(molecularDataRepository.getGeneMolecularAlterations(MOLECULAR_PROFILE_ID, entrezGeneIds, "ID"))
             .thenReturn(molecularAlterationList);
 

--- a/service/src/test/java/org/cbioportal/service/impl/MrnaPercentileServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MrnaPercentileServiceImplTest.java
@@ -34,19 +34,19 @@ public class MrnaPercentileServiceImplTest extends BaseServiceImplTest {
         List<GeneMolecularData> molecularDataList = new ArrayList<>();
         GeneMolecularData molecularData1 = new GeneMolecularData();
         molecularData1.setMolecularProfileId(MOLECULAR_PROFILE_ID);
-        molecularData1.setEntrezGeneId(ENTREZ_GENE_ID);
+        molecularData1.setEntrezGeneId(ENTREZ_GENE_ID_1);
         molecularData1.setSampleId(SAMPLE_ID1);
         molecularData1.setValue("0.3456");
         molecularDataList.add(molecularData1);
         GeneMolecularData molecularData2 = new GeneMolecularData();
         molecularData2.setMolecularProfileId(MOLECULAR_PROFILE_ID);
-        molecularData2.setEntrezGeneId(ENTREZ_GENE_ID);
+        molecularData2.setEntrezGeneId(ENTREZ_GENE_ID_1);
         molecularData2.setSampleId("sample_id_2");
         molecularData2.setValue("0.2456");
         molecularDataList.add(molecularData2);
         GeneMolecularData molecularData3 = new GeneMolecularData();
         molecularData3.setMolecularProfileId(MOLECULAR_PROFILE_ID);
-        molecularData3.setEntrezGeneId(ENTREZ_GENE_ID);
+        molecularData3.setEntrezGeneId(ENTREZ_GENE_ID_1);
         molecularData3.setSampleId("sample_id_3");
         molecularData3.setValue("0.2457");
         molecularDataList.add(molecularData3);
@@ -74,7 +74,7 @@ public class MrnaPercentileServiceImplTest extends BaseServiceImplTest {
         Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
         
         List<Integer> entrezGeneIds = new ArrayList<>();
-        entrezGeneIds.add(ENTREZ_GENE_ID);
+        entrezGeneIds.add(ENTREZ_GENE_ID_1);
         entrezGeneIds.add(2);
 
         Mockito.when(molecularDataService.fetchMolecularData(MOLECULAR_PROFILE_ID, null, entrezGeneIds, 
@@ -87,7 +87,7 @@ public class MrnaPercentileServiceImplTest extends BaseServiceImplTest {
         MrnaPercentile mrnaPercentile1 = result.get(0);
         Assert.assertEquals(MOLECULAR_PROFILE_ID, mrnaPercentile1.getMolecularProfileId());
         Assert.assertEquals("sample_id_2", mrnaPercentile1.getSampleId());
-        Assert.assertEquals(ENTREZ_GENE_ID, mrnaPercentile1.getEntrezGeneId());
+        Assert.assertEquals(ENTREZ_GENE_ID_1, mrnaPercentile1.getEntrezGeneId());
         Assert.assertEquals(new BigDecimal("0.2456"), mrnaPercentile1.getzScore());
         Assert.assertEquals(new BigDecimal("33.33"), mrnaPercentile1.getPercentile());
         MrnaPercentile mrnaPercentile2 = result.get(1);

--- a/service/src/test/java/org/cbioportal/service/impl/MutationServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MutationServiceImplTest.java
@@ -45,7 +45,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         expectedMutationList.add(mutation);
 
         Mockito.when(mutationRepository.getMutationsInMolecularProfileBySampleListId(MOLECULAR_PROFILE_ID, 
-            SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID), null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION))
+            SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID_1), null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION))
             .thenReturn(expectedMutationList);
         Mockito.doAnswer(invocationOnMock -> {
             ((Gene) invocationOnMock.getArguments()[0]).setChromosome("19");
@@ -53,7 +53,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         }).when(chromosomeCalculator).setChromosome(gene);
         
         List<Mutation> result = mutationService.getMutationsInMolecularProfileBySampleListId(MOLECULAR_PROFILE_ID, 
-            SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID), null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+            SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID_1), null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
 
         Assert.assertEquals(expectedMutationList, result);
         Assert.assertEquals("19", result.get(0).getGene().getChromosome());
@@ -65,7 +65,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenThrow(
             new MolecularProfileNotFoundException(MOLECULAR_PROFILE_ID));
         mutationService.getMutationsInMolecularProfileBySampleListId(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, 
-            Arrays.asList(ENTREZ_GENE_ID), null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+            Arrays.asList(ENTREZ_GENE_ID_1), null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
     }
 
     @Test
@@ -77,9 +77,9 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         
         MutationMeta expectedMutationMeta = new MutationMeta();
         Mockito.when(mutationRepository.getMetaMutationsInMolecularProfileBySampleListId(MOLECULAR_PROFILE_ID,
-            SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID))).thenReturn(expectedMutationMeta);
+            SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID_1))).thenReturn(expectedMutationMeta);
         MutationMeta result = mutationService.getMetaMutationsInMolecularProfileBySampleListId(MOLECULAR_PROFILE_ID, 
-            SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID));
+            SAMPLE_LIST_ID, Arrays.asList(ENTREZ_GENE_ID_1));
 
         Assert.assertEquals(expectedMutationMeta, result);
     }
@@ -90,7 +90,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenThrow(
             new MolecularProfileNotFoundException(MOLECULAR_PROFILE_ID));
         mutationService.getMetaMutationsInMolecularProfileBySampleListId(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, 
-            Arrays.asList(ENTREZ_GENE_ID));
+            Arrays.asList(ENTREZ_GENE_ID_1));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         expectedMutationList.add(mutation);
 
         Mockito.when(mutationRepository.getMutationsInMultipleMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID), 
-            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID), PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, 
+            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, 
             DIRECTION)).thenReturn(expectedMutationList);
         Mockito.doAnswer(invocationOnMock -> {
             ((Gene) invocationOnMock.getArguments()[0]).setChromosome("19");
@@ -111,7 +111,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         }).when(chromosomeCalculator).setChromosome(gene);
         
         List<Mutation> result = mutationService.getMutationsInMultipleMolecularProfiles(
-            Arrays.asList(MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID), PROJECTION, 
+            Arrays.asList(MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), PROJECTION, 
             PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
 
         Assert.assertEquals(expectedMutationList, result);
@@ -123,9 +123,9 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
 
         MutationMeta expectedMutationMeta = new MutationMeta();
         Mockito.when(mutationRepository.getMetaMutationsInMultipleMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID),
-            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID))).thenReturn(expectedMutationMeta);
+            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1))).thenReturn(expectedMutationMeta);
         MutationMeta result = mutationService.getMetaMutationsInMultipleMolecularProfiles(
-            Arrays.asList(MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID));
+            Arrays.asList(MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1));
 
         Assert.assertEquals(expectedMutationMeta, result);
     }
@@ -144,7 +144,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         expectedMutationList.add(mutation);
 
         Mockito.when(mutationRepository.fetchMutationsInMolecularProfile(MOLECULAR_PROFILE_ID,
-            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID), null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, 
+            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, 
             DIRECTION)).thenReturn(expectedMutationList);
         Mockito.doAnswer(invocationOnMock -> {
             ((Gene) invocationOnMock.getArguments()[0]).setChromosome("19");
@@ -152,7 +152,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         }).when(chromosomeCalculator).setChromosome(gene);
 
         List<Mutation> result = mutationService.fetchMutationsInMolecularProfile(MOLECULAR_PROFILE_ID, 
-            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID), null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT,
+            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT,
             DIRECTION);
 
         Assert.assertEquals(expectedMutationList, result);
@@ -165,7 +165,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenThrow(
             new MolecularProfileNotFoundException(MOLECULAR_PROFILE_ID));
         mutationService.fetchMutationsInMolecularProfile(MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1),
-            Arrays.asList(ENTREZ_GENE_ID), null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+            Arrays.asList(ENTREZ_GENE_ID_1), null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
     }
 
     @Test
@@ -177,9 +177,9 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
 
         MutationMeta expectedMutationMeta = new MutationMeta();
         Mockito.when(mutationRepository.fetchMetaMutationsInMolecularProfile(MOLECULAR_PROFILE_ID, 
-            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID))).thenReturn(expectedMutationMeta);
+            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1))).thenReturn(expectedMutationMeta);
         MutationMeta result = mutationService.fetchMetaMutationsInMolecularProfile(MOLECULAR_PROFILE_ID, 
-            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID));
+            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1));
 
         Assert.assertEquals(expectedMutationMeta, result);
     }
@@ -190,7 +190,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenThrow(
             new MolecularProfileNotFoundException(MOLECULAR_PROFILE_ID));
         mutationService.fetchMetaMutationsInMolecularProfile(MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1),
-            Arrays.asList(ENTREZ_GENE_ID));
+            Arrays.asList(ENTREZ_GENE_ID_1));
     }
 
     @Test
@@ -205,10 +205,10 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         expectedMutationSampleCountByGeneList.add(mutationSampleCountByGene);
         
         Mockito.when(mutationRepository.getSampleCountByEntrezGeneIdsAndSampleIds(MOLECULAR_PROFILE_ID, null,
-            Arrays.asList(ENTREZ_GENE_ID))).thenReturn(expectedMutationSampleCountByGeneList);
+            Arrays.asList(ENTREZ_GENE_ID_1))).thenReturn(expectedMutationSampleCountByGeneList);
         
         List<MutationCountByGene> result = mutationService.getSampleCountByEntrezGeneIdsAndSampleIds(
-            MOLECULAR_PROFILE_ID, null, Arrays.asList(ENTREZ_GENE_ID));
+            MOLECULAR_PROFILE_ID, null, Arrays.asList(ENTREZ_GENE_ID_1));
         
         Assert.assertEquals(expectedMutationSampleCountByGeneList, result);
     }
@@ -219,7 +219,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenThrow(
             new MolecularProfileNotFoundException(MOLECULAR_PROFILE_ID));
         mutationService.getSampleCountByEntrezGeneIdsAndSampleIds(MOLECULAR_PROFILE_ID, null,
-            Arrays.asList(ENTREZ_GENE_ID));
+            Arrays.asList(ENTREZ_GENE_ID_1));
     }
 
     @Test
@@ -234,10 +234,10 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         expectedMutationPatientCountByGeneList.add(mutationPatientCountByGene);
         
         Mockito.when(mutationRepository.getPatientCountByEntrezGeneIdsAndSampleIds(MOLECULAR_PROFILE_ID, null,
-            Arrays.asList(ENTREZ_GENE_ID))).thenReturn(expectedMutationPatientCountByGeneList);
+            Arrays.asList(ENTREZ_GENE_ID_1))).thenReturn(expectedMutationPatientCountByGeneList);
         
         List<MutationCountByGene> result = mutationService.getPatientCountByEntrezGeneIdsAndSampleIds(
-            MOLECULAR_PROFILE_ID, null, Arrays.asList(ENTREZ_GENE_ID));
+            MOLECULAR_PROFILE_ID, null, Arrays.asList(ENTREZ_GENE_ID_1));
         
         Assert.assertEquals(expectedMutationPatientCountByGeneList, result);
     }
@@ -248,7 +248,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenThrow(
             new MolecularProfileNotFoundException(MOLECULAR_PROFILE_ID));
         mutationService.getPatientCountByEntrezGeneIdsAndSampleIds(MOLECULAR_PROFILE_ID, null,
-            Arrays.asList(ENTREZ_GENE_ID));
+            Arrays.asList(ENTREZ_GENE_ID_1));
     }
     
     @Test
@@ -311,11 +311,11 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
     public void fetchMutationCountsByPosition() throws Exception {
 
         MutationCountByPosition expectedMutationCountByPosition = new MutationCountByPosition();
-        Mockito.when(mutationRepository.getMutationCountByPosition(ENTREZ_GENE_ID,
+        Mockito.when(mutationRepository.getMutationCountByPosition(ENTREZ_GENE_ID_1,
             PROTEIN_POS_START, PROTEIN_POS_END)).thenReturn(expectedMutationCountByPosition);
         
         List<MutationCountByPosition> result = mutationService.fetchMutationCountsByPosition(
-            Arrays.asList(ENTREZ_GENE_ID), Arrays.asList(PROTEIN_POS_START), Arrays.asList(PROTEIN_POS_END));
+            Arrays.asList(ENTREZ_GENE_ID_1), Arrays.asList(PROTEIN_POS_START), Arrays.asList(PROTEIN_POS_END));
         
         Assert.assertEquals(1, result.size());
         Assert.assertEquals(expectedMutationCountByPosition, result.get(0));

--- a/service/src/test/java/org/cbioportal/service/impl/PatientServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/PatientServiceImplTest.java
@@ -72,23 +72,23 @@ public class PatientServiceImplTest extends BaseServiceImplTest {
     @Test(expected = PatientNotFoundException.class)
     public void getPatientInStudyPatientNotFound() throws Exception {
 
-        Mockito.when(patientRepository.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenReturn(null);
-        patientService.getPatientInStudy(STUDY_ID, PATIENT_ID);
+        Mockito.when(patientRepository.getPatientInStudy(STUDY_ID, PATIENT_ID_1)).thenReturn(null);
+        patientService.getPatientInStudy(STUDY_ID, PATIENT_ID_1);
     }
 
     @Test(expected = StudyNotFoundException.class)
     public void getPatientInStudyNotFound() throws Exception {
 
         Mockito.when(studyService.getStudy(STUDY_ID)).thenThrow(new StudyNotFoundException(STUDY_ID));
-        patientService.getPatientInStudy(STUDY_ID, PATIENT_ID);
+        patientService.getPatientInStudy(STUDY_ID, PATIENT_ID_1);
     }
 
     @Test
     public void getPatientInStudy() throws Exception {
 
         Patient expectedPatient = new Patient();
-        Mockito.when(patientRepository.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenReturn(expectedPatient);
-        Patient result = patientService.getPatientInStudy(STUDY_ID, PATIENT_ID);
+        Mockito.when(patientRepository.getPatientInStudy(STUDY_ID, PATIENT_ID_1)).thenReturn(expectedPatient);
+        Patient result = patientService.getPatientInStudy(STUDY_ID, PATIENT_ID_1);
 
         Assert.assertEquals(expectedPatient, result);
     }
@@ -100,10 +100,10 @@ public class PatientServiceImplTest extends BaseServiceImplTest {
         Patient patient = new Patient();
         expectedPatientList.add(patient);
 
-        Mockito.when(patientRepository.fetchPatients(Arrays.asList(STUDY_ID), Arrays.asList(PATIENT_ID), PROJECTION))
+        Mockito.when(patientRepository.fetchPatients(Arrays.asList(STUDY_ID), Arrays.asList(PATIENT_ID_1), PROJECTION))
             .thenReturn(expectedPatientList);
 
-        List<Patient> result = patientService.fetchPatients(Arrays.asList(STUDY_ID), Arrays.asList(PATIENT_ID),
+        List<Patient> result = patientService.fetchPatients(Arrays.asList(STUDY_ID), Arrays.asList(PATIENT_ID_1),
             PROJECTION);
 
         Assert.assertEquals(expectedPatientList, result);
@@ -113,9 +113,9 @@ public class PatientServiceImplTest extends BaseServiceImplTest {
     public void fetchMetaPatients() throws Exception {
 
         BaseMeta expectedBaseMeta = new BaseMeta();
-        Mockito.when(patientRepository.fetchMetaPatients(Arrays.asList(STUDY_ID), Arrays.asList(PATIENT_ID)))
+        Mockito.when(patientRepository.fetchMetaPatients(Arrays.asList(STUDY_ID), Arrays.asList(PATIENT_ID_1)))
             .thenReturn(expectedBaseMeta);
-        BaseMeta result = patientService.fetchMetaPatients(Arrays.asList(STUDY_ID), Arrays.asList(PATIENT_ID));
+        BaseMeta result = patientService.fetchMetaPatients(Arrays.asList(STUDY_ID), Arrays.asList(PATIENT_ID_1));
 
         Assert.assertEquals(expectedBaseMeta, result);
     }

--- a/service/src/test/java/org/cbioportal/service/impl/SampleServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/SampleServiceImplTest.java
@@ -119,14 +119,14 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
         Sample sample = new Sample();
         expectedSampleList.add(sample);
 
-        Mockito.when(sampleRepository.getAllSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID, PROJECTION, PAGE_SIZE,
+        Mockito.when(sampleRepository.getAllSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID_1, PROJECTION, PAGE_SIZE,
                 PAGE_NUMBER, SORT, DIRECTION)).thenReturn(expectedSampleList);
         Mockito.when(sampleListRepository.getAllSampleIdsInSampleList(Mockito.anyString()))
             .thenReturn(new ArrayList<>());
         Mockito.when(copyNumberSegmentRepository.fetchCopyNumberSegments(Mockito.anyListOf(String.class),
             Mockito.anyListOf(String.class), Mockito.anyString())).thenReturn(new ArrayList<>());
 
-        List<Sample> result = sampleService.getAllSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID, PROJECTION, PAGE_SIZE,
+        List<Sample> result = sampleService.getAllSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID_1, PROJECTION, PAGE_SIZE,
                 PAGE_NUMBER, SORT, DIRECTION);
 
         Assert.assertEquals(expectedSampleList, result);
@@ -135,9 +135,9 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
     @Test(expected = PatientNotFoundException.class)
     public void getAllSamplesOfPatientInStudyPatientNotFound() throws Exception {
 
-        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenThrow(new PatientNotFoundException(
-            STUDY_ID, PATIENT_ID));
-        sampleService.getAllSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, 
+        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID_1)).thenThrow(new PatientNotFoundException(
+            STUDY_ID, PATIENT_ID_1));
+        sampleService.getAllSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID_1, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, 
             DIRECTION);
     }
 
@@ -145,8 +145,8 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
     public void getMetaSamplesOfPatientInStudy() throws Exception {
 
         BaseMeta expectedBaseMeta = new BaseMeta();
-        Mockito.when(sampleRepository.getMetaSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID)).thenReturn(expectedBaseMeta);
-        BaseMeta result = sampleService.getMetaSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID);
+        Mockito.when(sampleRepository.getMetaSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID_1)).thenReturn(expectedBaseMeta);
+        BaseMeta result = sampleService.getMetaSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID_1);
 
         Assert.assertEquals(expectedBaseMeta, result);
     }
@@ -154,9 +154,9 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
     @Test(expected = PatientNotFoundException.class)
     public void getMetaSamplesOfPatientInStudyPatientNotFound() throws Exception {
         
-        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID)).thenThrow(new PatientNotFoundException(
-            STUDY_ID, PATIENT_ID));
-        sampleService.getMetaSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID);
+        Mockito.when(patientService.getPatientInStudy(STUDY_ID, PATIENT_ID_1)).thenThrow(new PatientNotFoundException(
+            STUDY_ID, PATIENT_ID_1));
+        sampleService.getMetaSamplesOfPatientInStudy(STUDY_ID, PATIENT_ID_1);
     }
 
     @Test
@@ -166,14 +166,14 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
         Sample sample = new Sample();
         expectedSampleList.add(sample);
 
-        Mockito.when(sampleRepository.getAllSamplesOfPatientsInStudy(STUDY_ID, Arrays.asList(PATIENT_ID), PROJECTION))
+        Mockito.when(sampleRepository.getAllSamplesOfPatientsInStudy(STUDY_ID, Arrays.asList(PATIENT_ID_1), PROJECTION))
             .thenReturn(expectedSampleList);
         Mockito.when(sampleListRepository.getAllSampleIdsInSampleList(Mockito.anyString()))
             .thenReturn(new ArrayList<>());
         Mockito.when(copyNumberSegmentRepository.fetchCopyNumberSegments(Mockito.anyListOf(String.class),
             Mockito.anyListOf(String.class), Mockito.anyString())).thenReturn(new ArrayList<>());
 
-        List<Sample> result = sampleService.getAllSamplesOfPatientsInStudy(STUDY_ID, Arrays.asList(PATIENT_ID), PROJECTION);
+        List<Sample> result = sampleService.getAllSamplesOfPatientsInStudy(STUDY_ID, Arrays.asList(PATIENT_ID_1), PROJECTION);
 
         Assert.assertEquals(expectedSampleList, result);
     }

--- a/service/src/test/java/org/cbioportal/service/impl/VariantCountServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/VariantCountServiceImplTest.java
@@ -56,11 +56,11 @@ public class VariantCountServiceImplTest extends BaseServiceImplTest {
         VariantCount variantCount = new VariantCount();
         expectedVariantCounts.add(variantCount);
         
-        Mockito.when(variantCountRepository.fetchVariantCounts(MOLECULAR_PROFILE_ID, Arrays.asList(ENTREZ_GENE_ID), 
+        Mockito.when(variantCountRepository.fetchVariantCounts(MOLECULAR_PROFILE_ID, Arrays.asList(ENTREZ_GENE_ID_1), 
             Arrays.asList(KEYWORD))).thenReturn(expectedVariantCounts);
         
         List<VariantCount> result = variantCountService.fetchVariantCounts(MOLECULAR_PROFILE_ID, 
-            Arrays.asList(ENTREZ_GENE_ID), Arrays.asList(KEYWORD));
+            Arrays.asList(ENTREZ_GENE_ID_1), Arrays.asList(KEYWORD));
 
         Assert.assertEquals(expectedVariantCounts, result);
         Assert.assertEquals((Integer) 5, result.get(0).getNumberOfSamples());

--- a/web/src/main/java/org/cbioportal/web/GenePanelController.java
+++ b/web/src/main/java/org/cbioportal/web/GenePanelController.java
@@ -5,7 +5,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.GenePanel;
 import org.cbioportal.model.GenePanelData;
-import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.service.GenePanelService;
 import org.cbioportal.service.exception.GenePanelNotFoundException;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;

--- a/web/src/test/java/org/cbioportal/web/GenePanelControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GenePanelControllerTest.java
@@ -42,6 +42,8 @@ public class GenePanelControllerTest {
     private static final int TEST_INTERNAL_ID_1 = 1;
     private static final String TEST_DESCRIPTION_1 = "test_description_1";
     private static final String TEST_SAMPLE_ID_1 = "test_sample_id_1";
+    private static final String TEST_PATIENT_ID_1 = "test_patient_id_1";
+    private static final String TEST_STUDY_ID_1 = "test_study_id_1";
     private static final String TEST_MOLECULAR_PROFILE_ID_1 = "test_molecular_profile_id_1";
     private static final int TEST_ENTREZ_GENE_ID_1 = 100;
     private static final String TEST_HUGO_GENE_SYMBOL_1 = "test_hugo_gene_symbol_1";
@@ -51,6 +53,8 @@ public class GenePanelControllerTest {
     private static final int TEST_INTERNAL_ID_2 = 2;
     private static final String TEST_DESCRIPTION_2 = "test_description_2";
     private static final String TEST_SAMPLE_ID_2 = "test_sample_id_2";
+    private static final String TEST_PATIENT_ID_2 = "test_patient_id_2";
+    private static final String TEST_STUDY_ID_2 = "test_study_id_2";
     private static final String TEST_MOLECULAR_PROFILE_ID_2 = "test_molecular_profile_id_2";
     private static final int TEST_ENTREZ_GENE_ID_3 = 300;
     private static final String TEST_HUGO_GENE_SYMBOL_3 = "test_hugo_gene_symbol_3";
@@ -233,13 +237,19 @@ public class GenePanelControllerTest {
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].molecularProfileId").value(TEST_MOLECULAR_PROFILE_ID_1))
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].sampleId").value(TEST_SAMPLE_ID_1))
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].genePanelId").value(TEST_GENE_PANEL_ID_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneIds[0]").value(TEST_ENTREZ_GENE_ID_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneIds[1]").value(TEST_ENTREZ_GENE_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneId").value(TEST_ENTREZ_GENE_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].patientId").value(TEST_PATIENT_ID_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].studyId").value(TEST_STUDY_ID_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].sequenced").value(true))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].wholeExomeSequenced").value(false))
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].molecularProfileId").value(TEST_MOLECULAR_PROFILE_ID_2))
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].sampleId").value(TEST_SAMPLE_ID_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].genePanelId").value(TEST_GENE_PANEL_ID_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneIds[0]").value(TEST_ENTREZ_GENE_ID_3))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneIds[1]").value(TEST_ENTREZ_GENE_ID_4));
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].genePanelId").doesNotExist())
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneId").value(TEST_ENTREZ_GENE_ID_3))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].patientId").value(TEST_PATIENT_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].studyId").value(TEST_STUDY_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].sequenced").value(true))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].wholeExomeSequenced").value(true));
     }
 
     @Test
@@ -266,13 +276,19 @@ public class GenePanelControllerTest {
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].molecularProfileId").value(TEST_MOLECULAR_PROFILE_ID_1))
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].sampleId").value(TEST_SAMPLE_ID_1))
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].genePanelId").value(TEST_GENE_PANEL_ID_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneIds[0]").value(TEST_ENTREZ_GENE_ID_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneIds[1]").value(TEST_ENTREZ_GENE_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneId").value(TEST_ENTREZ_GENE_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].patientId").value(TEST_PATIENT_ID_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].studyId").value(TEST_STUDY_ID_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].sequenced").value(true))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].wholeExomeSequenced").value(false))
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].molecularProfileId").value(TEST_MOLECULAR_PROFILE_ID_2))
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].sampleId").value(TEST_SAMPLE_ID_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].genePanelId").value(TEST_GENE_PANEL_ID_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneIds[0]").value(TEST_ENTREZ_GENE_ID_3))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneIds[1]").value(TEST_ENTREZ_GENE_ID_4));
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].genePanelId").doesNotExist())
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneId").value(TEST_ENTREZ_GENE_ID_3))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].patientId").value(TEST_PATIENT_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].studyId").value(TEST_STUDY_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].sequenced").value(true))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].wholeExomeSequenced").value(true));
     }
 
     private List<GenePanelData> createExampleGenePanelData() {
@@ -282,13 +298,20 @@ public class GenePanelControllerTest {
         genePanelData1.setGenePanelId(TEST_GENE_PANEL_ID_1);
         genePanelData1.setSampleId(TEST_SAMPLE_ID_1);
         genePanelData1.setMolecularProfileId(TEST_MOLECULAR_PROFILE_ID_1);
-        genePanelData1.setEntrezGeneIds(Arrays.asList(TEST_ENTREZ_GENE_ID_1, TEST_ENTREZ_GENE_ID_2));
+        genePanelData1.setEntrezGeneId(TEST_ENTREZ_GENE_ID_2);
+        genePanelData1.setPatientId(TEST_PATIENT_ID_1);
+        genePanelData1.setStudyId(TEST_STUDY_ID_1);
+        genePanelData1.setSequenced(true);
+        genePanelData1.setWholeExomeSequenced(false);
         genePanelDataList.add(genePanelData1);
         GenePanelData genePanelData2 = new GenePanelData();
-        genePanelData2.setGenePanelId(TEST_GENE_PANEL_ID_2);
         genePanelData2.setSampleId(TEST_SAMPLE_ID_2);
         genePanelData2.setMolecularProfileId(TEST_MOLECULAR_PROFILE_ID_2);
-        genePanelData2.setEntrezGeneIds(Arrays.asList(TEST_ENTREZ_GENE_ID_3, TEST_ENTREZ_GENE_ID_4));
+        genePanelData2.setEntrezGeneId(TEST_ENTREZ_GENE_ID_3);
+        genePanelData2.setPatientId(TEST_PATIENT_ID_2);
+        genePanelData2.setStudyId(TEST_STUDY_ID_2);
+        genePanelData2.setSequenced(true);
+        genePanelData2.setWholeExomeSequenced(true);
         genePanelDataList.add(genePanelData2);
         return genePanelDataList;
     }


### PR DESCRIPTION
Fixes https://github.com/cBioPortal/cbioportal/issues/3628
Old response type:
```
{
    "entrezGeneIds": [
      0
    ],
    "genePanelId": "string",
    "molecularProfileId": "string",
    "patientId": "string",
    "sampleId": "string",
    "studyId": "string",
    "uniquePatientKey": "string",
    "uniqueSampleKey": "string"
  }
```
New response type:
```
{
    "uniqueSampleKey": "WTAzOm5zY2xjX3VuaXRvXzIwMTY",
    "uniquePatientKey": "WTAzOm5zY2xjX3VuaXRvXzIwMTY",
    "molecularProfileId": "nsclc_unito_2016_mutations",
    "sampleId": "Y03",
    "patientId": "Y03",
    "studyId": "nsclc_unito_2016",
    "genePanelId": "NSCLC_UNITO_2016_PANEL",
    "entrezGeneId": 1,
    "sequenced": false,
    "wholeExomeSequenced": false
  }
```