### PR TITLE
Disable mybatis cache

### DIFF
--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -84,6 +84,11 @@
             <property name="typeAliasesPackage" value="org.mskcc.cbio.portal.model" />
             <property name="typeHandlersPackage" value="org.cbioportal.persistence.mybatis.typehandler" />
             <property name="objectFactory" ref="customObjectFactory" />
+            <property name="configuration">
+                <bean class="org.apache.ibatis.session.Configuration">
+                    <property name="cacheEnabled" value="false"/>
+                </bean>
+            </property>
         </bean>
     </beans>
   


### PR DESCRIPTION
In current mybatis configuration, the memory usage continuesly goes up and eventually creates out-of-memory issue. Before figuring out which mybatis mapper causing the issue, we suggest to turn it off for beta portals.

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line can be automatically added by git if you run the `git-commit` command with the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to hotfix.


# Notify reviewers
@inodb @ersinciftci  @cBioPortal/backend 