### PR TITLE
Add localdev and localdist url params

### DIFF
--- a/portal/src/main/webapp/js/src/load-frontend.js
+++ b/portal/src/main/webapp/js/src/load-frontend.js
@@ -1,75 +1,50 @@
 
 function clearDevState(e){
     localStorage.removeItem('localdev');
+    localStorage.removeItem('localdist');
     localStorage.removeItem('heroku');
     window.location.reload();
 }
 
+function showFrontendPopup(url) {
+    document.addEventListener("DOMContentLoaded", function(event) {
+        var newDiv = document.createElement("div");
+        newDiv.setAttribute('style', 'position: fixed; z-index:100; top: 0; left: 0; width: 100%');
+        document.body.appendChild(newDiv);
+        newDiv.innerHTML = '<div style="">' +
+            '<div class="alert alert-warning">' +
+            '<button type="button" class="close" data-dismiss="alert">&times;</button>' +
+            'cbioportal-frontend dev mode, using ' + url +
+            '</div>' +
+            '</div>';
+        newDiv.onclick=function(){
+            document.body.removeChild(this);
+        }
+    });
+}
+
 window.loadReactApp = function(config) {
-    
     // Set frontend route to /patient
     window.defaultRoute = '/' + config.defaultRoute;
     
-    if (localStorage.getItem('localdev') === "true") {
-        // Use cbioportal-frontend localhost:3000 for dev
-        document.write('<link rel="stylesheet" type="text/css" href="//localhost:3000/reactapp/prefixed-bootstrap.min.css?'+ window.frontendConfig.appVersion +'" />');
-        document.write('<script src="//localhost:3000/reactapp/common.bundle.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');
-        document.write('<script src="//localhost:3000/reactapp/main.app.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');
-        // Show alert
-        
-        document.addEventListener("DOMContentLoaded", function(event) {
-            var newDiv = document.createElement("div");
-            newDiv.setAttribute('style', 'position: fixed; z-index:100; top: 0; left: 0; width: 100%');
-            document.body.appendChild(newDiv);
-            newDiv.innerHTML = '<div style="">' +
-                '<div class="alert alert-warning">' +
-                '<button type="button" class="close" data-dismiss="alert">&times;</button>' +
-                'cbioportal-frontend dev mode, using localhost:3000' +
-                '&nbsp;<a href="#" onclick="clearDevState()">clear</a>' +
-                '</div>' +
-                '</div>';
-            newDiv.onclick=function(){
-                document.body.removeChild(this);
-            }
-        });
-        
-    } else if (localStorage.getItem('heroku')) {
-        var herokuInstance = '//' + localStorage.getItem('heroku') + '.herokuapp.com';
-        document.write('<link rel="stylesheet" type="text/css" href="' + herokuInstance + '/reactapp/prefixed-bootstrap.min.css?'+ window.frontendConfig.appVersion +'" />');
-        document.write('<link rel="stylesheet" type="text/css" href="' + herokuInstance + '/reactapp/styles.css?'+ window.frontendConfig.appVersion +'" />');
-        document.write('<script src="' + herokuInstance + '/reactapp/common.bundle.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');
-        document.write('<script src="' + herokuInstance + '/reactapp/main.app.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');
-    
-        document.addEventListener("DOMContentLoaded", function(event) {
-            var newDiv = document.createElement("div");
-            newDiv.setAttribute('style', 'position: fixed; z-index:100; top: 0; left: 0; width: 100%');
-            document.body.appendChild(newDiv);
-            newDiv.innerHTML = '<div style="">' +
-                '<div class="alert alert-warning">' +
-                '<button type="button" class="close" data-dismiss="alert">&times;</button>' +
-                'cbioportal-frontend dev mode, using ' + herokuInstance +
-                '</div>' +
-                '</div>';
-            newDiv.onclick=function(){
-                document.body.removeChild(this);
-            }
-        });
-
-    } else {
-        if (window.frontendConfig.frontendUrl === undefined) {
-            // this should never happen
-            if (console.error) {
-                console.error('ERROR: No frontend URL defined, should at least be empty string');
-            } else {
-                console.log('ERROR: No frontend URL defined, should at least be empty string');
-            }
+    if (window.frontendConfig.frontendUrl === undefined) {
+        // this should never happen
+        if (console.error) {
+            console.error('ERROR: No frontend URL defined, should at least be empty string');
+        } else {
+            console.log('ERROR: No frontend URL defined, should at least be empty string');
         }
-        // Use deployed sources//
-        document.write('<link rel="stylesheet" type="text/css" href="' + window.frontendConfig.frontendUrl + 'reactapp/prefixed-bootstrap.min.css?'+ window.frontendConfig.appVersion +'" />');
-        document.write('<link rel="stylesheet" type="text/css" href="' + window.frontendConfig.frontendUrl + 'reactapp/styles.css?'+ window.frontendConfig.appVersion +'" />');
-        document.write('<script src="' + window.frontendConfig.frontendUrl + 'reactapp/common.bundle.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');
-        document.write('<script src="' + window.frontendConfig.frontendUrl + 'reactapp/main.app.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');
     }
+    if (window.localdev || window.localdist || localStorage.heroku) {
+        showFrontendPopup(window.frontendConfig.frontendUrl);
+    }
+    document.write('<link rel="stylesheet" type="text/css" href="' + window.frontendConfig.frontendUrl + 'reactapp/prefixed-bootstrap.min.css?'+ window.frontendConfig.appVersion +'" />');
+    // localdev gets styling in another manner
+    if (!window.localdev) {
+        document.write('<link rel="stylesheet" type="text/css" href="' + window.frontendConfig.frontendUrl + 'reactapp/styles.css?'+ window.frontendConfig.appVersion +'" />');
+    }
+    document.write('<script src="' + window.frontendConfig.frontendUrl + 'reactapp/common.bundle.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');
+    document.write('<script src="' + window.frontendConfig.frontendUrl + 'reactapp/main.app.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');
 
 };
 


### PR DESCRIPTION
We have been using `localStorage.localdev === true` for getting artifacts from
local machine. Now we supply this same option as URL parameter
`?localdev=true`. This also adds an extra feature if you want to use a local
static server instead of `npm run start`, one can now use `?localdist=true`.
Artifacts always need to be served on port 3000.