### PR TITLE
Deploy cBioPortal with k8s and kops

### DIFF
--- a/Dockerfile.jre
+++ b/Dockerfile.jre
@@ -1,0 +1,14 @@
+FROM openjdk:8-jre-alpine
+# copy application WAR (with libraries inside)
+COPY portal/target/cbioportal*.war /app.war
+COPY portal/target/dependency/webapp-runner.jar /webapp-runner.jar
+# specify default command
+CMD /usr/bin/java \
+    -Ddbconnector=dbcp \
+    -Ddb.suppress_schema_version_mismatch_errors=true \
+    -jar \
+    /webapp-runner.jar \
+    --expand-war \
+    --enable-compression \
+    --port ${PORT} \
+    /app.war

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,19 @@
+# Deploy to AWS using Kubernetes
+## Initialize AWS cloud with kops
+- Install aws command line client
+- Use following env variables
+    ```
+    export NAME=cbioportal.review.k8s.local
+    export KOPS_STATE_STORE=s3://cbioportal-state-of-k8s # need to create this bucket in s3 first
+    ```
+- Make an S3 bucket for keeping track of K8s state
+    ```
+    aws s3api create-bucket --bucket ${KOPS_STATE_STORE/s3:\/\//}
+    ```
+- Install [kops](https://github.com/kubernetes/kops) (creates kubernetes
+  cluster on amazon)
+    ```
+    kops create cluster --state=${KOPS_STATE_STORE} --cloud=aws \
+        --zones=us-east-1a,us-east-1c --node-count=1  --node-size=t2.medium \
+        --master-size=t2.small ${NAME}
+    ```

--- a/deploy/k8s/cbioportal_jre.yaml
+++ b/deploy/k8s/cbioportal_jre.yaml
@@ -1,0 +1,57 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "4"
+  creationTimestamp: null
+  generation: 1
+  labels:
+    run: cbioportal-jre
+  name: cbioportal-jre
+  selfLink: /apis/extensions/v1beta1/namespaces/default/deployments/cbioportal-jre
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+        run: cbioportal-jre
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: cbioportal-jre
+    spec:
+      containers:
+      - env:
+        - name: PORT
+          value: "80"
+        - name: CBIOPORTAL_DB_HOST
+          value: "sm4sa6ozhn5ya6.cuooweljyhix.us-east-1.rds.amazonaws.com"
+        - name: CBIOPORTAL_DB_CONNECTION_STRING
+          value: "jdbc:mysql://sm4sa6ozhn5ya6.cuooweljyhix.us-east-1.rds.amazonaws.com:3306/"
+        image: inodb/cbioportal-jre:v1.12.0-8-ga4d3e20e1
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 5
+        name: cbioportal-jre
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status: {}

--- a/deploy/k8s/external_dns.yaml
+++ b/deploy/k8s/external_dns.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions"] 
+  resources: ["ingresses"] 
+  verbs: ["get","watch","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: default
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
+        args:
+        - --source=service
+        - --source=ingress
+        - --domain-filter=cbioportal.review # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
+        - --provider=aws
+        - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
+        - --aws-zone-type=public # only look at public hosted zones (valid values are public, private or no value for both)
+        - --registry=txt
+        - --txt-owner-id=my-identifier

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cbioportal
+  selfLink: /api/v1/namespaces/default/services/cbioportal
+  creationTimestamp: null
+  labels:
+    run: cbioportal-jre
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: test.cbioportal.review.
+spec:
+  # externalTrafficPolicy: Cluster
+  ports:
+  - port: 80
+    name: http
+    targetPort: 80
+  selector:
+    run: cbioportal-jre
+  sessionAffinity: None
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/deploy/kops/cbioportal.review.k8s.local.yaml
+++ b/deploy/kops/cbioportal.review.k8s.local.yaml
@@ -1,0 +1,96 @@
+apiVersion: kops/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: 2018-03-26T20:54:20Z
+  name: cbioportal.review.k8s.local
+spec:
+  additionalPolicies:
+    master: |
+      [
+         {
+           "Effect": "Allow",
+           "Action": [
+             "route53:ChangeResourceRecordSets"
+           ],
+           "Resource": [
+             "arn:aws:route53:::hostedzone/*"
+           ]
+         },
+         {
+           "Effect": "Allow",
+           "Action": [
+             "route53:ListHostedZones",
+             "route53:ListResourceRecordSets"
+           ],
+           "Resource": [
+             "*"
+           ]
+         }
+       ]
+    node: |
+      [
+         {
+           "Effect": "Allow",
+           "Action": [
+             "route53:ChangeResourceRecordSets"
+           ],
+           "Resource": [
+             "arn:aws:route53:::hostedzone/*"
+           ]
+         },
+         {
+           "Effect": "Allow",
+           "Action": [
+             "route53:ListHostedZones",
+             "route53:ListResourceRecordSets"
+           ],
+           "Resource": [
+             "*"
+           ]
+         }
+       ]
+  api:
+    loadBalancer:
+      type: Public
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: s3://cbioportal-state-of-k8s/cbioportal.review.k8s.local
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-us-east-1a
+      name: a
+    name: main
+  - etcdMembers:
+    - instanceGroup: master-us-east-1a
+      name: a
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: 1.9.3
+  masterInternalName: api.internal.cbioportal.review.k8s.local
+  masterPublicName: api.cbioportal.review.k8s.local
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-east-1a
+    type: Public
+    zone: us-east-1a
+  - cidr: 172.20.64.0/19
+    name: us-east-1c
+    type: Public
+    zone: us-east-1c
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public


### PR DESCRIPTION
Deploy cBioPortal with kubernetes and kops on AWS.

See: http://test.cbioportal.review (on my personal AWS account now, so not always up)

Features:
- Specify number of running instances
- Load balancer
- Rolling deployments
- Small container image with just JRE (no JDK necessary). Built the docker image locally, but we could do this on e.g. Travis/CircleCI
- Can assign domain names through dnsexternal service (uses aws route53 under the hood)

What's left for production:
- [ ] get amazon account from hpc
- [ ] either change current production load balancer to point some traffic here or point cbioportal.org to this
- [ ] monitoring java apps (how is JAVA_OPTS being set etc)

Optional:
- [ ] automated https certificates
- [ ] persistent logging