### PR TITLE
Add includeNonMutated parameter to fetch endpoints in Mutations API

### DIFF
--- a/model/src/main/java/org/cbioportal/model/Mutation.java
+++ b/model/src/main/java/org/cbioportal/model/Mutation.java
@@ -34,6 +34,8 @@ public class Mutation extends Alteration implements Serializable {
     private String driverFilterAnnotation;
     private String driverTiersFilter;
     private String driverTiersFilterAnnotation;
+    private Boolean sequenced;
+    private Boolean wildType;
     
     public String getCenter() {
         return center;
@@ -266,4 +268,20 @@ public class Mutation extends Alteration implements Serializable {
     public void setDriverTiersFilterAnnotation(String driverTiersFilterAnnotation) {
         this.driverTiersFilterAnnotation = driverTiersFilterAnnotation;
     }
+
+	public Boolean getSequenced() {
+		return sequenced;
+	}
+
+	public void setSequenced(Boolean sequenced) {
+		this.sequenced = sequenced;
+	}
+
+	public Boolean getWildType() {
+		return wildType;
+	}
+
+	public void setWildType(Boolean wildType) {
+		this.wildType = wildType;
+	}
 }

--- a/service/src/main/java/org/cbioportal/service/MutationService.java
+++ b/service/src/main/java/org/cbioportal/service/MutationService.java
@@ -10,52 +10,42 @@ import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import java.util.List;
 
 public interface MutationService {
-    
+
     List<Mutation> getMutationsInMolecularProfileBySampleListId(String molecularProfileId, String sampleListId,
-                                                                List<Integer> entrezGeneIds, Boolean snpOnly,
-                                                                String projection, Integer pageSize, Integer pageNumber,
-                                                                String sortBy, String direction) 
-        throws MolecularProfileNotFoundException;
+            List<Integer> entrezGeneIds, Boolean snpOnly, Boolean includeNonMutated, String projection,
+            Integer pageSize, Integer pageNumber, String sortBy, String direction)
+            throws MolecularProfileNotFoundException;
 
     MutationMeta getMetaMutationsInMolecularProfileBySampleListId(String molecularProfileId, String sampleListId,
-                                                                  List<Integer> entrezGeneIds) 
-        throws MolecularProfileNotFoundException;
+            List<Integer> entrezGeneIds, Boolean includeNonMutated) throws MolecularProfileNotFoundException;
 
     List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
-                                                           List<Integer> entrezGeneIds, String projection,
-                                                           Integer pageSize, Integer pageNumber,
-                                                           String sortBy, String direction);
+            List<Integer> entrezGeneIds, Boolean includeNonMutated, String projection, Integer pageSize,
+            Integer pageNumber, String sortBy, String direction);
 
     MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
-                                                             List<Integer> entrezGeneIds);
+            List<Integer> entrezGeneIds, Boolean includeNonMutated);
 
     List<Mutation> fetchMutationsInMolecularProfile(String molecularProfileId, List<String> sampleIds,
-                                                    List<Integer> entrezGeneIds, Boolean snpOnly, String projection,
-                                                    Integer pageSize, Integer pageNumber, String sortBy, 
-                                                    String direction) 
-        throws MolecularProfileNotFoundException;
+            List<Integer> entrezGeneIds, Boolean snpOnly, Boolean includeNonMutated, String projection,
+            Integer pageSize, Integer pageNumber, String sortBy, String direction)
+            throws MolecularProfileNotFoundException;
 
     MutationMeta fetchMetaMutationsInMolecularProfile(String molecularProfileId, List<String> sampleIds,
-                                                      List<Integer> entrezGeneIds) 
-        throws MolecularProfileNotFoundException;
+            List<Integer> entrezGeneIds, Boolean includeNonMutated) throws MolecularProfileNotFoundException;
 
     List<MutationCountByGene> getSampleCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
-                                                                        List<String> sampleIds,
-                                                                        List<Integer> entrezGeneIds)
-        throws MolecularProfileNotFoundException;
+            List<String> sampleIds, List<Integer> entrezGeneIds) throws MolecularProfileNotFoundException;
 
     List<MutationCountByGene> getPatientCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
-                                                                        List<String> patientIds,
-                                                                        List<Integer> entrezGeneIds)
-        throws MolecularProfileNotFoundException;
+            List<String> patientIds, List<Integer> entrezGeneIds) throws MolecularProfileNotFoundException;
 
-    List<MutationCount> getMutationCountsInMolecularProfileBySampleListId(String molecularProfileId, String sampleListId) 
-        throws MolecularProfileNotFoundException;
+    List<MutationCount> getMutationCountsInMolecularProfileBySampleListId(String molecularProfileId,
+            String sampleListId) throws MolecularProfileNotFoundException;
 
-    List<MutationCount> fetchMutationCountsInMolecularProfile(String molecularProfileId, List<String> sampleIds) 
-        throws MolecularProfileNotFoundException;
+    List<MutationCount> fetchMutationCountsInMolecularProfile(String molecularProfileId, List<String> sampleIds)
+            throws MolecularProfileNotFoundException;
 
-    List<MutationCountByPosition> fetchMutationCountsByPosition(List<Integer> entrezGeneIds, 
-                                                                List<Integer> proteinPosStarts, 
-                                                                List<Integer> proteinPosEnds);
+    List<MutationCountByPosition> fetchMutationCountsByPosition(List<Integer> entrezGeneIds,
+            List<Integer> proteinPosStarts, List<Integer> proteinPosEnds);
 }

--- a/service/src/main/java/org/cbioportal/service/impl/MutationEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationEnrichmentServiceImpl.java
@@ -46,7 +46,7 @@ public class MutationEnrichmentServiceImpl implements MutationEnrichmentService 
             mutationCountByGeneList = mutationService.getSampleCountByEntrezGeneIdsAndSampleIds(molecularProfileId, 
                 allIds, null);
             mutations = mutationService.fetchMutationsInMolecularProfile(molecularProfileId, alteredIds, null, null, 
-                "ID", null, null, null, null);
+                false, "ID", null, null, null, null);
         } else {
             mutationCountByGeneList = mutationService.getPatientCountByEntrezGeneIdsAndSampleIds(molecularProfileId,
                 allIds, null);
@@ -54,8 +54,8 @@ public class MutationEnrichmentServiceImpl implements MutationEnrichmentService 
             List<Sample> sampleList = sampleService.getAllSamplesOfPatientsInStudy(
                 molecularProfile.getCancerStudyIdentifier(), alteredIds, "ID");
             mutations = mutationService.fetchMutationsInMolecularProfile(molecularProfileId,
-                sampleList.stream().map(Sample::getStableId).collect(Collectors.toList()), null, null, "ID", null, null,
-                null, null);
+                sampleList.stream().map(Sample::getStableId).collect(Collectors.toList()), null, null, false, "ID", 
+                null, null, null, null);
         }
 
         return alterationEnrichmentUtil.createAlterationEnrichments(alteredIds.size(), unalteredIds.size(),

--- a/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
@@ -2,7 +2,11 @@ package org.cbioportal.service.impl;
 
 import org.cbioportal.model.*;
 import org.cbioportal.model.meta.MutationMeta;
+import org.cbioportal.persistence.GeneRepository;
 import org.cbioportal.persistence.MutationRepository;
+import org.cbioportal.persistence.SampleListRepository;
+import org.cbioportal.persistence.mybatis.util.OffsetCalculator;
+import org.cbioportal.service.GenePanelService;
 import org.cbioportal.service.MolecularProfileService;
 import org.cbioportal.service.MutationService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
@@ -12,7 +16,10 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 @Service
 public class MutationServiceImpl implements MutationService {
@@ -23,14 +30,22 @@ public class MutationServiceImpl implements MutationService {
     private MolecularProfileService molecularProfileService;
     @Autowired
     private ChromosomeCalculator chromosomeCalculator;
+    @Autowired
+    private GenePanelService genePanelService;
+    @Autowired
+    private SampleListRepository sampleListRepository;
+    @Autowired
+    private GeneRepository geneRepository;
+    @Autowired
+    private OffsetCalculator offsetCalculator;
 
     @Override
     @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<Mutation> getMutationsInMolecularProfileBySampleListId(String molecularProfileId, String sampleListId,
                                                                        List<Integer> entrezGeneIds, Boolean snpOnly,
-                                                                       String projection, Integer pageSize,
-                                                                       Integer pageNumber, String sortBy,
-                                                                       String direction)
+                                                                       Boolean includeNonMutated, String projection, 
+                                                                       Integer pageSize, Integer pageNumber, 
+                                                                       String sortBy, String direction)
         throws MolecularProfileNotFoundException {
 
         validateMolecularProfile(molecularProfileId);
@@ -38,17 +53,30 @@ public class MutationServiceImpl implements MutationService {
         List<Mutation> mutationList = mutationRepository.getMutationsInMolecularProfileBySampleListId(molecularProfileId,
             sampleListId, entrezGeneIds, snpOnly, projection, pageSize, pageNumber, sortBy, direction);
 
-        mutationList.forEach(mutation -> chromosomeCalculator.setChromosome(mutation.getGene()));
-        return mutationList;
+        List<String> sampleIds = sampleListRepository.getAllSampleIdsInSampleList(sampleListId);
+        List<String> molecularProfileIds = new ArrayList<>();
+        sampleIds.forEach(s -> molecularProfileIds.add(molecularProfileId));
+
+        return createMutationData(mutationList, molecularProfileIds, sampleIds, entrezGeneIds, includeNonMutated, 
+            projection, pageSize, pageNumber);
     }
 
     @Override
     @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
-    public MutationMeta getMetaMutationsInMolecularProfileBySampleListId(String molecularProfileId, String sampleListId,
-                                                                         List<Integer> entrezGeneIds)
+    public MutationMeta getMetaMutationsInMolecularProfileBySampleListId(String molecularProfileId, 
+                                                                         String sampleListId, 
+                                                                         List<Integer> entrezGeneIds,
+                                                                         Boolean includeNonMutated)
         throws MolecularProfileNotFoundException {
 
         validateMolecularProfile(molecularProfileId);
+
+        if (includeNonMutated != null && includeNonMutated) {
+            MutationMeta mutationMeta = new MutationMeta();
+            mutationMeta.setTotalCount(getMutationsInMolecularProfileBySampleListId(molecularProfileId, sampleListId, 
+                entrezGeneIds, false, true, "ID", null, null, null, null).size());
+            return mutationMeta;
+        }
 
         return mutationRepository.getMetaMutationsInMolecularProfileBySampleListId(molecularProfileId, sampleListId,
             entrezGeneIds);
@@ -58,21 +86,30 @@ public class MutationServiceImpl implements MutationService {
     @PreAuthorize("hasPermission(#molecularProfileIds, 'List<MolecularProfileId>', 'read')")
     public List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
                                                                   List<String> sampleIds, List<Integer> entrezGeneIds, 
-                                                                  String projection, Integer pageSize, 
-                                                                  Integer pageNumber, String sortBy, String direction) {
+                                                                  Boolean includeNonMutated, String projection, 
+                                                                  Integer pageSize, Integer pageNumber, String sortBy, 
+                                                                  String direction) {
 
         List<Mutation> mutationList = mutationRepository.getMutationsInMultipleMolecularProfiles(molecularProfileIds,
             sampleIds, entrezGeneIds, projection, pageSize, pageNumber, sortBy, direction);
 
-        mutationList.forEach(mutation -> chromosomeCalculator.setChromosome(mutation.getGene()));
-        return mutationList;
+        return createMutationData(mutationList, molecularProfileIds, sampleIds, entrezGeneIds, includeNonMutated, 
+            projection, pageSize, pageNumber);
     }
 
     @Override
     @PreAuthorize("hasPermission(#molecularProfileIds, 'List<MolecularProfileId>', 'read')")
-    public MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
+    public MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                     List<String> sampleIds, 
-                                                                    List<Integer> entrezGeneIds) {
+                                                                    List<Integer> entrezGeneIds, 
+                                                                    Boolean includeNonMutated) {
+
+        if (includeNonMutated != null && includeNonMutated) {
+            MutationMeta mutationMeta = new MutationMeta();
+            mutationMeta.setTotalCount(getMutationsInMultipleMolecularProfiles(molecularProfileIds, sampleIds, 
+                entrezGeneIds, true, "ID", null, null, null, null).size());
+            return mutationMeta;
+        }
 
         return mutationRepository.getMetaMutationsInMultipleMolecularProfiles(molecularProfileIds, sampleIds,
             entrezGeneIds);
@@ -82,8 +119,9 @@ public class MutationServiceImpl implements MutationService {
     @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<Mutation> fetchMutationsInMolecularProfile(String molecularProfileId, List<String> sampleIds,
                                                            List<Integer> entrezGeneIds, Boolean snpOnly,
-                                                           String projection, Integer pageSize, Integer pageNumber,
-                                                           String sortBy, String direction)
+                                                           Boolean includeNonMutated, String projection, 
+                                                           Integer pageSize, Integer pageNumber, String sortBy, 
+                                                           String direction)
         throws MolecularProfileNotFoundException {
 
         validateMolecularProfile(molecularProfileId);
@@ -91,17 +129,27 @@ public class MutationServiceImpl implements MutationService {
         List<Mutation> mutationList = mutationRepository.fetchMutationsInMolecularProfile(molecularProfileId, sampleIds,
             entrezGeneIds, snpOnly, projection, pageSize, pageNumber, sortBy, direction);
 
-        mutationList.forEach(mutation -> chromosomeCalculator.setChromosome(mutation.getGene()));
-        return mutationList;
+        List<String> molecularProfileIds = new ArrayList<>();
+        sampleIds.forEach(s -> molecularProfileIds.add(molecularProfileId));
+
+        return createMutationData(mutationList, molecularProfileIds, sampleIds, entrezGeneIds, includeNonMutated, 
+            projection, pageSize, pageNumber);
     }
 
     @Override
     @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public MutationMeta fetchMetaMutationsInMolecularProfile(String molecularProfileId, List<String> sampleIds,
-                                                             List<Integer> entrezGeneIds)
+                                                             List<Integer> entrezGeneIds, Boolean includeNonMutated)
         throws MolecularProfileNotFoundException {
 
         validateMolecularProfile(molecularProfileId);
+
+        if (includeNonMutated != null && includeNonMutated) {
+            MutationMeta mutationMeta = new MutationMeta();
+            mutationMeta.setTotalCount(fetchMutationsInMolecularProfile(molecularProfileId, sampleIds, 
+                entrezGeneIds, false, true, "ID", null, null, null, null).size());
+            return mutationMeta;
+        }
 
         return mutationRepository.fetchMetaMutationsInMolecularProfile(molecularProfileId, sampleIds, entrezGeneIds);
     }
@@ -178,5 +226,65 @@ public class MutationServiceImpl implements MutationService {
 
             throw new MolecularProfileNotFoundException(molecularProfileId);
         }
+    }
+
+    private List<Mutation> createMutationData(List<Mutation> mutationList, List<String> molecularProfileIds, 
+        List<String> sampleIds, List<Integer> entrezGeneIds, Boolean includeNonMutated, String projection, 
+        Integer pageSize, Integer pageNumber) {
+
+        Set<Integer> mutationKeys = new HashSet<>();
+
+        mutationList.forEach(mutation -> {
+            chromosomeCalculator.setChromosome(mutation.getGene());
+            mutation.setSequenced(true);
+            mutation.setWildType(false);
+        });
+
+        if (includeNonMutated != null && includeNonMutated && entrezGeneIds != null) {
+
+            mutationList.forEach(mutation -> {
+                mutationKeys.add(Objects.hash(mutation.getSampleId(), mutation.getMolecularProfileId(), 
+                    mutation.getEntrezGeneId()));
+            });
+
+            List<GenePanelData> genePanelDataList = genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(
+                molecularProfileIds, sampleIds, entrezGeneIds);
+
+            genePanelDataList.forEach(genePanelData -> {
+                if (!genePanelData.getSequenced()) {
+                    Mutation mutation = createMutationFromGenePanelData(genePanelData, projection);
+                    mutation.setSequenced(false);
+                    mutation.setWildType(false);
+                    mutationList.add(mutation);
+                } else if (!mutationKeys.contains(Objects.hash(genePanelData.getSampleId(), 
+                    genePanelData.getMolecularProfileId(), genePanelData.getEntrezGeneId()))) {
+                    Mutation mutation = createMutationFromGenePanelData(genePanelData, projection);
+                    mutation.setWildType(true);
+                    mutation.setSequenced(true);
+                    mutationList.add(mutation);
+                }
+            });
+
+            Integer offset = offsetCalculator.calculate(pageSize, pageNumber);
+            if (offset != null && offset + pageSize <= mutationList.size()) {
+                return mutationList.subList(offset, offset + pageSize);
+            }
+        }
+        
+        return mutationList;
+    }
+
+    private Mutation createMutationFromGenePanelData(GenePanelData genePanelData, String projection) {
+
+        Mutation mutation = new Mutation();
+        mutation.setStudyId(genePanelData.getStudyId());
+        mutation.setMolecularProfileId(genePanelData.getMolecularProfileId());
+        mutation.setSampleId(genePanelData.getSampleId());
+        mutation.setPatientId(genePanelData.getPatientId());
+        mutation.setEntrezGeneId(genePanelData.getEntrezGeneId());
+        if (projection == "DETAILED") {
+            mutation.setGene(geneRepository.getGeneByEntrezGeneId(mutation.getEntrezGeneId()));
+        }
+        return mutation;
     }
 }

--- a/service/src/main/java/org/cbioportal/service/impl/MutationSpectrumServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationSpectrumServiceImpl.java
@@ -26,7 +26,7 @@ public class MutationSpectrumServiceImpl implements MutationSpectrumService {
         throws MolecularProfileNotFoundException {
 
         List<Mutation> mutations = mutationService.getMutationsInMolecularProfileBySampleListId(molecularProfileId, 
-            sampleListId, null, true, "SUMMARY", null, null, null, null);
+            sampleListId, null, true, false, "SUMMARY", null, null, null, null);
         
         return createMutationSpectrums(molecularProfileId, mutations);
     }
@@ -37,7 +37,7 @@ public class MutationSpectrumServiceImpl implements MutationSpectrumService {
         throws MolecularProfileNotFoundException {
         
         List<Mutation> mutations = mutationService.fetchMutationsInMolecularProfile(molecularProfileId, sampleIds, null, 
-            true, "SUMMARY", null, null, null, null);
+            true, false, "SUMMARY", null, null, null, null);
         
         return createMutationSpectrums(molecularProfileId, mutations);
     }

--- a/service/src/main/java/org/cbioportal/service/impl/VariantCountServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/VariantCountServiceImpl.java
@@ -51,8 +51,8 @@ public class VariantCountServiceImpl implements VariantCountService {
             return sampleListService.getSampleList(
                 molecularProfile.getCancerStudyIdentifier() + SEQUENCED_LIST_SUFFIX).getSampleCount();
         } catch (SampleListNotFoundException ex) {
-            return mutationService.fetchMetaMutationsInMolecularProfile(molecularProfile.getStableId(), null, null)
-                .getSampleCount();
+            return mutationService.fetchMetaMutationsInMolecularProfile(molecularProfile.getStableId(), null, null, 
+                false).getSampleCount();
         }
 	}
 

--- a/service/src/test/java/org/cbioportal/service/impl/BaseServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/BaseServiceImplTest.java
@@ -20,6 +20,7 @@ public class BaseServiceImplTest {
     public static final String CLINICAL_DATA_TYPE = "clinical_data_type";
     public static final Integer ENTREZ_GENE_ID_1 = 1;
     public static final Integer ENTREZ_GENE_ID_2 = 2;
+    public static final Integer ENTREZ_GENE_ID_3 = 3;
     public static final String GENESET_ID1 = "geneset_id1";
     public static final String GENESET_ID2 = "geneset_id2";
     public static final String HUGO_GENE_SYMBOL = "hugo_gene_symbol";

--- a/service/src/test/java/org/cbioportal/service/impl/MutationEnrichmentServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MutationEnrichmentServiceImplTest.java
@@ -44,8 +44,8 @@ public class MutationEnrichmentServiceImplTest extends BaseServiceImplTest {
             .thenReturn(mutationSampleCountByGeneList);
         
         List<Mutation> mutations = new ArrayList<>();
-        Mockito.when(mutationService.fetchMutationsInMolecularProfile(MOLECULAR_PROFILE_ID, alteredSampleIds, null, null, 
-            "ID", null, null, null, null)).thenReturn(mutations);
+        Mockito.when(mutationService.fetchMutationsInMolecularProfile(MOLECULAR_PROFILE_ID, alteredSampleIds, null, 
+            null, false, "ID", null, null, null, null)).thenReturn(mutations);
         
         List<AlterationEnrichment> expectedAlterationEnrichments = new ArrayList<>(); 
         Mockito.when(alterationEnrichmentUtil.createAlterationEnrichments(2, 2, mutationSampleCountByGeneList, 

--- a/service/src/test/java/org/cbioportal/service/impl/MutationSpectrumServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MutationSpectrumServiceImplTest.java
@@ -30,7 +30,7 @@ public class MutationSpectrumServiceImplTest extends BaseServiceImplTest {
         List<Mutation> mutationList = createMutationList();
 
         Mockito.when(mutationService.getMutationsInMolecularProfileBySampleListId(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, 
-            null, true, "SUMMARY", null, null, null, null)).thenReturn(mutationList);
+            null, true, false, "SUMMARY", null, null, null, null)).thenReturn(mutationList);
         
         List<MutationSpectrum> result = mutationSpectrumService.getMutationSpectrums(MOLECULAR_PROFILE_ID, 
             SAMPLE_LIST_ID);
@@ -62,7 +62,7 @@ public class MutationSpectrumServiceImplTest extends BaseServiceImplTest {
         List<Mutation> mutationList = createMutationList();
 
         Mockito.when(mutationService.fetchMutationsInMolecularProfile(MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1, 
-            SAMPLE_ID2), null, true, "SUMMARY", null, null, null, null)).thenReturn(mutationList);
+            SAMPLE_ID2), null, true, false, "SUMMARY", null, null, null, null)).thenReturn(mutationList);
 
         List<MutationSpectrum> result = mutationSpectrumService.fetchMutationSpectrums(MOLECULAR_PROFILE_ID,
             Arrays.asList(SAMPLE_ID1, SAMPLE_ID2));

--- a/service/src/test/java/org/cbioportal/service/impl/VariantCountServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/VariantCountServiceImplTest.java
@@ -45,7 +45,7 @@ public class VariantCountServiceImplTest extends BaseServiceImplTest {
 
         MutationMeta mutationMeta = new MutationMeta();
         mutationMeta.setSampleCount(5);
-        Mockito.when(mutationService.fetchMetaMutationsInMolecularProfile(MOLECULAR_PROFILE_ID, null, null))
+        Mockito.when(mutationService.fetchMetaMutationsInMolecularProfile(MOLECULAR_PROFILE_ID, null, null, false))
             .thenReturn(mutationMeta);
 
         SampleList sampleList = new SampleList();

--- a/web/src/main/java/org/cbioportal/web/MutationController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationController.java
@@ -78,14 +78,14 @@ public class MutationController {
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();
             responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT,
-                mutationService.getMetaMutationsInMolecularProfileBySampleListId(molecularProfileId, sampleListId, null)
-                    .getTotalCount().toString());
+                mutationService.getMetaMutationsInMolecularProfileBySampleListId(molecularProfileId, sampleListId, 
+                null, false).getTotalCount().toString());
             return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
         } else {
             return new ResponseEntity<>(
-                mutationService.getMutationsInMolecularProfileBySampleListId(molecularProfileId, sampleListId, null, null,
-                    projection.name(), pageSize, pageNumber, sortBy == null ? null : sortBy.getOriginalValue(),
-                    direction.name()), HttpStatus.OK);
+                mutationService.getMutationsInMolecularProfileBySampleListId(molecularProfileId, sampleListId, null, 
+                null, false, projection.name(), pageSize, pageNumber, 
+                sortBy == null ? null : sortBy.getOriginalValue(), direction.name()), HttpStatus.OK);
         }
     }
 
@@ -97,6 +97,9 @@ public class MutationController {
         @PathVariable String molecularProfileId,
         @ApiParam(required = true, value = "List of Sample IDs/Sample List ID and Entrez Gene IDs")
         @Valid @RequestBody MutationFilter mutationFilter,
+        @ApiParam("Include non-sequenced and wild-type values in the result. Ineffective when entrezGeneIds is missing."
+            + " sortBy is ineffective when true")
+        @RequestParam(defaultValue = "false") Boolean includeNonMutated,
         @ApiParam("Level of detail of the response")
         @RequestParam(defaultValue = "SUMMARY") Projection projection,
         @ApiParam("Page size of the result list")
@@ -117,10 +120,10 @@ public class MutationController {
 
             if (mutationFilter.getSampleListId() != null) {
                 mutationMeta = mutationService.getMetaMutationsInMolecularProfileBySampleListId(molecularProfileId,
-                    mutationFilter.getSampleListId(), mutationFilter.getEntrezGeneIds());
+                    mutationFilter.getSampleListId(), mutationFilter.getEntrezGeneIds(), includeNonMutated);
             } else {
                 mutationMeta = mutationService.fetchMetaMutationsInMolecularProfile(molecularProfileId,
-                    mutationFilter.getSampleIds(), mutationFilter.getEntrezGeneIds());
+                    mutationFilter.getSampleIds(), mutationFilter.getEntrezGeneIds(), includeNonMutated);
             }
             responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, mutationMeta.getTotalCount().toString());
             return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
@@ -128,12 +131,14 @@ public class MutationController {
             List<Mutation> mutations;
             if (mutationFilter.getSampleListId() != null) {
                 mutations = mutationService.getMutationsInMolecularProfileBySampleListId(molecularProfileId,
-                    mutationFilter.getSampleListId(), mutationFilter.getEntrezGeneIds(), null, projection.name(), 
-                    pageSize, pageNumber, sortBy == null ? null : sortBy.getOriginalValue(), direction.name());
+                    mutationFilter.getSampleListId(), mutationFilter.getEntrezGeneIds(), null, includeNonMutated, 
+                    projection.name(), pageSize, pageNumber, sortBy == null ? null : sortBy.getOriginalValue(), 
+                    direction.name());
             } else {
                 mutations = mutationService.fetchMutationsInMolecularProfile(molecularProfileId,
-                    mutationFilter.getSampleIds(), mutationFilter.getEntrezGeneIds(), null, projection.name(), pageSize,
-                    pageNumber, sortBy == null ? null : sortBy.getOriginalValue(), direction.name());
+                    mutationFilter.getSampleIds(), mutationFilter.getEntrezGeneIds(), null, includeNonMutated, 
+                    projection.name(), pageSize, pageNumber, sortBy == null ? null : sortBy.getOriginalValue(), 
+                    direction.name());
             }
 
             return new ResponseEntity<>(mutations, HttpStatus.OK);
@@ -146,6 +151,9 @@ public class MutationController {
     public ResponseEntity<List<Mutation>> fetchMutationsInMultipleMolecularProfiles(
         @ApiParam(required = true, value = "List of Molecular Profile ID and Sample ID pairs and Entrez Gene IDs")
         @Valid @RequestBody MutationMultipleStudyFilter mutationMultipleStudyFilter,
+        @ApiParam("Include non-sequenced and wild-type values in the result. Ineffective when entrezGeneIds is missing."
+            + " sortBy is ineffective when true")
+        @RequestParam(defaultValue = "false") Boolean includeNonMutated,
         @ApiParam("Level of detail of the response")
         @RequestParam(defaultValue = "SUMMARY") Projection projection,
         @ApiParam("Page size of the result list")
@@ -167,14 +175,14 @@ public class MutationController {
             if (mutationMultipleStudyFilter.getMolecularProfileIds() != null) {
                 mutationMeta = mutationService.getMetaMutationsInMultipleMolecularProfiles(
                     mutationMultipleStudyFilter.getMolecularProfileIds(), null, 
-                    mutationMultipleStudyFilter.getEntrezGeneIds());
+                    mutationMultipleStudyFilter.getEntrezGeneIds(), includeNonMutated);
             } else {
 
                 List<String> molecularProfileIds = new ArrayList<>();
                 List<String> sampleIds = new ArrayList<>();
                 extractMolecularProfileAndSampleIds(mutationMultipleStudyFilter, molecularProfileIds, sampleIds);
                 mutationMeta = mutationService.getMetaMutationsInMultipleMolecularProfiles(molecularProfileIds,
-                    sampleIds, mutationMultipleStudyFilter.getEntrezGeneIds());
+                    sampleIds, mutationMultipleStudyFilter.getEntrezGeneIds(), includeNonMutated);
             }
             responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, mutationMeta.getTotalCount().toString());
             return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
@@ -183,16 +191,16 @@ public class MutationController {
             if (mutationMultipleStudyFilter.getMolecularProfileIds() != null) {
                 mutations = mutationService.getMutationsInMultipleMolecularProfiles(
                     mutationMultipleStudyFilter.getMolecularProfileIds(), null, 
-                    mutationMultipleStudyFilter.getEntrezGeneIds(), projection.name(), pageSize, pageNumber, 
-                    sortBy == null ? null : sortBy.getOriginalValue(), direction.name());
+                    mutationMultipleStudyFilter.getEntrezGeneIds(), includeNonMutated, projection.name(), pageSize, 
+                    pageNumber, sortBy == null ? null : sortBy.getOriginalValue(), direction.name());
             } else {
 
                 List<String> molecularProfileIds = new ArrayList<>();
                 List<String> sampleIds = new ArrayList<>();
                 extractMolecularProfileAndSampleIds(mutationMultipleStudyFilter, molecularProfileIds, sampleIds);
                 mutations = mutationService.getMutationsInMultipleMolecularProfiles(molecularProfileIds,
-                    sampleIds, mutationMultipleStudyFilter.getEntrezGeneIds(), projection.name(), pageSize,
-                    pageNumber, sortBy == null ? null : sortBy.getOriginalValue(), direction.name());
+                    sampleIds, mutationMultipleStudyFilter.getEntrezGeneIds(), includeNonMutated, projection.name(), 
+                    pageSize, pageNumber, sortBy == null ? null : sortBy.getOriginalValue(), direction.name());
             }
 
             return new ResponseEntity<>(mutations, HttpStatus.OK);
@@ -223,8 +231,8 @@ public class MutationController {
         @Size(min = 1, max = MUTATION_MAX_PAGE_SIZE)
         @RequestBody List<String> sampleIds) throws MolecularProfileNotFoundException {
 
-        return new ResponseEntity<>(mutationService.fetchMutationCountsInMolecularProfile(molecularProfileId, sampleIds), 
-            HttpStatus.OK);
+        return new ResponseEntity<>(mutationService.fetchMutationCountsInMolecularProfile(molecularProfileId, 
+            sampleIds), HttpStatus.OK);
     }
 
     @RequestMapping(value = "/mutation-counts-by-position/fetch", method = RequestMethod.POST,

--- a/web/src/main/java/org/cbioportal/web/parameter/GenePanelDataFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/GenePanelDataFilter.java
@@ -1,6 +1,7 @@
 package org.cbioportal.web.parameter;
 
 import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.List;
 
@@ -9,6 +10,7 @@ public class GenePanelDataFilter {
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> sampleIds;
     private String sampleListId;
+    @NotNull
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<Integer> entrezGeneIds;
 

--- a/web/src/main/java/org/cbioportal/web/parameter/GenePanelMultipleStudyFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/GenePanelMultipleStudyFilter.java
@@ -1,6 +1,7 @@
 package org.cbioportal.web.parameter;
 
 import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.List;
 
@@ -9,6 +10,7 @@ public class GenePanelMultipleStudyFilter {
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<SampleMolecularIdentifier> sampleMolecularIdentifiers;
     private List<String> molecularProfileIds;
+    @NotNull
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<Integer> entrezGeneIds;
 

--- a/web/src/test/java/org/cbioportal/web/MutationControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MutationControllerTest.java
@@ -148,8 +148,9 @@ public class MutationControllerTest {
         List<Mutation> mutationList = createExampleMutations();
         
         Mockito.when(mutationService.getMutationsInMolecularProfileBySampleListId(Mockito.anyString(), 
-            Mockito.anyString(), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), Mockito.anyString(), 
-            Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString())).thenReturn(mutationList);
+            Mockito.anyString(), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), Mockito.anyBoolean(), 
+            Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
+            .thenReturn(mutationList);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/molecular-profiles/test_molecular_profile_id/mutations")
             .param("sampleListId", TEST_SAMPLE_LIST_ID)
@@ -235,8 +236,9 @@ public class MutationControllerTest {
         List<Mutation> mutationList = createExampleMutationsWithGene();
 
         Mockito.when(mutationService.getMutationsInMolecularProfileBySampleListId(Mockito.anyString(), 
-            Mockito.anyString(), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), Mockito.anyString(), 
-            Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString())).thenReturn(mutationList);
+            Mockito.anyString(), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), Mockito.anyBoolean(), 
+            Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
+            .thenReturn(mutationList);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/molecular-profiles/test_molecular_profile_id/mutations")
             .param("sampleListId", TEST_SAMPLE_LIST_ID)
@@ -333,7 +335,7 @@ public class MutationControllerTest {
         mutationMeta.setTotalCount(2);
 
         Mockito.when(mutationService.getMetaMutationsInMolecularProfileBySampleListId(Mockito.anyString(), 
-            Mockito.anyString(), Mockito.anyListOf(Integer.class))).thenReturn(mutationMeta);
+            Mockito.anyString(), Mockito.anyListOf(Integer.class), Mockito.anyBoolean())).thenReturn(mutationMeta);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/molecular-profiles/test_molecular_profile_id/mutations")
             .param("sampleListId", TEST_SAMPLE_LIST_ID)
@@ -348,8 +350,9 @@ public class MutationControllerTest {
         List<Mutation> mutationList = createExampleMutations();
 
         Mockito.when(mutationService.getMutationsInMultipleMolecularProfiles(Mockito.anyListOf(String.class),
-            Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyString(), Mockito.anyInt(),
-            Mockito.anyInt(), Mockito.anyString(), Mockito.anyString())).thenReturn(mutationList);
+            Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), 
+            Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
+            .thenReturn(mutationList);
 
         List<SampleMolecularIdentifier> sampleMolecularIdentifiers = new ArrayList<>();
         SampleMolecularIdentifier sampleMolecularIdentifier1 = new SampleMolecularIdentifier();
@@ -360,8 +363,12 @@ public class MutationControllerTest {
         sampleMolecularIdentifier2.setMolecularProfileId(TEST_MOLECULAR_PROFILE_STABLE_ID_2);
         sampleMolecularIdentifier2.setSampleId(TEST_SAMPLE_STABLE_ID_2);
         sampleMolecularIdentifiers.add(sampleMolecularIdentifier2);
+        List<Integer> entrezGeneIds = new ArrayList<>();
+        entrezGeneIds.add(TEST_ENTREZ_GENE_ID_1);
+        entrezGeneIds.add(TEST_ENTREZ_GENE_ID_2);
         MutationMultipleStudyFilter mutationMultipleStudyFilter = new MutationMultipleStudyFilter();
         mutationMultipleStudyFilter.setSampleMolecularIdentifiers(sampleMolecularIdentifiers);
+        mutationMultipleStudyFilter.setEntrezGeneIds(entrezGeneIds);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/mutations/fetch")
             .accept(MediaType.APPLICATION_JSON)
@@ -449,14 +456,18 @@ public class MutationControllerTest {
 
         Mockito.when(mutationService.fetchMutationsInMolecularProfile(Mockito.anyString(), 
             Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), 
-            Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
-            .thenReturn(mutationList);
+            Mockito.anyBoolean(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), 
+            Mockito.anyString())).thenReturn(mutationList);
         
         List<String> sampleIds = new ArrayList<>();
         sampleIds.add(TEST_SAMPLE_STABLE_ID_1);
         sampleIds.add(TEST_SAMPLE_STABLE_ID_2);
+        List<Integer> entrezGeneIds = new ArrayList<>();
+        entrezGeneIds.add(TEST_ENTREZ_GENE_ID_1);
+        entrezGeneIds.add(TEST_ENTREZ_GENE_ID_2);
         MutationFilter mutationFilter = new MutationFilter();
         mutationFilter.setSampleIds(sampleIds);
+        mutationFilter.setEntrezGeneIds(entrezGeneIds);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/molecular-profiles/test_molecular_profile_id/mutations/fetch")
             .accept(MediaType.APPLICATION_JSON)
@@ -544,14 +555,18 @@ public class MutationControllerTest {
 
         Mockito.when(mutationService.fetchMutationsInMolecularProfile(Mockito.anyString(),
             Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), 
-            Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
-            .thenReturn(mutationList);
+            Mockito.anyBoolean(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), 
+            Mockito.anyString())).thenReturn(mutationList);
 
         List<String> sampleIds = new ArrayList<>();
         sampleIds.add(TEST_SAMPLE_STABLE_ID_1);
         sampleIds.add(TEST_SAMPLE_STABLE_ID_2);
+        List<Integer> entrezGeneIds = new ArrayList<>();
+        entrezGeneIds.add(TEST_ENTREZ_GENE_ID_1);
+        entrezGeneIds.add(TEST_ENTREZ_GENE_ID_2);
         MutationFilter mutationFilter = new MutationFilter();
         mutationFilter.setSampleIds(sampleIds);
+        mutationFilter.setEntrezGeneIds(entrezGeneIds);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/molecular-profiles/test_molecular_profile_id/mutations/fetch")
             .param("projection", "DETAILED")
@@ -650,13 +665,18 @@ public class MutationControllerTest {
         mutationMeta.setTotalCount(2);
 
         Mockito.when(mutationService.fetchMetaMutationsInMolecularProfile(Mockito.anyString(), 
-            Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class))).thenReturn(mutationMeta);
+            Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyBoolean()))
+            .thenReturn(mutationMeta);
 
         List<String> sampleIds = new ArrayList<>();
         sampleIds.add(TEST_SAMPLE_STABLE_ID_1);
         sampleIds.add(TEST_SAMPLE_STABLE_ID_2);
+        List<Integer> entrezGeneIds = new ArrayList<>();
+        entrezGeneIds.add(TEST_ENTREZ_GENE_ID_1);
+        entrezGeneIds.add(TEST_ENTREZ_GENE_ID_2);
         MutationFilter mutationFilter = new MutationFilter();
         mutationFilter.setSampleIds(sampleIds);
+        mutationFilter.setEntrezGeneIds(entrezGeneIds);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/molecular-profiles/test_molecular_profile_id/mutations/fetch")
             .param("projection", "META")


### PR DESCRIPTION
Default by `false`. When `true`, the endpoints will also return data for non-sequenced and wild-type combinations.
Added `sequenced` and `wildType` fields to the response type.
Fixes https://github.com/cBioPortal/cbioportal/issues/3351