### PR TITLE
Recommend MySQL <=5.7.x

### DIFF
--- a/docs/Import-the-Seed-Database.md
+++ b/docs/Import-the-Seed-Database.md
@@ -20,6 +20,8 @@ After download, the files can be unzipped by entering the following command:
     mysql --user=cbio_user --password=somepassword cbioportal < cgds.sql
     ```
 
+    Note that this may currently fail when using the default character encoding on MySQL 8.0 (`utf8mb4`); this is why MySQL 5.7 (which uses `latin1`) is recommended.
+
 2. Import the main part of the seed database:
 
     ```

--- a/docs/System-Requirements.md
+++ b/docs/System-Requirements.md
@@ -8,7 +8,8 @@ Hardware requirements will vary depending on the volume of users you anticipate 
 
 ## MySQL
 
-As of this writing, the cBioPortal software runs properly on MySQL version 5.0.x.  The software can be found and downloaded from the [MySQL website](http://www.mysql.com/).
+The cBioPortal software should run properly on MySQL version 5.x.x; to avoid a known issue while loading the database schema, 5.7.x or lower is recommended.
+The software can be found and downloaded from the [MySQL website](http://www.mysql.com/).
 
 On Ubuntu:  ```sudo apt-get install mysql-server```
 


### PR DESCRIPTION
Tell people who want to install a cBioPortal server not to use MySQL 8.0 for now unless they know what they're doing, as the new default character encoding is not compatible with the cBioPortal
database schema for now. See https://github.com/cBioPortal/cbioportal/issues/2478.