### PR TITLE
MySQL8 support

### DIFF
--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -97,7 +97,7 @@
         <!-- setting minIdle/maxIdle to 1 doesn't limit the number of active -->
         <bean id="businessDataSource" destroy-method="close" class="org.apache.commons.dbcp2.BasicDataSource">
             <property name="driverClassName" value="${db.driver}"/>
-            <property name="url" value="${db.connection_string}${db.portal_db_name}?zeroDateTimeBehavior=convertToNull"/>
+            <property name="url" value="${db.connection_string}${db.portal_db_name}?zeroDateTimeBehavior=CONVERT_TO_NULL"/>
             <property name="username" value="${db.user}"/>
             <property name="password" value="${db.password}"/>
             <property name="minIdle" value="0"/>

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/StudyMapperLegacy.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/StudyMapperLegacy.xml
@@ -14,7 +14,7 @@
         DESCRIPTION as description,
         PMID as pmid,
         CITATION as citation,
-        GROUPS as groups,
+        "GROUPS" as "groups",
         CANCER_STUDY_ID  as internal_id
     from cancer_study
     where CANCER_STUDY_IDENTIFIER in <foreach item="item" collection="study_ids" open="(" separator="," close=")">#{item}</foreach>
@@ -28,7 +28,7 @@
         DESCRIPTION as description,
         PMID as pmid,
         CITATION as citation,
-        GROUPS as groups,
+        "GROUPS" as groups,
         CANCER_STUDY_ID as internal_id
     from cancer_study
 </select>    

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-dbcp2</artifactId>
-        <version>2.1.1</version>
+        <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>commons-fileupload</groupId>
@@ -338,7 +338,7 @@
         <version>2.16</version>
         <configuration>
           <forkMode>always</forkMode>
-          <filtering>true</filtering>
+          <!-- filtering>true</filtering -->
           <systemProperties>
             <property>
               <name>log4j.configuration</name>
@@ -398,7 +398,7 @@
           <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.0.3</version>
+            <version>8.0.11</version>
           </dependency>
         </dependencies>
         <executions>
@@ -414,7 +414,7 @@
               <url>${db.test.url}</url>
               <username>${db.test.username}</username>
               <password>${db.test.password}</password>
-              <sqlCommand>SET storage_engine=INNODB</sqlCommand>
+              <sqlCommand>SET default_storage_engine=INNODB</sqlCommand>
               <sqlCommand>SET SESSION sql_mode = 'ANSI_QUOTES'</sqlCommand>
               <srcFiles>
                 <srcFile>${project.build.testOutputDirectory}/cgds.sql</srcFile>
@@ -422,7 +422,7 @@
               </srcFiles>
               <!-- added encoding to prevent Unknown initial character set index '192' received from server error -->
               <encoding>UTF-8</encoding>
-              <driverProperties>characterEncoding=utf8, connectionCollation=utf8_general_ci</driverProperties>
+              <!-- driverProperties>characterEncoding=utf8, connectionCollation=utf8_general_ci</driverProperties -->
               <!--all executions are ignored if -DskipTests -->
               <skip>${skipTests}</skip>
             </configuration>

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
@@ -77,10 +77,10 @@ public class JdbcUtil {
         String database = dbProperties.getDbName();
         String url ="jdbc:mysql://" + host + "/" + database +
                         "?user=" + userName + "&password=" + password +
-                        "&zeroDateTimeBehavior=convertToNull";
+                        "&zeroDateTimeBehavior=CONVERT_TO_NULL&serverTimezone=America/Toronto";
         //  Set up poolable data source
         BasicDataSource dataSource = new BasicDataSource();
-        dataSource.setDriverClassName("com.mysql.jdbc.Driver");
+        dataSource.setDriverClassName("com.mysql.cj.jdbc.Driver");
         dataSource.setUsername(userName);
         dataSource.setPassword(password);
         dataSource.setUrl(url);

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
@@ -75,9 +75,10 @@ public class JdbcUtil {
         String userName = dbProperties.getDbUser();
         String password = dbProperties.getDbPassword();
         String database = dbProperties.getDbName();
+        String timezone = dbProperties.getTimeZone();
         String url ="jdbc:mysql://" + host + "/" + database +
                         "?user=" + userName + "&password=" + password +
-                        "&zeroDateTimeBehavior=CONVERT_TO_NULL&serverTimezone=America/Toronto";
+                        "&zeroDateTimeBehavior=CONVERT_TO_NULL&serverTimezone=" + timezone;
         //  Set up poolable data source
         BasicDataSource dataSource = new BasicDataSource();
         dataSource.setDriverClassName("com.mysql.cj.jdbc.Driver");

--- a/core/src/main/java/org/mskcc/cbio/portal/util/DatabaseProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/DatabaseProperties.java
@@ -45,6 +45,7 @@ public class DatabaseProperties {
     private String dbName;
     private String dbEncryptedKey;
     private String dbDriverClassName;
+    private String timeZone;
 
     // No production keys stored in filesystem or code: digest the key; put it in properties; load it into dbms on startup
     private static DatabaseProperties dbProperties;
@@ -59,6 +60,7 @@ public class DatabaseProperties {
             dbProperties.setDbPassword(GlobalProperties.getProperty("db.password"));
             dbProperties.setDbEncryptedKey(GlobalProperties.getProperty("db.encryptedKey"));
             dbProperties.setDbDriverClassName(GlobalProperties.getProperty("db.driver"));
+            dbProperties.setTimeZone(GlobalProperties.getProperty("db.timezone"));
         }
         return dbProperties;
     }
@@ -113,4 +115,8 @@ public class DatabaseProperties {
     public void setDbDriverClassName(String dbDriverClassName) {
         this.dbDriverClassName = dbDriverClassName;
     }
+    
+    public String getTimeZone() { return timeZone; }
+    
+    public void setTimeZone(String timeZone) { this.timeZone = timeZone; }
 }

--- a/core/src/test/resources/applicationContext-dao.xml
+++ b/core/src/test/resources/applicationContext-dao.xml
@@ -46,7 +46,7 @@
 	
 	<!-- Values are for testing only, so need to correspond to the cgds in the pom.xml -->
 	<bean id="dbcpDataSource" destroy-method="close" class="org.apache.commons.dbcp2.BasicDataSource">
-		<property name="driverClassName" value="com.mysql.jdbc.Driver" />
+		<property name="driverClassName" value="com.mysql.cj.jdbc.Driver" />
 		<property name="url" value="jdbc:mysql://localhost:3306/cgds_test" />
 		<property name="username" value="${db.user}" />
 		<property name="password" value="${db.password}" />

--- a/db-scripts/src/main/resources/adjust_col_size_to_utf8.sql
+++ b/db-scripts/src/main/resources/adjust_col_size_to_utf8.sql
@@ -1,0 +1,16 @@
+DROP PROCEDURE IF EXISTS adjust_col_size_to_utf8;
+DELIMITER $$
+CREATE PROCEDURE adjust_col_size_to_utf8() BEGIN 
+ IF ((SELECT MAX(LENGTH(TUMOR_SEQ_ALLELE)) FROM mutation_event) < 256 
+    AND (SELECT  MAX(LENGTH(REFERENCE_ALLELE)) FROM mutation_event) < 256)
+ THEN 
+    ALTER TABLE mutation_event 
+        MODIFY REFERENCE_ALLELE varchar(255),
+        MODIFY TUMOR_SEQ_ALLELE varchar(255),
+        MODIFY MUTATION_TYPE varchar(64),
+        MODIFY LINK_XVAR varchar(255),
+        MODIFY LINK_PDB varchar(255),
+        MODIFY LINK_MSA varchar(255);
+ END IF;
+END$$
+DELIMITER ;

--- a/db-scripts/src/main/resources/cgds.sql
+++ b/db-scripts/src/main/resources/cgds.sql
@@ -398,15 +398,15 @@ CREATE TABLE `mutation_event` (
   `CHR` varchar(5),
   `START_POSITION` bigint(20),
   `END_POSITION` bigint(20),
-  `REFERENCE_ALLELE` varchar(400),
-  `TUMOR_SEQ_ALLELE` varchar(400),
+  `REFERENCE_ALLELE` varchar(255),
+  `TUMOR_SEQ_ALLELE` varchar(255),
   `PROTEIN_CHANGE` varchar(255),
-  `MUTATION_TYPE` varchar(255) COMMENT 'e.g. Missense, Nonsence, etc.',
+  `MUTATION_TYPE` varchar(64) COMMENT 'e.g. Missense, Nonsence, etc.',
   `FUNCTIONAL_IMPACT_SCORE` varchar(50) COMMENT 'Result from OMA/XVAR.',
   `FIS_VALUE` float,
-  `LINK_XVAR` varchar(500) COMMENT 'Link to OMA/XVAR Landing Page for the specific mutation.',
-  `LINK_PDB` varchar(500),
-  `LINK_MSA` varchar(500),
+  `LINK_XVAR` varchar(255) COMMENT 'Link to OMA/XVAR Landing Page for the specific mutation.',
+  `LINK_PDB` varchar(255),
+  `LINK_MSA` varchar(255),
   `NCBI_BUILD` varchar(10),
   `STRAND` varchar(2),
   `VARIANT_TYPE` varchar(15),
@@ -820,4 +820,4 @@ CREATE TABLE `info` (
   `GENESET_VERSION` varchar(24)
 );
 -- THIS MUST BE KEPT IN SYNC WITH db.version PROPERTY IN pom.xml
-INSERT INTO info VALUES ('2.6.0', NULL);
+INSERT INTO info VALUES ('2.7.0', NULL);

--- a/db-scripts/src/main/resources/migration.sql
+++ b/db-scripts/src/main/resources/migration.sql
@@ -454,3 +454,13 @@ ALTER TABLE gistic_to_gene DROP FOREIGN KEY gistic_to_gene_ibfk_2;
 ALTER TABLE gistic_to_gene ADD CONSTRAINT `gistic_to_gene_ibfk_2` FOREIGN KEY (`GISTIC_ROI_ID`) REFERENCES `gistic` (`GISTIC_ROI_ID`) ON DELETE CASCADE;
 
 UPDATE info SET DB_SCHEMA_VERSION="2.6.0";
+
+##version: 2.7.0
+-- adjust mutation_event table columns to be compatible with UTF8, the default in mySQL8
+-- execute adjust_col_size_to_utf8.sql script to create a stored procedure before running the migration script
+CALL adjust_col_size_to_utf8();
+DROP PROCEDURE IF EXISTS adjust_col_size_to_utf8;
+
+UPDATE info SET DB_SCHEMA_VERSION="2.7.0";
+    
+

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -34,8 +34,8 @@ Apache Tomcat provides the database database connection pool to the cBioPortal. 
          ...
          <Resource name="jdbc/cbioportal" auth="Container" type="javax.sql.DataSource"
             maxActive="100" maxIdle="30" maxWait="10000"
-            username="cbio_user" password="somepassword" driverClassName="com.mysql.jdbc.Driver"
-            connectionProperties="zeroDateTimeBehavior=convertToNull;"
+            username="cbio_user" password="somepassword" driverClassName="com.mysql.cj.jdbc.Driver"
+            connectionProperties="zeroDateTimeBehavior=CONVERT_TO_NULL;"
             testOnBorrow="true"
             validationQuery="SELECT 1"
             url="jdbc:mysql://localhost:3306/cbioportal"/>

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -21,7 +21,7 @@ db.user=
 db.password=
 db.host=[e.g. localhost to connect via socket, or e.g. 127.0.0.1:3307 to connect to a different port like 3307. Used by Java data import layer]
 db.portal_db_name=[the database name in mysql, e.g. cbiodb]
-db.driver=[this is the name of your JDBC driver, e.g., com.mysql.jdbc.Driver]
+db.driver=[this is the name of your JDBC driver, e.g., com.mysql.jdbc.Driver (MySQL 5.7) or com.mysql.cj.jdbc.Driver]
 ```
 
 Include `db_connection_string` with the format specified below, and replace `localhost` by the value of `db.host`:
@@ -33,7 +33,10 @@ db.tomcat_resource_name is required in order to work with the tomcat database co
 ```
 db.tomcat_resource_name=jdbc/cbioportal
 ```
-
+db.timezone is required when connect to a MySQL8 database. You can find system time zone using `timedatectl` on linux or `systemsetup -gettimezone` on Mac 
+```
+db.timezone = America/Toronto
+```
 # Segment File URL
 
 This is a root URL to where segment files can be found.  This is used when you want to provide segment file viewing via external tools such as [IGV](http://www.broadinstitute.org/igv/).

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SignificantlyMutatedGeneMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SignificantlyMutatedGeneMapper.xml
@@ -9,7 +9,7 @@
         mut_sig.CANCER_STUDY_ID AS cancerStudyId,
         cancer_study.CANCER_STUDY_IDENTIFIER AS cancerStudyIdentifier,
         gene.HUGO_GENE_SYMBOL AS hugoGeneSymbol,
-        mut_sig.RANK AS rank,
+        mut_sig."RANK" AS "rank",
         mut_sig.NumBasesCovered AS numBasesCovered,
         mut_sig.NumMutations AS numMutations,
         mut_sig.P_VALUE AS pValue,

--- a/pom.xml
+++ b/pom.xml
@@ -207,9 +207,9 @@
 
     <final.war.name>cbioportal-${project.version}</final.war.name>
 
-  <db.test.driver>com.mysql.jdbc.Driver</db.test.driver>
+  <db.test.driver>com.mysql.cj.jdbc.Driver</db.test.driver>
     <!-- For MySQL < 5.5 change 'default_storage_engine' to 'storage_engine' -->
-  <db.test.url>jdbc:mysql://127.0.0.1:3306/cgds_test?sessionVariables=default_storage_engine=InnoDB</db.test.url>
+  <db.test.url>jdbc:mysql://127.0.0.1:3306/cgds_test</db.test.url>
     <db.test.username>cbio_user</db.test.username>
     <db.test.password>somepassword</db.test.password>
 
@@ -217,7 +217,7 @@
     <tomcat.catalina.scope>provided</tomcat.catalina.scope>
 
     <!-- THIS SHOULD BE KEPT IN SYNC TO VERSION IN CGDS.SQL -->
-    <db.version>2.6.0</db.version>
+    <db.version>2.7.0</db.version>
 
   </properties>
 
@@ -296,7 +296,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.16</version>
+      <version>8.0.11</version>
     </dependency>
     <!-- slf4j -->
     <dependency>
@@ -492,7 +492,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
+        <version>3.0.1</version>
         <configuration>
           <doclet>org.umlgraph.doclet.UmlGraphDoc</doclet>
           <docletArtifact>
@@ -512,7 +512,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.9</version>
       </plugin>
     </plugins>
   </reporting>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -11,6 +11,7 @@ db.connection_string=jdbc:mysql://localhost/
 db.tomcat_resource_name=jdbc/cbioportal
 # this should normally be set to false. In some cases you could set this to true (e.g. for testing a feature of a newer release that is not related to the schema change in expected db version above):
 db.suppress_schema_version_mismatch_errors=false
+db.timezone = America/Toronto
 
 # web page cosmetics
 skin.title=cBioPortal for Cancer Genomics


### PR DESCRIPTION
# What? Why?

- Adjust table column size to 255 bytes to be compatible with UTF8 
- Limit 3072 bytes per index to support MySQL8
- Fix #4345

Changes proposed in this pull request:
- Change **mutation_event** table schema
- - Downsize columns with size > 255 to 255 bytes
- - Limit the unique constraint to 3072 bytes
- Upgrade **mysql-connector-java** to the latest `8.0.11`
- Update JDBC driver from `com.mysql.jdbc.Driver` to `com.mysql.cj.jdbc.Driver`
- Add a new `db.timezone` property to portal.properties file 

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
