### PR TITLE
Move TUMOR_SITE to patient attributes

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1948,7 +1948,7 @@ class ClinicalValidator(Validator):
         'TUMOR_GRADE': {
         },
         'TUMOR_SITE': {
-            'is_patient_attribute': '0',
+            'is_patient_attribute': '1',
             'datatype': 'STRING',
         },
         'TUMOR_STAGE_2009': {

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -151,9 +151,10 @@ The first four rows of the clinical data file contain tab-delimited metadata abo
     
     Please see [here](Study-View.md) for more detailed information about how study view utilize priority and how the layout is calculated based on priority.
 - Row 5: **The attribute name for the database**: This name should be in upper case.
-    
+- Row 6: This is the first row that contains actual data.
 
-#### Example metadata rows
+
+#### Example clinical header
 Below is an example of the first 4 rows with the respective metadata for the attributes defined in the 5th row. 
 ```
 #Patient Identifier<TAB>Overall Survival Status<TAB>Overall Survival (Months)<TAB>Disease Free Status<TAB>Disease Free (Months)<TAB>...
@@ -166,10 +167,7 @@ data - see examples below
 ....
 ```
 
-Following the metadata rows comes a tab delimited list of clinical attributes (column headers). The sixth row is the first row to contain actual data. 
-
-##### The patient file
-
+#### Clinical patient columns
 The file containing the patient attributes has one **required** column:
 - **PATIENT_ID (required)**: a unique patient ID. This field allows only numbers, letters, points, underscores and hyphens.
 
@@ -188,6 +186,7 @@ These columns, when provided, add additional information to the patient descript
 - **PATIENT_DISPLAY_NAME**: Patient display name (string)
 - **GENDER** or **SEX**: Gender or sex of the patient (string)
 - **AGE**: Age at which the condition or disease was first diagnosed, in years (number)
+- **TUMOR_SITE**
 
 Optional attributes:
 - **Other Clinical Attribute Headers**: Clinical attribute headers are free-form. You can add any additional clinical attribute and cBioPortal will add them to the database. Be sure to provide the correct `'Datatype'`, as described above, for optimal search, sorting, filtering (in [clinical data tab](http://www.cbioportal.org/study?id=brca_tcga#clinical)) and display.
@@ -204,7 +203,7 @@ PATIENT_ID_2<TAB>LIVING<TAB>63.01<TAB>DiseaseFree<TAB>63.01<TAB>...
 ...
 ```
 
-##### The samples file
+##### Clinical sample columns
 The file containing the sample attributes has two **required** columns:
 - **PATIENT_ID (required)**: A patient ID. This field can only contain numbers, letters, points, underscores and hyphens.
 - **SAMPLE_ID (required)**: A sample ID. This field can only contain numbers, letters, points, underscores and hyphens.
@@ -217,21 +216,8 @@ The following columns are required if you want the [pan-cancer summary statistic
 
 The following columns affect the header of the patient view by adding text to the samples in the header:
 - **SAMPLE_DISPLAY_NAME**: displayed in addition to the ID
-- **TYPE_OF_CANCER**: Overrides CANCER_TYPE in the header
-- **DETAILED_CANCER_TYPE**: Overrides CANCER_TYPE_DETAILED in the header
-- **KNOWN_MOLECULAR_CLASSIFIER**
-- **TUMOR_SITE**
-- **METASTATIC_SITE** or **PRIMARY_SITE**: Override TUMOR_SITE depending on sample type
 - **SAMPLE_CLASS**
-- **GLEASON_SCORE**: Radical prostatectomy Gleason score for prostate cancer
-- **HISTOLOGY**
-- **TUMOR_STAGE_2009**
-- **TUMOR_GRADE**
-- **ETS_RAF_SPINK1_STATUS**
-- **TMPRSS2_ERG_FUSION_STATUS**
-- **ERG_FUSION_ACGH**
-- **SERUM_PSA**
-- **DRIVER_MUTATIONS**
+- **METASTATIC_SITE** or **PRIMARY_SITE**: Override TUMOR_SITE (patient level attribute) depending on sample type
 
 The following columns additionally affect the [Timeline data](#timeline-data) visualization:
 - **OTHER_SAMPLE_ID**: sometimes the timeline data (see the [timeline data section](#timeline-data)) will not have the SAMPLE_ID but instead an alias to the sample (in the field `SPECIMEN_REFERENCE_NUMBER`). To ensure that the timeline data field `SPECIMEN_REFERENCE_NUMBER` is correctly linked to this sample, be sure to add this column `OTHER_SAMPLE_ID` as an attribute to your sample attributes file.  
@@ -239,10 +225,6 @@ The following columns additionally affect the [Timeline data](#timeline-data) vi
     - If set to `recurrence`, `recurred`, `progression` or `progressed`: orange
     - If set to `metastatic` or `metastasis`: red
     - If set to `primary` or otherwise: black
-
-Optional attributes
-- **Other Clinical Attribute Headers**: Clinical attribute headers are free-form. You can add any additional clinical attribute you have tracked and cBioPortal will add them to the database. Be sure to provide the correct `Datatype`, as described above (for the header lines), for optimal search, sorting, filtering (in [clinical data tab](http://www.cbioportal.org/study?id=brca_tcga#clinical)) and display.
-
 
 ###### Example sample data file
 ```
@@ -255,6 +237,24 @@ PATIENT_ID_1<TAB>SAMPLE_ID_1<TAB>basal-like<TAB>...
 PATIENT_ID_2<TAB>SAMPLE_ID_2<TAB>Her2 enriched<TAB>...
 ...
 ```
+
+##### Other columns with specific functionality
+These columns can be in either the patient or sample file.
+- **CANCER_TYPE**: Overrides study wide cancer type
+- **CANCER_TYPE_DETAILED**
+- **KNOWN_MOLECULAR_CLASSIFIER**
+- **GLEASON_SCORE**: Radical prostatectomy Gleason score for prostate cancer
+- **HISTOLOGY**
+- **TUMOR_STAGE_2009**
+- **TUMOR_GRADE**
+- **ETS_RAF_SPINK1_STATUS**
+- **TMPRSS2_ERG_FUSION_STATUS**
+- **ERG_FUSION_ACGH**
+- **SERUM_PSA**
+- **DRIVER_MUTATIONS**
+
+##### Other columns without specific functionality
+You can add any additional columns with clinical data to either the patient or sample file. If correctly formatted with the 5-row header, cBioPortal will add them to the database. Be sure to provide the correct `Datatype`, as described above (for the header lines), for optimal search, sorting, filtering (in [clinical data tab](http://www.cbioportal.org/study?id=brca_tcga#clinical)) and visualization.
 
 ## Discrete Copy Number Data
 The discrete copy number data file contain values that would be derived from copy-number analysis algorithms like [GISTIC](http://www.ncbi.nlm.nih.gov/sites/entrez?term=18077431) or [RAE](http://www.ncbi.nlm.nih.gov/sites/entrez?term=18784837). GISTIC can be [installed](http://www.broadinstitute.org/cgi-bin/cancer/publications/pub_paper.cgi?mode=view&paper_id=216&p=t) or run online using the GISTIC 2.0 module on [GenePattern](http://genepattern.broadinstitute.org/gp/pages/login.jsf). For some help on using GISTIC, check the [Data Loading: Tips and Best Practices](Data-Loading-Tips-and-Best-Practices.md) page.


### PR DESCRIPTION
# What? Why?
Change the following attribute to be a PATIENT attribute instead of a SAMPLE attribute
- `TUMOR_SITE`

This was requested by @yichaoS to let several studies pass validation on CircleCI, such as `blca_tcga_pub_2017`, see:
https://384-63335718-gh.circle-artifacts.com/0/test-reports/ERRORS/blca_tcga_pub_2017-validation.html
I have **not** tested if the front end works as expected when these data types are in the clinical patient file.

Also, File-Formats is updated to reflect these changes. @jjgao @n1zea144 please comment if you agree with this data format. 