### PR TITLE
Change error to warning for incorrect UniProtKB accession

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1431,10 +1431,13 @@ class MutationsExtendedValidator(Validator):
                     r'^([OPQ][0-9][A-Z0-9]{3}[0-9]|'
                     r'[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2})$',
                      value):
-                # return this as an error
-                self.extra = 'SWISSPROT value is not a UniProtKB accession.'
-                self.extra_exists = True
-                return False
+                # Return this as a warning. The cBioPortal front-end currently (1.13.2) does not use the SWISSPROT
+                # column for the Mutation Tab. It retrieves SWISSPROT accession and name based on Entrez Gene Id
+                self.logger.warning('SWISSPROT value is not a (single) UniProtKB accession. '
+                                    'Loader will try to find UniProtKB accession using Entrez gene id or '
+                                    'gene symbol.',
+                                    extra={'line_number': self.line_number, 'cause': value})
+                return True
         else:
             # format described on http://www.uniprot.org/help/entry_name
             if not re.match(
@@ -1444,12 +1447,12 @@ class MutationsExtendedValidator(Validator):
                 if ',' in value:
                     self.logger.warning('SWISSPROT value is not a single UniProtKB/Swiss-Prot name. '
                                         'Found multiple separated by a `,`. '
-                                        'Loader will try to find UniProt accession using Entrez gene id or '
+                                        'Loader will try to find UniProtKB accession using Entrez gene id or '
                                         'gene symbol.',
                                         extra={'line_number': self.line_number, 'cause': value})
                 else:
                     self.logger.warning('SWISSPROT value is not a (single) UniProtKB/Swiss-Prot name. '
-                                        'Loader will try to find UniProt accession using Entrez gene id or '
+                                        'Loader will try to find UniProtKB accession using Entrez gene id or '
                                         'gene symbol.',
                                         extra={'line_number': self.line_number, 'cause': value})
                 return True

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -939,7 +939,7 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
                       record_list[0].getMessage().lower())
 
     def test_unknown_or_invalid_swissprot(self):
-        """Test errors for invalid and unknown accessions under SWISSPROT."""
+        """Test warnings for invalid and unknown accessions under SWISSPROT."""
         self.logger.setLevel(logging.WARNING)
         record_list = self.validate(
                 'mutations/data_mutations_invalid_swissprot.maf',
@@ -950,13 +950,13 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
         record_iterator = iter(record_list)
         # used a name instead of an accession
         record = record_iterator.next()
-        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.levelno, logging.WARNING)
         self.assertEqual(record.line_number, 3)
         self.assertEqual(record.cause, 'A1CF_HUMAN')
         self.assertNotIn('portal', record.getMessage().lower())
         # neither a name nor an accession
         record = record_iterator.next()
-        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.levelno, logging.WARNING)
         self.assertEqual(record.line_number, 5)
         self.assertEqual(record.cause, 'P99999,Z9ZZZ9ZZZ9')
         self.assertNotIn('portal', record.getMessage().lower())


### PR DESCRIPTION
# What? Why?
Currently, the validator gives an error for incorrect UniProtKB accession value in SWISSPROT column. The front-end does not break because it retrieves the UniProtKB accession and name by querying MyGeneInfo and UniProt. 
(UPDATE June 2018: I believe GenomeNexus is currently queried)

Changes proposed in this pull request:
- Change error to a warning. It is still informative for the user to fix the data, although this value is currently not used.

Discussion regarding using external services or data for UniProtKB accession in https://github.com/cBioPortal/cbioportal/issues/3802