### PR TITLE
Fix issue that when query VS without filter

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
@@ -326,16 +326,23 @@ public class QueryBuilder extends HttpServlet {
                     if (errorsExist) {
                         httpServletRequest.setAttribute(QueryBuilder.USER_ERROR_MESSAGE, "Please fix the errors below.");
                     }
-                    
+
                     // Returning the list of physical studies for the shared virtual study.
                     // This is needed for the new front-end structure and keep the same behavior as result's page
                     // TODO: Modify the logic to distinguish shared virtual study and saved virtual study.
-                    if(cohortDetails != null) {
+                    if (cohortDetails != null) {
                         List<String> studies = new ArrayList<>();
-                        for(Map.Entry<String, Set<String>> map : cohortDetails.getStudySampleMap().entrySet()) {
+                        Set<String> samples = new HashSet<>();
+                        for (Map.Entry<String, Set<String>> map : cohortDetails.getStudySampleMap().entrySet()) {
                             studies.add(map.getKey());
+                            for (String sample : map.getValue()) {
+                                samples.add(map.getKey() + ":" + sample);
+                            }
                         }
                         httpServletRequest.setAttribute(CANCER_STUDY_LIST, StringUtils.join(studies, ","));
+                        if (httpServletRequest.getAttribute(CASE_IDS) == null) {
+                            httpServletRequest.setAttribute(CASE_IDS, StringUtils.join(samples, "+"));
+                        }
                     }
                     RequestDispatcher dispatcher = getServletContext().getRequestDispatcher("/WEB-INF/jsp/index.jsp");
                     dispatcher.forward(httpServletRequest, httpServletResponse);

--- a/portal/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -43,7 +43,7 @@
         (String) request.getAttribute(QueryBuilder.CANCER_STUDY_ID);
 
     String selectedSampleIds =
-        (String) request.getParameter(QueryBuilder.CASE_IDS);
+        (String) request.getAttribute(QueryBuilder.CASE_IDS);
     if (siteTitle == null) {
         siteTitle = "cBioPortal for Cancer Genomics";
     }


### PR DESCRIPTION
In this scenario, if the VS only contains partial cases from physical
studies, `All` list should not be used, instead, the partial sample ids
should be used.

Heroku: https://young-oasis-68402.herokuapp.com/
# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line can be automatically added by git if you run the `git-commit` command with the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to hotfix.
