### PR TITLE
Create "isolateNetwork" mode in which network tab will render alone

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/networks.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/networks.jsp
@@ -73,12 +73,13 @@
 <script type="text/javascript" src="js/lib/d3.min.js?<%=GlobalProperties.getAppVersion()%>"></script>
 
 <script type="text/javascript">
-    
+
     	//whether this tab has already been initialized or not:
     	var tab_init = false;
     	//function that will listen to tab changes and init this one when applicable:
     	function tabsUpdate() {
-    		if ($("#network").is(":visible")) {
+
+    		if ($("#network").is(":visible") || window.isolateNetwork) {
 	    		if (tab_init === false) {
     	    		fireQuerySession();
     	    		

--- a/portal/src/main/webapp/WEB-INF/jsp/visualize.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/visualize.jsp
@@ -38,7 +38,14 @@
 <jsp:include page="global/header.jsp" flush="true" />
 
 <script>
+
+if (/isolateNetwork=1/.test(window.location.search)) {
+    window.isolateNetwork = true;
+    document.body.className = document.body.className + " isolateNetwork";
+}
+
 window.loadReactApp({ defaultRoute: 'results' });
+
 </script>
 
 <div id="reactRoot" class="hidden"></div>
@@ -329,7 +336,7 @@ window.loadReactApp({ defaultRoute: 'results' });
 
         $("#toggle_query_form").tipTip();
         // check if network tab is initially selected
-        if ($("div.section#network").is(":visible"))
+        if ($("div.section#network").is(":visible") || window.isolateNetwork)
         {
             // init the network tab
             //send2cytoscapeweb(window.networkGraphJSON, "cytoscapeweb", "network");

--- a/portal/src/main/webapp/css/global_portal.css
+++ b/portal/src/main/webapp/css/global_portal.css
@@ -202,7 +202,7 @@ A:hover {
 }
 
 #network {
-    height: 750px;
+    /*height: 750px;*/
   /* never allow setting display to none
      this is to fix flash (CytoWeb) repaint problem */
   /*display: block !important;*/
@@ -1715,4 +1715,51 @@ ul.ui-autocomplete li.ui-menu-item { font-size: 0.6em; text-align: left; }
 
 .combined-study-title-toggle-icon {
     cursor: pointer;
+}
+
+
+/* for when we open Network in iframe */
+
+.isolateNetwork #tabs {
+    border:none;
+    position:absolute;
+    top:0;
+    left:0;
+    z-index:0;
+}
+
+.isolateNetwork #network {
+    display:block !important;
+}
+
+.isolateNetwork #tabs > .ui-tabs-nav {
+    display:none;
+}
+
+.isolateNetwork .main_smry {
+    display:none;
+}
+
+.isolateNetwork #footer {
+    display:none;
+}
+
+.isolateNetwork .ui-tabs-panel#network {
+    padding:0 !important;
+    margin:0;
+    height:auto;
+}    
+
+.isolateNetwork #vis_content {
+    width:auto;
+    border:none;
+}
+
+body.isolateNetwork {
+    overflow:hidden;
+}
+
+
+.isolateNetwork .pageTopContainer {
+    display:none;
 }


### PR DESCRIPTION
This code will have no effect unless the isolateNetwork parameter is passed in URL.   When that is so, styles will hide portal's chrome so only network tab shows.  This will allow network tag to be shown inside of iframe

# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
