### PR TITLE
GISTIC_TO_GENE FKC fix

### DIFF
--- a/db-scripts/src/main/resources/cgds.sql
+++ b/db-scripts/src/main/resources/cgds.sql
@@ -625,7 +625,7 @@ CREATE TABLE `gistic_to_gene` (
   `ENTREZ_GENE_ID` int(11) NOT NULL,
   PRIMARY KEY(`GISTIC_ROI_ID`, `ENTREZ_GENE_ID`),
   FOREIGN KEY (`ENTREZ_GENE_ID`) REFERENCES `gene` (`ENTREZ_GENE_ID`),
-  FOREIGN KEY (`GISTIC_ROI_ID`) REFERENCES `gistic` (`GISTIC_ROI_ID`)
+  FOREIGN KEY (`GISTIC_ROI_ID`) REFERENCES `gistic` (`GISTIC_ROI_ID`) ON DELETE CASCADE
 );
 
 -- --------------------------------------------------------
@@ -820,4 +820,4 @@ CREATE TABLE `info` (
   `GENESET_VERSION` varchar(24)
 );
 -- THIS MUST BE KEPT IN SYNC WITH db.version PROPERTY IN pom.xml
-INSERT INTO info VALUES ('2.5.0', NULL);
+INSERT INTO info VALUES ('2.6.0', NULL);

--- a/db-scripts/src/main/resources/migration.sql
+++ b/db-scripts/src/main/resources/migration.sql
@@ -445,3 +445,10 @@ ABS(c2.`SEGMENT_MEAN`) >= 0.2) / SUM(`END`-`START`)) AS `VALUE` FROM `copy_numbe
 c1.`CANCER_STUDY_ID` = cancer_study.`CANCER_STUDY_ID` GROUP BY cancer_study.`CANCER_STUDY_ID`, `SAMPLE_ID` HAVING SUM(`END`-`START`) > 0;
 
 UPDATE info SET DB_SCHEMA_VERSION="2.5.0";
+
+##version 2.6.0
+-- modify fkc for gistic_to_gene
+ALTER TABLE gistic_to_gene DROP FOREIGN KEY gistic_to_gene_ibfk_2;
+ALTER TABLE gistic_to_gene ADD CONSTRAINT `gistic_to_gene_ibfk_2` FOREIGN KEY (`GISTIC_ROI_ID`) REFERENCES `gistic` (`GISTIC_ROI_ID`) ON DELETE CASCADE;
+
+UPDATE info SET DB_SCHEMA_VERSION="2.6.0";

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
     <tomcat.catalina.scope>provided</tomcat.catalina.scope>
 
     <!-- THIS SHOULD BE KEPT IN SYNC TO VERSION IN CGDS.SQL -->
-    <db.version>2.5.0</db.version>
+    <db.version>2.6.0</db.version>
 
   </properties>
 


### PR DESCRIPTION
# What? Why?
`cancer_study` delete cascade does not propagate to `gistic_to_gene` because `gistic_to_gene` is missing the `DELETE ON CASCADE` reference to FKC on `gistic` 

Changes proposed in this pull request:
- Modify `gistic_to_gene` FKC on `gistic` to include `ON DELETE CASCADE`

# Checks
- [ ] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] Make sure your commit messages end with a Signed-off-by string (this line can be automatically added by git if you run the `git-commit` command with the `-s` option)
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging policy](../CONTRIBUTING.md#pull-request-merging-policy) and identify reviewer if you can.

If you are not part of the cBioPortal organization look at who worked on the file before you. Please use `git blame <filename>` to determine that and notify them here:

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>