### PR TITLE
update keycloak server installation doc URL

### DIFF
--- a/docs/Authenticating-and-Authorizing-Users-via-keycloak.md
+++ b/docs/Authenticating-and-Authorizing-Users-via-keycloak.md
@@ -7,7 +7,7 @@ This document explains why you might find Keycloak authentication useful for sto
 the cBioPortal database. It also shows you how to configure Keycloak to communicate with your instance of cBioPortal using
 SAML (Security Assertion Markup Language).
 
-Please note that configuring your local instance to use Keycloak authentication requires a Keycloak server to be set up. For details on how to set up a Keycloak server, please read online document at <https://keycloak.gitbooks.io/documentation/server_installation/index.html>.
+Please note that configuring your local instance to use Keycloak authentication requires a Keycloak server to be set up. For details on how to set up a Keycloak server, please read online document at <https://www.keycloak.org/docs/latest/server_installation/index.html>.
 
 This document focuses mainly on the steps to configure Keycloak for **authenticating** and **authorizing** cBioPortal users.
 


### PR DESCRIPTION
# What? Why?
The link to Keycloak online document is outdated.

Changes proposed in this pull request:
- update Keycloak server installation document URL.

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
