### PR TITLE
Enable basic authentication for session service

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -152,6 +152,14 @@ public class GlobalProperties {
     @Value("${session.service.url:}") // default is empty string
     public void setSessionServiceURL(String property) { sessionServiceURL = property; }
 
+    private static String sessionServiceUser;
+    @Value("${session.service.user:}") // default is empty string
+    public void setSessionServiceUser(String property) { sessionServiceUser = property; }
+
+    private static String sessionServicePassword;
+    @Value("${session.service.password:}") // default is empty string
+    public void setSessionServicePassword(String property) { sessionServicePassword = property; }
+
     private static String frontendConfig;
     @Value("${frontend.config:}") // default is empty string
     public void setFrontendConfig(String property) { frontendConfig = property; }
@@ -829,6 +837,16 @@ public class GlobalProperties {
     public static String getSessionServiceUrl()
     {
         return sessionServiceURL;
+    }
+
+    public static String getSessionServiceUser()
+    {
+        return sessionServiceUser;
+    }
+
+    public static String getSessionServicePassword()
+    {
+        return sessionServicePassword;
     }
 
     public static String getOncoKBPublicApiUrl()

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -184,6 +184,9 @@ recache_study_after_update=false
 # WARNING: do not use session service with -Dauthenticate=false
 #  either use authentication or change to -Dauthenticate=noauthsessionservice
 session.service.url=
+# if basic authentication is enabled on session service one should set:
+# session.service.user=user
+# session.service.password=pass
 
 # disabled tabs, | delimited
 # possible values: cancer_types_summary, mutual_exclusivity, plots, mutations, co_expression, enrichments, survival, network, download, bookmark, IGV

--- a/web/src/main/java/org/mskcc/cbio/portal/web/ProxySessionServiceController.java
+++ b/web/src/main/java/org/mskcc/cbio/portal/web/ProxySessionServiceController.java
@@ -1,6 +1,7 @@
 package org.mskcc.cbio.portal.web;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -13,24 +14,30 @@ import java.util.Set;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.codec.binary.Base64;
 import org.json.simple.JSONObject;
 import org.mskcc.cbio.portal.model.virtualstudy.VirtualStudy;
 import org.mskcc.cbio.portal.model.virtualstudy.VirtualStudyData;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -38,12 +45,21 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
+
 @Controller
 @RequestMapping("/proxy/session")
 public class ProxySessionServiceController {
 
     @Value("${session.service.url:}")
     private String sessionServiceURL;
+
+    @Value("${session.service.user:}")
+    private String sessionServiceUser;
+
+    @Value("${session.service.password:}")
+    private String sessionServicePassword;
     
     
     @RequestMapping(value = "/{type}/{id}", method = RequestMethod.GET)
@@ -55,12 +71,14 @@ public class ProxySessionServiceController {
         try {
             RestTemplate restTemplate = new RestTemplate();
 
+            // add basic authentication in header
+            HttpEntity<String> headers = new HttpEntity<String>(getHttpHeaders());
             ResponseEntity<HashMap> responseEntity = restTemplate.exchange(sessionServiceURL + type + "/" + id,
-                                                                           HttpMethod.GET,
-                                                                           null,
-                                                                           HashMap.class);
+                                                                        HttpMethod.GET,
+                                                                        headers,
+                                                                        HashMap.class);
             
-            if(type.equals(SessionType.virtual_study)) {
+            if (type.equals(SessionType.virtual_study)) {
                 ObjectMapper mapper = new ObjectMapper()
                         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
                 
@@ -75,6 +93,22 @@ public class ProxySessionServiceController {
         }
         return null;
     }
+
+    public Boolean isBasicAuthEnabled() {
+        return sessionServiceUser != null && !sessionServiceUser.equals("") && sessionServicePassword != null && !sessionServicePassword.equals("");
+    }
+
+    public HttpHeaders getHttpHeaders() {
+        return new HttpHeaders() {{
+            if (isBasicAuthEnabled()) {
+                String auth = sessionServiceUser + ":" + sessionServicePassword;
+                byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(Charset.forName("US-ASCII")));
+                String authHeader = "Basic " + new String(encodedAuth);
+                set( "Authorization", authHeader);
+            }
+            set( "Content-Type", "application/json");
+        }};
+     }
     
     @RequestMapping(value = "/virtual_study", method = RequestMethod.GET)
     public @ResponseBody List<VirtualStudy> getUserStudies() {
@@ -82,9 +116,12 @@ public class ProxySessionServiceController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (!StringUtils.isEmpty(sessionServiceURL) && authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
             RestTemplate restTemplate = new RestTemplate();
-            ResponseEntity<VirtualStudy[]> responseEntity = restTemplate.getForEntity(
+            HttpEntity<Object> headers = new HttpEntity<Object>(getHttpHeaders());
+            ResponseEntity<VirtualStudy[]> responseEntity = restTemplate.exchange(
                     sessionServiceURL + "virtual_study/query?field=data.users&value=" + 
                     ((UserDetails)authentication.getPrincipal()).getUsername(),
+                    HttpMethod.GET,
+                    headers,
                     VirtualStudy[].class);
             virtualStudies = Arrays.asList(responseEntity.getBody());
         }
@@ -145,7 +182,7 @@ public class ProxySessionServiceController {
                            Optional<SessionOperation> operation,
                            JSONObject body) throws IOException, JsonParseException, JsonMappingException {
         
-        HttpEntity httpEntity = new HttpEntity<JSONObject>(body);
+        HttpEntity httpEntity = null;
         if (type.equals(SessionType.virtual_study)) {
             ObjectMapper mapper = new ObjectMapper();
             // JSON from file to Object
@@ -160,16 +197,18 @@ public class ProxySessionServiceController {
                     virtualStudyData.setUsers(Collections.singleton(userName));
                 }
             }
-            httpEntity = new HttpEntity<VirtualStudyData>(virtualStudyData);
+
+            // use basic authentication for session service if set
+            httpEntity = new HttpEntity<VirtualStudyData>(virtualStudyData, getHttpHeaders());
+        } else {
+            httpEntity = new HttpEntity<JSONObject>(body, getHttpHeaders());
         }
         // returns {"id":"5799648eef86c0e807a2e965"}
         // using HashMap because converter is MappingJackson2HttpMessageConverter
         // (Jackson 2 is on classpath)
         // was String when default converter StringHttpMessageConverter was used
         RestTemplate restTemplate = new RestTemplate();
-
-        ResponseEntity<HashMap> responseEntity = restTemplate.exchange(sessionServiceURL + type, HttpMethod.POST, httpEntity,
-                HashMap.class);
+        ResponseEntity<HashMap> responseEntity = restTemplate.exchange(sessionServiceURL + type, HttpMethod.POST, httpEntity, HashMap.class);
 
         return responseEntity.getBody();
     }
@@ -198,7 +237,10 @@ public class ProxySessionServiceController {
                 }
             }
             virtualStudy.getData().setUsers(users);
-            new RestTemplate().put(sessionServiceURL + SessionType.virtual_study + "/" + id, virtualStudy.getData());
+            RestTemplate restTemplate = new RestTemplate();
+            HttpEntity<Object> httpEntity = new HttpEntity<Object>(virtualStudy.getData(), getHttpHeaders());
+
+            restTemplate.exchange(sessionServiceURL + SessionType.virtual_study + "/" + id, HttpMethod.POST, httpEntity, HashMap.class);
 
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
When properties session.service.user and session.service.password are provided
enable basic authentication for the session service proxy.

Requires this to be merged: https://github.com/cBioPortal/session-service/pull/16

TODO:
- [x] Util and Controller class seem like they should just be merged? Little hard to understand what the diff is between the two 