### PR TITLE
Revisit of making mybatis second-level cache readOnly.

### DIFF
--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -76,11 +76,14 @@
             <property name="dataSource" ref="businessDataSource" />
         </bean>
 
+        <bean id="customObjectFactory" class="org.cbioportal.persistence.mybatis.util.CustomMyBatisObjectFactory" />
+
         <!-- define the SqlSessionFactory -->
         <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
             <property name="dataSource" ref="businessDataSource" />
             <property name="typeAliasesPackage" value="org.mskcc.cbio.portal.model" />
             <property name="typeHandlersPackage" value="org.cbioportal.persistence.mybatis.typehandler" />
+            <property name="objectFactory" ref="customObjectFactory" />
         </bean>
     </beans>
   

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/CustomMyBatisObjectFactory.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/CustomMyBatisObjectFactory.java
@@ -1,0 +1,19 @@
+package org.cbioportal.persistence.mybatis.util;
+
+import org.apache.ibatis.reflection.factory.DefaultObjectFactory;
+
+import java.util.*;
+
+public class CustomMyBatisObjectFactory extends DefaultObjectFactory {
+
+    public <T> T create(Class<T> type) {
+        String typeName = type.getName();
+        T toReturn = (T) super.create(type);
+        return (toReturn instanceof List) ? (T) new LimitedPermissionArrayList<T>() : toReturn;
+    }
+    public <T> T create(Class<T> type, List<Class<?>> constructorArgTypes, List<Object> constructorArgs) {
+        String typeName = type.getName();
+        T toReturn = (T) super.create(type, constructorArgTypes, constructorArgs);
+        return (toReturn instanceof List) ? (T) new LimitedPermissionArrayList<T>() : toReturn;
+    }
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/LimitedPermissionArrayList.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/LimitedPermissionArrayList.java
@@ -1,0 +1,62 @@
+package org.cbioportal.persistence.mybatis.util;
+
+import java.util.*;
+import java.util.function.*;
+
+public class LimitedPermissionArrayList<T> extends ArrayList<T> {
+
+    public boolean addAll(Collection<? extends T> c) {
+        System.out.println("addAll called");
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean addAll(int index, Collection<? extends T> c) {
+        System.out.println("addAll called");
+        throw new UnsupportedOperationException();
+    }
+
+    public void clear() {
+        System.out.println("clear called");
+        throw new UnsupportedOperationException();
+    }
+
+    public T remove(int index) {
+        System.out.println("remove called");
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean remove(Object o) {
+        System.out.println("LimitedPermissionArrayList:remove() called, throwing UnsupportedOperationException()");
+        throw new UnsupportedOperationException();
+    }
+    
+    public boolean removeAll(Collection<?> c) {
+        System.out.println("LimitedPermissionArrayList:removeAll() called, throwing UnsupportedOperationException()");
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean removeIf(Predicate<? super T> filter) {
+        System.out.println("LimitedPermissionArrayList:removeIF() called, throwing UnsupportedOperationException()");
+        throw new UnsupportedOperationException();
+    }
+
+    protected void removeRange(int fromIndex, int toIndex) {
+        System.out.println("LimitedPermissionArrayList:removeRange() called, throwing UnsupportedOperationException()");
+        throw new UnsupportedOperationException();
+    }
+
+    public void replaceAll(UnaryOperator<T> operator) {
+        System.out.println("LimitedPermissionArrayList:replaceAll() called, throwing UnsupportedOperationException()");
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean retainAll(Collection<?> c) {
+        System.out.println("LimitedPermissionArrayList:retainAlll() called, throwing UnsupportedOperationException()");
+        throw new UnsupportedOperationException();
+    }
+
+    public T set(int index, T element) {
+        System.out.println("LimitedPermissionArrayList:set() called, throwing UnsupportedOperationException()");
+        throw new UnsupportedOperationException();
+    }
+}

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CancerTypeMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CancerTypeMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.CancerTypeMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="select">
         type_of_cancer.TYPE_OF_CANCER_ID AS "${prefix}typeOfCancerId"

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalAttributeMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalAttributeMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.ClinicalAttributeMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="select">
         clinical_attribute_meta.ATTR_ID AS "${prefix}attrId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalDataMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.ClinicalDataMapper">
-    <cache size="100000"/>
+    <cache readOnly="true" size="100000"/>
 
     <sql id="selectSample">
         clinical_sample.INTERNAL_ID AS "${prefix}internalId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalEventMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalEventMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.ClinicalEventMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="select">
         clinical_event.CLINICAL_EVENT_ID AS clinicalEventId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CopyNumberSegmentMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CopyNumberSegmentMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.CopyNumberSegmentMapper">
-    <cache size="20000"/>
+    <cache readOnly="true" size="20000"/>
     
     <sql id="select">
         copy_number_seg.SEG_ID AS segId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CosmicCountMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/CosmicCountMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.CosmicCountMapper">
-    <cache size="50000"/>
+    <cache readOnly="true" size="50000"/>
 
     <select id="getCosmicCountsByKeywords" resultType="org.cbioportal.model.CosmicMutation">
         SELECT

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.DiscreteCopyNumberMapper">
-    <cache size="50000"/>
+    <cache readOnly="true" size="50000"/>
 
     <sql id="select">
         genetic_profile.STABLE_ID AS molecularProfileId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GeneMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GeneMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.GeneMapper">
-    <cache size="100000"/>
+    <cache readOnly="true" size="100000"/>
 
     <sql id="select">
         gene.ENTREZ_GENE_ID AS "${prefix}entrezGeneId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenePanelMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenePanelMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.GenePanelMapper">
-    <cache/>
+    <cache readOnly="true"/>
     
     <sql id="select">
         gene_panel.INTERNAL_ID AS internalId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetHierarchyMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetHierarchyMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.GenesetHierarchyMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="select">
         a.NODE_ID AS nodeId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.GenesetMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="select">
         geneset.ID AS "${prefix}internalId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.MolecularDataMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="whereInMultipleMolecularProfiles">
         <where>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularProfileMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularProfileMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.MolecularProfileMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="select">
         genetic_profile.GENETIC_PROFILE_ID AS "${prefix}molecularProfileId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.MutationMapper">
-    <cache size="100000"/>
+    <cache readOnly="true" size="100000"/>
 
     <sql id="select">
         genetic_profile.STABLE_ID AS molecularProfileId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/PatientMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/PatientMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.PatientMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="select">
         patient.INTERNAL_ID AS "${prefix}internalId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleListMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleListMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.SampleListMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="select">
         sample_list.LIST_ID AS "${prefix}listId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.SampleMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="select">
         sample.INTERNAL_ID AS "${prefix}internalId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SignificantCopyNumberRegionMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SignificantCopyNumberRegionMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.SignificantCopyNumberRegionMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="select">
         gistic.GISTIC_ROI_ID AS gisticRoiId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SignificantlyMutatedGeneMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SignificantlyMutatedGeneMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.SignificantlyMutatedGeneMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="select">
         mut_sig.ENTREZ_GENE_ID AS entrezGeneId,

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.StudyMapper">
-    <cache/>
+    <cache readOnly="true"/>
 
     <sql id="select">
         cancer_study.CANCER_STUDY_ID AS "${prefix}cancerStudyId",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/VariantCountMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/VariantCountMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.VariantCountMapper">
-    <cache/>
+    <cache readOnly="true"/>
     
     <select id="fetchVariantCounts" resultType="org.cbioportal.model.VariantCount">
         SELECT

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -15,6 +15,12 @@
             <artifactId>persistence-mybatis</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service/src/main/java/org/cbioportal/service/impl/ClinicalAttributeServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ClinicalAttributeServiceImpl.java
@@ -8,11 +8,13 @@ import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.ClinicalAttributeNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.ArrayList;
 
 @Service
 public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
@@ -21,14 +23,18 @@ public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
     private ClinicalAttributeRepository clinicalAttributeRepository;
     @Autowired
     private StudyService studyService;
+    @Value("${authenticate:false}")
+    private String AUTHENTICATE;
 
     @Override
     @PostFilter("hasPermission(filterObject.cancerStudyIdentifier, 'CancerStudy', 'read')")
     public List<ClinicalAttribute> getAllClinicalAttributes(String projection, Integer pageSize, Integer pageNumber,
                                                             String sortBy, String direction) {
-
-        return clinicalAttributeRepository.getAllClinicalAttributes(projection, pageSize, pageNumber, sortBy,
-                direction);
+        
+        List<ClinicalAttribute> clinicalAttributes = clinicalAttributeRepository.getAllClinicalAttributes(projection, pageSize, pageNumber, sortBy,
+                                                                                                          direction);
+        // copy the list before returning so @PostFilter doesn't taint the list stored in the mybatis second-level cache
+        return (AUTHENTICATE.equals("false")) ? clinicalAttributes : new ArrayList<ClinicalAttribute>(clinicalAttributes);
     }
 
     @Override

--- a/service/src/main/java/org/cbioportal/service/impl/MolecularProfileServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularProfileServiceImpl.java
@@ -8,11 +8,13 @@ import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.ArrayList;
 
 @Service
 public class MolecularProfileServiceImpl implements MolecularProfileService {
@@ -21,13 +23,17 @@ public class MolecularProfileServiceImpl implements MolecularProfileService {
     private MolecularProfileRepository molecularProfileRepository;
     @Autowired
     private StudyService studyService;
+    @Value("${authenticate:false}")
+    private String AUTHENTICATE;
 
     @Override
     @PostFilter("hasPermission(filterObject, 'read')")
     public List<MolecularProfile> getAllMolecularProfiles(String projection, Integer pageSize, Integer pageNumber,
                                                           String sortBy, String direction) {
 
-        return molecularProfileRepository.getAllMolecularProfiles(projection, pageSize, pageNumber, sortBy, direction);
+        List<MolecularProfile> molecularProfiles = molecularProfileRepository.getAllMolecularProfiles(projection, pageSize, pageNumber, sortBy, direction);
+        // copy the list before returning so @PostFilter doesn't taint the list stored in the mybatis second-level cache
+        return (AUTHENTICATE.equals("false")) ? molecularProfiles : new ArrayList<MolecularProfile>(molecularProfiles);
     }
 
     @Override

--- a/service/src/main/java/org/cbioportal/service/impl/SampleListServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleListServiceImpl.java
@@ -9,12 +9,14 @@ import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.SampleListNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,14 +26,18 @@ public class SampleListServiceImpl implements SampleListService {
     private SampleListRepository sampleListRepository;
     @Autowired
     private StudyService studyService;
+    @Value("${authenticate:false}")
+    private String AUTHENTICATE;
 
     @Override
     @PostFilter("hasPermission(filterObject, 'read')")
     public List<SampleList> getAllSampleLists(String projection, Integer pageSize, Integer pageNumber, String sortBy,
                                               String direction) {
-
-        List<SampleList> sampleLists = sampleListRepository.getAllSampleLists(projection, pageSize, pageNumber, sortBy,
-            direction);
+        
+        List<SampleList> sampleListsFromRepo = sampleListRepository.getAllSampleLists(projection, pageSize, pageNumber, sortBy,
+                                                                                      direction);
+        // copy the list before returning so @PostFilter doesn't taint the list stored in the mybatis second-level cache
+        List<SampleList> sampleLists = (AUTHENTICATE.equals("false")) ? sampleListsFromRepo : new ArrayList<SampleList>(sampleListsFromRepo);
         
         if(projection.equals("DETAILED")) {
             addSampleIds(sampleLists);

--- a/service/src/main/java/org/cbioportal/service/impl/StudyServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/StudyServiceImpl.java
@@ -6,24 +6,30 @@ import org.cbioportal.persistence.StudyRepository;
 import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.ArrayList;
 
 @Service
 public class StudyServiceImpl implements StudyService {
 
     @Autowired
     private StudyRepository studyRepository;
+    @Value("${authenticate:false}")
+    private String AUTHENTICATE;
 
     @Override
     @PostFilter("hasPermission(filterObject, 'read')")
     public List<CancerStudy> getAllStudies(String projection, Integer pageSize, Integer pageNumber,
                                            String sortBy, String direction) {
 
-        return studyRepository.getAllStudies(projection, pageSize, pageNumber, sortBy, direction);
+        List<CancerStudy> allStudies = studyRepository.getAllStudies(projection, pageSize, pageNumber, sortBy, direction);
+        // copy the list before returning so @PostFilter doesn't taint the list stored in the mybatis second-level cache
+        return (AUTHENTICATE.equals("false")) ? allStudies : new ArrayList<CancerStudy>(allStudies);
     }
 
     @Override

--- a/service/src/test/java/org/cbioportal/service/impl/ClinicalAttributeServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ClinicalAttributeServiceImplTest.java
@@ -8,11 +8,13 @@ import org.cbioportal.service.exception.ClinicalAttributeNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,6 +30,11 @@ public class ClinicalAttributeServiceImplTest extends BaseServiceImplTest {
     private ClinicalAttributeRepository clinicalAttributeRepository;
     @Mock
     private StudyService studyService;
+
+    @Before
+    public void setup() {
+        ReflectionTestUtils.setField(clinicalAttributeService, "AUTHENTICATE", "false");
+    }
     
     @Test
     public void getAllClinicalAttributes() throws Exception {

--- a/service/src/test/java/org/cbioportal/service/impl/MolecularProfileServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MolecularProfileServiceImplTest.java
@@ -8,11 +8,13 @@ import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,6 +30,11 @@ public class MolecularProfileServiceImplTest extends BaseServiceImplTest {
     private MolecularProfileRepository molecularProfileRepository;
     @Mock
     private StudyService studyService;
+
+    @Before
+    public void setup() {
+        ReflectionTestUtils.setField(molecularProfileService, "AUTHENTICATE", "false");
+    }
 
     @Test
     public void getAllMolecularProfiles() throws Exception {

--- a/service/src/test/java/org/cbioportal/service/impl/SampleListServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/SampleListServiceImplTest.java
@@ -9,11 +9,13 @@ import org.cbioportal.service.exception.SampleListNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +31,11 @@ public class SampleListServiceImplTest extends BaseServiceImplTest {
     private SampleListRepository sampleListRepository;
     @Mock
     private StudyService studyService;
+
+    @Before
+    public void setup() {
+        ReflectionTestUtils.setField(sampleListService, "AUTHENTICATE", "false");
+    }
 
     @Test
     public void getAllSampleLists() throws Exception {

--- a/service/src/test/java/org/cbioportal/service/impl/StudyServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/StudyServiceImplTest.java
@@ -6,11 +6,13 @@ import org.cbioportal.persistence.StudyRepository;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,6 +26,11 @@ public class StudyServiceImplTest extends BaseServiceImplTest {
 
     @Mock
     private StudyRepository studyRepository;
+
+    @Before
+    public void setup() {
+        ReflectionTestUtils.setField(studyService, "AUTHENTICATE", "false");
+    }
 
     @Test
     public void getAllStudies() throws Exception {


### PR DESCRIPTION
Revisit of making mybatis second-level cache readOnly.  Updates to services classes to address modification of collections in mybatis cache my spring-security.  Includes custom mybatis object factory and 'limited permission' arraylist to mitigate modification of collections returned and stored in mybatis second-level cache.

Bypasses copy of references returned from MyBatis layer in the service layer before returning to controller when authentication is turned off (no @POST_FILTER call) since it is not necessary. Also, PR does not address (intentionally) legacy MyBatis code.