### PR TITLE
Option disable mybatis cache - enable by default

### DIFF
--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -86,7 +86,7 @@
             <property name="objectFactory" ref="customObjectFactory" />
             <property name="configuration">
                 <bean class="org.apache.ibatis.session.Configuration">
-                    <property name="cacheEnabled" value="false"/>
+                    <property name="cacheEnabled" value="${mybatis.cache.enabled:true}" />
                 </bean>
             </property>
         </bean>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -212,3 +212,7 @@ oncoprint.defaultview=patient
 
 # Custom gene sets
 # querypage.setsofgenes.location=file:/<path>
+#
+# Disable cache (for non authorized portals this can sometimes avoid running
+# out of memory with relatively little performance loss)
+# mybatis.cache.enabled=false

--- a/test/end-to-end/screenshots.yml
+++ b/test/end-to-end/screenshots.yml
@@ -3,18 +3,18 @@ selenium_hub_url: "http://hub:4444/wd/hub"
 python_selenium_container: endtoend_python-selenium_1
 screenshot:
   names:
-    # - patient_view_lgg_ucsf_2014_case_id_P04
+    - patient_view_lgg_ucsf_2014_case_id_P04
     - study_view_lgg_ucsf_2014
   urls:
-    # - case.do#/patient?studyId=lgg_ucsf_2014&caseId=P04
+    - case.do#/patient?studyId=lgg_ucsf_2014&caseId=P04
     - study.do?cancer_study_id=lgg_ucsf_2014
   # timeout in seconds
   timeout:
-    # - 25
+    - 10
     - 10
   # number of retries before failing
   retry:
-    # - 3
+    - 3
     - 2
 browsers:
   - firefox


### PR DESCRIPTION
We found that disabling cache in non auth portals gave relatively little performance less and less out of memory errors