### PR TITLE
Fix when custom case lists has newlines

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/global/server_vars.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/server_vars.jsp
@@ -33,6 +33,9 @@
     String sampleIdsKey = request.getAttribute(QueryBuilder.CASE_IDS_KEY) != null ? (String) request.getAttribute(QueryBuilder.CASE_IDS_KEY) : "";
     
     String caseIds = (String) request.getAttribute(QueryBuilder.CASE_IDS);
+    if (request.getAttribute(QueryBuilder.CASE_IDS) != null) {
+        caseIds = caseIds.replace("\n","+");
+    }
 
     sampleSetName = sampleSetName.replaceAll("'", "\\'");
     sampleSetName = sampleSetName.replaceAll("\"", "\\\"");


### PR DESCRIPTION
Issue introduced by #3924. When using custom case list with newlines, the JSP
variable can't be written to the page (multi line javascript string), instead
use `+` as the delimiter.

Failing URL was:

http://localhost:8080/index.do?cancer_study_id=ov_tcga_pub&Z_SCORE_THRESHOLD=2&RPPA_SCORE_THRESHOLD=2&data_priority=0&case_set_id=-1&case_ids=ov_tcga_pub%3ATCGA-24-1428-01%0D%0Aov_tcga_pub%3ATCGA-24-1928-01%0D%0Aov_tcga_pub%3ATCGA-29-1698-01%0D%0Aov_tcga_pub%3ATCGA-24-0980-01%0D%0Aov_tcga_pub%3ATCGA-24-0970-01%0D%0Aov_tcga_pub%3ATCGA-13-0725-01%0D%0Aov_tcga_pub%3ATCGA-23-1027-01%0D%0Aov_tcga_pub%3ATCGA-13-0755-01%0D%0Aov_tcga_pub%3ATCGA-25-1315-01&gene_list=BRCA1%2520BRCA2&geneset_list=+&tab_index=tab_visualize&Action=Submit&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=ov_tcga_pub_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=ov_tcga_pub_gistic#