### PR TITLE
Add validation to check for dates in non-date columns in clinical data

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1911,6 +1911,7 @@ class ClinicalValidator(Validator):
                         extra={'line_number': self.line_number,
                                'column_number': col_index + 1,
                                'cause': value})
+
             if col_name == 'PATIENT_ID' or col_name == 'SAMPLE_ID':
                 if re.findall(self.INVALID_ID_CHARACTERS, value):
                     self.logger.error(
@@ -1919,6 +1920,21 @@ class ClinicalValidator(Validator):
                         extra={'line_number': self.line_number,
                                'column_number': col_index + 1,
                                'cause': value})
+
+            # Scan for incorrect usage of dates, accidentally converted by excel. This is often in a format such as
+            # Jan-99 or 20-Oct. A future improvement would be to add a "DATE" datatype.
+            excel_months = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"]
+            if 'date' not in col_name.lower():
+                if '-' in value:
+                    if len(value.split('-')) == 2 and not any(i in value for i in [',', '.', ':', ';']):
+                        if any(value_part.lower() in excel_months for value_part in value.split('-')):
+                            self.logger.error(
+                                'Date found when no date was expected. Please check if values are accidentally '
+                                'converted to dates by Excel. If this data is correct, add "DATE" to column name',
+                                extra={'line_number': self.line_number,
+                                       'column_number': col_index + 1,
+                                       'cause': value})
+
 
 
 class SampleClinicalValidator(ClinicalValidator):

--- a/core/src/test/scripts/test_data/data_clin_date_in_nondate_column.txt
+++ b/core/src/test/scripts/test_data/data_clin_date_in_nondate_column.txt
@@ -1,0 +1,12 @@
+#Patient Identifier	Overall Survival Status	Overall Survival (Months)	Disease Free Status	Disease Free (Months)	Some Score
+#Patient identifier	Overall survival status	Overall survival in months since diagnosis	Disease free status	Disease free in months since treatment	Some Description
+#STRING	STRING	NUMBER	STRING	NUMBER	STRING
+#1	1	1	1	1	1
+PATIENT_ID	OS_STATUS	OS_MONTHS	DFS_STATUS	DFS_MONTHS	SOME_SCORE
+TCGA-A2-A04P			Recurred/Progressed	[Not Available]	5
+TCGA-A1-A0SK	DECEASED	31.77		[Not Available]	31-77
+TCGA-A2-A0CM	DECEASED	24.77	Recurred/Progressed	[Not Available]	Jan-14
+TCGA-AR-A1AR	DECEASED	17.18	[Not Available]	[Not Available]	4-Oct
+TCGA-B6-A0WX	DECEASED	21.45	Recurred/Progressed	[Not Available]	21.45
+TCGA-BH-A1F0	DECEASED	25.79	Recurred/Progressed	[Not Available]	25.79
+TCGA-B6-A0I6	DECEASED	32.56	Recurred/Progressed	[Not Available]	32.56

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -377,6 +377,28 @@ class PatientAttrFileTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(record.line_number, 6)
         self.assertIn('can only contain letters, numbers, points, underscores and/or hyphens', record.getMessage())
 
+    def test_date_in_nondate_column(self):
+        """Test when a sample is defined twice in the same file."""
+        self.logger.setLevel(logging.ERROR)
+        record_list = self.validate('data_clin_date_in_nondate_column.txt',
+                                    validateData.PatientClinicalValidator)
+        self.assertEqual(len(record_list), 2)
+        record_iterator = iter(record_list)
+        # First record contains 'Jan-14'
+        record = record_iterator.next()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.line_number, 8)
+        self.assertEqual(record.column_number, 6)
+        self.assertEqual(record.cause, 'Jan-14')
+        self.assertIn('Date found when no date was expected', record.getMessage())
+        # Second record contains '4-Oct'
+        record = record_iterator.next()
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.line_number, 9)
+        self.assertEqual(record.column_number, 6)
+        self.assertEqual(record.cause, '4-Oct')
+        self.assertIn('Date found when no date was expected', record.getMessage())
+
 
 # TODO: make tests in this testcase check the number of properly defined types
 class CancerTypeFileValidationTestCase(DataFileTestCase):


### PR DESCRIPTION
# What? Why?
Prevent issues like this https://github.com/cBioPortal/datahub/issues/218, when a numeric range is converted to date by Excel. I ran this validator on studies from current Datahub RC (June 12, 2018) and no errors were found.

Changes proposed in this pull request:
- If the column name does not contain the word 'date', give an error when a month is found in the column's values.