### PR TITLE
Modify validation of clinical attributes

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1541,27 +1541,23 @@ class ClinicalValidator(Validator):
                       'datatype',
                       'priority')
 
-    # Attributes required to have certain properties because of hard-coded use.
-    # Note: the 'when_wrong' property (found in some attributes like METASTATIC_SITE),
-    # can be set to WARNING to indicate that only a WARNING should be given
-    # if this attribute is found in the "wrong" file (e.g. a PATIENT attribute found
-    # in a SAMPLE file or vice-versa).
+    # Only a core set of attributes must be either specific in the patient or sample clinical data.
     PREDEFINED_ATTRIBUTES = {
         'AGE': {
             'is_patient_attribute': '1',
             'datatype': 'NUMBER'
         },
         'CANCER_TYPE': {
-            'is_patient_attribute': '0',
+            'is_patient_attribute': '1',
             'datatype': 'STRING'
         },
         'CANCER_TYPE_DETAILED': {
-            'is_patient_attribute': '0',
+            'is_patient_attribute': '1',
             'datatype': 'STRING'
         },
-        'DETAILED_CANCER_TYPE': {
-            'is_patient_attribute': '0',
-            'datatype': 'STRING'
+        'DERIVED_NORMALIZED_CASE_TYPE': {
+        },
+        'DERIVED_SAMPLE_LOCATION': {
         },
         'DFS_STATUS': {
             'is_patient_attribute': '1',
@@ -1572,38 +1568,27 @@ class ClinicalValidator(Validator):
             'datatype': 'NUMBER'
         },
         'DRIVER_MUTATIONS': {
-            'is_patient_attribute': '0'
         },
         'ERG_FUSION_ACGH': {
-            'is_patient_attribute': '0'
         },
         'ETS_RAF_SPINK1_STATUS': {
-            'is_patient_attribute': '0'
         },
         'GENDER': {
             'is_patient_attribute': '1',
             'datatype': 'STRING'
         },
         'GLEASON_SCORE': {
-            'is_patient_attribute': '0',
-            'when_wrong': 'WARNING'
-        },
-        'GLEASON_SCORE_1': {
-            'is_patient_attribute': '0'
-        },
-        'GLEASON_SCORE_2': {
-            'is_patient_attribute': '0'
         },
         'HISTOLOGY': {
-            'is_patient_attribute': '0'
+            'is_patient_attribute': '1'
         },
         'KNOWN_MOLECULAR_CLASSIFIER': {
-            'is_patient_attribute': '0'
+            'is_patient_attribute': '1'
         },
         'METASTATIC_SITE': {
-            'is_patient_attribute': '0',
             'datatype': 'STRING',
-            'when_wrong': 'WARNING'
+        },
+        'MOUSE_STRAIN': {
         },
         'OS_STATUS': {
             'is_patient_attribute': '1',
@@ -1622,12 +1607,9 @@ class ClinicalValidator(Validator):
             'datatype': 'STRING'
         },
         'PRIMARY_SITE': {
-            'is_patient_attribute': '0',
             'datatype': 'STRING',
-            'when_wrong': 'WARNING'
         },
         'SAMPLE_CLASS': {
-            'is_patient_attribute': '0',
             'datatype': 'STRING'
         },
         'SAMPLE_DISPLAY_NAME': {
@@ -1635,44 +1617,33 @@ class ClinicalValidator(Validator):
             'datatype': 'STRING'
         },
         'SAMPLE_TYPE': {
-            'is_patient_attribute': '0',
             'datatype': 'STRING'
         },
         'SERUM_PSA': {
-            'is_patient_attribute': '0'
         },
         'SEX': {
             'is_patient_attribute': '1',
             'datatype': 'STRING'
         },
         'TMPRSS2_ERG_FUSION_STATUS': {
-            'is_patient_attribute': '0'
         },
         'TUMOR_GRADE': {
-            'is_patient_attribute': '0'
         },
         'TUMOR_SITE': {
-            'is_patient_attribute': '0',
             'datatype': 'STRING',
-            'when_wrong': 'WARNING'
         },
         'TUMOR_STAGE_2009': {
-            'is_patient_attribute': '0'
         },
         'TUMOR_TISSUE_SITE': {
             'is_patient_attribute': '0',
             'datatype': 'STRING',
-            'when_wrong': 'WARNING'
         },
         'TUMOR_TYPE': {
             'is_patient_attribute': '0',
             'datatype': 'STRING'
         },
-        'TYPE_OF_CANCER': {
-            'is_patient_attribute': '0',
-            'datatype': 'STRING'
-        },
     }
+
 
     def __init__(self, *args, **kwargs):
         """Initialize the instance attributes of the data file validator."""
@@ -1820,26 +1791,14 @@ class ClinicalValidator(Validator):
             if col_name in self.PREDEFINED_ATTRIBUTES:
                 for attr_property in self.PREDEFINED_ATTRIBUTES[col_name]:
                     if attr_property == 'is_patient_attribute':
-                        expected_level = \
-                            self.PREDEFINED_ATTRIBUTES[col_name][attr_property]
+                        expected_level = self.PREDEFINED_ATTRIBUTES[col_name][attr_property]
                         if self.PROP_IS_PATIENT_ATTRIBUTE != expected_level:
-                            # check if only warning should be given:
-                            if ('when_wrong' in self.PREDEFINED_ATTRIBUTES[col_name] and
-                            self.PREDEFINED_ATTRIBUTES[col_name]['when_wrong'] == 'WARNING'):
-                                self.logger.warning(
-                                    'Attribute expected to be a %s-level attribute. Some *minor* details will be '
-                                    'missing in patient/sample view for this study',
-                                    {'0': 'sample', '1': 'patient'}[expected_level],
-                                    extra={'line_number': self.line_number,
-                                           'column_number': col_index + 1,
-                                           'cause': col_name})
-                            else:
-                                self.logger.error(
-                                    'Attribute must be a %s-level attribute',
-                                    {'0': 'sample', '1': 'patient'}[expected_level],
-                                    extra={'line_number': self.line_number,
-                                           'column_number': col_index + 1,
-                                           'cause': col_name})
+                            self.logger.error(
+                                'Attribute must to be a %s-level attribute',
+                                {'0': 'sample', '1': 'patient'}[expected_level],
+                                extra={'line_number': self.line_number,
+                                       'column_number': col_index + 1,
+                                       'cause': col_name})
                     # check pre-header datatype property:
                     if attr_property == 'datatype':
                         # check pre-header metadata if applicable -- if these were

--- a/core/src/test/scripts/test_data/data_clin_order1.txt
+++ b/core/src/test/scripts/test_data/data_clin_order1.txt
@@ -1,13 +1,13 @@
-#Patient Identifier	Sample Identifier	Subtype	Cancer Type	Cancer Type Detailed
-#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.	Disease type.	Cancer Type Detailed.
-#STRING	STRING	STRING	STRING	STRING
-#1	1	1	1	1
-PATIENT_ID	SAMPLE_ID	SUBTYPE	CANCER_TYPE	CANCER_TYPE_DETAILED
-TEST-PAT1	TEST-PAT1-SAMPLE1	Luminal A	Cancer_type20	Cancer_type20_Sub16
-TEST-PAT1	TEST-PAT1-SAMPLE2	Luminal B	Cancer_type27	Cancer_type27_Sub16
-TEST-PAT1	TEST-PAT1-SAMPLE3	basal-like	Cancer_type8	Cancer_type8_Sub13
-TEST-PAT1	TEST-PAT1-SAMPLE4	basal-like	Cancer_type17	Cancer_type17_Sub10
-TEST-PAT1	TEST-PAT1-SAMPLE5	Her2 enriched	Cancer_type27	Cancer_type27_Sub18
-TEST-PAT1	TEST-PAT1-SAMPLE6	Luminal A	Cancer_type7	Cancer_type7_Sub13
-TEST-PAT2	TEST-PAT2-SAMPLE1	Luminal A	Cancer_type23	Cancer_type23_Sub3
-TEST-PAT2	TEST-PAT2-SAMPLE2	basal-like	Cancer_type7	Cancer_type7_Sub5
+#Patient Identifier	Sample Identifier	Subtype
+#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.
+#STRING	STRING	STRING
+#1	1	1
+PATIENT_ID	SAMPLE_ID	SUBTYPE
+TEST-PAT1	TEST-PAT1-SAMPLE1	Luminal A
+TEST-PAT1	TEST-PAT1-SAMPLE2	Luminal B
+TEST-PAT1	TEST-PAT1-SAMPLE3	basal-like
+TEST-PAT1	TEST-PAT1-SAMPLE4	basal-like
+TEST-PAT1	TEST-PAT1-SAMPLE5	Her2 enriched
+TEST-PAT1	TEST-PAT1-SAMPLE6	Luminal A
+TEST-PAT2	TEST-PAT2-SAMPLE1	Luminal A
+TEST-PAT2	TEST-PAT2-SAMPLE2	basal-like

--- a/core/src/test/scripts/test_data/data_clin_order2.txt
+++ b/core/src/test/scripts/test_data/data_clin_order2.txt
@@ -1,13 +1,13 @@
-#Sample Identifier	Patient Identifier	Subtype	Cancer Type	Cancer Type Detailed
-#A unique sample identifier.	Identifier to uniquely specify a patient.	Subtype description.	Disease type.	Cancer Type Detailed.
-#STRING	STRING	STRING	STRING	STRING
-#1	1	1	1	1
-SAMPLE_ID	PATIENT_ID	SUBTYPE	CANCER_TYPE	CANCER_TYPE_DETAILED
-TEST-PAT1-SAMPLE1	TEST-PAT1	Luminal A	Cancer_type20	Cancer_type20_Sub16
-TEST-PAT1-SAMPLE2	TEST-PAT1	Luminal B	Cancer_type27	Cancer_type27_Sub16
-TEST-PAT1-SAMPLE3	TEST-PAT1	basal-like	Cancer_type8	Cancer_type8_Sub13
-TEST-PAT1-SAMPLE4	TEST-PAT1	basal-like	Cancer_type17	Cancer_type17_Sub10
-TEST-PAT1-SAMPLE5	TEST-PAT1	Her2 enriched	Cancer_type27	Cancer_type27_Sub18
-TEST-PAT1-SAMPLE6	TEST-PAT1	Luminal A	Cancer_type7	Cancer_type7_Sub13
-TEST-PAT2-SAMPLE1	TEST-PAT2	Luminal A	Cancer_type23	Cancer_type23_Sub3
-TEST-PAT2-SAMPLE2	TEST-PAT2	basal-like	Cancer_type7	Cancer_type7_Sub5
+#Sample Identifier	Patient Identifier	Subtype
+#A unique sample identifier.	Identifier to uniquely specify a patient.	Subtype description.
+#STRING	STRING	STRING
+#1	1	1
+SAMPLE_ID	PATIENT_ID	SUBTYPE
+TEST-PAT1-SAMPLE1	TEST-PAT1	Luminal A
+TEST-PAT1-SAMPLE2	TEST-PAT1	Luminal B
+TEST-PAT1-SAMPLE3	TEST-PAT1	basal-like
+TEST-PAT1-SAMPLE4	TEST-PAT1	basal-like
+TEST-PAT1-SAMPLE5	TEST-PAT1	Her2 enriched
+TEST-PAT1-SAMPLE6	TEST-PAT1	Luminal A
+TEST-PAT2-SAMPLE1	TEST-PAT2	Luminal A
+TEST-PAT2-SAMPLE2	TEST-PAT2	basal-like

--- a/core/src/test/scripts/test_data/data_clin_repeated_sample.txt
+++ b/core/src/test/scripts/test_data/data_clin_repeated_sample.txt
@@ -1,14 +1,14 @@
-#Patient Identifier	Sample Identifier	Subtype	Cancer Type	Cancer Type Detailed
-#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.	Disease type.	Cancer Type Detailed.
-#STRING	STRING	STRING	STRING	STRING
-#1	1	1	1	1
-PATIENT_ID	SAMPLE_ID	SUBTYPE	CANCER_TYPE	CANCER_TYPE_DETAILED
-TEST-PAT1	TEST-PAT1-SAMPLE1	Luminal A	Cancer_type20	Cancer_type20_Sub16
-TEST-PAT1	TEST-PAT1-SAMPLE2	Luminal B	Cancer_type27	Cancer_type27_Sub16
-TEST-PAT1	TEST-PAT1-SAMPLE3	basal-like	Cancer_type8	Cancer_type8_Sub13
-TEST-PAT1	TEST-PAT1-SAMPLE4	basal-like	Cancer_type17	Cancer_type17_Sub10
-TEST-PAT1	TEST-PAT1-SAMPLE5	Her2 enriched	Cancer_type27	Cancer_type27_Sub18
-TEST-PAT1	TEST-PAT1-SAMPLE2	Luminal B	Cancer_type27	Cancer_type27_Sub16
-TEST-PAT1	TEST-PAT1-SAMPLE6	Luminal A	Cancer_type7	Cancer_type7_Sub13
-TEST-PAT2	TEST-PAT2-SAMPLE1	Luminal A	Cancer_type23	Cancer_type23_Sub3
-TEST-PAT2	TEST-PAT2-SAMPLE2	basal-like	Cancer_type7	Cancer_type7_Sub5
+#Patient Identifier	Sample Identifier	Subtype
+#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.
+#STRING	STRING	STRING
+#1	1	1
+PATIENT_ID	SAMPLE_ID	SUBTYPE
+TEST-PAT1	TEST-PAT1-SAMPLE1	Luminal A
+TEST-PAT1	TEST-PAT1-SAMPLE2	Luminal B
+TEST-PAT1	TEST-PAT1-SAMPLE3	basal-like
+TEST-PAT1	TEST-PAT1-SAMPLE4	basal-like
+TEST-PAT1	TEST-PAT1-SAMPLE5	Her2 enriched
+TEST-PAT1	TEST-PAT1-SAMPLE2	Luminal B
+TEST-PAT1	TEST-PAT1-SAMPLE6	Luminal A
+TEST-PAT2	TEST-PAT2-SAMPLE1	Luminal A
+TEST-PAT2	TEST-PAT2-SAMPLE2	basal-like

--- a/core/src/test/scripts/test_data/data_clin_repeated_tcga_sample.txt
+++ b/core/src/test/scripts/test_data/data_clin_repeated_tcga_sample.txt
@@ -1,14 +1,14 @@
-#Patient Identifier	Sample Identifier	Subtype	Cancer Type	Cancer Type Detailed
-#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.	Disease type.	Cancer Type Detailed.
-#STRING	STRING	STRING	STRING	STRING
-#1	1	1	1	1
-PATIENT_ID	SAMPLE_ID	SUBTYPE	CANCER_TYPE	CANCER_TYPE_DETAILED
-TEST-PAT1	TCGA-PAT1-SAMPLE1	Luminal A	Cancer_type20	Cancer_type20_Sub16
-TEST-PAT1	TCGA-PAT1-SAMPLE2	Luminal B	Cancer_type27	Cancer_type27_Sub16
-TEST-PAT1	TCGA-PAT1-SAMPLE3	basal-like	Cancer_type8	Cancer_type8_Sub13
-TEST-PAT1	TCGA-PAT1-SAMPLE4	basal-like	Cancer_type17	Cancer_type17_Sub10
-TEST-PAT1	TCGA-PAT1-SAMPLE5	Her2 enriched	Cancer_type27	Cancer_type27_Sub18
-TEST-PAT1	TCGA-PAT1-SAMPLE2	Luminal B	Cancer_type27	Cancer_type27_Sub16
-TEST-PAT1	TCGA-PAT1-SAMPLE6	Luminal A	Cancer_type7	Cancer_type7_Sub13
-TEST-PAT2	TCGA-PAT2-SAMPLE1	Luminal A	Cancer_type23	Cancer_type23_Sub3
-TEST-PAT2	TCGA-PAT2-SAMPLE2	basal-like	Cancer_type7	Cancer_type7_Sub5
+#Patient Identifier	Sample Identifier	Subtype
+#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.
+#STRING	STRING	STRING
+#1	1	1
+PATIENT_ID	SAMPLE_ID	SUBTYPE
+TEST-PAT1	TCGA-PAT1-SAMPLE1	Luminal A
+TEST-PAT1	TCGA-PAT1-SAMPLE2	Luminal B
+TEST-PAT1	TCGA-PAT1-SAMPLE3	basal-like
+TEST-PAT1	TCGA-PAT1-SAMPLE4	basal-like
+TEST-PAT1	TCGA-PAT1-SAMPLE5	Her2 enriched
+TEST-PAT1	TCGA-PAT1-SAMPLE2	Luminal B
+TEST-PAT1	TCGA-PAT1-SAMPLE6	Luminal A
+TEST-PAT2	TCGA-PAT2-SAMPLE1	Luminal A
+TEST-PAT2	TCGA-PAT2-SAMPLE2	basal-like

--- a/core/src/test/scripts/test_data/data_clin_wrong_ids.txt
+++ b/core/src/test/scripts/test_data/data_clin_wrong_ids.txt
@@ -1,11 +1,11 @@
-#Patient Identifier	Sample Identifier	Subtype	Cancer Type	Cancer Type Detailed
-#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.	Disease type.	Cancer Type Detailed.
-#STRING	STRING	STRING	STRING	STRING
-#1	1	1	1	1
-PATIENT_ID	SAMPLE_ID	SUBTYPE	CANCER_TYPE	CANCER_TYPE_DETAILED
-TEST-PAT1	TEST-PAT1- SAMPLE1	Luminal A	Cancer_type20	Cancer_type20_Sub16
-TEST-PAT1	TEST-PAT1,SAMPLE2	Luminal B	Cancer_type27	Cancer_type27_Sub16
-TEST-PAT1	TEST-PAT1;SAMPLE3	basal-like	Cancer_type8	Cancer_type8_Sub13
-TEST-PAT1	TEST+PAT1/SAMPLE4	basal-like	Cancer_type17	Cancer_type17_Sub10
-TEST-PAT1	TEST-PAT1-SAMPLE5	Her2 enriched	Cancer_type27	Cancer_type27_Sub18
-TEST-PAT1	TEST-PAT1*SAMPLE6	Luminal A	Cancer_type7	Cancer_type7_Sub13
+#Patient Identifier	Sample Identifier	Subtype
+#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.
+#STRING	STRING	STRING
+#1	1	1
+PATIENT_ID	SAMPLE_ID	SUBTYPE
+TEST-PAT1	TEST-PAT1- SAMPLE1	Luminal A
+TEST-PAT1	TEST-PAT1,SAMPLE2	Luminal B
+TEST-PAT1	TEST-PAT1;SAMPLE3	basal-like
+TEST-PAT1	TEST+PAT1/SAMPLE4	basal-like
+TEST-PAT1	TEST-PAT1-SAMPLE5	Her2 enriched
+TEST-PAT1	TEST-PAT1*SAMPLE6	Luminal A

--- a/core/src/test/scripts/test_data/study_cancertype_two_files/data_samples.txt
+++ b/core/src/test/scripts/test_data/study_cancertype_two_files/data_samples.txt
@@ -1,13 +1,13 @@
-#Patient Identifier	Sample Identifier	Subtype	Cancer Type	Cancer Type Detailed
-#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.	Disease type.	Cancer Type Detailed.
-#STRING	STRING	STRING	STRING	STRING
-#1	1	1	1	1
-PATIENT_ID	SAMPLE_ID	SUBTYPE	CANCER_TYPE	CANCER_TYPE_DETAILED
-TEST-PAT1	TEST-PAT1-SAMPLE1	Luminal A	Cancer_type20	Cancer_type20_Sub16
-TEST-PAT1	TEST-PAT1-SAMPLE2	Luminal B	Cancer_type27	Cancer_type27_Sub16
-TEST-PAT1	TEST-PAT1-SAMPLE3	basal-like	Cancer_type8	Cancer_type8_Sub13
-TEST-PAT1	TEST-PAT1-SAMPLE4	basal-like	Cancer_type17	Cancer_type17_Sub10
-TEST-PAT1	TEST-PAT1-SAMPLE5	Her2 enriched	Cancer_type27	Cancer_type27_Sub18
-TEST-PAT1	TEST-PAT1-SAMPLE6	Luminal A	Cancer_type7	Cancer_type7_Sub13
-TEST-PAT2	TEST-PAT2-SAMPLE1	Luminal A	Cancer_type23	Cancer_type23_Sub3
-TEST-PAT2	TEST-PAT2-SAMPLE2	basal-like	Cancer_type7	Cancer_type7_Sub5
+#Patient Identifier	Sample Identifier	Subtype
+#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.
+#STRING	STRING	STRING
+#1	1	1
+PATIENT_ID	SAMPLE_ID	SUBTYPE
+TEST-PAT1	TEST-PAT1-SAMPLE1	Luminal A
+TEST-PAT1	TEST-PAT1-SAMPLE2	Luminal B
+TEST-PAT1	TEST-PAT1-SAMPLE3	basal-like
+TEST-PAT1	TEST-PAT1-SAMPLE4	basal-like
+TEST-PAT1	TEST-PAT1-SAMPLE5	Her2 enriched
+TEST-PAT1	TEST-PAT1-SAMPLE6	Luminal A
+TEST-PAT2	TEST-PAT2-SAMPLE1	Luminal A
+TEST-PAT2	TEST-PAT2-SAMPLE2	basal-like

--- a/core/src/test/scripts/test_data/study_missing_caselists/data_samples.txt
+++ b/core/src/test/scripts/test_data/study_missing_caselists/data_samples.txt
@@ -1,13 +1,13 @@
-#Patient Identifier	Sample Identifier	Subtype	Cancer Type	Cancer Type Detailed
-#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.	Disease type.	Cancer Type Detailed.
-#STRING	STRING	STRING	STRING	STRING
-#1	1	1	1	1
-PATIENT_ID	SAMPLE_ID	SUBTYPE	CANCER_TYPE	CANCER_TYPE_DETAILED
-TEST-PAT1	TEST-PAT1-SAMPLE1	Luminal A	Cancer_type20	Cancer_type20_Sub16
-TEST-PAT1	TEST-PAT1-SAMPLE2	Luminal B	Cancer_type27	Cancer_type27_Sub16
-TEST-PAT1	TEST-PAT1-SAMPLE3	basal-like	Cancer_type8	Cancer_type8_Sub13
-TEST-PAT1	TEST-PAT1-SAMPLE4	basal-like	Cancer_type17	Cancer_type17_Sub10
-TEST-PAT1	TEST-PAT1-SAMPLE5	Her2 enriched	Cancer_type27	Cancer_type27_Sub18
-TEST-PAT1	TEST-PAT1-SAMPLE6	Luminal A	Cancer_type7	Cancer_type7_Sub13
-TEST-PAT2	TEST-PAT2-SAMPLE1	Luminal A	Cancer_type23	Cancer_type23_Sub3
-TEST-PAT2	TEST-PAT2-SAMPLE2	basal-like	Cancer_type7	Cancer_type7_Sub5
+#Patient Identifier	Sample Identifier	Subtype
+#Identifier to uniquely specify a patient.	A unique sample identifier.	Subtype description.
+#STRING	STRING	STRING
+#1	1	1
+PATIENT_ID	SAMPLE_ID	SUBTYPE
+TEST-PAT1	TEST-PAT1-SAMPLE1	Luminal A
+TEST-PAT1	TEST-PAT1-SAMPLE2	Luminal B
+TEST-PAT1	TEST-PAT1-SAMPLE3	basal-like
+TEST-PAT1	TEST-PAT1-SAMPLE4	basal-like
+TEST-PAT1	TEST-PAT1-SAMPLE5	Her2 enriched
+TEST-PAT1	TEST-PAT1-SAMPLE6	Luminal A
+TEST-PAT2	TEST-PAT2-SAMPLE1	Luminal A
+TEST-PAT2	TEST-PAT2-SAMPLE2	basal-like

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -218,18 +218,15 @@ class ClinicalColumnDefsTestCase(PostClinicalDataFileTestCase):
         self.logger.setLevel(logging.WARNING)
         record_list = self.validate('data_clin_coldefs_hardcoded_attrs.txt',
                                     validateData.PatientClinicalValidator)
-        self.assertEqual(len(record_list), 3)
+        self.assertEqual(len(record_list), 2)
         osmonths_records = []
         other_sid_records = []
-        other_warn_records = []
         for record in record_list:
             self.assertNotIn('portal', record.getMessage().lower())
             if 'OS_MONTHS' in record.getMessage():
                 osmonths_records.append(record)
             if hasattr(record, 'cause') and record.cause == 'OTHER_SAMPLE_ID':
                 other_sid_records.append(record)
-            if 'details will be missing' in record.getMessage():
-                other_warn_records.append(record)
 
         self.assertEqual(len(osmonths_records), 1)
         record = osmonths_records.pop()
@@ -237,18 +234,12 @@ class ClinicalColumnDefsTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(record.line_number, 3)
         self.assertEqual(record.column_number, 2)
 
+        # Expect warning for sample attribute in patient clinical data
         self.assertEqual(len(other_sid_records), 1)
         record = other_sid_records.pop()
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 5)
         self.assertEqual(record.column_number, 6)
-
-        self.assertEqual(len(other_warn_records), 1)
-        record = other_warn_records.pop()
-        self.assertEqual(record.levelno, logging.WARNING)
-        self.assertEqual(record.line_number, 5)
-        self.assertEqual(record.column_number, 7)
-
 
 
 class ClinicalValuesTestCase(DataFileTestCase):


### PR DESCRIPTION
# What? Why?
This PR removes validation to be either a patient or sample attribute for many attributes but leaves a **core** set of patient attributes.

Fix https://github.com/cBioPortal/datahub/issues/51.
Previous PR that was only moving some attributes from sample to patient level #2889.

A later PR will update the documentation of these and non-core attributes in File-Formats.

# Changes proposed in this pull request:
- For many attributes, remove validation of being in sample or patient data
- Move `CANCER_TYPE`, `CANCER_TYPE_DETAILED`, `HISTOLOGY` and `KNOWN_MOLECULAR_CLASSIFIER` from sample to patient level
- For a core set of attributes, set an ERROR if in incorrect data file
- Remove deprecated attributes, like `TYPE_OF_CANCER` 
- Added new attributes like `MOUSE_STRAIN`

### Core set of patient attributes
- `AGE`
- `CANCER_TYPE`
- `CANCER_TYPE_DETAILED`
- `DFS_STATUS`
- `DFS_MONTHS`
- `GENDER`
- `HISTOLOGY`
- `KNOWN_MOLECULAR_CLASSIFIER`
- `OS_STATUS`
- `OS_MONTHS`
- `PATIENT_DISPLAY_NAME`
- `SEX`

### Core set of sample attributes
- `SAMPLE_ID`
- `OTHER_SAMPLE_ID`
- `SAMPLE_DISPLAY_NAME`
- `TUMOR_TISSUE_SITE`
- `TUMOR_TYPE`
