### PR TITLE
Support fusion GML events import

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/maf/FusionFileUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/maf/FusionFileUtil.java
@@ -44,74 +44,76 @@ import java.util.HashMap;
  */
 public class FusionFileUtil
 {
-	public static final String FUSION = "Fusion";
-	public static final String DNA_SUPPORT = "DNA_support";
-	public static final String RNA_SUPPORT = "RNA_support";
-	public static final String METHOD = "Method";
-	public static final String FRAME = "Frame";
+    public static final String FUSION = "Fusion";
+    public static final String DNA_SUPPORT = "DNA_support";
+    public static final String RNA_SUPPORT = "RNA_support";
+    public static final String METHOD = "Method";
+    public static final String FRAME = "Frame";
+    public static final String FUSION_STATUS = "Fusion_Status";
 
-	// number of headers in the header line
-	private int headerCount;
+    // number of headers in the header line
+    private int headerCount;
 
-	// mapping for all column names (both standard and custom columns)
-	private HashMap<String, Integer> columnIndexMap;
+    // mapping for all column names (both standard and custom columns)
+    private HashMap<String, Integer> columnIndexMap;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param headerLine    Header Line.
-	 */
-	public FusionFileUtil(String headerLine)
-	{
-		// init column index map
-		this.columnIndexMap = new HashMap<String, Integer>();
+    /**
+     * Constructor.
+     *
+     * @param headerLine    Header Line.
+     */
+    public FusionFileUtil(String headerLine)
+    {
+        // init column index map
+        this.columnIndexMap = new HashMap<String, Integer>();
 
-		// split header names
-		String parts[] = headerLine.split("\t");
+        // split header names
+        String parts[] = headerLine.split("\t");
 
-		// update header count
-		this.headerCount = parts.length;
+        // update header count
+        this.headerCount = parts.length;
 
-		// find required header indices
-		for (int i=0; i<parts.length; i++)
-		{
-			String header = parts[i];
+        // find required header indices
+        for (int i=0; i<parts.length; i++)
+        {
+                String header = parts[i];
 
-			// put the index to the map
-			this.columnIndexMap.put(header.toLowerCase(), i);
-		}
-	}
+                // put the index to the map
+                this.columnIndexMap.put(header.toLowerCase(), i);
+        }
+    }
 
-	public FusionRecord parseRecord(String line)
-	{
-		String parts[] = line.split("\t", -1);
+    public FusionRecord parseRecord(String line)
+    {
+        String parts[] = line.split("\t", -1);
 
-		FusionRecord record = new FusionRecord();
+        FusionRecord record = new FusionRecord();
 
-		record.setHugoGeneSymbol(TabDelimitedFileUtil.getPartStringAllowEmpty(this.getColumnIndex(MafUtil.HUGO_SYMBOL), parts));
-		record.setEntrezGeneId(TabDelimitedFileUtil.getPartLong(this.getColumnIndex(MafUtil.ENTREZ_GENE_ID), parts));
-		record.setCenter(TabDelimitedFileUtil.getPartString(this.getColumnIndex(MafUtil.CENTER), parts));
-		record.setTumorSampleID(TabDelimitedFileUtil.getPartString(this.getColumnIndex(MafUtil.TUMOR_SAMPLE_BARCODE), parts));
-		record.setFusion(TabDelimitedFileUtil.getPartString(this.getColumnIndex(FUSION), parts));
-		record.setDnaSupport(TabDelimitedFileUtil.getPartString(this.getColumnIndex(DNA_SUPPORT), parts));
-		record.setRnaSupport(TabDelimitedFileUtil.getPartString(this.getColumnIndex(RNA_SUPPORT), parts));
-		record.setMethod(TabDelimitedFileUtil.getPartString(this.getColumnIndex(METHOD), parts));
-		record.setFrame(TabDelimitedFileUtil.getPartString(this.getColumnIndex(FRAME), parts));
+        record.setHugoGeneSymbol(TabDelimitedFileUtil.getPartStringAllowEmpty(this.getColumnIndex(MafUtil.HUGO_SYMBOL), parts));
+        record.setEntrezGeneId(TabDelimitedFileUtil.getPartLong(this.getColumnIndex(MafUtil.ENTREZ_GENE_ID), parts));
+        record.setCenter(TabDelimitedFileUtil.getPartString(this.getColumnIndex(MafUtil.CENTER), parts));
+        record.setTumorSampleID(TabDelimitedFileUtil.getPartString(this.getColumnIndex(MafUtil.TUMOR_SAMPLE_BARCODE), parts));
+        record.setFusion(TabDelimitedFileUtil.getPartString(this.getColumnIndex(FUSION), parts));
+        record.setDnaSupport(TabDelimitedFileUtil.getPartString(this.getColumnIndex(DNA_SUPPORT), parts));
+        record.setRnaSupport(TabDelimitedFileUtil.getPartString(this.getColumnIndex(RNA_SUPPORT), parts));
+        record.setMethod(TabDelimitedFileUtil.getPartString(this.getColumnIndex(METHOD), parts));
+        record.setFrame(TabDelimitedFileUtil.getPartString(this.getColumnIndex(FRAME), parts));
+        record.setFusionStatus(TabDelimitedFileUtil.getPartString(this.getColumnIndex(FUSION_STATUS), parts));
 
-		return record;
-	}
+        return record;
+    }
 
-	// TODO this is a duplicate (MafUtil has the same method)
-	// try to factor out it into TabDelimitedFileUtil
-	public int getColumnIndex(String colName)
-	{
-		Integer index = this.columnIndexMap.get(colName.toLowerCase());
+    // TODO this is a duplicate (MafUtil has the same method)
+    // try to factor out it into TabDelimitedFileUtil
+    public int getColumnIndex(String colName)
+    {
+        Integer index = this.columnIndexMap.get(colName.toLowerCase());
 
-		if (index == null)
-		{
-			index = -1;
-		}
+        if (index == null)
+        {
+                index = -1;
+        }
 
-		return index;
-	}
+        return index;
+    }
 }

--- a/core/src/main/java/org/mskcc/cbio/maf/FusionRecord.java
+++ b/core/src/main/java/org/mskcc/cbio/maf/FusionRecord.java
@@ -39,103 +39,114 @@ package org.mskcc.cbio.maf;
  */
 public class FusionRecord
 {
-	private String hugoGeneSymbol;
-	private long entrezGeneId;
-	private String center; // sequencing center
-	private String tumorSampleID;
-	private String fusion;
-	private String dnaSupport;
-	private String rnaSupport;
-	private String method;
-	private String frame;
+    private String hugoGeneSymbol;
+    private long entrezGeneId;
+    private String center; // sequencing center
+    private String tumorSampleID;
+    private String fusion;
+    private String dnaSupport;
+    private String rnaSupport;
+    private String method;
+    private String frame;
+    private String fusionStatus;
 
-	public String getHugoGeneSymbol()
-	{
-		return hugoGeneSymbol;
-	}
+    public String getHugoGeneSymbol()
+    {
+            return hugoGeneSymbol;
+    }
 
-	public void setHugoGeneSymbol(String hugoGeneSymbol)
-	{
-		this.hugoGeneSymbol = hugoGeneSymbol;
-	}
+    public void setHugoGeneSymbol(String hugoGeneSymbol)
+    {
+            this.hugoGeneSymbol = hugoGeneSymbol;
+    }
 
-	public long getEntrezGeneId()
-	{
-		return entrezGeneId;
-	}
+    public long getEntrezGeneId()
+    {
+            return entrezGeneId;
+    }
 
-	public void setEntrezGeneId(long entrezGeneId)
-	{
-		this.entrezGeneId = entrezGeneId;
-	}
+    public void setEntrezGeneId(long entrezGeneId)
+    {
+            this.entrezGeneId = entrezGeneId;
+    }
 
-	public String getCenter()
-	{
-		return center;
-	}
+    public String getCenter()
+    {
+            return center;
+    }
 
-	public void setCenter(String center)
-	{
-		this.center = center;
-	}
+    public void setCenter(String center)
+    {
+            this.center = center;
+    }
 
-	public String getTumorSampleID()
-	{
-		return tumorSampleID;
-	}
+    public String getTumorSampleID()
+    {
+            return tumorSampleID;
+    }
 
-	public void setTumorSampleID(String tumorSampleID)
-	{
-		this.tumorSampleID = tumorSampleID;
-	}
+    public void setTumorSampleID(String tumorSampleID)
+    {
+            this.tumorSampleID = tumorSampleID;
+    }
 
-	public String getFusion()
-	{
-		return fusion;
-	}
+    public String getFusion()
+    {
+            return fusion;
+    }
 
-	public void setFusion(String fusion)
-	{
-		this.fusion = fusion;
-	}
+    public void setFusion(String fusion)
+    {
+            this.fusion = fusion;
+    }
 
-	public String getDnaSupport()
-	{
-		return dnaSupport;
-	}
+    public String getDnaSupport()
+    {
+            return dnaSupport;
+    }
 
-	public void setDnaSupport(String dnaSupport)
-	{
-		this.dnaSupport = dnaSupport;
-	}
+    public void setDnaSupport(String dnaSupport)
+    {
+            this.dnaSupport = dnaSupport;
+    }
 
-	public String getRnaSupport()
-	{
-		return rnaSupport;
-	}
+    public String getRnaSupport()
+    {
+            return rnaSupport;
+    }
 
-	public void setRnaSupport(String rnaSupport)
-	{
-		this.rnaSupport = rnaSupport;
-	}
+    public void setRnaSupport(String rnaSupport)
+    {
+            this.rnaSupport = rnaSupport;
+    }
 
-	public String getMethod()
-	{
-		return method;
-	}
+    public String getMethod()
+    {
+            return method;
+    }
 
-	public void setMethod(String method)
-	{
-		this.method = method;
-	}
+    public void setMethod(String method)
+    {
+            this.method = method;
+    }
 
-	public String getFrame()
-	{
-		return frame;
-	}
+    public String getFrame()
+    {
+            return frame;
+    }
 
-	public void setFrame(String frame)
-	{
-		this.frame = frame;
-	}
+    public void setFrame(String frame)
+    {
+            this.frame = frame;
+    }
+
+    public String getFusionStatus()
+    {
+        return fusionStatus;
+    }
+
+    public void setFusionStatus(String fusionStatus)
+    {
+        this.fusionStatus = fusionStatus;
+    }
 }

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportFusionData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportFusionData.java
@@ -138,6 +138,7 @@ public class ImportFusionData {
                     // TODO we may need get mutation type from the file
                     // instead of defining a constant
                     mutation.setMutationType(FUSION);
+                    mutation.setMutationStatus(record.getFusionStatus().toUpperCase());
                     MutationEvent event =
                         existingEvents.containsKey(mutation.getEvent()) ?
                         existingEvents.get(mutation.getEvent()) :

--- a/core/src/test/scripts/test_data/study_es_0/data_fusions.txt
+++ b/core/src/test/scripts/test_data/study_es_0/data_fusions.txt
@@ -1,4 +1,4 @@
-Hugo_Symbol	Entrez_Gene_Id	Center	Tumor_Sample_Barcode	Fusion	DNA_support	RNA_support	Method	Frame
-FGFR3	2261	saturn	TEST-A2B8-01	TMPRSS2-ERG fusion	yes	yes	unknown	unknown
-ERBB2	2064	jupiter	TEST-A2FF-01	Fusion2	yes	yes	unknown	unknown
-ERBB2	2064	uranus	TCGA-GI-A2C8-01	ERBB2-TEST Fusion	yes	yes	unknown	frameshift
+Hugo_Symbol	Entrez_Gene_Id	Center	Tumor_Sample_Barcode	Fusion	DNA_support	RNA_support	Method	Frame	Fusion_Status
+FGFR3	2261	saturn	TEST-A2B8-01	TMPRSS2-ERG fusion	yes	yes	unknown	unknown	
+ERBB2	2064	jupiter	TEST-A2FF-01	Fusion2	yes	yes	unknown	unknown	
+ERBB2	2064	uranus	TCGA-GI-A2C8-01	ERBB2-TEST Fusion	yes	yes	unknown	frameshift	

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -783,6 +783,7 @@ A fusion data file is a two dimensional matrix with one gene per row.  For each 
 7. **RNA_support**: Fusion detected from RNA sequence data, "yes" or "no".
 8. **Method**: Fusion detected algorithm/tool.
 9. **Frame**: "in-frame" or "frameshift".
+10. **Fusion_Status (OPTIONAL)**: An assessment of the mutation type (i.e., "SOMATIC", "GERMLINE", "UNKNOWN", or empty)
 
 **Note:** If a fusion event includes a gene, e.g., Hugo_Symbol or Entrez_Gene_Id, that is not profiled, the event will be filter out during import into the database.
 


### PR DESCRIPTION
# What? Why?
Hack for supporting germline fusion/structural variant events. The idea is to be able to annotate these events with red "Germline" sup-script next to the protein change.

Example 
![screen shot 2018-07-09 at 4 30 25 pm](https://user-images.githubusercontent.com/15623749/42474393-73fff160-8395-11e8-8a37-636c8ae50388.png)


Changes proposed in this pull request:
- Override mutation status for fusion events to value in `Fusion_Status` column if available

# Checks
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
