### PR TITLE
Disable patient view screenshot (takes too long)

### DIFF
--- a/test/end-to-end/screenshots.yml
+++ b/test/end-to-end/screenshots.yml
@@ -3,18 +3,18 @@ selenium_hub_url: "http://hub:4444/wd/hub"
 python_selenium_container: endtoend_python-selenium_1
 screenshot:
   names:
-    - patient_view_lgg_ucsf_2014_case_id_P04
+    # - patient_view_lgg_ucsf_2014_case_id_P04
     - study_view_lgg_ucsf_2014
   urls:
-    - case.do#/patient?studyId=lgg_ucsf_2014&caseId=P04
+    # - case.do#/patient?studyId=lgg_ucsf_2014&caseId=P04
     - study.do?cancer_study_id=lgg_ucsf_2014
   # timeout in seconds
   timeout:
-    - 10
+    # - 30
     - 10
   # number of retries before failing
   retry:
-    - 3
+    # - 3
     - 2
 browsers:
   - firefox


### PR DESCRIPTION
We are also running this test in frontend repo so not that necessary (rather run the same tests on backend repo instead)