### PR TITLE
Handle unknown status in validateStudies and decrease log cache size

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -4036,7 +4036,7 @@ def main_validate(args):
     text_handler.setFormatter(
         cbioportal_common.LogfileStyleFormatter(study_dir))
     collapsing_text_handler = cbioportal_common.CollapsingLogMessageHandler(
-        capacity=1e6,
+        capacity=5e5,
         flushLevel=logging.CRITICAL,
         target=text_handler)
     collapsing_text_handler.setLevel(output_loglevel)
@@ -4078,7 +4078,7 @@ def main_validate(args):
         # TODO extend CollapsingLogMessageHandler to flush to multiple targets,
         # and get rid of the duplicated buffering of messages here
         collapsing_html_handler = cbioportal_common.CollapsingLogMessageHandler(
-            capacity=1e6,
+            capacity=5e5,
             flushLevel=logging.CRITICAL,
             target=html_handler)
         collapsing_html_handler.setLevel(output_loglevel)
@@ -4090,7 +4090,7 @@ def main_validate(args):
         # TODO extend CollapsingLogMessageHandler to flush to multiple targets,
         # and get rid of the duplicated buffering of messages here
         coll_errfile_handler = cbioportal_common.CollapsingLogMessageHandler(
-            capacity=1e6,
+            capacity=5e5,
             flushLevel=logging.CRITICAL,
             target=errfile_handler)
         coll_errfile_handler.setLevel(logging.WARNING)

--- a/core/src/main/scripts/importer/validateStudies.py
+++ b/core/src/main/scripts/importer/validateStudies.py
@@ -131,11 +131,12 @@ def main(args):
             exit_status_study = 2
 
         # Check exit status and print result
-        if exit_status_study == 1 or exit_status_study == 2:
-            print '\x1b[0m' + "Result: " + '\x1b[31m' + possible_exit_status[exit_status_study] + '\x1b[0m'
-            validation_exit_status = 1  # When invalid check the exit status to one, for failing circleCI
+        exit_status_message = possible_exit_status.get(exit_status_study, 'Unknown status: {}'.format(exit_status_study))
+        if exit_status_study == 0 or exit_status_study == 3:
+            print '\x1b[0m' + "Result: %s" % exit_status_message
         else:
-            print '\x1b[0m' + "Result: %s" % possible_exit_status[exit_status_study]
+            print '\x1b[0m' + "Result: " + '\x1b[31m' + exit_status_message + '\x1b[0m'
+            validation_exit_status = 1  # When invalid check the exit status to one, for failing circleCI
 
     return validation_exit_status
 


### PR DESCRIPTION
# What? Why?
- Fix a crash when an unknown exit status occurs. 
- Decrease the size of validation log cache from 1,000,000 to 500,000. This will solve an out-of-memory issue when running the validator on CircleCI.

This is the case in https://circleci.com/gh/cBioPortal/datahub/326?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link for PR https://github.com/cBioPortal/datahub/pull/239