### PR TITLE
Use maintained copy of OQL parser to query virtual studies

### DIFF
--- a/portal/src/main/webapp/js/src/cgx_jquery.js
+++ b/portal/src/main/webapp/js/src/cgx_jquery.js
@@ -55,7 +55,7 @@ function setUpTabs() {
     }
      var activeIndex = (matchedIndex === -1) ? null : matchedIndex;
 
-     var summaryIsDefault = (window.isVirtualStudy && window.oql_parser.parse(serverVars.theQuery).length === 1);
+     var summaryIsDefault = (window.isVirtualStudy && window.frontendVars.oqlGenes(serverVars.theQuery).length === 1);
      activeIndex = (activeIndex !== null) ? activeIndex : (summaryIsDefault ? 1 : 0);
      $('#tabs').tabs({ active:activeIndex});
      $('#tabs').show();


### PR DESCRIPTION
As @adamabeshouse noticed in review of the feature presented in cBioPortal/cbioportal-frontend#1143, multi-study queries used a copy of the OQL parser that's no longer actively maintained. As it turned out, it was to decide between showing the Oncoprint tab or the Cancer Types Summary tab after querying. This caused issues integrating new OQL syntaxes, which are readily fixed by using the new parser instead. That solution has the additional advantage that `DATATYPES` statements are no longer counted as genes in that decision.