### PR TITLE
turn on expression plots for pancan studies

### DIFF
--- a/portal/src/main/webapp/js/src/cross-cancer-plotly-plots.js
+++ b/portal/src/main/webapp/js/src/cross-cancer-plotly-plots.js
@@ -50,13 +50,18 @@ var ccPlots = (function (Plotly, _, $) {
         
         $.when(ccPlots.util.getGeneticProfiles_(_queriedStudyIds)).then(function(_profiles) {
             
-            var _param_mrna_profile_arr = _.map(_queriedStudyIds, function (_sid) {
+            var _param_mrna_profile_arr = _.reduce(_queriedStudyIds, function (memo, _sid) {
                 if ($("#cc_plots_profile_list").val() === 'v1') {
-                    return _sid + "_rna_seq_mrna";
+                    memo.push( _sid + "_rna_seq_mrna" );
+                    //return _sid + ""
                 } else if ($("#cc_plots_profile_list").val() === 'v2') {
-                    return _sid + "_rna_seq_v2_mrna";
+                    //return _sid + "_rna_seq_v2_mrna";
+                    memo.push(_sid + "_rna_seq_v2_mrna");
+                    memo.push(_sid + "_rna_seq_v2_mrna_median");
+                    //return _sid + "_rna_seq_v2_mrna_median";
                 }
-            });
+                return memo;
+            },[]);
             var _param_mut_profile_arr = _.map(_queriedStudyIds, function (_sid) {
                 return _sid + "_mutations";
             });
@@ -460,7 +465,6 @@ var ccPlots = (function (Plotly, _, $) {
     }
     
     var renderStudySelBox = function() {
-        
             // generate the content of the study selection expendable section
             $("#cc_plots_study_selection_btn").attr("data-toggle", "collapse");
             $("#cc_plots_study_selection_btn").removeClass("disabled");
@@ -469,10 +473,19 @@ var ccPlots = (function (Plotly, _, $) {
                 // html 
                 $("#cc_plots_select_study_box").append("select <a href='#' id='cc_plots_select_tcga_provisional'>TCGA provisional</a> / <a href='#' id='cc_plots_select_all'>all</a> / <a href='#' id='cc_plots_select_none'>none</a><br><br>");
                 var _fg = false; // no studies is selected in the box
+                
+                var onlyPanCan = _.every(study_meta,(study)=>/pan_can_atlas/.test(study.id));
+               
                 _.each(study_meta, function(_study_meta_obj) {
                     var _checked = ''; //by default select only TCGA provisional studies
-                    if (_study_meta_obj.name.toLowerCase().indexOf("tcga") !== -1 && _study_meta_obj.name.toLowerCase().indexOf("provisional") !== -1) {
+                    // if we don't only have pan can, then we're going to default all provisional studies
+                    if (!onlyPanCan &&_study_meta_obj.name.toLowerCase().indexOf("tcga") !== -1 && _study_meta_obj.name.toLowerCase().indexOf("provisional") !== -1) {
                         _checked = 'checked';
+                        _fg = true;
+                    }
+                    // if we're only pan can, turn all pan on
+                    if (onlyPanCan) {
+                        _checked = "checked";
                         _fg = true;
                     }
                     $("#cc_plots_select_study_box").append("<input type='checkbox' id='cc_plots_" + _study_meta_obj.id + "_sel' name='cc_plots_selected_studies' value='" + _study_meta_obj.id + "' title='Select "+_study_meta_obj.name+"' " + _checked + ">" + _study_meta_obj.name + "<br>");


### PR DESCRIPTION
The new pan can atlas studies have expression data.  but Expression tab excludes all but tcga studies.  change this show that pancan studies show up.  Also, pan can studies are turned off by default, but will default on if query includes ONLY pancan studies

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] Make sure your commit messages end with a Signed-off-by string (this line can be automatically added by git if you run the `git-commit` command with the `-s` option)
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to hotfix.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).

# Notify reviewers
Read our [Pull request merging policy](../CONTRIBUTING.md#pull-request-merging-policy) and identify reviewer if you can.

If you are not part of the cBioPortal organization look at who worked on the file before you. Please use `git blame <filename>` to determine that and notify them here:
