### PR TITLE
'Targeted_Region' can be without gene

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1363,7 +1363,7 @@ class MutationsExtendedValidator(Validator):
             entrez_id = data[self.cols.index('Entrez_Gene_Id')]
         if hugo_symbol == 'Unknown' and entrez_id == '0':
             is_silent = True
-            if variant_classification == 'IGR':
+            if variant_classification in ['IGR', 'Targeted_Region']:
                 self.logger.info("This variant (Gene symbol 'Unknown', Entrez gene ID 0) will be filtered out",
                                  extra={'line_number': self.line_number,
                                         'cause': variant_classification})
@@ -1376,7 +1376,7 @@ class MutationsExtendedValidator(Validator):
                 self.logger.warning(
                                     "Gene specification (Gene symbol 'Unknown', Entrez gene ID 0) for this variant "
                                     "implies intergenic even though Variant_Classification is "
-                                    "not 'IGR'; this variant will be filtered out",
+                                    "not 'IGR' or 'Targeted_Region'; this variant will be filtered out",
                                     extra={'line_number': self.line_number,
                                            'cause': variant_classification})
         elif variant_classification in self.SKIP_VARIANT_TYPES:


### PR DESCRIPTION
- Add 'Targeted_Region' to possible Variant_Classifications without gene ID

This was requested by @yichaoS . 

The format for genes without a gene ID is:
- 'Hugo_Symbol' should be 'Unknown'
- 'Entrez_Gene_Id' should be '0'

https://wiki.nci.nih.gov/display/TCGA/Mutation+Annotation+Format+(MAF)+Specification
https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/