### PR TITLE
Update documentation on the location of study staging files.

### DIFF
--- a/docs/Data-Loading.md
+++ b/docs/Data-Loading.md
@@ -56,4 +56,4 @@ To load the data into cBioPortal, the [metaImport script](Using-the-metaImport-s
 To remove a study, the [cbioportalImporter script](Development,-debugging-and-maintenance-mode-using-cbioportalImporter.md#deleting-a-study) can be used. 
 
 ## Example studies
-Examples for the different types of data are available on the [File Formats](File-Formats.md) page. The Provisional TCGA studies (\*\_tcga.tar.gz) from [cBioPortal Datahub](https://github.com/cBioPortal/datahub/tree/master/public) are complete studies that can be used as reference when creating data files.
+Examples for the different types of data are available on the [File Formats](File-Formats.md) page. The Provisional TCGA studies, downloadable from the [Data Sets section](http://www.cbioportal.org/data_sets.jsp) are complete studies that can be used as reference when creating data files.

--- a/docs/Downloads.md
+++ b/docs/Downloads.md
@@ -1,24 +1,20 @@
 * [Introduction](#introduction)
 * [Seed Database](#seed-database)
-* [MAF Example](#maf-example)
-* [Public Study Data](#public-study-data)
+* [Study staging files](#study-staging-files)
+* [Complete cBioPortal database](#complete-cbioportal-database)
 
 # Introduction
-
 This page describes the various files available for download.
 
 # Seed Database
-
 The seed database is a MySQL dump for seeding a new instance of the cBioPortal. Instructions for loading the seed database can be found [here](Import-the-Seed-Database.md). The seed database for human can be downloaded from [cBioPortal Datahub](https://github.com/cBioPortal/datahub/tree/master/seedDB). A mouse version can be found [here](https://github.com/cBioPortal/datahub/tree/master/seedDB_mouse).
 
-# MAF Example
+# Study staging files
+Staging files for the studies on cbioportal.org can be download from the [Data Sets section](http://www.cbioportal.org/data_sets.jsp). These studies can be validated and loaded in a local cBioPortal instances using the [validator and importer](https://github.com/cBioPortal/cbioportal/blob/master/docs/Data-Loading.md). Any issues with a downloaded study can be reported on [cBioPortal DataHub](https://github.com/cBioPortal/datahub/).
 
-This is an example of the file format used to import mutation data into the cBioPortal.  It is derived from the [Mutation Annotation Format](https://wiki.nci.nih.gov/display/TCGA/Mutation+Annotation+Format+%28MAF%29+Specification) created as part of the [TCGA](https://wiki.nci.nih.gov/display/TCGA/TCGA+Home) project. The example MAF file is part of the cBioPortal test study and available here:
+#### Example studies
+TCGA Provisional studies often contain many different data types. These are excellent examples to use as reference when creating your own staging files. A detailed description on supported data types can be found in the [File Formats documentation](File-Formats.md).
 
-[brca_tcga_pub.maf](https://github.com/cBioPortal/cbioportal/blob/master/core/src/test/scripts/test_data/study_es_0/brca_tcga_pub.maf)
-
-[vcf2maf](https://github.com/mskcc/vcf2maf) can be used to convert a VCF to MAF. More information on the MAF format used in cBioPortal can be found on the [File Formats](File-Formats.md#mutation-data) page.
-
-# Public Study Data
-
-Staging files for the studies on [www.cbioportal.org][www.cbioportal.org] are available on [cBioPortal Datahub](https://github.com/cBioPortal/datahub/tree/master/public). The Provisional TCGA studies (\*\_tcga.tar.gz) are complete studies which can be used as reference when creating cBioPortal staging files.
+# Complete cBioPortal database
+A MySQL database dump of the complete cbioportal.org database can be found here:
+http://download.cbioportal.org/mysql-snapshots/public-portal-dump.latest.sql.gz

--- a/docs/Using-the-metaImport-script.md
+++ b/docs/Using-the-metaImport-script.md
@@ -1,7 +1,7 @@
 ## Importing Data into cBioPortal
 The metaImport script should be used to automate the process of validating and loading datasets. It also has some nice features like an extra option to only load datasets that completely pass validation (i.e. with no errors, while warnings can be explicitly allowed by the user). 
 
-####Running the metaImport Script
+#### Running the metaImport Script
 To run the metaImport script first go to the importer folder
 `<your_cbioportal_dir>/core/src/main/scripts/importer` 
 and then run the following command:
@@ -45,7 +45,7 @@ Export PORTAL_HOME, e.g.
 export PORTAL_HOME=<your_cbioportal_home_dir>
 ```
 
-and then run (this simple command only works if your cBioPortal is running at http://localhost/cbioportal - if this is not the case, follow the next example):
+and then run (this simple command only works if your cBioPortal is running at http://localhost/cbioportal - if this is not the case, follow the advanced example):
 
 ```
 ./metaImport.py -s ../../../test/scripts/test_data/study_es_0/
@@ -56,6 +56,8 @@ This example imports the study to the localhost, creates an html report and show
 ```
 ./metaImport.py -s ../../../test/scripts/test_data/study_es_0/ -u http://localhost:8080/cbioportal -html myReport.html -v
 ```
+
+By adding `-o`, warnings will be overridden and import will start after validation.
 
 ## Development / debugging mode
 For developers and specific testing purposes, an extra script, cbioportalImporter.py, is available which imports data regardless of validation results. Check [this](Development,-debugging-and-maintenance-mode-using-cbioportalImporter.md) page for more information on how to use it.


### PR DESCRIPTION
# What? Why?
As discussed in https://github.com/cBioPortal/datahub/issues/68, all study staging files will be gzipped and downloadable directly from Data Sets section. This PR updates the documentation on the location of these files. I also added a link to the complete MySQL database dump.

This PR is waiting on https://github.com/cBioPortal/cbioportal-frontend/pull/943