### PR TITLE
Add configurable cutoff for max line numbers and encountered values in HTML report

### DIFF
--- a/core/src/main/scripts/importer/metaImport.py
+++ b/core/src/main/scripts/importer/metaImport.py
@@ -76,7 +76,13 @@ def interface():
                         action='store_true', default=False,
                         help='Option to enable strict mode for validator when '
                              'validating mutation data')
-
+    parser.add_argument('-a', '--max_reported_values', required=False,
+                        type=int, default=3,
+                        help='Cutoff in report for the maximum number of line numbers '
+                             'and values encountered to report for each message in the HTML '
+                             'report. For example, set this to a high number to '
+                             'report all genes that could not be loaded, instead '
+                             'of reporting "(GeneA, GeneB, GeneC, 213 more)".')
     parser = parser.parse_args()
     return parser
 

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -3818,11 +3818,11 @@ def interface(args=None):
                              'validating mutation data')
     parser.add_argument('-a', '--max_reported_values', required=False,
                         type=int, default=3,
-                        help='Cutoff in report for the maximum number of line numbers '
-                             'and values encountered to report for each message in the HTML '
-                             'report. For example, set this to a high number to '
+                        help='Cutoff in HTML report for the maximum number of line numbers '
+                             'and values encountered to report for each message. '
+                             'For example, set this to a high number to '
                              'report all genes that could not be loaded, instead '
-                             'of reporting "(GeneA, GeneB, GeneC, 213 more)".')
+                             'of reporting "GeneA, GeneB, GeneC, 213 more"')
 
     parser = parser.parse_args(args)
     return parser

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -144,11 +144,12 @@ class Jinja2HtmlHandler(logging.handlers.BufferingHandler):
 
     """Logging handler that formats aggregated HTML reports using Jinja2."""
 
-    def __init__(self, study_dir, output_filename, cbio_version, *args, **kwargs):
+    def __init__(self, study_dir, output_filename, cbio_version, max_reported_values, *args, **kwargs):
         """Set study directory name, output filename and buffer size."""
         self.study_dir = study_dir
         self.output_filename = output_filename
         self.cbio_version = cbio_version
+        self.max_reported_values = max_reported_values
         self.max_level = logging.NOTSET
         self.closed = False
         # get the directory name of the currently running script,
@@ -186,6 +187,7 @@ class Jinja2HtmlHandler(logging.handlers.BufferingHandler):
         doc = template.render(   # pylint: disable=no-member
             study_dir=self.study_dir,
             cbio_version=self.cbio_version,
+            max_reported_values=self.max_reported_values,
             record_list=self.buffer,
             max_level=logging.getLevelName(self.max_level))
         with open(self.output_filename, 'w') as f:
@@ -3814,6 +3816,13 @@ def interface(args=None):
                         action='store_true', default=False,
                         help='Option to enable strict mode for validator when '
                              'validating mutation data')
+    parser.add_argument('-a', '--max_reported_values', required=False,
+                        type=int, default=3,
+                        help='Cutoff in report for the maximum number of line numbers '
+                             'and values encountered to report for each message in the HTML '
+                             'report. For example, set this to a high number to '
+                             'report all genes that could not be loaded, instead '
+                             'of reporting "(GeneA, GeneB, GeneC, 213 more)".')
 
     parser = parser.parse_args(args)
     return parser
@@ -3981,6 +3990,7 @@ def main_validate(args):
     html_output_filename = args.html_table
     relaxed_mode = args.relaxed_clinical_definitions
     strict_maf_checks = args.strict_maf_checks
+    max_reported_values = args.max_reported_values
 
     # determine the log level for terminal and html output
     output_loglevel = logging.INFO
@@ -4034,7 +4044,8 @@ def main_validate(args):
         html_handler = Jinja2HtmlHandler(
             study_dir,
             html_output_filename,
-            cbio_version = cbio_version,
+            cbio_version=cbio_version,
+            max_reported_values=max_reported_values,
             capacity=1e5)
         # TODO extend CollapsingLogMessageHandler to flush to multiple targets,
         # and get rid of the duplicated buffering of messages here

--- a/core/src/main/scripts/importer/validateStudies.py
+++ b/core/src/main/scripts/importer/validateStudies.py
@@ -83,6 +83,10 @@ def main(args):
         if args.strict_mutation_checks is not False:
             validator_args.append('-m')
 
+        # Append argument for maximum reported line numbers and encountered values in HTML
+        if args.max_reported_values != 3:
+            validator_args.append('-a %s' % args.max_reported_values)
+
         # When HTML file is required, create html file name and add to arguments for validateData
         if output_folder is not None:
             try:
@@ -176,6 +180,13 @@ def interface(args=None):
                         action='store_true', default=False,
                         help='Option to enable strict mode for validator when '
                              'validating mutation data')
+    parser.add_argument('-a', '--max_reported_values', required=False,
+                        type=int, default = 3,
+                        help='Cutoff in report for the maximum number of line numbers '
+                             'and values encountered to report for each message in the HTML '
+                             'report. For example, set this to a high number to '
+                             'report all genes that could not be loaded, instead '
+                             'of reporting "(GeneA, GeneB, GeneC, 213 more)".')
 
     args = parser.parse_args(args)
 

--- a/core/src/main/scripts/importer/validateStudies.py
+++ b/core/src/main/scripts/importer/validateStudies.py
@@ -80,7 +80,7 @@ def main(args):
             validator_args.append(args.portal_properties)
             
         # Append argument for strict mode when supplied by user
-        if args.strict_mutation_checks is not False:
+        if args.strict_maf_checks is not False:
             validator_args.append('-m')
 
         # Append argument for maximum reported line numbers and encountered values in HTML
@@ -176,17 +176,17 @@ def interface(args=None):
                         help='portal.properties file path (default: assumed hg19)',
                         required=False)
 
-    parser.add_argument('-m', '--strict_mutation_checks', required=False,
+    parser.add_argument('-m', '--strict_maf_checks', required=False,
                         action='store_true', default=False,
                         help='Option to enable strict mode for validator when '
                              'validating mutation data')
     parser.add_argument('-a', '--max_reported_values', required=False,
                         type=int, default = 3,
-                        help='Cutoff in report for the maximum number of line numbers '
-                             'and values encountered to report for each message in the HTML '
-                             'report. For example, set this to a high number to '
+                        help='Cutoff in HTML report for the maximum number of line numbers '
+                             'and values encountered to report for each message. '
+                             'For example, set this to a high number to '
                              'report all genes that could not be loaded, instead '
-                             'of reporting "(GeneA, GeneB, GeneC, 213 more)".')
+                             'of reporting "GeneA, GeneB, GeneC, 213 more"')
 
     args = parser.parse_args(args)
 

--- a/core/src/main/scripts/importer/validation_report_template.html.jinja
+++ b/core/src/main/scripts/importer/validation_report_template.html.jinja
@@ -175,10 +175,10 @@
               <tr class="{{ record_class }}">
                 {% macro format_aggregated(record, attr_name) %}
                     {% if record[attr_name + '_list'] is defined -%}
-                      {% if (record['show_all_values'] is not defined or record['show_all_values'] == False) and (record[attr_name + '_list']|length) > 3 -%}
-                              {{ (record[attr_name + '_list'][:3]|join(', ') +
+                      {% if (record['show_all_values'] is not defined or record['show_all_values'] == False) and (record[attr_name + '_list']|length) > max_reported_values -%}
+                              {{ (record[attr_name + '_list'][:max_reported_values]|join(', ') +
                                   ', (' +
-                                  record[attr_name + '_list'][3:]|length|string +
+                                  record[attr_name + '_list'][max_reported_values:]|length|string +
                                   ' more)')|e }}
                           {%- else -%}
                                   {{ (record[attr_name + '_list']|join(', '))|e }}

--- a/docs/Using-the-dataset-validator.md
+++ b/docs/Using-the-dataset-validator.md
@@ -20,8 +20,8 @@ This will tell you the parameters you can use:
 ```console
 usage: validateData.py [-h] -s STUDY_DIRECTORY
                        [-u URL_SERVER | -p PORTAL_INFO_DIR | -n]
-                       [-html HTML_TABLE] [-e ERROR_FILE] [-v]
-                       [-r] [-m]
+                       [-P PORTAL_PROPERTIES] [-html HTML_TABLE]
+                       [-e ERROR_FILE] [-v] [-r] [-m] [-a MAX_REPORTED_VALUES]
 
 cBioPortal study validator
 
@@ -53,6 +53,12 @@ optional arguments:
   -m, --strict_maf_checks
                         Option to enable strict mode for validator when validating
                         mutation data
+  -a MAX_REPORTED_VALUES, --max_reported_values MAX_REPORTED_VALUES
+                        Cutoff in HTML report for the maximum number of line
+                        numbers and values encountered to report for each
+                        message. For example, set this to a high number to
+                        report all genes that could not be loaded, instead of
+                        reporting "GeneA, GeneB, GeneC, 213 more"
 ```
 
 For more information on the `--portal_info_dir` option, see [Offline validation](#offline-validation) below. If your cBioPortal is not using `hg19`, you must use the `--portal_properties` option. For more information, see [Validation of non-human data](#validation-of-non-human-data).
@@ -446,33 +452,39 @@ The following parameters can be used:
 usage: validateStudies.py [-h] [-d ROOT_DIRECTORY] [-l LIST_OF_STUDIES]
                           [-html HTML_FOLDER]
                           [-u URL_SERVER | -p PORTAL_INFO_DIR | -n]
-                          [-P PORTAL_PROPERTIES]
+                          [-P PORTAL_PROPERTIES] [-m] [-a MAX_REPORTED_VALUES]
 
 Wrapper where cBioPortal study validator is run for multiple studies
 
 optional arguments:
--h, --help            show this help message and exit
--d ROOT_DIRECTORY, --root-directory ROOT_DIRECTORY
-                      Path to directory with all studies that should be
-                      validated
--l LIST_OF_STUDIES, --list-of-studies LIST_OF_STUDIES
-                      List with paths of studies which should be validated
--html HTML_FOLDER, --html-folder HTML_FOLDER
-                      Path to folder for output HTML reports
--u URL_SERVER, --url_server URL_SERVER
-                      URL to cBioPortal server. You can set this if your URL
-                      is not http://localhost:8080/cbioportal
--p PORTAL_INFO_DIR, --portal_info_dir PORTAL_INFO_DIR
-                      Path to a directory of cBioPortal info files to be
-                      used instead of contacting a server
--n, --no_portal_checks
-                      Skip tests requiring information from the cBioPortal
-                      installation
--P PORTAL_PROPERTIES, --portal_properties PORTAL_PROPERTIES
-                      portal.properties file path (default: assumed hg19)
--m, --strict_maf_checks
-                      Option to enable strict mode for validator when validating
-                      mutation data
+  -h, --help            show this help message and exit
+  -d ROOT_DIRECTORY, --root-directory ROOT_DIRECTORY
+                        Path to directory with all studies that should be
+                        validated
+  -l LIST_OF_STUDIES, --list-of-studies LIST_OF_STUDIES
+                        List with paths of studies which should be validated
+  -html HTML_FOLDER, --html-folder HTML_FOLDER
+                        Path to folder for output HTML reports
+  -u URL_SERVER, --url_server URL_SERVER
+                        URL to cBioPortal server. You can set this if your URL
+                        is not http://localhost:8080/cbioportal
+  -p PORTAL_INFO_DIR, --portal_info_dir PORTAL_INFO_DIR
+                        Path to a directory of cBioPortal info files to be
+                        used instead of contacting a server
+  -n, --no_portal_checks
+                        Skip tests requiring information from the cBioPortal
+                        installation
+  -P PORTAL_PROPERTIES, --portal_properties PORTAL_PROPERTIES
+                        portal.properties file path (default: assumed hg19)
+  -m, --strict_maf_checks
+                        Option to enable strict mode for validator when
+                        validating mutation data
+  -a MAX_REPORTED_VALUES, --max_reported_values MAX_REPORTED_VALUES
+                        Cutoff in HTML report for the maximum number of line
+                        numbers and values encountered to report for each
+                        message. For example, set this to a high number to
+                        report all genes that could not be loaded, instead of
+                        reporting "GeneA, GeneB, GeneC, 213 more"
 ```
 
 Parameters `--url_server`, `--portal_info_dir`, `--no_portal_checks` and `--portal_properties` are equal to the parameters with the same name in `validateData.py`. The script will save a log file with validation output (`log-validate-studies.txt`) and output the validation status from the input studies:


### PR DESCRIPTION
For example, set this to a high number to report all genes that could not be loaded, instead
of reporting "(GeneA, GeneB, GeneC, 213 more)"

## Cutoff at 25
<img width="1146" alt="screen shot 2018-08-01 at 22 02 25" src="https://user-images.githubusercontent.com/9624990/43547378-637a2fe2-95db-11e8-8421-122442b0119c.png">

## Cutoff at 10,000
<img width="1115" alt="screen shot 2018-08-01 at 22 30 08" src="https://user-images.githubusercontent.com/9624990/43547389-6c9324bc-95db-11e8-8f72-4e6aa6ad6006.png">
