### PR TITLE
Add cache buster for study view config

### DIFF
--- a/portal/src/main/webapp/js/src/dashboard/model/dataProxy.js
+++ b/portal/src/main/webapp/js/src/dashboard/model/dataProxy.js
@@ -817,7 +817,7 @@ window.DataManagerForIviz = (function($, _) {
           if (_.isObject(configs_)) {
             fetch_promise.resolve(configs_);
           } else {
-            $.getJSON(window.cbioResourceURL + 'configs.json')
+            $.getJSON(window.cbioResourceURL + 'configs.json?' + appVersion)
               .then(function(data) {
                 var configs = {
                   styles: {


### PR DESCRIPTION
Genie requires changes to `configs.json` on study view. To prevent people using their old cached `configs.json` enable cache buster.

This might've actually already given problems in the past whenever we made changes to `configs.json`