### PR TITLE
Fix build error on readthedocs.org

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 recommonmark==0.4.0
+sphinx==1.5.6


### PR DESCRIPTION
Set build version to 1.5.6, see:

https://github.com/sphinx-doc/sphinx/issues/3800#issuecomment-355887410

Fix #3860 