### PR TITLE
Move security annotations from service to web layer.

### DIFF
--- a/security/security-spring/pom.xml
+++ b/security/security-spring/pom.xml
@@ -17,7 +17,7 @@
     <dependencies>
       <dependency>
         <groupId>org.mskcc.cbio</groupId>
-        <artifactId>persistence-mybatis</artifactId>
+        <artifactId>web</artifactId>
         <version>${project.version}</version>
       </dependency>
       <!-- Spring Security -->

--- a/security/security-spring/src/main/java/org/cbioportal/security/spring/CancerStudyPermissionEvaluator.java
+++ b/security/security-spring/src/main/java/org/cbioportal/security/spring/CancerStudyPermissionEvaluator.java
@@ -38,6 +38,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.Collection;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -50,6 +52,19 @@ import org.cbioportal.persistence.SampleRepository;
 import org.cbioportal.persistence.SampleListRepository;
 import org.cbioportal.persistence.SecurityRepository;
 import org.cbioportal.persistence.StudyRepository;
+import org.cbioportal.web.parameter.ClinicalAttributeFilter;
+import org.cbioportal.web.parameter.ClinicalDataMultiStudyFilter;
+import org.cbioportal.web.parameter.ClinicalDataIdentifier;
+import org.cbioportal.web.parameter.GenePanelMultipleStudyFilter;
+import org.cbioportal.web.parameter.SampleMolecularIdentifier;
+import org.cbioportal.web.parameter.MolecularDataMultipleStudyFilter;
+import org.cbioportal.web.parameter.MolecularProfileFilter;
+import org.cbioportal.web.parameter.MutationMultipleStudyFilter;
+import org.cbioportal.web.parameter.PatientFilter;
+import org.cbioportal.web.parameter.PatientIdentifier;
+import org.cbioportal.web.parameter.SampleFilter;
+import org.cbioportal.web.parameter.SampleIdentifier;
+import org.cbioportal.web.util.UniqueKeyExtractor;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -83,6 +98,9 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
 
     @Autowired
     private SampleListRepository sampleListRepository;
+
+    @Autowired
+    private UniqueKeyExtractor uniqueKeyExtractor;
 
     @Value("${app.name:}")
     private String APP_NAME;
@@ -123,6 +141,9 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
      *   'SampleList',
      *   'List<CancerStudyId>', 
      *   'List<MolecularProfileId>', 
+     *   'MolecularDataMultipleStudyFilter',
+     *   'MolecularProfileFilter',
+     *   'MutationMultipleStudyFilter',
      *   or 'List<SampleListId>'
      * @param permission
      */
@@ -151,45 +172,77 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
                 return false;
             }
             return hasPermission(authentication, cancerStudy, permission);
-        } else if ("MolecularProfile".equals(targetType) || "GeneticProfile".equals(targetType)) {
+        }
+        else if ("MolecularProfile".equals(targetType) || "GeneticProfile".equals(targetType)) {
             MolecularProfile molecularProfile = molecularProfileRepository.getMolecularProfile(targetId.toString());
             if (molecularProfile == null) {
                 return false;
             }
             return hasPermission(authentication, molecularProfile, permission);
-        } else if ("SampleList".equals(targetType)) {
+        }
+        else if ("SampleList".equals(targetType)) {
             SampleList sampleList = sampleListRepository.getSampleList(targetId.toString());
             if (sampleList == null) {
                 return false;
             }
             return hasPermission(authentication, sampleList, permission);
-        }  else if ("List<CancerStudyId>".equals(targetType)) {
-            List<String> studyIds = (List<String>) targetId;
-            for (String studyId : studyIds) {
-                if (!hasPermission(authentication, studyId, "CancerStudy", permission)) {
-                    return false;
-                }
+        }
+        else if ("List<SampleListId>".equals(targetType)) {
+            return hasAccessToSampleLists(authentication, (List<String>) targetId, permission);
+        }
+        else if ("List<CancerStudyId>".equals(targetType)) {
+            return hasAccessToCancerStudies(authentication, (List<String>)targetId, permission);
+        }
+        else if ("List<MolecularProfileId>".equals(targetType) || "List<GeneticProfileId>".equals(targetType)) {
+            return hasAccessToMolecularProfiles(authentication, (List<String>)targetId, permission);
+        }
+        else if ("ClinicalAttributeFilter".equals(targetType)) {
+            return hasAccessToCancerStudies(authentication, (ClinicalAttributeFilter)targetId, permission);
+        }
+        else if ("ClinicalDataMultiStudyFilter".equals(targetType)) {
+            return hasAccessToCancerStudies(authentication, (ClinicalDataMultiStudyFilter)targetId, permission);
+        }
+        else if ("GenePanelMultipleStudyFilter".equals(targetType)) {
+            GenePanelMultipleStudyFilter genePanelMultipleStudyFilter = (GenePanelMultipleStudyFilter)targetId;
+            return hasAccessToCancerStudiesBySampleMolecularIdentifier(authentication, genePanelMultipleStudyFilter.getSampleMolecularIdentifiers(), permission);
+        }
+        else if ("MolecularDataMultipleStudyFilter".equals(targetType)) {
+            MolecularDataMultipleStudyFilter molecularDataMultipleStudyFilter = (MolecularDataMultipleStudyFilter)targetId;
+            if (molecularDataMultipleStudyFilter.getMolecularProfileIds() != null) {
+                return hasAccessToMolecularProfiles(authentication, molecularDataMultipleStudyFilter.getMolecularProfileIds(), permission);
             }
-            return true;
-        } else if ("List<MolecularProfileId>".equals(targetType) || "List<GeneticProfileId>".equals(targetType)) {
-            List<String> molecularProfileIds = (List<String>) targetId;
-            for (String molecularProfileId : molecularProfileIds) {
-                MolecularProfile molecularProfile = molecularProfileRepository.getMolecularProfile(molecularProfileId);
-                if (molecularProfile == null || !hasPermission(authentication, molecularProfile, permission)) {
-                    return false;
-                }
+            else {
+                return hasAccessToCancerStudiesBySampleMolecularIdentifier(authentication, molecularDataMultipleStudyFilter.getSampleMolecularIdentifiers(), permission);
             }
-            return true;
-        } else if ("List<SampleListId>".equals(targetType)) {
-            List<String> sampleListIds = (List<String>) targetId;
-            for (String sampleListId : sampleListIds) {
-                SampleList sampleList = sampleListRepository.getSampleList(sampleListId);
-                if (sampleList == null || !hasPermission(authentication, sampleList, permission)) {
-                    return false;
-                }
+        }
+        else if ("MolecularProfileFilter".equals(targetType)) {
+            MolecularProfileFilter molecularProfileFilter = (MolecularProfileFilter)targetId;
+            if (molecularProfileFilter.getStudyIds() != null) {
+                return hasAccessToCancerStudies(authentication, molecularProfileFilter.getStudyIds(), permission);
             }
-            return true;
-        } else {
+            else {
+                return hasAccessToMolecularProfiles(authentication, molecularProfileFilter.getMolecularProfileIds(), permission);
+            }
+        }
+        else if ("MutationMultipleStudyFilter".equals(targetType)) {
+            MutationMultipleStudyFilter mutationMultipleStudyFilter = (MutationMultipleStudyFilter)targetId;
+            if (mutationMultipleStudyFilter.getMolecularProfileIds() != null) {
+                return hasAccessToMolecularProfiles(authentication, mutationMultipleStudyFilter.getMolecularProfileIds(), permission);
+            }
+            else {
+                return hasAccessToCancerStudiesBySampleMolecularIdentifier(authentication, mutationMultipleStudyFilter.getSampleMolecularIdentifiers(), permission);
+            }
+        }
+        else if ("PatientFilter".equals(targetType)) {
+            return hasAccessToCancerStudies(authentication, (PatientFilter)targetId, permission);
+        }
+        else if ("SampleFilter".equals(targetType)) {
+            return hasAccessToCancerStudies(authentication, (SampleFilter)targetId, permission);
+        }
+        else if ("List<SampleIdentifier>".equals(targetType)) {
+            return hasAccessToCancerStudiesBySampleIdentifier(authentication, (List<SampleIdentifier>)targetId, permission);
+        }
+        else {
             if (log.isDebugEnabled()) {
                 log.debug("hasPermission(), unknown targetType '" + targetType + "'");
             }
@@ -262,6 +315,120 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
         }
     }
 
+    private boolean hasAccessToCancerStudies(Authentication authentication, ClinicalAttributeFilter clinicalAttributeFilter, Object permission)
+    {
+        String sampleListId = clinicalAttributeFilter.getSampleListId();
+        if (sampleListId != null) {
+            SampleList sampleList = sampleListRepository.getSampleList(sampleListId);
+            if (sampleList == null || !hasPermission(authentication, sampleList, permission)) {
+                return false;
+            }
+            return true;
+        }
+        else {
+            // use hashset as this list can be populated with many duplicate values
+            Set<String> studyIds = new HashSet<String>();
+            for (SampleIdentifier identifier : clinicalAttributeFilter.getSampleIdentifiers()) {
+                studyIds.add(identifier.getStudyId());
+            }
+            return hasAccessToCancerStudies(authentication, studyIds, permission);
+        }
+    }
+
+    private boolean hasAccessToCancerStudiesBySampleMolecularIdentifier(Authentication authentication, List<SampleMolecularIdentifier> sampleMolecularIdentifiers, Object permission)
+    {
+        // use hashset as this list can be populated with many duplicate values
+        Set<String> molecularProfileIds = new HashSet<String>();
+        for (SampleMolecularIdentifier sampleMolecularIdentifier : sampleMolecularIdentifiers) {
+            molecularProfileIds.add(sampleMolecularIdentifier.getMolecularProfileId());
+        }
+        return hasAccessToMolecularProfiles(authentication, molecularProfileIds, permission);
+    }
+
+    private boolean hasAccessToCancerStudies(Authentication authentication, ClinicalDataMultiStudyFilter clinicalDataMultiStudyFilter, Object permission)
+    {
+        // use hashset as this list can be populated with many duplicate values
+        Set<String> studyIds = new HashSet<String>();
+        for (ClinicalDataIdentifier identifier : clinicalDataMultiStudyFilter.getIdentifiers()) {
+            studyIds.add(identifier.getStudyId());
+        }
+        return hasAccessToCancerStudies(authentication, studyIds, permission);
+    }
+
+    private boolean hasAccessToCancerStudies(Authentication authentication, PatientFilter patientFilter, Object permission)
+    {
+        // use hashset as this list can be populated with many duplicate values
+        Set<String> studyIds = new HashSet<String>();
+        if (patientFilter.getPatientIdentifiers() != null) {
+            for (PatientIdentifier patientIdentifier : patientFilter.getPatientIdentifiers()) {
+                studyIds.add(patientIdentifier.getStudyId());
+            }
+        }
+        else {
+            uniqueKeyExtractor.extractUniqueKeys(patientFilter.getUniquePatientKeys(), studyIds);
+        }
+        return hasAccessToCancerStudies(authentication, studyIds, permission);
+    }
+
+    private boolean hasAccessToCancerStudies(Authentication authentication, SampleFilter sampleFilter, Object permission)
+    {
+        if (sampleFilter.getSampleListIds() != null) {
+            return hasAccessToSampleLists(authentication, sampleFilter.getSampleListIds(), permission);
+        }
+        else if (sampleFilter.getSampleIdentifiers() != null) {
+            return hasAccessToCancerStudiesBySampleIdentifier(authentication, sampleFilter.getSampleIdentifiers(), permission);
+        }
+        else {
+            // use hashset as this list can be populated with many duplicate values
+            Set<String> studyIds = new HashSet<String>();
+            uniqueKeyExtractor.extractUniqueKeys(sampleFilter.getUniqueSampleKeys(), studyIds);
+            return hasAccessToCancerStudies(authentication, studyIds, permission);
+        }
+    }
+
+    private boolean hasAccessToCancerStudiesBySampleIdentifier(Authentication authentication, List<SampleIdentifier> sampleIdentifiers, Object permission)
+    {
+        // use hashset as this list can be populated with many duplicate values
+        Set<String> studyIds = new HashSet<String>();
+        for (SampleIdentifier sampleIdentifier : sampleIdentifiers) {
+            studyIds.add(sampleIdentifier.getStudyId());
+        }
+        return hasAccessToCancerStudies(authentication, studyIds, permission);
+    }
+
+    private boolean hasAccessToCancerStudies(Authentication authentication, Collection<String> studyIds, Object permission)
+    {
+        for (String studyId : studyIds) {
+            if (!hasPermission(authentication, studyId, "CancerStudy", permission)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean hasAccessToMolecularProfiles(Authentication authentication, Collection<String> molecularProfileIds, Object permission)
+    {
+        List<String> profileIds = (molecularProfileIds instanceof List) ?
+            (List<String>)molecularProfileIds : new ArrayList<String>(molecularProfileIds);
+        for (MolecularProfile molecularProfile : molecularProfileRepository.getMolecularProfiles(profileIds, "SUMMARY")) {
+            if (molecularProfile == null || !hasPermission(authentication, molecularProfile, permission)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean hasAccessToSampleLists(Authentication authentication, List<String> sampleListIds, Object permission)
+    {
+        for (String sampleListId : sampleListIds) {
+            SampleList sampleList = sampleListRepository.getSampleList(sampleListId);
+            if (sampleList == null || !hasPermission(authentication, sampleList, permission)) {
+                return false;
+            }
+        }
+        return true;
+    }
+     
     /**
      * Helper function to determine if given user has access to given cancer study.
      *

--- a/security/security-spring/src/main/java/org/cbioportal/security/spring/CancerStudyPermissionEvaluator.java
+++ b/security/security-spring/src/main/java/org/cbioportal/security/spring/CancerStudyPermissionEvaluator.java
@@ -410,7 +410,7 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
     {
         List<String> profileIds = (molecularProfileIds instanceof List) ?
             (List<String>)molecularProfileIds : new ArrayList<String>(molecularProfileIds);
-        for (MolecularProfile molecularProfile : molecularProfileRepository.getMolecularProfiles(profileIds, "SUMMARY")) {
+        for (MolecularProfile molecularProfile : molecularProfileRepository.getMolecularProfiles(profileIds, "DETAILED")) {
             if (molecularProfile == null || !hasPermission(authentication, molecularProfile, permission)) {
                 return false;
             }
@@ -420,8 +420,7 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
 
     private boolean hasAccessToSampleLists(Authentication authentication, List<String> sampleListIds, Object permission)
     {
-        for (String sampleListId : sampleListIds) {
-            SampleList sampleList = sampleListRepository.getSampleList(sampleListId);
+        for (SampleList sampleList : sampleListRepository.getSampleLists(sampleListIds, "DETAILED")) {
             if (sampleList == null || !hasPermission(authentication, sampleList, permission)) {
                 return false;
             }

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -24,6 +24,9 @@
            </b:property>
         </b:bean>
 
+    <!-- We are autowiring some components from web into the customPermissionEvaluator below -->
+    <context:component-scan base-package="org.cbioportal.web.util" />
+
     <!-- support for general annotations within class definitions (used in AccessControl) -->
     <context:annotation-config/>
 
@@ -48,8 +51,10 @@
     <http pattern="/gfx/**" security="none"/>
     <http pattern="/saml/gfx/**" security="none"/>
     <http pattern="/reactapp/**" security="none"/>
+    <http pattern="/api/swagger-resources/**" security="none"/>
+    <http pattern="/api/swagger-ui.html" security="none"/>
         
-    <!-- this must come before the default entry point which will capture everything not matched by pattern -->
+    <!-- This must come before the default entry point which will capture everything not matched by pattern -->
     <http use-expressions="true" pattern="/api/**" entry-point-ref="restAuthenticationEntryPoint" create-session="never">
         <intercept-url pattern="/**" access="isAuthenticated()"/>
     </http>

--- a/service/src/main/java/org/cbioportal/service/impl/ClinicalAttributeServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ClinicalAttributeServiceImpl.java
@@ -10,7 +10,6 @@ import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PostFilter;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -44,7 +43,6 @@ public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public ClinicalAttribute getClinicalAttribute(String studyId, String clinicalAttributeId)
         throws ClinicalAttributeNotFoundException, StudyNotFoundException {
 
@@ -61,7 +59,6 @@ public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<ClinicalAttribute> getAllClinicalAttributesInStudy(String studyId, String projection, Integer pageSize,
                                                                    Integer pageNumber, String sortBy,
                                                                    String direction) throws StudyNotFoundException {
@@ -73,7 +70,6 @@ public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaClinicalAttributesInStudy(String studyId) throws StudyNotFoundException {
 
         studyService.getStudy(studyId);
@@ -82,21 +78,18 @@ public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
     public List<ClinicalAttribute> fetchClinicalAttributes(List<String> studyIds, String projection) {
         
         return clinicalAttributeRepository.fetchClinicalAttributes(studyIds, projection);
         }
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
     public BaseMeta fetchMetaClinicalAttributes(List<String> studyIds) {
         
         return clinicalAttributeRepository.fetchMetaClinicalAttributes(studyIds);
         }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<ClinicalAttribute> getAllClinicalAttributesInStudiesBySampleIds(List<String> studyIds, List<String> sampleIds, 
                                                                                 String projection, String sortBy, String direction) {
         
@@ -105,7 +98,6 @@ public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<ClinicalAttribute> getAllClinicalAttributesInStudiesBySampleListId(String sampleListId, String projection, 
                                                                                    String sortBy, String direction) {
 

--- a/service/src/main/java/org/cbioportal/service/impl/ClinicalDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ClinicalDataServiceImpl.java
@@ -11,7 +11,6 @@ import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -29,7 +28,6 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
     private SampleService sampleService;
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<ClinicalData> getAllClinicalDataOfSampleInStudy(String studyId, String sampleId, String attributeId, 
                                                                 String projection, Integer pageSize, Integer pageNumber,
                                                                 String sortBy, String direction)
@@ -42,7 +40,6 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaSampleClinicalData(String studyId, String sampleId, String attributeId)
         throws SampleNotFoundException, StudyNotFoundException {
 
@@ -52,7 +49,6 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<ClinicalData> getAllClinicalDataOfPatientInStudy(String studyId, String patientId, String attributeId, 
                                                                  String projection, Integer pageSize, 
                                                                  Integer pageNumber, String sortBy, String direction)
@@ -65,7 +61,6 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaPatientClinicalData(String studyId, String patientId, String attributeId)
         throws PatientNotFoundException, StudyNotFoundException {
 
@@ -75,7 +70,6 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<ClinicalData> getAllClinicalDataInStudy(String studyId, String attributeId, String clinicalDataType, 
                                                         String projection, Integer pageSize, Integer pageNumber,
                                                         String sortBy, String direction) throws StudyNotFoundException {
@@ -87,7 +81,6 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaAllClinicalData(String studyId, String attributeId, String clinicalDataType) 
         throws StudyNotFoundException {
 
@@ -117,7 +110,6 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
     public List<ClinicalData> fetchClinicalData(List<String> studyIds, List<String> ids, List<String> attributeIds, 
                                                 String clinicalDataType, String projection) {
 
@@ -125,7 +117,6 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
     public BaseMeta fetchMetaClinicalData(List<String> studyIds, List<String> ids, List<String> attributeIds, 
                                           String clinicalDataType) {
 

--- a/service/src/main/java/org/cbioportal/service/impl/ClinicalEventServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ClinicalEventServiceImpl.java
@@ -9,7 +9,6 @@ import org.cbioportal.service.PatientService;
 import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -24,7 +23,6 @@ public class ClinicalEventServiceImpl implements ClinicalEventService {
     private PatientService patientService;
     
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<ClinicalEvent> getAllClinicalEventsOfPatientInStudy(String studyId, String patientId, String projection, 
                                                                     Integer pageSize, Integer pageNumber, String sortBy, 
                                                                     String direction) throws PatientNotFoundException, 
@@ -48,7 +46,6 @@ public class ClinicalEventServiceImpl implements ClinicalEventService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaPatientClinicalEvents(String studyId, String patientId) throws PatientNotFoundException, 
         StudyNotFoundException {
 

--- a/service/src/main/java/org/cbioportal/service/impl/CopyNumberEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CopyNumberEnrichmentServiceImpl.java
@@ -12,7 +12,6 @@ import org.cbioportal.service.SampleService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.util.AlterationEnrichmentUtil;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -32,7 +31,6 @@ public class CopyNumberEnrichmentServiceImpl implements CopyNumberEnrichmentServ
     private AlterationEnrichmentUtil alterationEnrichmentUtil;
     
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<AlterationEnrichment> getCopyNumberEnrichments(String molecularProfileId, List<String> alteredIds,
                                                                List<String> unalteredIds, List<Integer> alterationTypes, 
                                                                String enrichmentType)

--- a/service/src/main/java/org/cbioportal/service/impl/CopyNumberSegmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CopyNumberSegmentServiceImpl.java
@@ -8,7 +8,6 @@ import org.cbioportal.service.SampleService;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,7 +21,6 @@ public class CopyNumberSegmentServiceImpl implements CopyNumberSegmentService {
     private SampleService sampleService;
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<CopyNumberSeg> getCopyNumberSegmentsInSampleInStudy(String studyId, String sampleId,
                                                                     String projection, Integer pageSize,
                                                                     Integer pageNumber, String sortBy,
@@ -36,7 +34,6 @@ public class CopyNumberSegmentServiceImpl implements CopyNumberSegmentService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaCopyNumberSegmentsInSampleInStudy(String studyId, String sampleId)
         throws SampleNotFoundException, StudyNotFoundException {
 
@@ -46,7 +43,6 @@ public class CopyNumberSegmentServiceImpl implements CopyNumberSegmentService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
     public List<CopyNumberSeg> fetchCopyNumberSegments(List<String> studyIds, List<String> sampleIds, 
                                                        String projection) {
         
@@ -54,7 +50,6 @@ public class CopyNumberSegmentServiceImpl implements CopyNumberSegmentService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
     public BaseMeta fetchMetaCopyNumberSegments(List<String> studyIds, List<String> sampleIds) {
         
         return copyNumberSegmentRepository.fetchMetaCopyNumberSegments(studyIds, sampleIds);

--- a/service/src/main/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImpl.java
@@ -12,7 +12,6 @@ import org.cbioportal.service.MolecularDataService;
 import org.cbioportal.service.MolecularProfileService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -31,7 +30,6 @@ public class DiscreteCopyNumberServiceImpl implements DiscreteCopyNumberService 
     private MolecularProfileService molecularProfileService;
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMolecularProfileBySampleListId(
         String molecularProfileId,
         String sampleListId,
@@ -52,7 +50,6 @@ public class DiscreteCopyNumberServiceImpl implements DiscreteCopyNumberService 
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public BaseMeta getMetaDiscreteCopyNumbersInMolecularProfileBySampleListId(String molecularProfileId,
                                                                                String sampleListId,
                                                                                List<Integer> entrezGeneIds,
@@ -75,7 +72,6 @@ public class DiscreteCopyNumberServiceImpl implements DiscreteCopyNumberService 
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<DiscreteCopyNumberData> fetchDiscreteCopyNumbersInMolecularProfile(String molecularProfileId,
                                                                                    List<String> sampleIds,
                                                                                    List<Integer> entrezGeneIds,
@@ -95,7 +91,6 @@ public class DiscreteCopyNumberServiceImpl implements DiscreteCopyNumberService 
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public BaseMeta fetchMetaDiscreteCopyNumbersInMolecularProfile(String molecularProfileId,
                                                                    List<String> sampleIds,
                                                                    List<Integer> entrezGeneIds,
@@ -118,7 +113,6 @@ public class DiscreteCopyNumberServiceImpl implements DiscreteCopyNumberService 
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<CopyNumberCountByGene> getSampleCountByGeneAndAlterationAndSampleIds(
         String molecularProfileId,
         List<String> sampleIds,
@@ -140,7 +134,6 @@ public class DiscreteCopyNumberServiceImpl implements DiscreteCopyNumberService 
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<CopyNumberCount> fetchCopyNumberCounts(String molecularProfileId, List<Integer> entrezGeneIds,
                                                        List<Integer> alterations)
         throws MolecularProfileNotFoundException {

--- a/service/src/main/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImpl.java
@@ -17,7 +17,6 @@ import org.cbioportal.service.SampleService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.util.BenjaminiHochbergFDRCalculator;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -45,7 +44,6 @@ public class ExpressionEnrichmentServiceImpl implements ExpressionEnrichmentServ
     private BenjaminiHochbergFDRCalculator benjaminiHochbergFDRCalculator;
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<ExpressionEnrichment> getExpressionEnrichments(String molecularProfileId, List<String> alteredIds, 
                                                                List<String> unalteredIds, String enrichmentType) 
         throws MolecularProfileNotFoundException {

--- a/service/src/main/java/org/cbioportal/service/impl/FractionGenomeAlteredServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/FractionGenomeAlteredServiceImpl.java
@@ -5,7 +5,6 @@ import org.cbioportal.model.FractionGenomeAltered;
 import org.cbioportal.service.CopyNumberSegmentService;
 import org.cbioportal.service.FractionGenomeAlteredService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -21,7 +20,6 @@ public class FractionGenomeAlteredServiceImpl implements FractionGenomeAlteredSe
     private CopyNumberSegmentService copyNumberSegmentService;
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<FractionGenomeAltered> getFractionGenomeAltered(String studyId, String sampleListId, Double cutoff) {
 
         List<CopyNumberSeg> copyNumberSegList = copyNumberSegmentService
@@ -30,7 +28,6 @@ public class FractionGenomeAlteredServiceImpl implements FractionGenomeAlteredSe
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<FractionGenomeAltered> fetchFractionGenomeAltered(String studyId, List<String> sampleIds,
                                                                   Double cutoff) {
         

--- a/service/src/main/java/org/cbioportal/service/impl/GenePanelServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenePanelServiceImpl.java
@@ -16,7 +16,6 @@ import org.cbioportal.service.SampleService;
 import org.cbioportal.service.exception.GenePanelNotFoundException;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -79,7 +78,6 @@ public class GenePanelServiceImpl implements GenePanelService {
     }
     
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<GenePanelData> getGenePanelData(String molecularProfileId, String sampleListId, 
                                                 List<Integer> entrezGeneIds) throws MolecularProfileNotFoundException {
 
@@ -93,7 +91,6 @@ public class GenePanelServiceImpl implements GenePanelService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<GenePanelData> fetchGenePanelData(String molecularProfileId, List<String> sampleIds, 
                                                   List<Integer> entrezGeneIds) throws MolecularProfileNotFoundException {
 
@@ -106,7 +103,6 @@ public class GenePanelServiceImpl implements GenePanelService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileIds, 'List<MolecularProfileId>', 'read')")
 	public List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<String> molecularProfileIds,
 			List<String> sampleIds, List<Integer> entrezGeneIds) {
         

--- a/service/src/main/java/org/cbioportal/service/impl/GenesetCorrelationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenesetCorrelationServiceImpl.java
@@ -50,7 +50,6 @@ import org.cbioportal.service.exception.GenesetNotFoundException;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.exception.SampleListNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -70,7 +69,6 @@ public class GenesetCorrelationServiceImpl implements GenesetCorrelationService 
 	private SampleListService sampleListService;
 
 
-	@PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
 	public List<GenesetCorrelation> fetchCorrelatedGenes(String genesetId, String molecularProfileId,
 			double correlationThreshold) throws MolecularProfileNotFoundException, GenesetNotFoundException {
 
@@ -82,7 +80,6 @@ public class GenesetCorrelationServiceImpl implements GenesetCorrelationService 
 		return fetchCorrelatedGenes(genesetId, molecularProfileId, sampleIds, correlationThreshold);
 	}
 
-	@PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
 	public List<GenesetCorrelation> fetchCorrelatedGenes(String genesetId, String molecularProfileId, 
                                                          String sampleListId, double correlationThreshold) 
         throws MolecularProfileNotFoundException, SampleListNotFoundException, GenesetNotFoundException {
@@ -92,7 +89,6 @@ public class GenesetCorrelationServiceImpl implements GenesetCorrelationService 
 		return fetchCorrelatedGenes(genesetId, molecularProfileId, sampleIds, correlationThreshold);
 	}
 
-	@PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
 	public List<GenesetCorrelation> fetchCorrelatedGenes(String genesetId, String molecularProfileId, 
                                                          List<String> sampleIds, double correlationThreshold) 
         throws MolecularProfileNotFoundException, GenesetNotFoundException {

--- a/service/src/main/java/org/cbioportal/service/impl/GenesetDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenesetDataServiceImpl.java
@@ -40,7 +40,6 @@ import org.cbioportal.service.SampleService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.exception.SampleListNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -55,7 +54,6 @@ public class GenesetDataServiceImpl implements GenesetDataService {
     @Autowired
     private SampleListService sampleListService;
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<GenesetMolecularData> fetchGenesetData(String molecularProfileId, List<String> sampleIds, List<String> genesetIds)
             throws MolecularProfileNotFoundException {
 
@@ -104,7 +102,6 @@ public class GenesetDataServiceImpl implements GenesetDataService {
         return genesetDataList;
     }
 
-    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfile', 'read')")
     public List<GenesetMolecularData> fetchGenesetData(String geneticProfileId, String sampleListId, List<String> genesetIds) 
             throws MolecularProfileNotFoundException, SampleListNotFoundException {
 

--- a/service/src/main/java/org/cbioportal/service/impl/GenesetHierarchyServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenesetHierarchyServiceImpl.java
@@ -46,7 +46,6 @@ import org.cbioportal.service.SampleService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.exception.SampleListNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -63,7 +62,6 @@ public class GenesetHierarchyServiceImpl implements GenesetHierarchyService {
     @Autowired
     private SampleListService sampleListService;
 	
-	@PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfile', 'read')")
 	public List<GenesetHierarchyInfo> fetchGenesetHierarchyInfo(String geneticProfileId, Integer percentile, 
 			Double scoreThreshold, Double pvalueThreshold) throws MolecularProfileNotFoundException {
 		
@@ -75,7 +73,6 @@ public class GenesetHierarchyServiceImpl implements GenesetHierarchyService {
 		return fetchGenesetHierarchyInfo(geneticProfileId, percentile, scoreThreshold, pvalueThreshold, sampleIds);
 	}
 
-	@PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfile', 'read')")
 	public List<GenesetHierarchyInfo> fetchGenesetHierarchyInfo(String geneticProfileId, Integer percentile,
 			Double scoreThreshold, Double pvalueThreshold, String sampleListId) throws MolecularProfileNotFoundException, SampleListNotFoundException {
 		
@@ -84,7 +81,6 @@ public class GenesetHierarchyServiceImpl implements GenesetHierarchyService {
 		return fetchGenesetHierarchyInfo(geneticProfileId, percentile, scoreThreshold, pvalueThreshold, sampleIds);
 	}
 
-	@PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfile', 'read')")
 	public List<GenesetHierarchyInfo> fetchGenesetHierarchyInfo(String geneticProfileId, Integer percentile,
 			Double scoreThreshold, Double pvalueThreshold, List<String> sampleIds) throws MolecularProfileNotFoundException {
 

--- a/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
@@ -38,7 +38,6 @@ public class MolecularDataServiceImpl implements MolecularDataService {
     private SampleListRepository sampleListRepository;
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<GeneMolecularData> getMolecularData(String molecularProfileId, String sampleListId,
                                                     List<Integer> entrezGeneIds, String projection)
         throws MolecularProfileNotFoundException {
@@ -52,7 +51,6 @@ public class MolecularDataServiceImpl implements MolecularDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public BaseMeta getMetaMolecularData(String molecularProfileId, String sampleListId, List<Integer> entrezGeneIds) 
         throws MolecularProfileNotFoundException {
         
@@ -62,7 +60,6 @@ public class MolecularDataServiceImpl implements MolecularDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<GeneMolecularData> fetchMolecularData(String molecularProfileId, List<String> sampleIds,
                                                       List<Integer> entrezGeneIds, String projection) 
         throws MolecularProfileNotFoundException {
@@ -112,7 +109,6 @@ public class MolecularDataServiceImpl implements MolecularDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public BaseMeta fetchMetaMolecularData(String molecularProfileId, List<String> sampleIds, 
                                            List<Integer> entrezGeneIds) throws MolecularProfileNotFoundException {
         
@@ -122,7 +118,6 @@ public class MolecularDataServiceImpl implements MolecularDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public Integer getNumberOfSamplesInMolecularProfile(String molecularProfileId) {
 
         String commaSeparatedSampleIdsOfMolecularProfile = molecularDataRepository
@@ -135,7 +130,6 @@ public class MolecularDataServiceImpl implements MolecularDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileIds, 'List<MolecularProfileId>', 'read')")
 	public List<GeneMolecularData> getMolecularDataInMultipleMolecularProfiles(List<String> molecularProfileIds,
 			List<String> sampleIds, List<Integer> entrezGeneIds, String projection) {
 

--- a/service/src/main/java/org/cbioportal/service/impl/MolecularProfileServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularProfileServiceImpl.java
@@ -10,7 +10,6 @@ import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PostFilter;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -43,7 +42,6 @@ public class MolecularProfileServiceImpl implements MolecularProfileService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public MolecularProfile getMolecularProfile(String molecularProfileId) throws MolecularProfileNotFoundException {
 
         MolecularProfile molecularProfile = molecularProfileRepository.getMolecularProfile(molecularProfileId);
@@ -55,21 +53,18 @@ public class MolecularProfileServiceImpl implements MolecularProfileService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileIds, 'List<MolecularProfileId>', 'read')")
 	public List<MolecularProfile> getMolecularProfiles(List<String> molecularProfileIds, String projection) {
         
         return molecularProfileRepository.getMolecularProfiles(molecularProfileIds, projection);
     }
     
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileIds, 'List<MolecularProfileId>', 'read')")
 	public BaseMeta getMetaMolecularProfiles(List<String> molecularProfileIds) {
         
         return molecularProfileRepository.getMetaMolecularProfiles(molecularProfileIds);
 	}
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<MolecularProfile> getAllMolecularProfilesInStudy(String studyId, String projection, Integer pageSize,
                                                                  Integer pageNumber, String sortBy, String direction) 
         throws StudyNotFoundException {
@@ -81,7 +76,6 @@ public class MolecularProfileServiceImpl implements MolecularProfileService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaMolecularProfilesInStudy(String studyId) throws StudyNotFoundException {
 
         studyService.getStudy(studyId);
@@ -90,14 +84,12 @@ public class MolecularProfileServiceImpl implements MolecularProfileService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
 	public List<MolecularProfile> getMolecularProfilesInStudies(List<String> studyIds, String projection) {
         
         return molecularProfileRepository.getMolecularProfilesInStudies(studyIds, projection);
 	}
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
 	public BaseMeta getMetaMolecularProfilesInStudies(List<String> studyIds) {
         
         return molecularProfileRepository.getMetaMolecularProfilesInStudies(studyIds);

--- a/service/src/main/java/org/cbioportal/service/impl/MrnaPercentileServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MrnaPercentileServiceImpl.java
@@ -12,7 +12,6 @@ import org.cbioportal.service.MolecularProfileService;
 import org.cbioportal.service.MrnaPercentileService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -31,7 +30,6 @@ public class MrnaPercentileServiceImpl implements MrnaPercentileService {
     private NaturalRanking naturalRanking = new NaturalRanking(NaNStrategy.REMOVED, TiesStrategy.MAXIMUM);
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<MrnaPercentile> fetchMrnaPercentile(String molecularProfileId, String sampleId,
                                                     List<Integer> entrezGeneIds)
         throws MolecularProfileNotFoundException {

--- a/service/src/main/java/org/cbioportal/service/impl/MutationEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationEnrichmentServiceImpl.java
@@ -12,7 +12,6 @@ import org.cbioportal.service.SampleService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.util.AlterationEnrichmentUtil;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -32,7 +31,6 @@ public class MutationEnrichmentServiceImpl implements MutationEnrichmentService 
     private AlterationEnrichmentUtil alterationEnrichmentUtil;
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<AlterationEnrichment> getMutationEnrichments(String molecularProfileId, List<String> alteredIds,
                                                              List<String> unalteredIds, String enrichmentType)
         throws MolecularProfileNotFoundException {

--- a/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
@@ -12,7 +12,6 @@ import org.cbioportal.service.MutationService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.util.ChromosomeCalculator;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -40,7 +39,6 @@ public class MutationServiceImpl implements MutationService {
     private OffsetCalculator offsetCalculator;
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<Mutation> getMutationsInMolecularProfileBySampleListId(String molecularProfileId, String sampleListId,
                                                                        List<Integer> entrezGeneIds, Boolean snpOnly,
                                                                        Boolean includeNonMutated, String projection, 
@@ -62,7 +60,6 @@ public class MutationServiceImpl implements MutationService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public MutationMeta getMetaMutationsInMolecularProfileBySampleListId(String molecularProfileId, 
                                                                          String sampleListId, 
                                                                          List<Integer> entrezGeneIds,
@@ -83,7 +80,6 @@ public class MutationServiceImpl implements MutationService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileIds, 'List<MolecularProfileId>', 'read')")
     public List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
                                                                   List<String> sampleIds, List<Integer> entrezGeneIds, 
                                                                   Boolean includeNonMutated, String projection, 
@@ -98,7 +94,6 @@ public class MutationServiceImpl implements MutationService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileIds, 'List<MolecularProfileId>', 'read')")
     public MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                     List<String> sampleIds, 
                                                                     List<Integer> entrezGeneIds, 
@@ -116,7 +111,6 @@ public class MutationServiceImpl implements MutationService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<Mutation> fetchMutationsInMolecularProfile(String molecularProfileId, List<String> sampleIds,
                                                            List<Integer> entrezGeneIds, Boolean snpOnly,
                                                            Boolean includeNonMutated, String projection, 
@@ -137,7 +131,6 @@ public class MutationServiceImpl implements MutationService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public MutationMeta fetchMetaMutationsInMolecularProfile(String molecularProfileId, List<String> sampleIds,
                                                              List<Integer> entrezGeneIds, Boolean includeNonMutated)
         throws MolecularProfileNotFoundException {
@@ -155,7 +148,6 @@ public class MutationServiceImpl implements MutationService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<MutationCountByGene> getSampleCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
                                                                                List<String> sampleIds,
                                                                                List<Integer> entrezGeneIds)
@@ -168,7 +160,6 @@ public class MutationServiceImpl implements MutationService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<MutationCountByGene> getPatientCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
                                                                                 List<String> patientIds,
                                                                                 List<Integer> entrezGeneIds)
@@ -181,7 +172,6 @@ public class MutationServiceImpl implements MutationService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<MutationCount> getMutationCountsInMolecularProfileBySampleListId(String molecularProfileId,
                                                                                  String sampleListId)
         throws MolecularProfileNotFoundException {
@@ -192,7 +182,6 @@ public class MutationServiceImpl implements MutationService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<MutationCount> fetchMutationCountsInMolecularProfile(String molecularProfileId, List<String> sampleIds)
         throws MolecularProfileNotFoundException {
 

--- a/service/src/main/java/org/cbioportal/service/impl/MutationSpectrumServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationSpectrumServiceImpl.java
@@ -6,7 +6,6 @@ import org.cbioportal.service.MutationService;
 import org.cbioportal.service.MutationSpectrumService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -21,7 +20,6 @@ public class MutationSpectrumServiceImpl implements MutationSpectrumService {
     private MutationService mutationService;
     
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<MutationSpectrum> getMutationSpectrums(String molecularProfileId, String sampleListId) 
         throws MolecularProfileNotFoundException {
 
@@ -32,7 +30,6 @@ public class MutationSpectrumServiceImpl implements MutationSpectrumService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<MutationSpectrum> fetchMutationSpectrums(String molecularProfileId, List<String> sampleIds) 
         throws MolecularProfileNotFoundException {
         

--- a/service/src/main/java/org/cbioportal/service/impl/PatientServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/PatientServiceImpl.java
@@ -8,7 +8,6 @@ import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,7 +21,6 @@ public class PatientServiceImpl implements PatientService {
     private StudyService studyService;
     
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<Patient> getAllPatientsInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber, 
                                                String sortBy, String direction) throws StudyNotFoundException {
         
@@ -32,7 +30,6 @@ public class PatientServiceImpl implements PatientService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaPatientsInStudy(String studyId) throws StudyNotFoundException {
 
         studyService.getStudy(studyId);
@@ -41,7 +38,6 @@ public class PatientServiceImpl implements PatientService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public Patient getPatientInStudy(String studyId, String patientId) throws PatientNotFoundException, 
         StudyNotFoundException {
 
@@ -57,14 +53,12 @@ public class PatientServiceImpl implements PatientService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
     public List<Patient> fetchPatients(List<String> studyIds, List<String> patientIds, String projection) {
         
         return patientRepository.fetchPatients(studyIds, patientIds, projection);
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
     public BaseMeta fetchMetaPatients(List<String> studyIds, List<String> patientIds) {
         
         return patientRepository.fetchMetaPatients(studyIds, patientIds);

--- a/service/src/main/java/org/cbioportal/service/impl/SampleListServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleListServiceImpl.java
@@ -10,7 +10,6 @@ import org.cbioportal.service.exception.SampleListNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
 
@@ -54,7 +53,6 @@ public class SampleListServiceImpl implements SampleListService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#sampleListId, 'SampleList', 'read')")
     public SampleList getSampleList(String sampleListId) throws SampleListNotFoundException {
 
         SampleList sampleList = sampleListRepository.getSampleList(sampleListId);
@@ -71,7 +69,6 @@ public class SampleListServiceImpl implements SampleListService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<SampleList> getAllSampleListsInStudy(String studyId, String projection, Integer pageSize,
                                                      Integer pageNumber, String sortBy, String direction) 
         throws StudyNotFoundException {
@@ -90,7 +87,6 @@ public class SampleListServiceImpl implements SampleListService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaSampleListsInStudy(String studyId) throws StudyNotFoundException {
 
         studyService.getStudy(studyId);
@@ -99,7 +95,6 @@ public class SampleListServiceImpl implements SampleListService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#sampleListId, 'SampleList', 'read')")
     public List<String> getAllSampleIdsInSampleList(String sampleListId) throws SampleListNotFoundException {
         
         getSampleList(sampleListId);
@@ -108,7 +103,6 @@ public class SampleListServiceImpl implements SampleListService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#sampleListIds, 'List<SampleListId>', 'read')")
 	public List<SampleList> fetchSampleLists(List<String> sampleListIds, String projection) {
 
         List<SampleList> sampleLists = sampleListRepository.getSampleLists(sampleListIds, projection);

--- a/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
@@ -13,7 +13,6 @@ import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
@@ -39,7 +38,6 @@ public class SampleServiceImpl implements SampleService {
     private CopyNumberSegmentRepository copyNumberSegmentRepository;
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<Sample> getAllSamplesInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber,
                                              String sortBy, String direction) throws StudyNotFoundException {
 
@@ -52,7 +50,6 @@ public class SampleServiceImpl implements SampleService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaSamplesInStudy(String studyId) throws StudyNotFoundException {
 
         studyService.getStudy(studyId);
@@ -61,7 +58,6 @@ public class SampleServiceImpl implements SampleService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public Sample getSampleInStudy(String studyId, String sampleId) throws SampleNotFoundException,
         StudyNotFoundException {
 
@@ -77,7 +73,6 @@ public class SampleServiceImpl implements SampleService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<Sample> getAllSamplesOfPatientInStudy(String studyId, String patientId, String projection,
                                                       Integer pageSize, Integer pageNumber, String sortBy,
                                                       String direction) throws StudyNotFoundException,
@@ -92,7 +87,6 @@ public class SampleServiceImpl implements SampleService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaSamplesOfPatientInStudy(String studyId, String patientId) throws StudyNotFoundException,
         PatientNotFoundException {
 
@@ -102,7 +96,6 @@ public class SampleServiceImpl implements SampleService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<Sample> getAllSamplesOfPatientsInStudy(String studyId, List<String> patientIds, String projection) {
 
         List<Sample> samples = sampleRepository.getAllSamplesOfPatientsInStudy(studyId, patientIds, projection);
@@ -112,7 +105,6 @@ public class SampleServiceImpl implements SampleService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
     public List<Sample> fetchSamples(List<String> studyIds, List<String> sampleIds, String projection) {
 
         List<Sample> samples = sampleRepository.fetchSamples(studyIds, sampleIds, projection);
@@ -121,28 +113,23 @@ public class SampleServiceImpl implements SampleService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#sampleListIds, 'List<SampleListId>', 'read')")
 	public List<Sample> fetchSamples(List<String> sampleListIds, String projection) {
         
         return sampleRepository.fetchSamples(sampleListIds, projection);
 	}
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
     public BaseMeta fetchMetaSamples(List<String> studyIds, List<String> sampleIds) {
 
         return sampleRepository.fetchMetaSamples(studyIds, sampleIds);
     }
 
     @Override
-    @PreAuthorize("hasPermission(#sampleListIds, 'List<SampleListId>', 'read')")
 	public BaseMeta fetchMetaSamples(List<String> sampleListIds) {
         
         return sampleRepository.fetchMetaSamples(sampleListIds);
 	}
 
-    // this is not secured as it is only used interally by other services which have
-    // already had permissions checked
     @Override
     public List<Sample> getSamplesByInternalIds(List<Integer> internalIds) {
 

--- a/service/src/main/java/org/cbioportal/service/impl/SignificantCopyNumberRegionServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SignificantCopyNumberRegionServiceImpl.java
@@ -8,7 +8,6 @@ import org.cbioportal.service.SignificantCopyNumberRegionService;
 import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -23,7 +22,6 @@ public class SignificantCopyNumberRegionServiceImpl implements SignificantCopyNu
     private StudyService studyService;
     
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<Gistic> getSignificantCopyNumberRegions(String studyId, String projection, Integer pageSize, 
                                                         Integer pageNumber, String sortBy, String direction) 
         throws StudyNotFoundException {
@@ -46,7 +44,6 @@ public class SignificantCopyNumberRegionServiceImpl implements SignificantCopyNu
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaSignificantCopyNumberRegions(String studyId) throws StudyNotFoundException {
 
         studyService.getStudy(studyId);

--- a/service/src/main/java/org/cbioportal/service/impl/SignificantlyMutatedGeneServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SignificantlyMutatedGeneServiceImpl.java
@@ -7,7 +7,6 @@ import org.cbioportal.service.SignificantlyMutatedGeneService;
 import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -21,7 +20,6 @@ public class SignificantlyMutatedGeneServiceImpl implements SignificantlyMutated
     private StudyService studyService;
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public List<MutSig> getSignificantlyMutatedGenes(String studyId, String projection, Integer pageSize,
                                                      Integer pageNumber, String sortBy, String direction) 
         throws StudyNotFoundException {
@@ -33,7 +31,6 @@ public class SignificantlyMutatedGeneServiceImpl implements SignificantlyMutated
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public BaseMeta getMetaSignificantlyMutatedGenes(String studyId) throws StudyNotFoundException {
 
         studyService.getStudy(studyId);

--- a/service/src/main/java/org/cbioportal/service/impl/StudyServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/StudyServiceImpl.java
@@ -8,7 +8,6 @@ import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PostFilter;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -38,7 +37,6 @@ public class StudyServiceImpl implements StudyService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     public CancerStudy getStudy(String studyId) throws StudyNotFoundException {
 
         CancerStudy cancerStudy = studyRepository.getStudy(studyId, "DETAILED");
@@ -50,14 +48,12 @@ public class StudyServiceImpl implements StudyService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
 	public List<CancerStudy> fetchStudies(List<String> studyIds, String projection) {
         
         return studyRepository.fetchStudies(studyIds, projection);
 	}
 
     @Override
-    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
 	public BaseMeta fetchMetaStudies(List<String> studyIds) {
         
         return studyRepository.fetchMetaStudies(studyIds);

--- a/service/src/main/java/org/cbioportal/service/impl/VariantCountServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/VariantCountServiceImpl.java
@@ -10,7 +10,6 @@ import org.cbioportal.service.VariantCountService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.exception.SampleListNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -30,7 +29,6 @@ public class VariantCountServiceImpl implements VariantCountService {
     private MolecularProfileService molecularProfileService;
     
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     public List<VariantCount> fetchVariantCounts(String molecularProfileId, List<Integer> entrezGeneIds, 
                                                  List<String> keywords) throws MolecularProfileNotFoundException {
 

--- a/web/src/main/java/org/cbioportal/web/ClinicalAttributeController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalAttributeController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -75,6 +76,7 @@ public class ClinicalAttributeController {
         }
     }
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/clinical-attributes", method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all clinical attributes in the specified study")
@@ -108,6 +110,7 @@ public class ClinicalAttributeController {
         }
     }
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/clinical-attributes/{clinicalAttributeId}", method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get specified clinical attribute")
@@ -122,6 +125,7 @@ public class ClinicalAttributeController {
                 HttpStatus.OK);
     }
 
+    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
     @RequestMapping(value = "/clinical-attributes/fetch", method = RequestMethod.POST, 
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical attributes")
@@ -143,6 +147,7 @@ public class ClinicalAttributeController {
         }
     }
 
+    @PreAuthorize("hasPermission(#clinicalAttributeFilter, 'ClinicalAttributeFilter', 'read')")
     @RequestMapping(value = "/clinical-attributes/counts/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
                     produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all clinical attributes in specified sampleIdentifiers or sampleListID with clinical attribute count")

--- a/web/src/main/java/org/cbioportal/web/ClinicalDataController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalDataController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -49,6 +50,7 @@ public class ClinicalDataController {
     @Autowired
     private ClinicalDataService clinicalDataService;
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/samples/{sampleId}/clinical-data", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all clinical data of a sample in a study")
@@ -87,6 +89,7 @@ public class ClinicalDataController {
         }
     }
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/patients/{patientId}/clinical-data", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all clinical data of a patient in a study")
@@ -125,6 +128,7 @@ public class ClinicalDataController {
         }
     }
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/clinical-data", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all clinical data in a study")
@@ -162,6 +166,7 @@ public class ClinicalDataController {
         }
     }
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/clinical-data/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical data by patient IDs or sample IDs (specific study)")
@@ -189,6 +194,7 @@ public class ClinicalDataController {
         }
     }
 
+    @PreAuthorize("hasPermission(#clinicalDataMultiStudyFilter, 'ClinicalDataMultiStudyFilter', 'read')")
     @RequestMapping(value = "/clinical-data/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical data by patient IDs or sample IDs (all studies)")

--- a/web/src/main/java/org/cbioportal/web/ClinicalEventController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalEventController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -38,6 +39,7 @@ public class ClinicalEventController {
     @Autowired
     private ClinicalEventService clinicalEventService;
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/patients/{patientId}/clinical-events", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all clinical events of a patient in a study")

--- a/web/src/main/java/org/cbioportal/web/CoExpressionController.java
+++ b/web/src/main/java/org/cbioportal/web/CoExpressionController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -32,6 +33,7 @@ public class CoExpressionController {
     @Autowired
     private CoExpressionService coExpressionService;
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/co-expressions/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/CopyNumberEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/CopyNumberEnrichmentController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -34,6 +35,7 @@ public class CopyNumberEnrichmentController {
     @Autowired
     private CopyNumberEnrichmentService copyNumberEnrichmentService;
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/copy-number-enrichments/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/CopyNumberSegmentController.java
+++ b/web/src/main/java/org/cbioportal/web/CopyNumberSegmentController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -45,6 +46,7 @@ public class CopyNumberSegmentController {
     @Autowired
     private CopyNumberSegmentService copyNumberSegmentService;
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/samples/{sampleId}/copy-number-segments", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get copy number segments in a sample in a study")
@@ -81,6 +83,7 @@ public class CopyNumberSegmentController {
         }
     }
 
+    @PreAuthorize("hasPermission(#sampleIdentifiers, 'List<SampleIdentifier>', 'read')")
     @RequestMapping(value = "/copy-number-segments/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch copy number segments by sample ID")

--- a/web/src/main/java/org/cbioportal/web/DiscreteCopyNumberController.java
+++ b/web/src/main/java/org/cbioportal/web/DiscreteCopyNumberController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
@@ -43,6 +44,7 @@ public class DiscreteCopyNumberController {
     @Autowired
     private DiscreteCopyNumberService discreteCopyNumberService;
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/discrete-copy-number", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get discrete copy number alterations in a molecular profile")
@@ -70,6 +72,7 @@ public class DiscreteCopyNumberController {
         }
     }
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/discrete-copy-number/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
@@ -118,6 +121,7 @@ public class DiscreteCopyNumberController {
         }
     }
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/discrete-copy-number-counts/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/ExpressionEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/ExpressionEnrichmentController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -33,6 +34,7 @@ public class ExpressionEnrichmentController {
     @Autowired
     private ExpressionEnrichmentService expressionEnrichmentService;
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/expression-enrichments/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/FractionGenomeAlteredController.java
+++ b/web/src/main/java/org/cbioportal/web/FractionGenomeAlteredController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -31,6 +32,7 @@ public class FractionGenomeAlteredController {
     @Autowired
     private FractionGenomeAlteredService fractionGenomeAlteredService;
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/fraction-genome-altered/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/GenePanelController.java
+++ b/web/src/main/java/org/cbioportal/web/GenePanelController.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -85,6 +86,7 @@ public class GenePanelController {
         return new ResponseEntity<>(genePanelService.getGenePanel(genePanelId), HttpStatus.OK);
     }
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/gene-panel-data/fetch", method = RequestMethod.POST, 
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get gene panel data")
@@ -106,6 +108,7 @@ public class GenePanelController {
         return new ResponseEntity<>(genePanelDataList, HttpStatus.OK);
     }
 
+    @PreAuthorize("hasPermission(#genePanelMultipleStudyFilter, 'GenePanelMultipleStudyFilter', 'read')")
     @RequestMapping(value = "/gene-panel-data/fetch", method = RequestMethod.POST, 
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch gene panel data")

--- a/web/src/main/java/org/cbioportal/web/GenesetCorrelationController.java
+++ b/web/src/main/java/org/cbioportal/web/GenesetCorrelationController.java
@@ -45,6 +45,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -59,6 +60,7 @@ public class GenesetCorrelationController {
     @Autowired
     private GenesetCorrelationService genesetCorrelationService;
 
+    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfile', 'read')")
     @RequestMapping(value = "/genesets/{genesetId}/expression-correlation/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get the genes in a gene set that have expression correlated to the gene set scores (calculated using Spearman's correlation)")

--- a/web/src/main/java/org/cbioportal/web/GenesetDataController.java
+++ b/web/src/main/java/org/cbioportal/web/GenesetDataController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -32,7 +33,8 @@ public class GenesetDataController {
 
 	@Autowired
     private GenesetDataService genesetDataService;
-    
+
+    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfile', 'read')")    
     @RequestMapping(value = "/genetic-profiles/{geneticProfileId}/geneset-genetic-data/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch gene set \"genetic data\" items (gene set scores) by profile Id, gene set ids and sample ids")

--- a/web/src/main/java/org/cbioportal/web/GenesetHierarchyController.java
+++ b/web/src/main/java/org/cbioportal/web/GenesetHierarchyController.java
@@ -43,6 +43,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -57,6 +58,7 @@ public class GenesetHierarchyController {
     @Autowired
     private GenesetHierarchyService genesetHierarchyService;
 
+    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfile', 'read')")
     @RequestMapping(value = "/geneset-hierarchy/fetch", method = RequestMethod.POST,
             consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get gene set hierarchical organization information. I.e. how different gene sets relate to other gene sets, in a hierarchy")

--- a/web/src/main/java/org/cbioportal/web/MolecularDataController.java
+++ b/web/src/main/java/org/cbioportal/web/MolecularDataController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.Valid;
 import java.util.ArrayList;
@@ -39,7 +40,8 @@ public class MolecularDataController {
     
     @Autowired
     private MolecularDataService molecularDataService;
-    
+
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/molecular-data", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all molecular data in a molecular profile")
@@ -64,6 +66,7 @@ public class MolecularDataController {
         }
     }
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/molecular-data/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
@@ -103,6 +106,7 @@ public class MolecularDataController {
         }
     }
 
+    @PreAuthorize("hasPermission(#molecularDataMultipleStudyFilter, 'MolecularDataMultipleStudyFilter', 'read')")
     @RequestMapping(value = "/molecular-data/fetch", method = RequestMethod.POST, 
     consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch molecular data")

--- a/web/src/main/java/org/cbioportal/web/MolecularProfileController.java
+++ b/web/src/main/java/org/cbioportal/web/MolecularProfileController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -71,6 +72,7 @@ public class MolecularProfileController {
         }
     }
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get molecular profile")
@@ -81,6 +83,7 @@ public class MolecularProfileController {
         return new ResponseEntity<>(molecularProfileService.getMolecularProfile(molecularProfileId), HttpStatus.OK);
     }
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/molecular-profiles", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all molecular profiles in a study")
@@ -113,6 +116,7 @@ public class MolecularProfileController {
         }
     }
 
+    @PreAuthorize("hasPermission(#molecularProfileFilter, 'MolecularProfileFilter', 'read')")
     @RequestMapping(value = "/molecular-profiles/fetch", method = RequestMethod.POST, 
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch molecular profiles")

--- a/web/src/main/java/org/cbioportal/web/MrnaPercentileController.java
+++ b/web/src/main/java/org/cbioportal/web/MrnaPercentileController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.constraints.Size;
 import java.util.List;
@@ -32,6 +33,7 @@ public class MrnaPercentileController {
     @Autowired
     private MrnaPercentileService mrnaPercentileService;
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mrna-percentile/fetch", 
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, 
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/MutationController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationController.java
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -53,6 +54,7 @@ public class MutationController {
     @Autowired
     private MutationService mutationService;
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mutations", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get mutations in a molecular profile by Sample List ID")
@@ -89,6 +91,7 @@ public class MutationController {
         }
     }
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mutations/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch mutations in a molecular profile")
@@ -145,6 +148,7 @@ public class MutationController {
         }
     }
 
+    @PreAuthorize("hasPermission(#mutationMultipleStudyFilter, 'MutationMultipleStudyFilter', 'read')")
     @RequestMapping(value = "/mutations/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch mutations in multiple molecular profiles by sample IDs")
@@ -207,6 +211,7 @@ public class MutationController {
         }
     }
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mutation-counts", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get mutation counts in a molecular profile by Sample List ID")
@@ -220,6 +225,7 @@ public class MutationController {
             molecularProfileId, sampleListId), HttpStatus.OK);
     }
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mutation-counts/fetch", 
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, 
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/MutationEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationEnrichmentController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -33,6 +34,7 @@ public class MutationEnrichmentController {
     @Autowired
     private MutationEnrichmentService mutationEnrichmentService;
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mutation-enrichments/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/MutationSpectrumController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationSpectrumController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -31,6 +32,7 @@ public class MutationSpectrumController {
     @Autowired
     private MutationSpectrumService mutationSpectrumService;
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mutation-spectrums/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/SampleListController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleListController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -70,6 +71,7 @@ public class SampleListController {
         }
     }
 
+    @PreAuthorize("hasPermission(#sampleListId, 'SampleList', 'read')")
     @RequestMapping(value = "/sample-lists/{sampleListId}", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get sample list")
@@ -80,6 +82,7 @@ public class SampleListController {
         return new ResponseEntity<>(sampleListService.getSampleList(sampleListId), HttpStatus.OK);
     }
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/sample-lists", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all sample lists in a study")
@@ -112,6 +115,7 @@ public class SampleListController {
         }
     }
 
+    @PreAuthorize("hasPermission(#sampleListId, 'SampleList', 'read')")
     @RequestMapping(value = "/sample-lists/{sampleListId}/sample-ids", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all sample IDs in a sample list")
@@ -122,6 +126,7 @@ public class SampleListController {
         return new ResponseEntity<>(sampleListService.getAllSampleIdsInSampleList(sampleListId), HttpStatus.OK);
     }
 
+    @PreAuthorize("hasPermission(#sampleListIds, 'List<SampleListId>', 'read')")
     @RequestMapping(value = "/sample-lists/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, 
     produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch sample lists by ID")

--- a/web/src/main/java/org/cbioportal/web/SignificantCopyNumberRegionController.java
+++ b/web/src/main/java/org/cbioportal/web/SignificantCopyNumberRegionController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -37,6 +38,7 @@ public class SignificantCopyNumberRegionController {
     @Autowired
     private SignificantCopyNumberRegionService significantCopyNumberRegionService;
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/significant-copy-number-regions", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get significant copy number alteration regions in a study")

--- a/web/src/main/java/org/cbioportal/web/SignificantlyMutatedGenesController.java
+++ b/web/src/main/java/org/cbioportal/web/SignificantlyMutatedGenesController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -37,6 +38,7 @@ public class SignificantlyMutatedGenesController {
     @Autowired
     private SignificantlyMutatedGeneService significantlyMutatedGeneService;
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}/significantly-mutated-genes", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get significantly mutated genes in a study")

--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -69,6 +70,7 @@ public class StudyController {
         }
     }
 
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudy', 'read')")
     @RequestMapping(value = "/studies/{studyId}", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get a study")
@@ -79,6 +81,7 @@ public class StudyController {
         return new ResponseEntity<>(studyService.getStudy(studyId), HttpStatus.OK);
     }
 
+    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
     @RequestMapping(value = "/studies/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, 
     produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch studies by IDs")

--- a/web/src/main/java/org/cbioportal/web/VariantCountController.java
+++ b/web/src/main/java/org/cbioportal/web/VariantCountController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import javax.validation.constraints.Size;
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ public class VariantCountController {
     @Autowired
     private VariantCountService variantCountService;
 
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/variant-counts/fetch", 
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, 
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/config/SwaggerConfig.java
+++ b/web/src/main/java/org/cbioportal/web/config/SwaggerConfig.java
@@ -11,6 +11,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import springfox.documentation.swagger.web.UiConfiguration;
+import springfox.documentation.swagger.web.UiConfigurationBuilder;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,6 +43,14 @@ public class SwaggerConfig {
             .useDefaultResponseMessages(false)
             .protocols(new HashSet<>(Arrays.asList("http", "https")))
             .apiInfo(apiInfo());
+    }
+
+    @Bean
+    UiConfiguration uiConfig() {
+        return UiConfigurationBuilder.builder()
+            .displayRequestDuration(true)
+            .validatorUrl("")
+            .build();
     }
 
     private ApiInfo apiInfo() {

--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalAttributeFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalAttributeFilter.java
@@ -3,8 +3,9 @@ package org.cbioportal.web.parameter;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
 import java.util.List;
+import java.io.Serializable;
 
-public class ClinicalAttributeFilter {
+public class ClinicalAttributeFilter implements Serializable {
 
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<SampleIdentifier> sampleIdentifiers;

--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataIdentifier.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataIdentifier.java
@@ -1,6 +1,8 @@
 package org.cbioportal.web.parameter;
 
-public class ClinicalDataIdentifier {
+import java.io.Serializable;
+
+public class ClinicalDataIdentifier implements Serializable {
 
     private String entityId;
     private String studyId;

--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataMultiStudyFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataMultiStudyFilter.java
@@ -4,10 +4,11 @@ import org.cbioportal.web.ClinicalDataController;
 
 import javax.validation.constraints.Size;
 import java.util.List;
+import java.io.Serializable;
 
 import static org.cbioportal.web.parameter.PagingConstants.MAX_PAGE_SIZE;
 
-public class ClinicalDataMultiStudyFilter {
+public class ClinicalDataMultiStudyFilter implements Serializable {
 
     @Size(min = 1, max = ClinicalDataController.CLINICAL_DATA_MAX_PAGE_SIZE)
     List<ClinicalDataIdentifier> identifiers;

--- a/web/src/main/java/org/cbioportal/web/parameter/GenePanelMultipleStudyFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/GenePanelMultipleStudyFilter.java
@@ -3,8 +3,9 @@ package org.cbioportal.web.parameter;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.List;
+import java.io.Serializable;
 
-public class GenePanelMultipleStudyFilter {
+public class GenePanelMultipleStudyFilter implements Serializable {
 
     @NotNull
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)

--- a/web/src/main/java/org/cbioportal/web/parameter/MolecularDataMultipleStudyFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/MolecularDataMultipleStudyFilter.java
@@ -3,8 +3,9 @@ package org.cbioportal.web.parameter;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
 import java.util.List;
+import java.io.Serializable;
 
-public class MolecularDataMultipleStudyFilter {
+public class MolecularDataMultipleStudyFilter implements Serializable {
 
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<SampleMolecularIdentifier> sampleMolecularIdentifiers;

--- a/web/src/main/java/org/cbioportal/web/parameter/MolecularProfileFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/MolecularProfileFilter.java
@@ -3,8 +3,9 @@ package org.cbioportal.web.parameter;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
 import java.util.List;
+import java.io.Serializable;
 
-public class MolecularProfileFilter {
+public class MolecularProfileFilter implements Serializable {
     
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> studyIds;

--- a/web/src/main/java/org/cbioportal/web/parameter/MutationMultipleStudyFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/MutationMultipleStudyFilter.java
@@ -5,8 +5,9 @@ import org.cbioportal.web.MutationController;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
 import java.util.List;
+import java.io.Serializable;
     
-public class MutationMultipleStudyFilter {
+public class MutationMultipleStudyFilter implements Serializable {
 
     @Size(min = 1, max = MutationController.MUTATION_MAX_PAGE_SIZE)
     private List<SampleMolecularIdentifier> sampleMolecularIdentifiers;

--- a/web/src/main/java/org/cbioportal/web/parameter/PatientFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/PatientFilter.java
@@ -3,8 +3,9 @@ package org.cbioportal.web.parameter;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
 import java.util.List;
+import java.io.Serializable;
 
-public class PatientFilter {
+public class PatientFilter implements Serializable {
     
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<PatientIdentifier> patientIdentifiers;

--- a/web/src/main/java/org/cbioportal/web/parameter/PatientIdentifier.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/PatientIdentifier.java
@@ -1,6 +1,8 @@
 package org.cbioportal.web.parameter;
 
-public class PatientIdentifier {
+import java.io.Serializable;
+
+public class PatientIdentifier implements Serializable {
 
     private String patientId;
     private String studyId;

--- a/web/src/main/java/org/cbioportal/web/parameter/SampleFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/SampleFilter.java
@@ -5,8 +5,9 @@ import org.cbioportal.web.SampleController;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
 import java.util.List;
+import java.io.Serializable;
 
-public class SampleFilter {
+public class SampleFilter implements Serializable {
     
     @Size(min = 1, max = SampleController.SAMPLE_MAX_PAGE_SIZE)
     private List<SampleIdentifier> sampleIdentifiers;

--- a/web/src/main/java/org/cbioportal/web/parameter/SampleIdentifier.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/SampleIdentifier.java
@@ -1,6 +1,8 @@
 package org.cbioportal.web.parameter;
 
-public class SampleIdentifier {
+import java.io.Serializable;
+
+public class SampleIdentifier implements Serializable {
 
     private String sampleId;
     private String studyId;

--- a/web/src/main/java/org/cbioportal/web/parameter/SampleMolecularIdentifier.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/SampleMolecularIdentifier.java
@@ -1,6 +1,8 @@
 package org.cbioportal.web.parameter;
 
-public class SampleMolecularIdentifier {
+import java.io.Serializable;
+
+public class SampleMolecularIdentifier implements Serializable {
     
     private String sampleId;
     private String molecularProfileId;

--- a/web/src/main/java/org/cbioportal/web/util/UniqueKeyExtractor.java
+++ b/web/src/main/java/org/cbioportal/web/util/UniqueKeyExtractor.java
@@ -1,0 +1,32 @@
+package org.cbioportal.web.util;
+
+import org.cbioportal.web.interceptor.UniqueKeyInterceptor;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.Collection;
+import java.util.Base64;
+
+@Component
+public class UniqueKeyExtractor {
+
+    private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
+
+    public void extractUniqueKeys(List<String> uniqueKeys, Collection<String> studyIdsToReturn) {
+
+        extractUniqueKeys(uniqueKeys, studyIdsToReturn, null);
+    }
+    
+    public void extractUniqueKeys(List<String> uniqueKeys, Collection<String> studyIdsToReturn, Collection<String> patientOrSampleIdsToReturn) {
+
+        for (String uniqueKey : uniqueKeys) {
+            String uniqueId = new String(BASE64_DECODER.decode(uniqueKey));
+            String[] patientOrSampleAndStudyId = uniqueId.split(UniqueKeyInterceptor.DELIMITER);
+            if (patientOrSampleAndStudyId.length == 2) {
+                if (patientOrSampleIdsToReturn != null) {
+                    patientOrSampleIdsToReturn.add(patientOrSampleAndStudyId[0]);
+                }
+                studyIdsToReturn.add(patientOrSampleAndStudyId[1]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
It was revealed during backend code profiling that authenticate added significant cost to the time it takes to process requests (see attached image as example).  After some further analysis, one reason for this increase is because security takes place in the service layer and intra-service communication results in multiple authorization checks for the same front-end request.  This is compounded when you have multiple requests entering the backend to load a single web page like Query Results.

This PR attempts to alleviate this issue by moving the security implementation from the service layer to the web layer.  As a result of this PR, the number or authorizations per request is reduced to one.

It was first thought that the task would amount to moving spring-security annotations from the  service classes to the controller classes.  The work became more involved as the use of "filter" classes from the web/src/main/java/org/cbioportal/web/parameter package were discovered.  As a result, additional code had to be added to CancerStudyPermissionEvaluator.  I did my best to keep this class as clean as possible and made improvements when there was opportunity.  For example, I utilized a Set when permission checks came in for lists 
 containing duplicate identifiers (for GENIE a list containing 22k+ identical cancer study IDs could be checked for read permission).

This PR also contains necessary updates so that SpringFox/Swagger documentation would operate properly with security running at the web level.

I should mention that there was code added to RC in a previous PR that added significant time to loading the query results page.  After some profiling it looks like the culprit is in fetchGenePanelDataInMultipleMolecularProfiles.  Specifically a call to java.util.stream.ReferencePipeline.findFirst in a method createGenePanelData (28 seconds for this call alone as its a nested for-loop over all genes over all samples (almost 22 thousand).  This code  clouds the optimizations made by this PR and should be addressed in a separate PR before the RC branch is put into production.
