### PR TITLE
Port the Python layer to Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,11 @@ script:
       source ~/python-env-validator/bin/activate
       trap 'deactivate' EXIT
       export PYTHONPATH="$PORTAL_HOME/core/src/main/scripts:$PYTHONPATH" && \
-      cd $PORTAL_HOME/core/src/test/scripts/ && \
+      pushd $PORTAL_HOME/core/src/test/scripts/ && \
       python $PORTAL_HOME/core/src/test/scripts/unit_tests_validate_data.py && \
-      python $PORTAL_HOME/core/src/test/scripts/./system_tests_validate_data.py && \
-      cd $PORTAL_HOME
+      python $PORTAL_HOME/core/src/test/scripts/system_tests_validate_data.py && \
+      python $PORTAL_HOME/core/src/test/scripts/system_tests_validate_studies.py && \
+      popd
   fi
 - |
   if [[ "${TEST}" == core ]]

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,11 @@ install:
 - |
   if [[ "${TEST}" == python-validator ]]
   then
-      sudo -H pip install -r requirements.txt
+      sudo apt-get install python3.4-venv
+      python3.4 -m venv ~/python-env-validator
+      source ~/python-env-validator/bin/activate
+      trap 'deactivate' EXIT
+      pip install -r requirements.txt
   fi
 before_script:
 - |
@@ -42,10 +46,12 @@ script:
 - |
   if [[ "${TEST}" == python-validator ]]
   then
-      export PYTHONPATH=$PYTHONPATH:$PORTAL_HOME/core/src/main/scripts:/usr/local/lib/python2.7/dist-packages:/usr/lib/python2.7/dist-packages && \
+      source ~/python-env-validator/bin/activate
+      trap 'deactivate' EXIT
+      export PYTHONPATH="$PORTAL_HOME/core/src/main/scripts:$PYTHONPATH" && \
       cd $PORTAL_HOME/core/src/test/scripts/ && \
-      $PORTAL_HOME/core/src/test/scripts/./unit_tests_validate_data.py && \
-      $PORTAL_HOME/core/src/test/scripts/./system_tests_validate_data.py && \
+      python $PORTAL_HOME/core/src/test/scripts/unit_tests_validate_data.py && \
+      python $PORTAL_HOME/core/src/test/scripts/./system_tests_validate_data.py && \
       cd $PORTAL_HOME
   fi
 - |

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         libmysql-java \
         patch \
-        python \
-        python-jinja2 \
-        python-mysqldb \
-        python-requests \
+        python3 \
+        python3-jinja2 \
+        python3-mysqldb \
+        python3-requests \
         maven \
         openjdk-8-jdk \
     && ln -s /usr/share/java/mysql-connector-java.jar "$CATALINA_HOME"/lib/ \

--- a/core/src/main/scripts/importer/cbioportalImporter.py
+++ b/core/src/main/scripts/importer/cbioportalImporter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 # ------------------------------------------------------------------------------
 # Script which imports portal data.
@@ -11,20 +11,20 @@ import argparse
 import logging
 import re
 
-import cbioportal_common
-from cbioportal_common import OUTPUT_FILE
-from cbioportal_common import ERROR_FILE
-from cbioportal_common import MetaFileTypes
-from cbioportal_common import IMPORTER_CLASSNAME_BY_META_TYPE
-from cbioportal_common import IMPORTER_REQUIRES_METADATA
-from cbioportal_common import IMPORT_CANCER_TYPE_CLASS
-from cbioportal_common import IMPORT_STUDY_CLASS
-from cbioportal_common import UPDATE_STUDY_STATUS_CLASS
-from cbioportal_common import REMOVE_STUDY_CLASS
-from cbioportal_common import IMPORT_CASE_LIST_CLASS
-from cbioportal_common import ADD_CASE_LIST_CLASS
-from cbioportal_common import VERSION_UTIL_CLASS
-from cbioportal_common import run_java
+from . import cbioportal_common
+from .cbioportal_common import OUTPUT_FILE
+from .cbioportal_common import ERROR_FILE
+from .cbioportal_common import MetaFileTypes
+from .cbioportal_common import IMPORTER_CLASSNAME_BY_META_TYPE
+from .cbioportal_common import IMPORTER_REQUIRES_METADATA
+from .cbioportal_common import IMPORT_CANCER_TYPE_CLASS
+from .cbioportal_common import IMPORT_STUDY_CLASS
+from .cbioportal_common import UPDATE_STUDY_STATUS_CLASS
+from .cbioportal_common import REMOVE_STUDY_CLASS
+from .cbioportal_common import IMPORT_CASE_LIST_CLASS
+from .cbioportal_common import ADD_CASE_LIST_CLASS
+from .cbioportal_common import VERSION_UTIL_CLASS
+from .cbioportal_common import run_java
 
 
 # ------------------------------------------------------------------------------
@@ -75,7 +75,7 @@ def remove_study(jvm_args, meta_filename):
         meta_filename, logger=LOGGER)
     if meta_dictionary['meta_file_type'] != MetaFileTypes.STUDY:
         # invalid file, skip
-        print >> ERROR_FILE, 'Not a study meta file: ' + meta_filename
+        print('Not a study meta file: ' + meta_filename, file=ERROR_FILE)
         return
     args.append(meta_dictionary['cancer_study_identifier'])
     args.append("--noprogress") # don't report memory usage and % progress
@@ -96,13 +96,13 @@ def import_study_data(jvm_args, meta_filename, data_filename, meta_file_dictiona
 
     # invalid file, skip
     if meta_file_type is None:
-        print >> ERROR_FILE, ("Unrecognized meta file type '%s', skipping file"
-                              % (meta_file_type))
+        print(("Unrecognized meta file type '%s', skipping file"
+                              % (meta_file_type)), file=ERROR_FILE)
         return
 
     if not data_filename.endswith(meta_file_dictionary['data_filename']):
-        print >> ERROR_FILE, ("'data_filename' in meta file contradicts "
-                              "data filename in command, skipping file")
+        print(("'data_filename' in meta file contradicts "
+                              "data filename in command, skipping file"), file=ERROR_FILE)
         return
 
     importer = IMPORTER_CLASSNAME_BY_META_TYPE[meta_file_type]
@@ -151,7 +151,7 @@ def check_version(jvm_args):
     try:
         run_java(*args)
     except:
-        print >> OUTPUT_FILE, 'Error, probably due to this version of the portal being out of sync with the database. Run the database migration script located at PORTAL_HOME/core/src/main/scripts/migrate_db.py before continuing.'
+        print('Error, probably due to this version of the portal being out of sync with the database. Run the database migration script located at PORTAL_HOME/core/src/main/scripts/migrate_db.py before continuing.', file=OUTPUT_FILE)
         raise
 
 def process_case_lists(jvm_args, case_list_dir):
@@ -334,11 +334,11 @@ def process_directory(jvm_args, study_directory):
 
 def usage():
     # TODO : replace this by usage string from interface()
-    print >> OUTPUT_FILE, ('cbioportalImporter.py --jar-path (path to scripts jar file) ' +
+    print(('cbioportalImporter.py --jar-path (path to scripts jar file) ' +
                            '--command [%s] --study_directory <path to directory> '
                            '--meta_filename <path to metafile>'
                            '--data_filename <path to datafile>'
-                           '--properties-filename <path to properties file> ' % (COMMANDS))
+                           '--properties-filename <path to properties file> ' % (COMMANDS)), file=OUTPUT_FILE)
 
 def check_args(command):
     if command not in COMMANDS:
@@ -348,16 +348,16 @@ def check_args(command):
 
 def check_files(meta_filename, data_filename):
     if meta_filename and not os.path.exists(meta_filename):
-        print >> ERROR_FILE, 'meta-file cannot be found: ' + meta_filename
+        print('meta-file cannot be found: ' + meta_filename, file=ERROR_FILE)
         sys.exit(2)
     if data_filename  and not os.path.exists(data_filename):
-        print >> ERROR_FILE, 'data-file cannot be found:' + data_filename
+        print('data-file cannot be found:' + data_filename, file=ERROR_FILE)
         sys.exit(2)
 
 def check_dir(study_directory):
     # check existence of directory
     if not os.path.exists(study_directory) and study_directory != '':
-        print >> ERROR_FILE, 'Study cannot be found: ' + study_directory
+        print('Study cannot be found: ' + study_directory, file=ERROR_FILE)
         sys.exit(2)
 
 def interface():
@@ -366,11 +366,11 @@ def interface():
                         help='Command for import. Allowed commands: import-cancer-type, '
                              'import-study, import-study-data, import-case-list or '
                              'remove-study')
-    parser.add_argument('-s', '--study_directory',type=str, required=False,
+    parser.add_argument('-s', '--study_directory', type=str, required=False,
                         help='Path to Study Directory')
-    parser.add_argument('-jar', '--jar_path',type=str, required=False,
+    parser.add_argument('-jar', '--jar_path', type=str, required=False,
                         help='Path to scripts JAR file')
-    parser.add_argument('-meta', '--meta_filename',type=str, required=False,
+    parser.add_argument('-meta', '--meta_filename', type=str, required=False,
                         help='Path to meta file')
     parser.add_argument('-data', '--data_filename', type=str, required=False,
                         help='Path to Data file')
@@ -399,17 +399,17 @@ def main(args):
         portal_home = os.environ.get('PORTAL_HOME', None)
         if portal_home is None:
             # PORTAL_HOME also not set...quit trying with error:
-            print 'Error: either --jar_path needs to be given or environment variable PORTAL_HOME needs to be set'
+            print('Error: either --jar_path needs to be given or environment variable PORTAL_HOME needs to be set')
             sys.exit(2)
         else:
             #find jar files in lib folder and add them to classpath:
             import glob
             jars = glob.glob(portal_home + "/scripts/target/scripts-*.jar")
             if len(jars) != 1:
-                print 'Expected to find 1 scripts-*.jar, but found: ' + str(len(jars))
+                print('Expected to find 1 scripts-*.jar, but found: ' + str(len(jars)))
                 sys.exit(2)
             args.jar_path = jars[0]
-            print 'Data loading step using: {}\n'.format(args.jar_path)
+            print('Data loading step using: {}\n'.format(args.jar_path))
 
     # process the options
     jvm_args = "-Dspring.profiles.active=dbcp -cp " + args.jar_path

--- a/core/src/main/scripts/importer/cbioportalImporter.py
+++ b/core/src/main/scripts/importer/cbioportalImporter.py
@@ -7,6 +7,7 @@
 
 import os
 import sys
+import importlib
 import argparse
 import logging
 import re
@@ -19,6 +20,9 @@ if __name__ == "__main__" and __package__ is None:
     # scope and *not* directly in sys.path; see PEP 395
     sys.path[0] = str(Path(sys.path[0]).resolve().parent)
     __package__ = 'importer'
+    # explicitly load the package, which is needed on CPython 3.4 because it
+    # doesn't include https://github.com/python/cpython/pull/2639
+    importlib.import_module(__package__)
 
 from . import cbioportal_common
 from .cbioportal_common import OUTPUT_FILE

--- a/core/src/main/scripts/importer/cbioportalImporter.py
+++ b/core/src/main/scripts/importer/cbioportalImporter.py
@@ -10,6 +10,15 @@ import sys
 import argparse
 import logging
 import re
+from pathlib import Path
+
+# configure relative imports if running as a script; see PEP 366
+if __name__ == "__main__" and __package__ is None:
+    # replace the script's location in the Python search path by the main
+    # scripts/ folder, above it, so that the importer package folder is in
+    # scope and *not* directly in sys.path; see PEP 395
+    sys.path[0] = str(Path(sys.path[0]).resolve().parent)
+    __package__ = 'importer'
 
 from . import cbioportal_common
 from .cbioportal_common import OUTPUT_FILE

--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 # ------------------------------------------------------------------------------
 # Common components used by various cbioportal scripts.
@@ -446,7 +446,7 @@ class CollapsingLogMessageHandler(logging.handlers.MemoryHandler):
 
         aggregated_buffer = []
         # for each list of same-message records
-        for record_list in grouping_dict.values():
+        for record_list in list(grouping_dict.values()):
             # make a dict to collect the fields for the aggregate record
             aggregated_field_dict = {}
             # for each field found in (the first of) the records
@@ -573,7 +573,7 @@ def validate_types_and_id(meta_dictionary, logger, filename):
                 data_line_nr += 1
                 # skip header, so if line is not header then process as tab separated:
                 if (data_line_nr > 1):
-                    line_cols = csv.reader([line], delimiter='\t').next()
+                    line_cols = next(csv.reader([line], delimiter='\t'))
                     genetic_alteration_type = line_cols[0]
                     data_type = line_cols[1]
                     # add to map:
@@ -821,7 +821,7 @@ def run_java(*args):
     while process.poll() is None:
         line = process.stdout.readline()
         if line != '' and line.endswith('\n'):
-            print >> OUTPUT_FILE, line.strip()
+            print(line.strip(), file=OUTPUT_FILE)
             ret.append(line[:-1])
     ret.append(process.returncode)
     # if cmd line parameters error:

--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -629,7 +629,7 @@ def parse_metadata_file(filename,
     logger.debug('Starting validation of meta file', extra={'filename_': filename})
 
     # Read meta file
-    meta_dictionary = {}
+    meta_dictionary = OrderedDict()
     with open(filename, 'r') as metafile:
         for line_index, line in enumerate(metafile):
             # skip empty lines:
@@ -642,7 +642,7 @@ def parse_metadata_file(filename,
                     extra={'filename_': filename,
                            'line_number': line_index + 1})
                 meta_dictionary['meta_file_type'] = None
-                return meta_dictionary
+                return dict(meta_dictionary)
             key_value = line.split(':', 1)
             if len(key_value) == 2:
                 meta_dictionary[key_value[0]] = key_value[1].strip()
@@ -656,7 +656,7 @@ def parse_metadata_file(filename,
         meta_dictionary['meta_file_type'] = meta_file_type
         # if type could not be inferred, no further validations are possible
         if meta_file_type is None:
-            return meta_dictionary
+            return dict(meta_dictionary)
 
 
     # Check for missing fields for this specific meta file type
@@ -673,7 +673,7 @@ def parse_metadata_file(filename,
     if missing_fields:
         # all further checks would depend on these fields being present
         meta_dictionary['meta_file_type'] = None
-        return meta_dictionary
+        return dict(meta_dictionary)
 
     # validate genetic_alteration_type, datatype, stable_id
     stable_id_mandatory = META_FIELD_MAP[meta_file_type].get('stable_id',
@@ -683,7 +683,7 @@ def parse_metadata_file(filename,
         if not valid_types_and_id:
             # invalid meta file type
             meta_dictionary['meta_file_type'] = None
-            return meta_dictionary
+            return dict(meta_dictionary)
 
     # check for extra unrecognized fields
     for field in meta_dictionary:
@@ -712,7 +712,7 @@ def parse_metadata_file(filename,
                    'cause': meta_dictionary['cancer_study_identifier']})
         # not a valid meta file in this study
         meta_dictionary['meta_file_type'] = None
-        return meta_dictionary
+        return dict(meta_dictionary)
 
     # type-specific validations
 

--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -630,7 +630,7 @@ def parse_metadata_file(filename,
 
     # Read meta file
     meta_dictionary = {}
-    with open(filename, 'rU') as metafile:
+    with open(filename, 'r') as metafile:
         for line_index, line in enumerate(metafile):
             # skip empty lines:
             if line.strip() == '':

--- a/core/src/main/scripts/importer/metaImport.py
+++ b/core/src/main/scripts/importer/metaImport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 __author__ = 'priti'
 
@@ -11,8 +11,8 @@ import sys
 import argparse
 import logging
 
-import validateData
-import cbioportalImporter
+from . import validateData
+from . import cbioportalImporter
 
 
 # ----------------------------------------------------------------------------
@@ -100,16 +100,16 @@ if __name__ == '__main__':
     study_dir = args.study_directory
 
     # Validate the study directory.
-    print >> sys.stderr, "Starting validation...\n"
+    print("Starting validation...\n", file=sys.stderr)
     try:
         exitcode = validateData.main_validate(args)
     except KeyboardInterrupt:
-        print >> sys.stderr, Color.BOLD + "\nProcess interrupted. " + Color.END
-        print >> sys.stderr, "#" * 71 + "\n"
+        print(Color.BOLD + "\nProcess interrupted. " + Color.END, file=sys.stderr)
+        print("#" * 71 + "\n", file=sys.stderr)
         raise
     except:
-        print >> sys.stderr, "!" * 71
-        print >> sys.stderr, Color.RED + "Error occurred during validation step:" + Color.END
+        print("!" * 71, file=sys.stderr)
+        print(Color.RED + "Error occurred during validation step:" + Color.END, file=sys.stderr)
         raise
     finally:
         # make sure all log messages are flushed
@@ -120,30 +120,30 @@ if __name__ == '__main__':
 
     # Depending on validation results, load the study or notify the user
     try:
-        print "\n"
-        print >> sys.stderr, "#" * 71
+        print("\n")
+        print("#" * 71, file=sys.stderr)
         if exitcode == 1:
-            print >> sys.stderr, Color.RED + "One or more errors reported above. Please fix your files accordingly" + Color.END
-            print >> sys.stderr, "!" * 71
+            print(Color.RED + "One or more errors reported above. Please fix your files accordingly" + Color.END, file=sys.stderr)
+            print("!" * 71, file=sys.stderr)
         elif exitcode == 3:
             if args.override_warning:
-                print >> sys.stderr, Color.BOLD + "Overriding Warnings. Importing study now" + Color.END
-                print >> sys.stderr, "#" * 71 + "\n"
+                print(Color.BOLD + "Overriding Warnings. Importing study now" + Color.END, file=sys.stderr)
+                print("#" * 71 + "\n", file=sys.stderr)
                 cbioportalImporter.main(args)
                 exitcode = 0
             else:
-                print >> sys.stderr, Color.BOLD + "Warnings. Please fix your files or import with override warning option" + Color.END
-                print >> sys.stderr, "#" * 71
+                print(Color.BOLD + "Warnings. Please fix your files or import with override warning option" + Color.END, file=sys.stderr)
+                print("#" * 71, file=sys.stderr)
         elif exitcode == 0:
-            print >> sys.stderr, Color.BOLD + "Everything looks good. Importing study now" + Color.END
-            print >> sys.stderr, "#" * 71 + "\n"
+            print(Color.BOLD + "Everything looks good. Importing study now" + Color.END, file=sys.stderr)
+            print("#" * 71 + "\n", file=sys.stderr)
             cbioportalImporter.main(args)
     except KeyboardInterrupt:
-        print >> sys.stderr, Color.BOLD + "\nProcess interrupted. You will have to run this again to make sure study is completely loaded." + Color.END
-        print >> sys.stderr, "#" * 71
+        print(Color.BOLD + "\nProcess interrupted. You will have to run this again to make sure study is completely loaded." + Color.END, file=sys.stderr)
+        print("#" * 71, file=sys.stderr)
         raise
     except:
-        print >> sys.stderr, "!" * 71
-        print >> sys.stderr, Color.RED + "Error occurred during data loading step. Please fix the problem and run this again to make sure study is completely loaded." + Color.END
+        print("!" * 71, file=sys.stderr)
+        print(Color.RED + "Error occurred during data loading step. Please fix the problem and run this again to make sure study is completely loaded." + Color.END, file=sys.stderr)
         raise
     sys.exit(exitcode)

--- a/core/src/main/scripts/importer/metaImport.py
+++ b/core/src/main/scripts/importer/metaImport.py
@@ -10,6 +10,15 @@ __author__ = 'priti'
 import sys
 import argparse
 import logging
+from pathlib import Path
+
+# configure relative imports if running as a script; see PEP 366
+if __name__ == "__main__" and __package__ is None:
+    # replace the script's location in the Python search path by the main
+    # scripts/ folder, above it, so that the importer package folder is in
+    # scope and *not* directly in sys.path; see PEP 395
+    sys.path[0] = str(Path(sys.path[0]).resolve().parent)
+    __package__ = 'importer'
 
 from . import validateData
 from . import cbioportalImporter

--- a/core/src/main/scripts/importer/metaImport.py
+++ b/core/src/main/scripts/importer/metaImport.py
@@ -8,6 +8,7 @@ __author__ = 'priti'
 
 
 import sys
+import importlib
 import argparse
 import logging
 from pathlib import Path
@@ -19,6 +20,9 @@ if __name__ == "__main__" and __package__ is None:
     # scope and *not* directly in sys.path; see PEP 395
     sys.path[0] = str(Path(sys.path[0]).resolve().parent)
     __package__ = 'importer'
+    # explicitly import the package, which is needed on CPython 3.4 because it
+    # doesn't include https://github.com/python/cpython/pull/2639
+    importlib.import_module(__package__)
 
 from . import validateData
 from . import cbioportalImporter

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -40,7 +40,15 @@ import itertools
 import requests
 import json
 import xml.etree.ElementTree as ET
-import re
+from pathlib import Path
+
+# configure relative imports if running as a script; see PEP 366
+if __name__ == "__main__" and __package__ is None:
+    # replace the script's location in the Python search path by the main
+    # scripts/ folder, above it, so that the importer package folder is in
+    # scope and *not* directly in sys.path; see PEP 395
+    sys.path[0] = str(Path(sys.path[0]).resolve().parent)
+    __package__ = 'importer'
 
 from . import cbioportal_common
 
@@ -2770,7 +2778,9 @@ class CancerTypeValidator(Validator):
 
     def checkHeader(self, cols):
         """Check the first uncommented line just like any other data line."""
-        return self.checkLine(cols)
+        self.checkLine(cols)
+        # the number of 'header errors' that break TSV parsing is always zero
+        return 0
 
     def checkLine(self, data):
         """Check a data line in a cancer type file."""
@@ -3671,7 +3681,7 @@ def read_portal_json_file(dir_path, api_name, logger):
     if os.path.isfile(json_fn):
         logger.debug('Reading portal information from %s',
                     json_fn)
-        with open(json_fn, 'rU') as json_file:
+        with open(json_fn, 'r') as json_file:
             parsed_json = json.load(json_file)
     return parsed_json
 

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -31,6 +31,7 @@ Run with the command line option --help for usage information.
 # imports
 import sys
 import os
+import importlib
 import logging.handlers
 from collections import OrderedDict
 import argparse
@@ -50,6 +51,9 @@ if __name__ == "__main__" and __package__ is None:
     # scope and *not* directly in sys.path; see PEP 395
     sys.path[0] = str(Path(sys.path[0]).resolve().parent)
     __package__ = 'importer'
+    # explicitly import the package, which is needed on CPython 3.4 because it
+    # doesn't include https://github.com/python/cpython/pull/2639
+    importlib.import_module(__package__)
 
 from . import cbioportal_common
 

--- a/core/src/main/scripts/importer/validateStudies.py
+++ b/core/src/main/scripts/importer/validateStudies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 """
 Copyright (c) 2018 The Hyve B.V.
@@ -46,13 +46,13 @@ def main(args):
     output_folder = args.html_folder
     if output_folder is not None:
         if not os.path.exists(output_folder):
-            print "HTML output folder did not exist, so is created: %s" % output_folder
+            print("HTML output folder did not exist, so is created: %s" % output_folder)
             os.makedirs(output_folder)
         logfilename = os.path.join(output_folder, only_logfilename)
     else:
         # Get systems temp directory and write log file
         logfilename = os.path.join(tempfile.gettempdir(), only_logfilename)
-    print '\nWriting validation logs to: {}'.format(logfilename)
+    print('\nWriting validation logs to: {}'.format(logfilename))
 
     # Make dictionary of possible exit status from validateData and values that should be printed in the console
     # when these exit statuses occur
@@ -64,7 +64,7 @@ def main(args):
     # Go through list of studies and run validation
     for study in list_studies:
         # Write to stdout and log file that we are validating this particular study
-        print "\n=== Validating study %s" %study
+        print("\n=== Validating study %s" %study)
 
         # Check which portal info variable is given as input, and set correctly in the arguments for validateData
         if args.portal_info_dir is not None:
@@ -111,9 +111,9 @@ def main(args):
             # file or when there is no cancer_study_identifier and it will not create the HTML file at all.
             except:
                 var_traceback = traceback.format_exc()
-                print '\x1b[31m' + "Error occurred during creating html file name:"
-                print var_traceback
-                print "Validation from study " + study + " will not be written to HTML file" + '\x1b[0m'
+                print('\x1b[31m' + "Error occurred during creating html file name:")
+                print(var_traceback)
+                print("Validation from study " + study + " will not be written to HTML file" + '\x1b[0m')
 
         # Get the path to the validator , in the same directory as this script
         validation_script = os.path.join(
@@ -137,9 +137,9 @@ def main(args):
         # Check exit status and print result
         exit_status_message = possible_exit_status.get(exit_status_study, 'Unknown status: {}'.format(exit_status_study))
         if exit_status_study == 0 or exit_status_study == 3:
-            print '\x1b[0m' + "Result: %s" % exit_status_message
+            print('\x1b[0m' + "Result: %s" % exit_status_message)
         else:
-            print '\x1b[0m' + "Result: " + '\x1b[31m' + exit_status_message + '\x1b[0m'
+            print('\x1b[0m' + "Result: " + '\x1b[31m' + exit_status_message + '\x1b[0m')
             validation_exit_status = 1  # When invalid check the exit status to one, for failing circleCI
 
     return validation_exit_status
@@ -201,6 +201,6 @@ if __name__ == '__main__':
     parsed_args = interface()
     exit_status = main(parsed_args)
 
-    print "\n\nOverall exit status: %s" %exit_status
+    print("\n\nOverall exit status: %s" %exit_status)
     sys.exit(exit_status)
 

--- a/core/src/main/scripts/importer/validation_report_template.html.jinja
+++ b/core/src/main/scripts/importer/validation_report_template.html.jinja
@@ -138,18 +138,18 @@
       {% endif %}
       <div class="panel panel-{{ file_level }}">
         <div class="panel-heading" role="tab"
-             {{ {'id': 'heading_%s'|format(filename|url_b64)}|xmlattr }}>
+             id="{{ 'heading_%s'|format(filename|url_b64) }}">
           <span class="header-icon">{{ level_icon(file_level) }}</span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-             {{ {'href': '#collapse_%s'|format(filename|url_b64),
-                 'aria-controls': 'collapse_%s'|format(filename|url_b64)}|xmlattr }}>
+             href="{{ '#collapse_%s'|format(filename|url_b64) }}",
+             aria-controls="{{ 'collapse_%s'|format(filename|url_b64) }}">
             <span class="badge">{{ file_level_list|length }}</span>
             <h4 class="panel-title">{{ filename|e }}</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-             {{ {'id':  'collapse_%s'|format(filename|url_b64),
-                 'aria-labelledby': 'heading_%s'|format(filename|url_b64)}|xmlattr }}>
+             id="{{ 'collapse_%s'|format(filename|url_b64) }}"
+             aria-labelledby="{{ 'heading_%s'|format(filename|url_b64) }}">
           <div class="panel-body">
             <table class="table">
             <thead>

--- a/core/src/main/scripts/importer/validation_report_template.html.jinja
+++ b/core/src/main/scripts/importer/validation_report_template.html.jinja
@@ -138,18 +138,18 @@
       {% endif %}
       <div class="panel panel-{{ file_level }}">
         <div class="panel-heading" role="tab"
-             {{ {'id': 'heading_%s'|format(filename.__hash__())}|xmlattr }}>
+             {{ {'id': 'heading_%s'|format(filename|url_b64)}|xmlattr }}>
           <span class="header-icon">{{ level_icon(file_level) }}</span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-             {{ {'href': '#collapse_%s'|format(filename.__hash__()),
-                 'aria-controls': 'collapse_%s'|format(filename.__hash__())}|xmlattr }}>
+             {{ {'href': '#collapse_%s'|format(filename|url_b64),
+                 'aria-controls': 'collapse_%s'|format(filename|url_b64)}|xmlattr }}>
             <span class="badge">{{ file_level_list|length }}</span>
             <h4 class="panel-title">{{ filename|e }}</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-             {{ {'id':  'collapse_%s'|format(filename.__hash__()),
-                 'aria-labelledby': 'heading_%s'|format(filename.__hash__())}|xmlattr }}>
+             {{ {'id':  'collapse_%s'|format(filename|url_b64),
+                 'aria-labelledby': 'heading_%s'|format(filename|url_b64)}|xmlattr }}>
           <div class="panel-body">
             <table class="table">
             <thead>

--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -55,16 +55,18 @@ def get_db_cursor(portal_properties):
             user = portal_properties.database_user,
             passwd = portal_properties.database_pw,
             db = portal_properties.database_name)
-    except MySQLdb.Error as msg:
-        print(msg, file=ERROR_FILE)
+    except MySQLdb.Error as exception:
+        print(exception, file=ERROR_FILE)
         port_info = ''
         if portal_properties.database_host.strip() != 'localhost':
             # only add port info if host is != localhost (since with localhost apparently sockets are used and not the given port) TODO - perhaps this applies for all names vs ips?
             port_info = " on port " + str(portal_properties.database_port)
-        print(
-            "--> Error connecting to server " + portal_properties.database_host + port_info,
-            file=ERROR_FILE)
-        return None
+        message = (
+            "--> Error connecting to server "
+            + portal_properties.database_host
+            + port_info)
+        print(message, file=ERROR_FILE)
+        raise ConnectionError(message) from exception
 
     if connection is not None:
         return connection, connection.cursor()

--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -1,13 +1,17 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 # imports
+
 import os
 import sys
-import MySQLdb
+import contextlib
 import argparse
 from collections import OrderedDict
 
-# Globals
+import MySQLdb
+
+
+# globals
 
 ERROR_FILE = sys.stderr
 OUTPUT_FILE = sys.stdout
@@ -30,7 +34,9 @@ class PortalProperties(object):
             host_and_port = database_host.split(':')
             self.database_host = host_and_port[0]
             if self.database_host.strip() == 'localhost':
-                print >> ERROR_FILE, "Invalid host config '" + database_host + "' in properties file. If you want to specify a port on local host use '127.0.0.1' instead of 'localhost'"
+                print(
+                    "Invalid host config '" + database_host + "' in properties file. If you want to specify a port on local host use '127.0.0.1' instead of 'localhost'",
+                    file=ERROR_FILE)
                 sys.exit(1)
             self.database_port = int(host_and_port[1])
         else:
@@ -49,13 +55,15 @@ def get_db_cursor(portal_properties):
             user = portal_properties.database_user,
             passwd = portal_properties.database_pw,
             db = portal_properties.database_name)
-    except MySQLdb.Error, msg:
-        print >> ERROR_FILE, msg
+    except MySQLdb.Error as msg:
+        print(msg, file=ERROR_FILE)
         port_info = ''
         if portal_properties.database_host.strip() != 'localhost':
             # only add port info if host is != localhost (since with localhost apparently sockets are used and not the given port) TODO - perhaps this applies for all names vs ips?
             port_info = " on port " + str(portal_properties.database_port)
-        print >> ERROR_FILE, "--> Error connecting to server " + portal_properties.database_host + port_info
+        print(
+            "--> Error connecting to server " + portal_properties.database_host + port_info,
+            file=ERROR_FILE)
         return None
 
     if connection is not None:
@@ -65,28 +73,30 @@ def get_portal_properties(properties_filename):
     """ Returns a properties object """
     
     properties = {}
-    properties_file = open(properties_filename, 'r')
+    with open(properties_filename, 'r') as properties_file:
+        for line in properties_file:
+            line = line.strip()
 
-    for line in properties_file:
-        line = line.strip()
+            # skip line if its blank or a comment
+            if len(line) == 0 or line.startswith('#'):
+                continue
 
-        # skip line if its blank or a comment
-        if len(line) == 0 or line.startswith('#'):
-            continue
-        
-        # store name/value
-        property = line.split('=')
-        if len(property) < 2:
-            print >> ERROR_FILE, 'Skipping invalid entry in property file: ' + line
-            continue
-        properties[property[0]] = property[1].strip()
-    properties_file.close()
+            try:
+                name, value = line.split('=', maxsplit=1)
+            except ValueError:
+                print(
+                    'Skipping invalid entry in property file: ' + line,
+                    file=ERROR_FILE)
+                continue
+            properties[name] = value.strip()
 
     if (DATABASE_HOST not in properties or len(properties[DATABASE_HOST]) == 0 or
         DATABASE_NAME not in properties or len(properties[DATABASE_NAME]) == 0 or
         DATABASE_USER not in properties or len(properties[DATABASE_USER]) == 0 or
         DATABASE_PW not in properties or len(properties[DATABASE_PW]) == 0):
-        print >> ERROR_FILE, 'Missing one or more required properties, please check property file'
+        print(
+            'Missing one or more required properties, please check property file',
+            file=ERROR_FILE)
         return None
     
     # return an instance of PortalProperties
@@ -105,20 +115,20 @@ def get_db_version(cursor):
         for row in cursor.fetchall():
             if VERSION_TABLE == row[0].lower().strip():
                 version_table_exists = True
-    except MySQLdb.Error, msg:
-        print >> ERROR_FILE, msg
+    except MySQLdb.Error as msg:
+        print(msg, file=ERROR_FILE)
         return None
     
     if not version_table_exists:
-        return (0,0,0)
+        return (0, 0, 0)
 
     # Now query the table for the version number
     try:
         cursor.execute('select ' + VERSION_FIELD + ' from ' + VERSION_TABLE)
         for row in cursor.fetchall():
             version = tuple(map(int, row[0].strip().split('.')))
-    except MySQLdb.Error, msg:
-        print >> ERROR_FILE, msg
+    except MySQLdb.Error as msg:
+        print(msg, file=ERROR_FILE)
         return None
 
     return version
@@ -152,7 +162,7 @@ def run_migration(db_version, sql_filename, connection, cursor):
     """
     
     sql_file = open(sql_filename, 'r')
-    sql_version = (0,0,0)
+    sql_version = (0, 0, 0)
     run_line = False
     statements = OrderedDict()
     statement = ''
@@ -181,42 +191,49 @@ def run_migration(db_version, sql_filename, connection, cursor):
                 else:
                     statements[sql_version].append(statement)
                 statement = ''
-    if len(statements.items()) > 0:
+    if len(statements) > 0:
         run_statements(statements, connection, cursor)
     else:
-        print 'Everything up to date, nothing to migrate.'
+        print('Everything up to date, nothing to migrate.')
     
 def run_statements(statements, connection, cursor):
     try:
         cursor.execute('SET autocommit=0;')
-    except MySQLdb.Error, msg:
-        print >> ERROR_FILE, msg
+    except MySQLdb.Error as msg:
+        print(msg, file=ERROR_FILE)
         sys.exit(1)
 
-    for version,statement_list in statements.iteritems():
-        print >> OUTPUT_FILE, 'Running statements for version: ' + '.'.join(map(str,version))
+    for version, statement_list in statements.items():
+        print(
+            'Running statements for version: ' + '.'.join(map(str, version)),
+            file=OUTPUT_FILE)
         for statement in statement_list:
-            print >> OUTPUT_FILE, '\tExecuting statement: ' + statement.strip()
+            print(
+                '\tExecuting statement: ' + statement.strip(),
+                file=OUTPUT_FILE)
             try:
                 cursor.execute(statement.strip())
-            except MySQLdb.Error, msg:
-                print >> ERROR_FILE, msg
+            except MySQLdb.Error as msg:
+                print(msg, file=ERROR_FILE)
                 sys.exit(1)
-        connection.commit();
+        connection.commit()
 
 def warn_user():
-    """
-    warn the user before the script runs, give them a chance to
-    back up their database if desired
-    """
-    response = raw_input('WARNING: This script will alter your database! Be sure to back up your data before running.\nContinue running DB migration? (y/n) ').strip()
+    """Warn the user to back up their database before the script runs."""
+    response = input(
+        'WARNING: This script will alter your database! Be sure to back up your data before running.\nContinue running DB migration? (y/n) '
+    ).strip()
     while response.lower() != 'y' and response.lower() != 'n':
-        response = raw_input('Did not recognize response.\nContinue running DB migration? (y/n) ').strip()
+        response = input(
+            'Did not recognize response.\nContinue running DB migration? (y/n) '
+        ).strip()
     if response.lower() == 'n':
         sys.exit()
 
 def usage():
-    print >> OUTPUT_FILE, 'migrate_db.py --properties-file [portal properties file] --sql [sql migration file]'
+    print(
+        'migrate_db.py --properties-file [portal properties file] --sql [sql migration file]',
+        file=OUTPUT_FILE)
 
 def main():
     """ main function to run mysql migration """
@@ -224,7 +241,7 @@ def main():
     parser = argparse.ArgumentParser(description='cBioPortal DB migration script')
     parser.add_argument('-p', '--properties-file', type=str, required=True,
                         help='Path to portal.properties file')
-    parser.add_argument('-s', '--sql',type=str, required=True,
+    parser.add_argument('-s', '--sql', type=str, required=True,
                         help='Path to official migration.sql script.')
     parser = parser.parse_args()
 
@@ -233,11 +250,13 @@ def main():
 
     # check existence of properties file
     if not os.path.exists(properties_filename):
-        print >> ERROR_FILE, 'properties file ' + properties_filename + ' cannot be found'
+        print(
+            'properties file ' + properties_filename + ' cannot be found',
+            file=ERROR_FILE)
         usage()
         sys.exit(2)
     if not os.path.exists(sql_filename):
-        print >> ERROR_FILE, 'sql file ' + sql_filename + ' cannot be found'
+        print('sql file ' + sql_filename + ' cannot be found', file=ERROR_FILE)
         usage()
         sys.exit(2)
 
@@ -248,14 +267,14 @@ def main():
     connection, cursor = get_db_cursor(portal_properties)
 
     if cursor is None:
-        print >> ERROR_FILE, 'failure connecting to sql database'
+        print('failure connecting to sql database', file=ERROR_FILE)
         sys.exit(1)
 
     # execute - get the database version and run the migration
-    db_version = get_db_version(cursor)
-    run_migration(db_version, sql_filename, connection, cursor)
-    connection.close();
-    print 'Finished.'
+    with contextlib.closing(connection):
+        db_version = get_db_version(cursor)
+        run_migration(db_version, sql_filename, connection, cursor)
+    print('Finished.')
     
 
 # do main

--- a/core/src/test/scripts/system_tests_validate_data.py
+++ b/core/src/test/scripts/system_tests_validate_data.py
@@ -53,8 +53,8 @@ class ValidateDataSystemTester(unittest.TestCase):
     def assertFileGenerated(self, tmp_file_name, expected_file_name):
         """Assert that a file has been generated with the expected contents."""
         self.assertTrue(os.path.exists(tmp_file_name))
-        with open(tmp_file_name, 'rU') as out_file, \
-             open(expected_file_name, 'rU') as ref_file:
+        with open(tmp_file_name, 'r') as out_file, \
+             open(expected_file_name, 'r') as ref_file:
             base_filename = os.path.basename(tmp_file_name)
             diff_result = difflib.context_diff(
                     ref_file.readlines(),

--- a/core/src/test/scripts/system_tests_validate_data.py
+++ b/core/src/test/scripts/system_tests_validate_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 '''
 Copyright (c) 2016 The Hyve B.V.
@@ -82,47 +82,47 @@ class ValidateDataSystemTester(unittest.TestCase):
         '''
 
         # build up the argument list
-        print "===study 0"
-        args = ['--study_directory','test_data/study_es_0/',
+        print("===study 0")
+        args = ['--study_directory', 'test_data/study_es_0/',
                 '--portal_info_dir', PORTAL_INFO_DIR, '-v']
         # execute main function with arguments provided as if from sys.argv
         args = validateData.interface(args)
         exit_status = validateData.main_validate(args)
-        self.assertEquals(0, exit_status)
+        self.assertEqual(0, exit_status)
 
     def test_exit_status_failure(self):
         '''study 1 : errors, expected exit_status = 1.'''
         #Build up arguments and run
-        print "===study 1"
-        args = ['--study_directory','test_data/study_es_1/',
+        print("===study 1")
+        args = ['--study_directory', 'test_data/study_es_1/',
                 '--portal_info_dir', PORTAL_INFO_DIR, '-v']
         args = validateData.interface(args)
         # Execute main function with arguments provided through sys.argv
         exit_status = validateData.main_validate(args)
-        self.assertEquals(1, exit_status)
+        self.assertEqual(1, exit_status)
 
     def test_exit_status_invalid(self):
         '''test to fail: give wrong hugo file, or let a meta file point to a non-existing data file, expected exit_status = 2.'''
         #Build up arguments and run
-        print "===study invalid"
-        args = ['--study_directory','test_data/study_es_invalid/',
+        print("===study invalid")
+        args = ['--study_directory', 'test_data/study_es_invalid/',
                 '--portal_info_dir', PORTAL_INFO_DIR, '-v']
         args = validateData.interface(args)
         # Execute main function with arguments provided through sys.argv
         exit_status = validateData.main_validate(args)
-        self.assertEquals(2, exit_status)
+        self.assertEqual(2, exit_status)
 
     def test_exit_status_warnings(self):
         '''study 3 : warnings only, expected exit_status = 3.'''
         # data_filename: test
         #Build up arguments and run
-        print "===study 3"
-        args = ['--study_directory','test_data/study_es_3/',
+        print("===study 3")
+        args = ['--study_directory', 'test_data/study_es_3/',
                 '--portal_info_dir', PORTAL_INFO_DIR, '-v']
         args = validateData.interface(args)
         # Execute main function with arguments provided through sys.argv
         exit_status = validateData.main_validate(args)
-        self.assertEquals(3, exit_status)
+        self.assertEqual(3, exit_status)
 
     def test_html_output(self):
         '''
@@ -130,13 +130,13 @@ class ValidateDataSystemTester(unittest.TestCase):
         '''
         #Build up arguments and run
         out_file_name = 'test_data/study_es_0/result_report.html~'
-        args = ['--study_directory','test_data/study_es_0/',
+        args = ['--study_directory', 'test_data/study_es_0/',
                 '--portal_info_dir', PORTAL_INFO_DIR, '-v',
                 '--html_table', out_file_name]
         args = validateData.interface(args)
         # Execute main function with arguments provided through sys.argv
         exit_status = validateData.main_validate(args)
-        self.assertEquals(0, exit_status)
+        self.assertEqual(0, exit_status)
         self.assertFileGenerated(out_file_name,
                                  'test_data/study_es_0/result_report.html')
 
@@ -152,7 +152,7 @@ class ValidateDataSystemTester(unittest.TestCase):
         for logging_handler in validator_logger.handlers:
             logging_handler.flush()
         # expecting only warnings (about the skipped checks), no errors
-        self.assertEquals(exit_status, 1)
+        self.assertEqual(exit_status, 1)
 
     def test_no_portal_checks(self):
         '''Test if validation skips portal-specific checks when instructed.'''
@@ -167,7 +167,7 @@ class ValidateDataSystemTester(unittest.TestCase):
         for logging_handler in validator_logger.handlers:
             logging_handler.flush()
         # expecting only warnings (about the skipped checks), no errors
-        self.assertEquals(exit_status, 3)
+        self.assertEqual(exit_status, 3)
 
     def test_problem_in_clinical(self):
         '''Test whether the script aborts if the sample file cannot be parsed.
@@ -177,14 +177,14 @@ class ValidateDataSystemTester(unittest.TestCase):
         '''
         # build the argument list
         out_file_name = 'test_data/study_wr_clin/result_report.html~'
-        print '==test_problem_in_clinical=='
-        args = ['--study_directory','test_data/study_wr_clin/',
+        print('==test_problem_in_clinical==')
+        args = ['--study_directory', 'test_data/study_wr_clin/',
                 '--portal_info_dir', PORTAL_INFO_DIR, '-v',
                 '--html_table', out_file_name]
         # execute main function with arguments provided as if from sys.argv
         args = validateData.interface(args)
         exit_status = validateData.main_validate(args)
-        self.assertEquals(1, exit_status)
+        self.assertEqual(1, exit_status)
         # TODO - set logger in main_validate and read out buffer here to assert on nr of errors
         self.assertFileGenerated(out_file_name,
                                  'test_data/study_wr_clin/result_report.html')
@@ -197,7 +197,7 @@ class ValidateDataSystemTester(unittest.TestCase):
         # build the argument list
         html_file_name = 'test_data/study_various_issues/result_report.html~'
         error_file_name = 'test_data/study_various_issues/error_file.txt~'
-        args = ['--study_directory','test_data/study_various_issues/',
+        args = ['--study_directory', 'test_data/study_various_issues/',
                 '--portal_info_dir', PORTAL_INFO_DIR, '-v',
                 '--html_table', html_file_name,
                 '--error_file', error_file_name]
@@ -209,7 +209,7 @@ class ValidateDataSystemTester(unittest.TestCase):
         for logging_handler in validator_logger.handlers:
             logging_handler.flush()
         # should fail because of various errors in addition to warnings
-        self.assertEquals(1, exit_status)
+        self.assertEqual(1, exit_status)
         # In MAF files (mutation data) there is a column called
         # "Matched_Norm_Sample_Barcode". The respective metadata file supports
         # giving a list of sample codes against which this column is validated.
@@ -227,15 +227,15 @@ class ValidateDataSystemTester(unittest.TestCase):
         '''
         #Build up arguments and run
         out_file_name = 'test_data/study_quotes/result_report.html~'
-        print '==test_files_with_quotes=='
-        args = ['--study_directory','test_data/study_quotes/',
+        print('==test_files_with_quotes==')
+        args = ['--study_directory', 'test_data/study_quotes/',
                 '--portal_info_dir', PORTAL_INFO_DIR, '-v',
                 '--html_table', out_file_name]
         args = validateData.interface(args)
         # Execute main function with arguments provided through sys.argv
         exit_status = validateData.main_validate(args)
         # should fail because of errors with quotes
-        self.assertEquals(1, exit_status)
+        self.assertEqual(1, exit_status)
         self.assertFileGenerated(out_file_name,
                                  'test_data/study_quotes/result_report.html')
 

--- a/core/src/test/scripts/system_tests_validate_studies.py
+++ b/core/src/test/scripts/system_tests_validate_studies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 """
 Copyright (c) 2018 The Hyve B.V.
@@ -11,7 +11,7 @@ import sys
 import os
 import glob
 from contextlib import contextmanager
-from StringIO import StringIO
+from io import StringIO
 import logging.handlers
 import tempfile
 import shutil
@@ -61,57 +61,57 @@ class ValidateStudiesSystemTester(unittest.TestCase):
         """
 
         # Build up arguments and run
-        print "===study 0"
+        print("===study 0")
         args = ['--list-of-studies', 'test_data/study_es_0/',
                 '--portal_info_dir', PORTAL_INFO_DIR]
         args = validateStudies.interface(args)
         exit_status = validateStudies.main(args)
-        self.assertEquals(0, exit_status)
+        self.assertEqual(0, exit_status)
 
     def test_exit_status_failure(self):
         """study 1 : errors, expected exit_status = 1."""
 
         # Build up arguments and run
-        print "===study 1"
+        print("===study 1")
         args = ['--list-of-studies', 'test_data/study_es_1/',
                 '--portal_info_dir', PORTAL_INFO_DIR]
         args = validateStudies.interface(args)
         exit_status = validateStudies.main(args)
-        self.assertEquals(1, exit_status)
+        self.assertEqual(1, exit_status)
 
     def test_exit_status_invalid(self):
         """test to fail: study directory not existing, so cannot run validation, expected exit_status = 1."""
 
         # Build up arguments and run
-        print "===study invalid"
+        print("===study invalid")
         args = ['--list-of-studies', 'test_data/study_es_invalid/',
                 '--portal_info_dir', PORTAL_INFO_DIR]
         args = validateStudies.interface(args)
         exit_status = validateStudies.main(args)
-        self.assertEquals(1, exit_status)
+        self.assertEqual(1, exit_status)
 
     def test_exit_status_warnings(self):
         """study 3 : warnings only, expected exit_status = 0."""
 
         # Build up arguments and run
-        print "===study 3"
-        args = ['--list-of-studies','test_data/study_es_3/',
+        print("===study 3")
+        args = ['--list-of-studies', 'test_data/study_es_3/',
                 '--portal_info_dir', PORTAL_INFO_DIR]
         args = validateStudies.interface(args)
         exit_status = validateStudies.main(args)
-        self.assertEquals(0, exit_status)
+        self.assertEqual(0, exit_status)
 
     def test_exit_status_multiple_studies(self):
         """Running validateStudies for four studies tested above, expected exit_status = 1."""
 
         # Build up arguments and run
-        print "===study0,1,invalid,3"
+        print("===study0,1,invalid,3")
         args = ['--root-directory', 'test_data',
                 '--list-of-studies', 'study_es_0,study_es_1,study_es_invalid,study_es_3',
                 '--portal_info_dir', PORTAL_INFO_DIR]
         args = validateStudies.interface(args)
         exit_status = validateStudies.main(args)
-        self.assertEquals(1, exit_status)
+        self.assertEqual(1, exit_status)
 
     def test_logs_study_label_before_validation_messages(self):
         """The log file should start with a line describing the study.
@@ -159,7 +159,7 @@ class ValidateStudiesWithEagerlyFlushingCollapser(unittest.TestCase):
                 """Set the buffer capacity to 3 regardless of args."""
                 # leave out any capacity argument from args and kwargs
                 args = args[1:]
-                kwargs = {k: v for k, v in kwargs.items() if k != 'capacity'}
+                kwargs = {k: v for k, v in list(kwargs.items()) if k != 'capacity'}
                 # pass 3 as the capacity argument
                 super(EagerFlusher, self).__init__(3, *args, **kwargs)
         class EagerFlushingCollapser(

--- a/core/src/test/scripts/test_data/study_es_0/result_report.html
+++ b/core/src/test/scripts/test_data/study_es_0/result_report.html
@@ -96,16 +96,16 @@
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_2689738401393696111">
+              id="heading_R2VuZXJhbA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_2689738401393696111" href="#collapse_2689738401393696111">
+              href="#collapse_R2VuZXJhbA" aria-controls="collapse_R2VuZXJhbA">
             <span class="badge">8</span>
             <h4 class="panel-title">General</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_2689738401393696111" id="collapse_2689738401393696111">
+              id="collapse_R2VuZXJhbA" aria-labelledby="heading_R2VuZXJhbA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -183,16 +183,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_6830388332935581942">
+              id="heading_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_6830388332935581942" href="#collapse_6830388332935581942">
+              href="#collapse_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn" aria-controls="collapse_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn">
             <span class="badge">3</span>
             <h4 class="panel-title">brca_tcga_data_cna_hg19.seg</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_6830388332935581942" id="collapse_6830388332935581942">
+              id="collapse_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn" aria-labelledby="heading_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -234,16 +234,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-8351599135575752606">
+              id="heading_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-8351599135575752606" href="#collapse_-8351599135575752606">
+              href="#collapse_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA" aria-controls="collapse_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">brca_tcga_meta_cna_hg19_seg.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-8351599135575752606" id="collapse_-8351599135575752606">
+              id="collapse_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA" aria-labelledby="heading_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -278,16 +278,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-5095920511176882161">
+              id="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-5095920511176882161" href="#collapse_-5095920511176882161">
+              href="#collapse_YnJjYV90Y2dhX3B1Yi5tYWY" aria-controls="collapse_YnJjYV90Y2dhX3B1Yi5tYWY">
             <span class="badge">5</span>
             <h4 class="panel-title">brca_tcga_pub.maf</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-5095920511176882161" id="collapse_-5095920511176882161">
+              id="collapse_YnJjYV90Y2dhX3B1Yi5tYWY" aria-labelledby="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -343,16 +343,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_4169938092580775838">
+              id="heading_Y2FuY2VyX3R5cGUudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_4169938092580775838" href="#collapse_4169938092580775838">
+              href="#collapse_Y2FuY2VyX3R5cGUudHh0" aria-controls="collapse_Y2FuY2VyX3R5cGUudHh0">
             <span class="badge">3</span>
             <h4 class="panel-title">cancer_type.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_4169938092580775838" id="collapse_4169938092580775838">
+              id="collapse_Y2FuY2VyX3R5cGUudHh0" aria-labelledby="heading_Y2FuY2VyX3R5cGUudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -394,16 +394,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-8084637708731552141">
+              id="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-8084637708731552141" href="#collapse_-8084637708731552141">
+              href="#collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0" aria-controls="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">case_lists/cases_custom.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-8084637708731552141" id="collapse_-8084637708731552141">
+              id="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0" aria-labelledby="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -438,16 +438,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-1211125621321342529">
+              id="heading_ZGF0YV9DTkEudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-1211125621321342529" href="#collapse_-1211125621321342529">
+              href="#collapse_ZGF0YV9DTkEudHh0" aria-controls="collapse_ZGF0YV9DTkEudHh0">
             <span class="badge">3</span>
             <h4 class="panel-title">data_CNA.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-1211125621321342529" id="collapse_-1211125621321342529">
+              id="collapse_ZGF0YV9DTkEudHh0" aria-labelledby="heading_ZGF0YV9DTkEudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -489,16 +489,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-468734380824350194">
+              id="heading_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-468734380824350194" href="#collapse_-468734380824350194">
+              href="#collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ" aria-controls="collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
             <span class="badge">3</span>
             <h4 class="panel-title">data_expression_median.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-468734380824350194" id="collapse_-468734380824350194">
+              id="collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ" aria-labelledby="heading_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -540,16 +540,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-8278679244543830000">
+              id="heading_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-8278679244543830000" href="#collapse_-8278679244543830000">
+              href="#collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA" aria-controls="collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_expression_median_Zscores.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-8278679244543830000" id="collapse_-8278679244543830000">
+              id="collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA" aria-labelledby="heading_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -591,16 +591,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-2178637330966976716">
+              id="heading_ZGF0YV9mdXNpb25zLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-2178637330966976716" href="#collapse_-2178637330966976716">
+              href="#collapse_ZGF0YV9mdXNpb25zLnR4dA" aria-controls="collapse_ZGF0YV9mdXNpb25zLnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_fusions.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-2178637330966976716" id="collapse_-2178637330966976716">
+              id="collapse_ZGF0YV9mdXNpb25zLnR4dA" aria-labelledby="heading_ZGF0YV9mdXNpb25zLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -642,16 +642,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-3034954899059960691">
+              id="heading_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-3034954899059960691" href="#collapse_-3034954899059960691">
+              href="#collapse_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ" aria-controls="collapse_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
             <span class="badge">3</span>
             <h4 class="panel-title">data_gene_panel_matrix.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-3034954899059960691" id="collapse_-3034954899059960691">
+              id="collapse_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ" aria-labelledby="heading_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -693,16 +693,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_4479070818687924185">
+              id="heading_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_4479070818687924185" href="#collapse_4479070818687924185">
+              href="#collapse_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA" aria-controls="collapse_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_gistic_genes_amp.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_4479070818687924185" id="collapse_4479070818687924185">
+              id="collapse_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA" aria-labelledby="heading_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -744,16 +744,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-7778222055991501802">
+              id="heading_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-7778222055991501802" href="#collapse_-7778222055991501802">
+              href="#collapse_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0" aria-controls="collapse_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0">
             <span class="badge">3</span>
             <h4 class="panel-title">data_gsva_pvalues.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-7778222055991501802" id="collapse_-7778222055991501802">
+              id="collapse_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0" aria-labelledby="heading_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -795,16 +795,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-2189730713391893502">
+              id="heading_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-2189730713391893502" href="#collapse_-2189730713391893502">
+              href="#collapse_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ" aria-controls="collapse_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ">
             <span class="badge">3</span>
             <h4 class="panel-title">data_gsva_scores.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-2189730713391893502" id="collapse_-2189730713391893502">
+              id="collapse_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ" aria-labelledby="heading_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -846,16 +846,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-354920586160768041">
+              id="heading_ZGF0YV9sb2cyQ05BLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-354920586160768041" href="#collapse_-354920586160768041">
+              href="#collapse_ZGF0YV9sb2cyQ05BLnR4dA" aria-controls="collapse_ZGF0YV9sb2cyQ05BLnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_log2CNA.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-354920586160768041" id="collapse_-354920586160768041">
+              id="collapse_ZGF0YV9sb2cyQ05BLnR4dA" aria-labelledby="heading_ZGF0YV9sb2cyQ05BLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -897,16 +897,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_2874052112030090675">
+              id="heading_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_2874052112030090675" href="#collapse_2874052112030090675">
+              href="#collapse_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA" aria-controls="collapse_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_methylation_hm27.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_2874052112030090675" id="collapse_2874052112030090675">
+              id="collapse_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA" aria-labelledby="heading_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -948,16 +948,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_2670945268483421722">
+              id="heading_ZGF0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_2670945268483421722" href="#collapse_2670945268483421722">
+              href="#collapse_ZGF0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_ZGF0YV9wYXRpZW50cy50eHQ">
             <span class="badge">3</span>
             <h4 class="panel-title">data_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_2670945268483421722" id="collapse_2670945268483421722">
+              id="collapse_ZGF0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_ZGF0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -999,16 +999,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_2353294301845676894">
+              id="heading_ZGF0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_2353294301845676894" href="#collapse_2353294301845676894">
+              href="#collapse_ZGF0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_ZGF0YV9zYW1wbGVzLnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_2353294301845676894" id="collapse_2353294301845676894">
+              id="collapse_ZGF0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_ZGF0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1050,16 +1050,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_6496178228918583572">
+              id="heading_bWV0YV9DTkEudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_6496178228918583572" href="#collapse_6496178228918583572">
+              href="#collapse_bWV0YV9DTkEudHh0" aria-controls="collapse_bWV0YV9DTkEudHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_CNA.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_6496178228918583572" id="collapse_6496178228918583572">
+              id="collapse_bWV0YV9DTkEudHh0" aria-labelledby="heading_bWV0YV9DTkEudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1094,16 +1094,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-89999803285066781">
+              id="heading_bWV0YV9jYW5jZXJfdHlwZS50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-89999803285066781" href="#collapse_-89999803285066781">
+              href="#collapse_bWV0YV9jYW5jZXJfdHlwZS50eHQ" aria-controls="collapse_bWV0YV9jYW5jZXJfdHlwZS50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_cancer_type.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-89999803285066781" id="collapse_-89999803285066781">
+              id="collapse_bWV0YV9jYW5jZXJfdHlwZS50eHQ" aria-labelledby="heading_bWV0YV9jYW5jZXJfdHlwZS50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1138,16 +1138,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-2036375308549423803">
+              id="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-2036375308549423803" href="#collapse_-2036375308549423803">
+              href="#collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ" aria-controls="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_expression_median.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-2036375308549423803" id="collapse_-2036375308549423803">
+              id="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ" aria-labelledby="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1182,16 +1182,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-1927902311056029521">
+              id="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-1927902311056029521" href="#collapse_-1927902311056029521">
+              href="#collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA" aria-controls="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_expression_median_Zscores.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-1927902311056029521" id="collapse_-1927902311056029521">
+              id="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA" aria-labelledby="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1226,16 +1226,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_2049352910318321071">
+              id="heading_bWV0YV9mdXNpb25zLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_2049352910318321071" href="#collapse_2049352910318321071">
+              href="#collapse_bWV0YV9mdXNpb25zLnR4dA" aria-controls="collapse_bWV0YV9mdXNpb25zLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_fusions.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_2049352910318321071" id="collapse_2049352910318321071">
+              id="collapse_bWV0YV9mdXNpb25zLnR4dA" aria-labelledby="heading_bWV0YV9mdXNpb25zLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1270,16 +1270,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_28174920185682614">
+              id="heading_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_28174920185682614" href="#collapse_28174920185682614">
+              href="#collapse_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ" aria-controls="collapse_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_gene_panel_matrix.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_28174920185682614" id="collapse_28174920185682614">
+              id="collapse_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ" aria-labelledby="heading_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1314,16 +1314,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-3330264176859895552">
+              id="heading_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-3330264176859895552" href="#collapse_-3330264176859895552">
+              href="#collapse_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA" aria-controls="collapse_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_gistic_genes_amp.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-3330264176859895552" id="collapse_-3330264176859895552">
+              id="collapse_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA" aria-labelledby="heading_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1358,16 +1358,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_3017671952976618787">
+              id="heading_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_3017671952976618787" href="#collapse_3017671952976618787">
+              href="#collapse_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0" aria-controls="collapse_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_gsva_pvalues.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_3017671952976618787" id="collapse_3017671952976618787">
+              id="collapse_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0" aria-labelledby="heading_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1402,16 +1402,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-4335364957921405327">
+              id="heading_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-4335364957921405327" href="#collapse_-4335364957921405327">
+              href="#collapse_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ" aria-controls="collapse_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_gsva_scores.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-4335364957921405327" id="collapse_-4335364957921405327">
+              id="collapse_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ" aria-labelledby="heading_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1446,16 +1446,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-6284842631443235332">
+              id="heading_bWV0YV9sb2cyQ05BLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-6284842631443235332" href="#collapse_-6284842631443235332">
+              href="#collapse_bWV0YV9sb2cyQ05BLnR4dA" aria-controls="collapse_bWV0YV9sb2cyQ05BLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_log2CNA.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-6284842631443235332" id="collapse_-6284842631443235332">
+              id="collapse_bWV0YV9sb2cyQ05BLnR4dA" aria-labelledby="heading_bWV0YV9sb2cyQ05BLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1490,16 +1490,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-9022107707184941918">
+              id="heading_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-9022107707184941918" href="#collapse_-9022107707184941918">
+              href="#collapse_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA" aria-controls="collapse_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_methylation_hm27.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-9022107707184941918" id="collapse_-9022107707184941918">
+              id="collapse_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA" aria-labelledby="heading_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1534,16 +1534,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-402917117353387965">
+              id="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-402917117353387965" href="#collapse_-402917117353387965">
+              href="#collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0" aria-controls="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_mutations_extended.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-402917117353387965" id="collapse_-402917117353387965">
+              id="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0" aria-labelledby="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1578,16 +1578,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-3052465516861932937">
+              id="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-3052465516861932937" href="#collapse_-3052465516861932937">
+              href="#collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_bWV0YV9wYXRpZW50cy50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-3052465516861932937" id="collapse_-3052465516861932937">
+              id="collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1622,16 +1622,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_5831084486634698153">
+              id="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_5831084486634698153" href="#collapse_5831084486634698153">
+              href="#collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_bWV0YV9zYW1wbGVzLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_5831084486634698153" id="collapse_5831084486634698153">
+              id="collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1666,16 +1666,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_4972704087644385041">
+              id="heading_bWV0YV9zdHVkeS50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_4972704087644385041" href="#collapse_4972704087644385041">
+              href="#collapse_bWV0YV9zdHVkeS50eHQ" aria-controls="collapse_bWV0YV9zdHVkeS50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_study.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_4972704087644385041" id="collapse_4972704087644385041">
+              id="collapse_bWV0YV9zdHVkeS50eHQ" aria-labelledby="heading_bWV0YV9zdHVkeS50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>

--- a/core/src/test/scripts/test_data/study_es_0/result_report.html
+++ b/core/src/test/scripts/test_data/study_es_0/result_report.html
@@ -96,16 +96,18 @@
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_R2VuZXJhbA">
+             id="heading_R2VuZXJhbA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_R2VuZXJhbA" aria-controls="collapse_R2VuZXJhbA">
+             href="#collapse_R2VuZXJhbA",
+             aria-controls="collapse_R2VuZXJhbA">
             <span class="badge">8</span>
             <h4 class="panel-title">General</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_R2VuZXJhbA" aria-labelledby="heading_R2VuZXJhbA">
+             id="collapse_R2VuZXJhbA"
+             aria-labelledby="heading_R2VuZXJhbA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -183,16 +185,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn">
+             id="heading_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn" aria-controls="collapse_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn">
+             href="#collapse_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn",
+             aria-controls="collapse_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn">
             <span class="badge">3</span>
             <h4 class="panel-title">brca_tcga_data_cna_hg19.seg</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn" aria-labelledby="heading_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn">
+             id="collapse_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn"
+             aria-labelledby="heading_YnJjYV90Y2dhX2RhdGFfY25hX2hnMTkuc2Vn">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -234,16 +238,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA">
+             id="heading_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA" aria-controls="collapse_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA">
+             href="#collapse_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA",
+             aria-controls="collapse_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">brca_tcga_meta_cna_hg19_seg.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA" aria-labelledby="heading_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA">
+             id="collapse_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA"
+             aria-labelledby="heading_YnJjYV90Y2dhX21ldGFfY25hX2hnMTlfc2VnLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -278,16 +284,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
+             id="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_YnJjYV90Y2dhX3B1Yi5tYWY" aria-controls="collapse_YnJjYV90Y2dhX3B1Yi5tYWY">
+             href="#collapse_YnJjYV90Y2dhX3B1Yi5tYWY",
+             aria-controls="collapse_YnJjYV90Y2dhX3B1Yi5tYWY">
             <span class="badge">5</span>
             <h4 class="panel-title">brca_tcga_pub.maf</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_YnJjYV90Y2dhX3B1Yi5tYWY" aria-labelledby="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
+             id="collapse_YnJjYV90Y2dhX3B1Yi5tYWY"
+             aria-labelledby="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -343,16 +351,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_Y2FuY2VyX3R5cGUudHh0">
+             id="heading_Y2FuY2VyX3R5cGUudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_Y2FuY2VyX3R5cGUudHh0" aria-controls="collapse_Y2FuY2VyX3R5cGUudHh0">
+             href="#collapse_Y2FuY2VyX3R5cGUudHh0",
+             aria-controls="collapse_Y2FuY2VyX3R5cGUudHh0">
             <span class="badge">3</span>
             <h4 class="panel-title">cancer_type.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_Y2FuY2VyX3R5cGUudHh0" aria-labelledby="heading_Y2FuY2VyX3R5cGUudHh0">
+             id="collapse_Y2FuY2VyX3R5cGUudHh0"
+             aria-labelledby="heading_Y2FuY2VyX3R5cGUudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -394,16 +404,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
+             id="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0" aria-controls="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
+             href="#collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0",
+             aria-controls="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">case_lists/cases_custom.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0" aria-labelledby="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
+             id="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0"
+             aria-labelledby="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -438,16 +450,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9DTkEudHh0">
+             id="heading_ZGF0YV9DTkEudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9DTkEudHh0" aria-controls="collapse_ZGF0YV9DTkEudHh0">
+             href="#collapse_ZGF0YV9DTkEudHh0",
+             aria-controls="collapse_ZGF0YV9DTkEudHh0">
             <span class="badge">3</span>
             <h4 class="panel-title">data_CNA.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9DTkEudHh0" aria-labelledby="heading_ZGF0YV9DTkEudHh0">
+             id="collapse_ZGF0YV9DTkEudHh0"
+             aria-labelledby="heading_ZGF0YV9DTkEudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -489,16 +503,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
+             id="heading_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ" aria-controls="collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
+             href="#collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ",
+             aria-controls="collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
             <span class="badge">3</span>
             <h4 class="panel-title">data_expression_median.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ" aria-labelledby="heading_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
+             id="collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ"
+             aria-labelledby="heading_ZGF0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -540,16 +556,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
+             id="heading_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA" aria-controls="collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
+             href="#collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA",
+             aria-controls="collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_expression_median_Zscores.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA" aria-labelledby="heading_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
+             id="collapse_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA"
+             aria-labelledby="heading_ZGF0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -591,16 +609,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9mdXNpb25zLnR4dA">
+             id="heading_ZGF0YV9mdXNpb25zLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9mdXNpb25zLnR4dA" aria-controls="collapse_ZGF0YV9mdXNpb25zLnR4dA">
+             href="#collapse_ZGF0YV9mdXNpb25zLnR4dA",
+             aria-controls="collapse_ZGF0YV9mdXNpb25zLnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_fusions.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9mdXNpb25zLnR4dA" aria-labelledby="heading_ZGF0YV9mdXNpb25zLnR4dA">
+             id="collapse_ZGF0YV9mdXNpb25zLnR4dA"
+             aria-labelledby="heading_ZGF0YV9mdXNpb25zLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -642,16 +662,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
+             id="heading_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ" aria-controls="collapse_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
+             href="#collapse_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ",
+             aria-controls="collapse_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
             <span class="badge">3</span>
             <h4 class="panel-title">data_gene_panel_matrix.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ" aria-labelledby="heading_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
+             id="collapse_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ"
+             aria-labelledby="heading_ZGF0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -693,16 +715,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
+             id="heading_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA" aria-controls="collapse_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
+             href="#collapse_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA",
+             aria-controls="collapse_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_gistic_genes_amp.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA" aria-labelledby="heading_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
+             id="collapse_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA"
+             aria-labelledby="heading_ZGF0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -744,16 +768,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0">
+             id="heading_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0" aria-controls="collapse_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0">
+             href="#collapse_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0",
+             aria-controls="collapse_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0">
             <span class="badge">3</span>
             <h4 class="panel-title">data_gsva_pvalues.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0" aria-labelledby="heading_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0">
+             id="collapse_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0"
+             aria-labelledby="heading_ZGF0YV9nc3ZhX3B2YWx1ZXMudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -795,16 +821,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ">
+             id="heading_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ" aria-controls="collapse_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ">
+             href="#collapse_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ",
+             aria-controls="collapse_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ">
             <span class="badge">3</span>
             <h4 class="panel-title">data_gsva_scores.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ" aria-labelledby="heading_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ">
+             id="collapse_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ"
+             aria-labelledby="heading_ZGF0YV9nc3ZhX3Njb3Jlcy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -846,16 +874,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9sb2cyQ05BLnR4dA">
+             id="heading_ZGF0YV9sb2cyQ05BLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9sb2cyQ05BLnR4dA" aria-controls="collapse_ZGF0YV9sb2cyQ05BLnR4dA">
+             href="#collapse_ZGF0YV9sb2cyQ05BLnR4dA",
+             aria-controls="collapse_ZGF0YV9sb2cyQ05BLnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_log2CNA.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9sb2cyQ05BLnR4dA" aria-labelledby="heading_ZGF0YV9sb2cyQ05BLnR4dA">
+             id="collapse_ZGF0YV9sb2cyQ05BLnR4dA"
+             aria-labelledby="heading_ZGF0YV9sb2cyQ05BLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -897,16 +927,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
+             id="heading_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA" aria-controls="collapse_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
+             href="#collapse_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA",
+             aria-controls="collapse_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_methylation_hm27.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA" aria-labelledby="heading_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
+             id="collapse_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA"
+             aria-labelledby="heading_ZGF0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -948,16 +980,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9wYXRpZW50cy50eHQ">
+             id="heading_ZGF0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_ZGF0YV9wYXRpZW50cy50eHQ">
+             href="#collapse_ZGF0YV9wYXRpZW50cy50eHQ",
+             aria-controls="collapse_ZGF0YV9wYXRpZW50cy50eHQ">
             <span class="badge">3</span>
             <h4 class="panel-title">data_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_ZGF0YV9wYXRpZW50cy50eHQ">
+             id="collapse_ZGF0YV9wYXRpZW50cy50eHQ"
+             aria-labelledby="heading_ZGF0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -999,16 +1033,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9zYW1wbGVzLnR4dA">
+             id="heading_ZGF0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_ZGF0YV9zYW1wbGVzLnR4dA">
+             href="#collapse_ZGF0YV9zYW1wbGVzLnR4dA",
+             aria-controls="collapse_ZGF0YV9zYW1wbGVzLnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_ZGF0YV9zYW1wbGVzLnR4dA">
+             id="collapse_ZGF0YV9zYW1wbGVzLnR4dA"
+             aria-labelledby="heading_ZGF0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1050,16 +1086,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9DTkEudHh0">
+             id="heading_bWV0YV9DTkEudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9DTkEudHh0" aria-controls="collapse_bWV0YV9DTkEudHh0">
+             href="#collapse_bWV0YV9DTkEudHh0",
+             aria-controls="collapse_bWV0YV9DTkEudHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_CNA.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9DTkEudHh0" aria-labelledby="heading_bWV0YV9DTkEudHh0">
+             id="collapse_bWV0YV9DTkEudHh0"
+             aria-labelledby="heading_bWV0YV9DTkEudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1094,16 +1132,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9jYW5jZXJfdHlwZS50eHQ">
+             id="heading_bWV0YV9jYW5jZXJfdHlwZS50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9jYW5jZXJfdHlwZS50eHQ" aria-controls="collapse_bWV0YV9jYW5jZXJfdHlwZS50eHQ">
+             href="#collapse_bWV0YV9jYW5jZXJfdHlwZS50eHQ",
+             aria-controls="collapse_bWV0YV9jYW5jZXJfdHlwZS50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_cancer_type.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9jYW5jZXJfdHlwZS50eHQ" aria-labelledby="heading_bWV0YV9jYW5jZXJfdHlwZS50eHQ">
+             id="collapse_bWV0YV9jYW5jZXJfdHlwZS50eHQ"
+             aria-labelledby="heading_bWV0YV9jYW5jZXJfdHlwZS50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1138,16 +1178,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
+             id="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ" aria-controls="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
+             href="#collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ",
+             aria-controls="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_expression_median.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ" aria-labelledby="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
+             id="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ"
+             aria-labelledby="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1182,16 +1224,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
+             id="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA" aria-controls="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
+             href="#collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA",
+             aria-controls="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_expression_median_Zscores.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA" aria-labelledby="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
+             id="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA"
+             aria-labelledby="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbl9ac2NvcmVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1226,16 +1270,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9mdXNpb25zLnR4dA">
+             id="heading_bWV0YV9mdXNpb25zLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9mdXNpb25zLnR4dA" aria-controls="collapse_bWV0YV9mdXNpb25zLnR4dA">
+             href="#collapse_bWV0YV9mdXNpb25zLnR4dA",
+             aria-controls="collapse_bWV0YV9mdXNpb25zLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_fusions.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9mdXNpb25zLnR4dA" aria-labelledby="heading_bWV0YV9mdXNpb25zLnR4dA">
+             id="collapse_bWV0YV9mdXNpb25zLnR4dA"
+             aria-labelledby="heading_bWV0YV9mdXNpb25zLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1270,16 +1316,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
+             id="heading_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ" aria-controls="collapse_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
+             href="#collapse_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ",
+             aria-controls="collapse_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_gene_panel_matrix.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ" aria-labelledby="heading_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
+             id="collapse_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ"
+             aria-labelledby="heading_bWV0YV9nZW5lX3BhbmVsX21hdHJpeC50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1314,16 +1362,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
+             id="heading_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA" aria-controls="collapse_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
+             href="#collapse_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA",
+             aria-controls="collapse_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_gistic_genes_amp.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA" aria-labelledby="heading_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
+             id="collapse_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA"
+             aria-labelledby="heading_bWV0YV9naXN0aWNfZ2VuZXNfYW1wLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1358,16 +1408,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0">
+             id="heading_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0" aria-controls="collapse_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0">
+             href="#collapse_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0",
+             aria-controls="collapse_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_gsva_pvalues.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0" aria-labelledby="heading_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0">
+             id="collapse_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0"
+             aria-labelledby="heading_bWV0YV9nc3ZhX3B2YWx1ZXMudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1402,16 +1454,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ">
+             id="heading_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ" aria-controls="collapse_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ">
+             href="#collapse_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ",
+             aria-controls="collapse_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_gsva_scores.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ" aria-labelledby="heading_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ">
+             id="collapse_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ"
+             aria-labelledby="heading_bWV0YV9nc3ZhX3Njb3Jlcy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1446,16 +1500,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9sb2cyQ05BLnR4dA">
+             id="heading_bWV0YV9sb2cyQ05BLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9sb2cyQ05BLnR4dA" aria-controls="collapse_bWV0YV9sb2cyQ05BLnR4dA">
+             href="#collapse_bWV0YV9sb2cyQ05BLnR4dA",
+             aria-controls="collapse_bWV0YV9sb2cyQ05BLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_log2CNA.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9sb2cyQ05BLnR4dA" aria-labelledby="heading_bWV0YV9sb2cyQ05BLnR4dA">
+             id="collapse_bWV0YV9sb2cyQ05BLnR4dA"
+             aria-labelledby="heading_bWV0YV9sb2cyQ05BLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1490,16 +1546,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
+             id="heading_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA" aria-controls="collapse_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
+             href="#collapse_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA",
+             aria-controls="collapse_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_methylation_hm27.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA" aria-labelledby="heading_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
+             id="collapse_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA"
+             aria-labelledby="heading_bWV0YV9tZXRoeWxhdGlvbl9obTI3LnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1534,16 +1592,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
+             id="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0" aria-controls="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
+             href="#collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0",
+             aria-controls="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_mutations_extended.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0" aria-labelledby="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
+             id="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0"
+             aria-labelledby="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1578,16 +1638,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9wYXRpZW50cy50eHQ">
+             id="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_bWV0YV9wYXRpZW50cy50eHQ">
+             href="#collapse_bWV0YV9wYXRpZW50cy50eHQ",
+             aria-controls="collapse_bWV0YV9wYXRpZW50cy50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_bWV0YV9wYXRpZW50cy50eHQ">
+             id="collapse_bWV0YV9wYXRpZW50cy50eHQ"
+             aria-labelledby="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1622,16 +1684,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9zYW1wbGVzLnR4dA">
+             id="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_bWV0YV9zYW1wbGVzLnR4dA">
+             href="#collapse_bWV0YV9zYW1wbGVzLnR4dA",
+             aria-controls="collapse_bWV0YV9zYW1wbGVzLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_bWV0YV9zYW1wbGVzLnR4dA">
+             id="collapse_bWV0YV9zYW1wbGVzLnR4dA"
+             aria-labelledby="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -1666,16 +1730,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9zdHVkeS50eHQ">
+             id="heading_bWV0YV9zdHVkeS50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9zdHVkeS50eHQ" aria-controls="collapse_bWV0YV9zdHVkeS50eHQ">
+             href="#collapse_bWV0YV9zdHVkeS50eHQ",
+             aria-controls="collapse_bWV0YV9zdHVkeS50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_study.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9zdHVkeS50eHQ" aria-labelledby="heading_bWV0YV9zdHVkeS50eHQ">
+             id="collapse_bWV0YV9zdHVkeS50eHQ"
+             aria-labelledby="heading_bWV0YV9zdHVkeS50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>

--- a/core/src/test/scripts/test_data/study_quotes/result_report.html
+++ b/core/src/test/scripts/test_data/study_quotes/result_report.html
@@ -96,16 +96,16 @@
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_2689738401393696111">
+              id="heading_R2VuZXJhbA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_2689738401393696111" href="#collapse_2689738401393696111">
+              href="#collapse_R2VuZXJhbA" aria-controls="collapse_R2VuZXJhbA">
             <span class="badge">7</span>
             <h4 class="panel-title">General</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_2689738401393696111" id="collapse_2689738401393696111">
+              id="collapse_R2VuZXJhbA" aria-labelledby="heading_R2VuZXJhbA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -176,16 +176,16 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_-5095920511176882161">
+              id="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-5095920511176882161" href="#collapse_-5095920511176882161">
+              href="#collapse_YnJjYV90Y2dhX3B1Yi5tYWY" aria-controls="collapse_YnJjYV90Y2dhX3B1Yi5tYWY">
             <span class="badge">8</span>
             <h4 class="panel-title">brca_tcga_pub.maf</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-5095920511176882161" id="collapse_-5095920511176882161">
+              id="collapse_YnJjYV90Y2dhX3B1Yi5tYWY" aria-labelledby="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -262,16 +262,16 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_-8084637708731552141">
+              id="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-8084637708731552141" href="#collapse_-8084637708731552141">
+              href="#collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0" aria-controls="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
             <span class="badge">3</span>
             <h4 class="panel-title">case_lists/cases_custom.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-8084637708731552141" id="collapse_-8084637708731552141">
+              id="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0" aria-labelledby="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -313,16 +313,16 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_-1211125621321342529">
+              id="heading_ZGF0YV9DTkEudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-1211125621321342529" href="#collapse_-1211125621321342529">
+              href="#collapse_ZGF0YV9DTkEudHh0" aria-controls="collapse_ZGF0YV9DTkEudHh0">
             <span class="badge">4</span>
             <h4 class="panel-title">data_CNA.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-1211125621321342529" id="collapse_-1211125621321342529">
+              id="collapse_ZGF0YV9DTkEudHh0" aria-labelledby="heading_ZGF0YV9DTkEudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -371,16 +371,16 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_2670945268483421722">
+              id="heading_ZGF0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_2670945268483421722" href="#collapse_2670945268483421722">
+              href="#collapse_ZGF0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_ZGF0YV9wYXRpZW50cy50eHQ">
             <span class="badge">7</span>
             <h4 class="panel-title">data_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_2670945268483421722" id="collapse_2670945268483421722">
+              id="collapse_ZGF0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_ZGF0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -450,16 +450,16 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_2353294301845676894">
+              id="heading_ZGF0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_2353294301845676894" href="#collapse_2353294301845676894">
+              href="#collapse_ZGF0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_ZGF0YV9zYW1wbGVzLnR4dA">
             <span class="badge">5</span>
             <h4 class="panel-title">data_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_2353294301845676894" id="collapse_2353294301845676894">
+              id="collapse_ZGF0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_ZGF0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -515,16 +515,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_6496178228918583572">
+              id="heading_bWV0YV9DTkEudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_6496178228918583572" href="#collapse_6496178228918583572">
+              href="#collapse_bWV0YV9DTkEudHh0" aria-controls="collapse_bWV0YV9DTkEudHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_CNA.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_6496178228918583572" id="collapse_6496178228918583572">
+              id="collapse_bWV0YV9DTkEudHh0" aria-labelledby="heading_bWV0YV9DTkEudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -559,16 +559,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-402917117353387965">
+              id="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-402917117353387965" href="#collapse_-402917117353387965">
+              href="#collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0" aria-controls="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_mutations_extended.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-402917117353387965" id="collapse_-402917117353387965">
+              id="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0" aria-labelledby="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -603,16 +603,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-3052465516861932937">
+              id="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-3052465516861932937" href="#collapse_-3052465516861932937">
+              href="#collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_bWV0YV9wYXRpZW50cy50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-3052465516861932937" id="collapse_-3052465516861932937">
+              id="collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -647,16 +647,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_5831084486634698153">
+              id="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_5831084486634698153" href="#collapse_5831084486634698153">
+              href="#collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_bWV0YV9zYW1wbGVzLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_5831084486634698153" id="collapse_5831084486634698153">
+              id="collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -691,16 +691,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_4972704087644385041">
+              id="heading_bWV0YV9zdHVkeS50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_4972704087644385041" href="#collapse_4972704087644385041">
+              href="#collapse_bWV0YV9zdHVkeS50eHQ" aria-controls="collapse_bWV0YV9zdHVkeS50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_study.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_4972704087644385041" id="collapse_4972704087644385041">
+              id="collapse_bWV0YV9zdHVkeS50eHQ" aria-labelledby="heading_bWV0YV9zdHVkeS50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>

--- a/core/src/test/scripts/test_data/study_quotes/result_report.html
+++ b/core/src/test/scripts/test_data/study_quotes/result_report.html
@@ -96,16 +96,18 @@
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_R2VuZXJhbA">
+             id="heading_R2VuZXJhbA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_R2VuZXJhbA" aria-controls="collapse_R2VuZXJhbA">
+             href="#collapse_R2VuZXJhbA",
+             aria-controls="collapse_R2VuZXJhbA">
             <span class="badge">7</span>
             <h4 class="panel-title">General</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_R2VuZXJhbA" aria-labelledby="heading_R2VuZXJhbA">
+             id="collapse_R2VuZXJhbA"
+             aria-labelledby="heading_R2VuZXJhbA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -176,16 +178,18 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
+             id="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_YnJjYV90Y2dhX3B1Yi5tYWY" aria-controls="collapse_YnJjYV90Y2dhX3B1Yi5tYWY">
+             href="#collapse_YnJjYV90Y2dhX3B1Yi5tYWY",
+             aria-controls="collapse_YnJjYV90Y2dhX3B1Yi5tYWY">
             <span class="badge">8</span>
             <h4 class="panel-title">brca_tcga_pub.maf</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_YnJjYV90Y2dhX3B1Yi5tYWY" aria-labelledby="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
+             id="collapse_YnJjYV90Y2dhX3B1Yi5tYWY"
+             aria-labelledby="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -262,16 +266,18 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
+             id="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0" aria-controls="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
+             href="#collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0",
+             aria-controls="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
             <span class="badge">3</span>
             <h4 class="panel-title">case_lists/cases_custom.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0" aria-labelledby="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
+             id="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0"
+             aria-labelledby="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -313,16 +319,18 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9DTkEudHh0">
+             id="heading_ZGF0YV9DTkEudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9DTkEudHh0" aria-controls="collapse_ZGF0YV9DTkEudHh0">
+             href="#collapse_ZGF0YV9DTkEudHh0",
+             aria-controls="collapse_ZGF0YV9DTkEudHh0">
             <span class="badge">4</span>
             <h4 class="panel-title">data_CNA.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9DTkEudHh0" aria-labelledby="heading_ZGF0YV9DTkEudHh0">
+             id="collapse_ZGF0YV9DTkEudHh0"
+             aria-labelledby="heading_ZGF0YV9DTkEudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -371,16 +379,18 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9wYXRpZW50cy50eHQ">
+             id="heading_ZGF0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_ZGF0YV9wYXRpZW50cy50eHQ">
+             href="#collapse_ZGF0YV9wYXRpZW50cy50eHQ",
+             aria-controls="collapse_ZGF0YV9wYXRpZW50cy50eHQ">
             <span class="badge">7</span>
             <h4 class="panel-title">data_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_ZGF0YV9wYXRpZW50cy50eHQ">
+             id="collapse_ZGF0YV9wYXRpZW50cy50eHQ"
+             aria-labelledby="heading_ZGF0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -450,16 +460,18 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9zYW1wbGVzLnR4dA">
+             id="heading_ZGF0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_ZGF0YV9zYW1wbGVzLnR4dA">
+             href="#collapse_ZGF0YV9zYW1wbGVzLnR4dA",
+             aria-controls="collapse_ZGF0YV9zYW1wbGVzLnR4dA">
             <span class="badge">5</span>
             <h4 class="panel-title">data_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_ZGF0YV9zYW1wbGVzLnR4dA">
+             id="collapse_ZGF0YV9zYW1wbGVzLnR4dA"
+             aria-labelledby="heading_ZGF0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -515,16 +527,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9DTkEudHh0">
+             id="heading_bWV0YV9DTkEudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9DTkEudHh0" aria-controls="collapse_bWV0YV9DTkEudHh0">
+             href="#collapse_bWV0YV9DTkEudHh0",
+             aria-controls="collapse_bWV0YV9DTkEudHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_CNA.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9DTkEudHh0" aria-labelledby="heading_bWV0YV9DTkEudHh0">
+             id="collapse_bWV0YV9DTkEudHh0"
+             aria-labelledby="heading_bWV0YV9DTkEudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -559,16 +573,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
+             id="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0" aria-controls="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
+             href="#collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0",
+             aria-controls="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_mutations_extended.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0" aria-labelledby="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
+             id="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0"
+             aria-labelledby="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -603,16 +619,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9wYXRpZW50cy50eHQ">
+             id="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_bWV0YV9wYXRpZW50cy50eHQ">
+             href="#collapse_bWV0YV9wYXRpZW50cy50eHQ",
+             aria-controls="collapse_bWV0YV9wYXRpZW50cy50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_bWV0YV9wYXRpZW50cy50eHQ">
+             id="collapse_bWV0YV9wYXRpZW50cy50eHQ"
+             aria-labelledby="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -647,16 +665,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9zYW1wbGVzLnR4dA">
+             id="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_bWV0YV9zYW1wbGVzLnR4dA">
+             href="#collapse_bWV0YV9zYW1wbGVzLnR4dA",
+             aria-controls="collapse_bWV0YV9zYW1wbGVzLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_bWV0YV9zYW1wbGVzLnR4dA">
+             id="collapse_bWV0YV9zYW1wbGVzLnR4dA"
+             aria-labelledby="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -691,16 +711,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9zdHVkeS50eHQ">
+             id="heading_bWV0YV9zdHVkeS50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9zdHVkeS50eHQ" aria-controls="collapse_bWV0YV9zdHVkeS50eHQ">
+             href="#collapse_bWV0YV9zdHVkeS50eHQ",
+             aria-controls="collapse_bWV0YV9zdHVkeS50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_study.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9zdHVkeS50eHQ" aria-labelledby="heading_bWV0YV9zdHVkeS50eHQ">
+             id="collapse_bWV0YV9zdHVkeS50eHQ"
+             aria-labelledby="heading_bWV0YV9zdHVkeS50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>

--- a/core/src/test/scripts/test_data/study_various_issues/result_report.html
+++ b/core/src/test/scripts/test_data/study_various_issues/result_report.html
@@ -96,16 +96,18 @@
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_R2VuZXJhbA">
+             id="heading_R2VuZXJhbA">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_R2VuZXJhbA" aria-controls="collapse_R2VuZXJhbA">
+             href="#collapse_R2VuZXJhbA",
+             aria-controls="collapse_R2VuZXJhbA">
             <span class="badge">8</span>
             <h4 class="panel-title">General</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_R2VuZXJhbA" aria-labelledby="heading_R2VuZXJhbA">
+             id="collapse_R2VuZXJhbA"
+             aria-labelledby="heading_R2VuZXJhbA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -183,16 +185,18 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
+             id="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_YnJjYV90Y2dhX3B1Yi5tYWY" aria-controls="collapse_YnJjYV90Y2dhX3B1Yi5tYWY">
+             href="#collapse_YnJjYV90Y2dhX3B1Yi5tYWY",
+             aria-controls="collapse_YnJjYV90Y2dhX3B1Yi5tYWY">
             <span class="badge">7</span>
             <h4 class="panel-title">brca_tcga_pub.maf</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_YnJjYV90Y2dhX3B1Yi5tYWY" aria-labelledby="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
+             id="collapse_YnJjYV90Y2dhX3B1Yi5tYWY"
+             aria-labelledby="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -262,16 +266,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
+             id="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0" aria-controls="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
+             href="#collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0",
+             aria-controls="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">case_lists/cases_custom.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0" aria-labelledby="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
+             id="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0"
+             aria-labelledby="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -306,16 +312,18 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9wYXRpZW50cy50eHQ">
+             id="heading_ZGF0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_ZGF0YV9wYXRpZW50cy50eHQ">
+             href="#collapse_ZGF0YV9wYXRpZW50cy50eHQ",
+             aria-controls="collapse_ZGF0YV9wYXRpZW50cy50eHQ">
             <span class="badge">6</span>
             <h4 class="panel-title">data_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_ZGF0YV9wYXRpZW50cy50eHQ">
+             id="collapse_ZGF0YV9wYXRpZW50cy50eHQ"
+             aria-labelledby="heading_ZGF0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -378,16 +386,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_ZGF0YV9zYW1wbGVzLnR4dA">
+             id="heading_ZGF0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_ZGF0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_ZGF0YV9zYW1wbGVzLnR4dA">
+             href="#collapse_ZGF0YV9zYW1wbGVzLnR4dA",
+             aria-controls="collapse_ZGF0YV9zYW1wbGVzLnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_ZGF0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_ZGF0YV9zYW1wbGVzLnR4dA">
+             id="collapse_ZGF0YV9zYW1wbGVzLnR4dA"
+             aria-labelledby="heading_ZGF0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -429,16 +439,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
+             id="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0" aria-controls="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
+             href="#collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0",
+             aria-controls="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_mutations_extended.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0" aria-labelledby="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
+             id="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0"
+             aria-labelledby="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -473,16 +485,18 @@
 
       <div class="panel panel-warning">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9wYXRpZW50cy50eHQ">
+             id="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_bWV0YV9wYXRpZW50cy50eHQ">
+             href="#collapse_bWV0YV9wYXRpZW50cy50eHQ",
+             aria-controls="collapse_bWV0YV9wYXRpZW50cy50eHQ">
             <span class="badge">3</span>
             <h4 class="panel-title">meta_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_bWV0YV9wYXRpZW50cy50eHQ">
+             id="collapse_bWV0YV9wYXRpZW50cy50eHQ"
+             aria-labelledby="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -507,7 +521,7 @@
                 <td>&ndash;</td>
                 <td>&ndash;</td>
                 <td>Unrecognized field in meta file</td>
-                <td>show_profile_in_analysis_tab, stable_id, profile_name, (1 more)</td>
+                <td>stable_id, show_profile_in_analysis_tab, profile_description, (1 more)</td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -524,16 +538,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9zYW1wbGVzLnR4dA">
+             id="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_bWV0YV9zYW1wbGVzLnR4dA">
+             href="#collapse_bWV0YV9zYW1wbGVzLnR4dA",
+             aria-controls="collapse_bWV0YV9zYW1wbGVzLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_bWV0YV9zYW1wbGVzLnR4dA">
+             id="collapse_bWV0YV9zYW1wbGVzLnR4dA"
+             aria-labelledby="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -568,16 +584,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9zdHVkeS50eHQ">
+             id="heading_bWV0YV9zdHVkeS50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9zdHVkeS50eHQ" aria-controls="collapse_bWV0YV9zdHVkeS50eHQ">
+             href="#collapse_bWV0YV9zdHVkeS50eHQ",
+             aria-controls="collapse_bWV0YV9zdHVkeS50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_study.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9zdHVkeS50eHQ" aria-labelledby="heading_bWV0YV9zdHVkeS50eHQ">
+             id="collapse_bWV0YV9zdHVkeS50eHQ"
+             aria-labelledby="heading_bWV0YV9zdHVkeS50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>

--- a/core/src/test/scripts/test_data/study_various_issues/result_report.html
+++ b/core/src/test/scripts/test_data/study_various_issues/result_report.html
@@ -96,16 +96,16 @@
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_2689738401393696111">
+              id="heading_R2VuZXJhbA">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_2689738401393696111" href="#collapse_2689738401393696111">
+              href="#collapse_R2VuZXJhbA" aria-controls="collapse_R2VuZXJhbA">
             <span class="badge">8</span>
             <h4 class="panel-title">General</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_2689738401393696111" id="collapse_2689738401393696111">
+              id="collapse_R2VuZXJhbA" aria-labelledby="heading_R2VuZXJhbA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -183,16 +183,16 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_-5095920511176882161">
+              id="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-5095920511176882161" href="#collapse_-5095920511176882161">
+              href="#collapse_YnJjYV90Y2dhX3B1Yi5tYWY" aria-controls="collapse_YnJjYV90Y2dhX3B1Yi5tYWY">
             <span class="badge">7</span>
             <h4 class="panel-title">brca_tcga_pub.maf</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-5095920511176882161" id="collapse_-5095920511176882161">
+              id="collapse_YnJjYV90Y2dhX3B1Yi5tYWY" aria-labelledby="heading_YnJjYV90Y2dhX3B1Yi5tYWY">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -262,16 +262,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-8084637708731552141">
+              id="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-8084637708731552141" href="#collapse_-8084637708731552141">
+              href="#collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0" aria-controls="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">case_lists/cases_custom.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-8084637708731552141" id="collapse_-8084637708731552141">
+              id="collapse_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0" aria-labelledby="heading_Y2FzZV9saXN0cy9jYXNlc19jdXN0b20udHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -306,16 +306,16 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_2670945268483421722">
+              id="heading_ZGF0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_2670945268483421722" href="#collapse_2670945268483421722">
+              href="#collapse_ZGF0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_ZGF0YV9wYXRpZW50cy50eHQ">
             <span class="badge">6</span>
             <h4 class="panel-title">data_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_2670945268483421722" id="collapse_2670945268483421722">
+              id="collapse_ZGF0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_ZGF0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -378,16 +378,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_2353294301845676894">
+              id="heading_ZGF0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_2353294301845676894" href="#collapse_2353294301845676894">
+              href="#collapse_ZGF0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_ZGF0YV9zYW1wbGVzLnR4dA">
             <span class="badge">3</span>
             <h4 class="panel-title">data_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_2353294301845676894" id="collapse_2353294301845676894">
+              id="collapse_ZGF0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_ZGF0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -429,16 +429,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-402917117353387965">
+              id="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-402917117353387965" href="#collapse_-402917117353387965">
+              href="#collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0" aria-controls="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_mutations_extended.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-402917117353387965" id="collapse_-402917117353387965">
+              id="collapse_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0" aria-labelledby="heading_bWV0YV9tdXRhdGlvbnNfZXh0ZW5kZWQudHh0">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -473,16 +473,16 @@
 
       <div class="panel panel-warning">
         <div class="panel-heading" role="tab"
-              id="heading_-3052465516861932937">
+              id="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-3052465516861932937" href="#collapse_-3052465516861932937">
+              href="#collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_bWV0YV9wYXRpZW50cy50eHQ">
             <span class="badge">3</span>
             <h4 class="panel-title">meta_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-3052465516861932937" id="collapse_-3052465516861932937">
+              id="collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -524,16 +524,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_5831084486634698153">
+              id="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_5831084486634698153" href="#collapse_5831084486634698153">
+              href="#collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_bWV0YV9zYW1wbGVzLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_5831084486634698153" id="collapse_5831084486634698153">
+              id="collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -568,16 +568,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_4972704087644385041">
+              id="heading_bWV0YV9zdHVkeS50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_4972704087644385041" href="#collapse_4972704087644385041">
+              href="#collapse_bWV0YV9zdHVkeS50eHQ" aria-controls="collapse_bWV0YV9zdHVkeS50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_study.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_4972704087644385041" id="collapse_4972704087644385041">
+              id="collapse_bWV0YV9zdHVkeS50eHQ" aria-labelledby="heading_bWV0YV9zdHVkeS50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>

--- a/core/src/test/scripts/test_data/study_wr_clin/result_report.html
+++ b/core/src/test/scripts/test_data/study_wr_clin/result_report.html
@@ -96,16 +96,18 @@
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_R2VuZXJhbA">
+             id="heading_R2VuZXJhbA">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_R2VuZXJhbA" aria-controls="collapse_R2VuZXJhbA">
+             href="#collapse_R2VuZXJhbA",
+             aria-controls="collapse_R2VuZXJhbA">
             <span class="badge">5</span>
             <h4 class="panel-title">General</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_R2VuZXJhbA" aria-labelledby="heading_R2VuZXJhbA">
+             id="collapse_R2VuZXJhbA"
+             aria-labelledby="heading_R2VuZXJhbA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -162,16 +164,18 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
+             id="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ" aria-controls="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
+             href="#collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ",
+             aria-controls="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_expression_median.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ" aria-labelledby="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
+             id="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ"
+             aria-labelledby="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -206,16 +210,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9wYXRpZW50cy50eHQ">
+             id="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_bWV0YV9wYXRpZW50cy50eHQ">
+             href="#collapse_bWV0YV9wYXRpZW50cy50eHQ",
+             aria-controls="collapse_bWV0YV9wYXRpZW50cy50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_bWV0YV9wYXRpZW50cy50eHQ">
+             id="collapse_bWV0YV9wYXRpZW50cy50eHQ"
+             aria-labelledby="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -250,16 +256,18 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9zYW1wbGVzLnR4dA">
+             id="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_bWV0YV9zYW1wbGVzLnR4dA">
+             href="#collapse_bWV0YV9zYW1wbGVzLnR4dA",
+             aria-controls="collapse_bWV0YV9zYW1wbGVzLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_bWV0YV9zYW1wbGVzLnR4dA">
+             id="collapse_bWV0YV9zYW1wbGVzLnR4dA"
+             aria-labelledby="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -294,16 +302,18 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_bWV0YV9zdHVkeS50eHQ">
+             id="heading_bWV0YV9zdHVkeS50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              href="#collapse_bWV0YV9zdHVkeS50eHQ" aria-controls="collapse_bWV0YV9zdHVkeS50eHQ">
+             href="#collapse_bWV0YV9zdHVkeS50eHQ",
+             aria-controls="collapse_bWV0YV9zdHVkeS50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_study.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              id="collapse_bWV0YV9zdHVkeS50eHQ" aria-labelledby="heading_bWV0YV9zdHVkeS50eHQ">
+             id="collapse_bWV0YV9zdHVkeS50eHQ"
+             aria-labelledby="heading_bWV0YV9zdHVkeS50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>

--- a/core/src/test/scripts/test_data/study_wr_clin/result_report.html
+++ b/core/src/test/scripts/test_data/study_wr_clin/result_report.html
@@ -96,16 +96,16 @@
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_2689738401393696111">
+              id="heading_R2VuZXJhbA">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_2689738401393696111" href="#collapse_2689738401393696111">
+              href="#collapse_R2VuZXJhbA" aria-controls="collapse_R2VuZXJhbA">
             <span class="badge">5</span>
             <h4 class="panel-title">General</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_2689738401393696111" id="collapse_2689738401393696111">
+              id="collapse_R2VuZXJhbA" aria-labelledby="heading_R2VuZXJhbA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -162,16 +162,16 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_-2036375308549423803">
+              id="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-2036375308549423803" href="#collapse_-2036375308549423803">
+              href="#collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ" aria-controls="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_expression_median.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-2036375308549423803" id="collapse_-2036375308549423803">
+              id="collapse_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ" aria-labelledby="heading_bWV0YV9leHByZXNzaW9uX21lZGlhbi50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -206,16 +206,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_-3052465516861932937">
+              id="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_-3052465516861932937" href="#collapse_-3052465516861932937">
+              href="#collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-controls="collapse_bWV0YV9wYXRpZW50cy50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_patients.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_-3052465516861932937" id="collapse_-3052465516861932937">
+              id="collapse_bWV0YV9wYXRpZW50cy50eHQ" aria-labelledby="heading_bWV0YV9wYXRpZW50cy50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -250,16 +250,16 @@
 
       <div class="panel panel-danger">
         <div class="panel-heading" role="tab"
-              id="heading_5831084486634698153">
+              id="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <span class="header-icon"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_5831084486634698153" href="#collapse_5831084486634698153">
+              href="#collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-controls="collapse_bWV0YV9zYW1wbGVzLnR4dA">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_samples.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_5831084486634698153" id="collapse_5831084486634698153">
+              id="collapse_bWV0YV9zYW1wbGVzLnR4dA" aria-labelledby="heading_bWV0YV9zYW1wbGVzLnR4dA">
           <div class="panel-body">
             <table class="table">
             <thead>
@@ -294,16 +294,16 @@
 
       <div class="panel panel-success">
         <div class="panel-heading" role="tab"
-              id="heading_4972704087644385041">
+              id="heading_bWV0YV9zdHVkeS50eHQ">
           <span class="header-icon"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></span>
           <a role="button" data-toggle="collapse" aria-expanded="true"
-              aria-controls="collapse_4972704087644385041" href="#collapse_4972704087644385041">
+              href="#collapse_bWV0YV9zdHVkeS50eHQ" aria-controls="collapse_bWV0YV9zdHVkeS50eHQ">
             <span class="badge">2</span>
             <h4 class="panel-title">meta_study.txt</h4>
           </a>
         </div>
         <div class="panel-collapse collapse" role="tabpanel"
-              aria-labelledby="heading_4972704087644385041" id="collapse_4972704087644385041">
+              id="collapse_bWV0YV9zdHVkeS50eHQ" aria-labelledby="heading_bWV0YV9zdHVkeS50eHQ">
           <div class="panel-body">
             <table class="table">
             <thead>

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -60,9 +60,9 @@ def temp_inputfolder(file_dict):
             with suppress(FileExistsError):
                 file_directory.mkdir(parents=True)
             # write the contents to the file
-            with open(study_dir / filename, 'w', encoding='utf-8') as f:
+            with (study_dir / filename).open('w', encoding='utf-8') as f:
                 f.write(contents)
-        yield study_dir
+        yield str(study_dir)
 
 
 class LogBufferTestCase(unittest.TestCase):

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 """
 Copyright (c) 2016 The Hyve B.V.
@@ -31,7 +31,7 @@ def setUpModule():
     DEFINED_SAMPLE_IDS = ["TCGA-A1-A0SB-01", "TCGA-A1-A0SD-01", "TCGA-A1-A0SE-01", "TCGA-A1-A0SH-01", "TCGA-A2-A04U-01", "TCGA-B6-A0RS-01", "TCGA-BH-A0HP-01", "TCGA-BH-A18P-01", "TCGA-BH-A18H-01", "TCGA-C8-A138-01", "TCGA-A2-A0EY-01", "TCGA-A8-A08G-01"]
     DEFINED_SAMPLE_ATTRIBUTES = {'PATIENT_ID', 'SAMPLE_ID', 'SUBTYPE', 'CANCER_TYPE', 'CANCER_TYPE_DETAILED'}
     PATIENTS_WITH_SAMPLES = set("TEST-PAT{}".format(num) for
-                                num in range(1, 10) if
+                                num in list(range(1, 10)) if
                                 num != 8)
     logger = logging.getLogger(__name__)
     # parse mock API results from a local directory
@@ -223,21 +223,21 @@ class ClinicalColumnDefsTestCase(PostClinicalDataFileTestCase):
         record_iterator = iter(record_list)
 
         # Expect error for OS_MONTHS being a STRING instead of NUMBER
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 3)
         self.assertEqual(record.column_number, 2)
         self.assertIn(record.cause, 'STRING')
 
         # Expect warning for sample attribute in patient clinical data
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 5)
         self.assertEqual(record.column_number, 6)
         self.assertIn(record.cause, 'OTHER_SAMPLE_ID')
 
         # Expect warning for sample attribute in patient clinical data
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 5)
         self.assertEqual(record.column_number, 7)
@@ -277,7 +277,7 @@ class ClinicalValuesTestCase(DataFileTestCase):
                                     validateData.SampleClinicalValidator)
         self.assertEqual(len(record_list), 6)
         record_iterator = iter(record_list)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 6)
         self.assertIn('can only contain letters, numbers, points, underscores and/or hyphens', record.getMessage())
@@ -326,31 +326,31 @@ class PatientAttrFileTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 5)
         record_iterator = iter(record_list)
         # OS_STATUS not in controlled vocabulary
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 6)
         self.assertEqual(record.column_number, 3)
         self.assertEqual(record.cause, 'ALIVE')
         # DFS_STATUS having an OS_STATUS value
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 7)
         self.assertEqual(record.column_number, 5)
         self.assertEqual(record.cause, 'LIVING')
         # wrong casing for OS_STATUS
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 9)
         self.assertEqual(record.column_number, 3)
         self.assertEqual(record.cause, 'living')
         # DFS_STATUS not in controlled vocabulary (wrong casing)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 11)
         self.assertEqual(record.column_number, 5)
         self.assertEqual(record.cause, 'recurred/progressed')
         # unspecified OS_MONTHS while OS_STATUS is DECEASED
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.WARNING)
         self.assertEqual(record.line_number, 13)
         self.assertIn('OS_MONTHS is not specified for deceased patient. Patient '
@@ -365,7 +365,7 @@ class PatientAttrFileTestCase(PostClinicalDataFileTestCase):
                                     validateData.PatientClinicalValidator)
         self.assertEqual(len(record_list), 24)
         record_iterator = iter(record_list)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 6)
         self.assertIn('can only contain letters, numbers, points, underscores and/or hyphens', record.getMessage())
@@ -378,14 +378,14 @@ class PatientAttrFileTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 2)
         record_iterator = iter(record_list)
         # First record contains 'Jan-14'
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 8)
         self.assertEqual(record.column_number, 6)
         self.assertEqual(record.cause, 'Jan-14')
         self.assertIn('Date found when no date was expected', record.getMessage())
         # Second record contains '4-Oct'
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 9)
         self.assertEqual(record.column_number, 6)
@@ -623,7 +623,7 @@ class GeneIdColumnsTestCase(PostClinicalDataFileTestCase):
         record = record_list.pop()
         self.assertEqual(record.levelno, logging.WARNING)
         # expecting this gene to be the cause
-        self.assertEquals(record.cause, 'TRAPPC2P1')
+        self.assertEqual(record.cause, 'TRAPPC2P1')
 
     def test_entrez_only_but_invalid(self):
         """Test when a file has an Entrez ID column but none for Hugo names, and entrez is wrong."""
@@ -652,7 +652,7 @@ class GeneIdColumnsTestCase(PostClinicalDataFileTestCase):
         record = record_list.pop()
         self.assertEqual(record.levelno, logging.WARNING)
         # expecting this gene to be the cause
-        self.assertEquals(record.cause, 'ACT')
+        self.assertEqual(record.cause, 'ACT')
 
     def test_blank_column_heading(self):
         """Test whether an error is issued if a column has a blank name."""
@@ -663,17 +663,17 @@ class GeneIdColumnsTestCase(PostClinicalDataFileTestCase):
         for record in record_list:
             self.assertEqual(record.levelno, logging.ERROR)
         record_iterator = iter(record_list)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 1)
         self.assertEqual(record.column_number, 2)
         self.assertEqual(record.cause, '')
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 1)
         self.assertEqual(record.column_number, 8)
         self.assertEqual(record.cause, '  ')
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertIn('white space in sample_id', record.getMessage().lower())
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertIn('cannot be parsed', record.getMessage().lower())
 
     def test_cytoband_column(self):
@@ -726,29 +726,29 @@ class FeatureWiseValuesTestCase(PostClinicalDataFileTestCase):
         for record in record_list:
             self.assertEqual(record.levelno, logging.ERROR)
         record_iterator = iter(record_list)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 3)
         self.assertEqual(record.column_number, 7)
         # self.assertEqual(record.cause, ' ') if blank cells had a 'cause'
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 5)
         self.assertEqual(record.column_number, 4)
         # self.assertEqual(record.cause, '') if blank cells had a 'cause'
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 6)
         self.assertEqual(record.column_number, 3)
         self.assertEqual(record.cause, '3')
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 7)
         self.assertEqual(record.column_number, 6)
         self.assertEqual(record.cause, 'AURKAIP1')
         # Only "NA" is supported, anything else should be an error:
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 8)
         self.assertEqual(record.column_number, 5)
         self.assertEqual(record.cause, '[Not Available]')
         # Only -2, -1.5, -1, 0, 1, 2 are supported, anything else should be an error:
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 9)
         self.assertEqual(record.column_number, 6)
         self.assertEqual(record.cause, '1.5')
@@ -773,15 +773,15 @@ class FeatureWiseValuesTestCase(PostClinicalDataFileTestCase):
         for record in record_list:
             self.assertEqual(record.levelno, logging.ERROR)
         record_iterator = iter(record_list)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 3)
         self.assertEqual(record.column_number, 3)
         self.assertEqual(record.cause, 'spam')
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 6)
         self.assertEqual(record.column_number, 5)
         self.assertEqual(record.cause, '')
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 9)
         self.assertEqual(record.column_number, 3)
         self.assertEqual(record.cause, ' ')
@@ -807,7 +807,7 @@ class FeatureWiseValuesTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 9)
         for record in record_list:
             self.assertEqual(record.levelno, logging.WARNING)
-        for record, expected_line in zip(record_list, range(14, 23)):
+        for record, expected_line in zip(record_list, list(range(14, 23))):
             self.assertEqual(record.line_number, expected_line)
             self.assertEqual(record.column_number, 1)
             self.assertIn('NA', record.getMessage())
@@ -822,16 +822,16 @@ class FeatureWiseValuesTestCase(PostClinicalDataFileTestCase):
         for record in record_list:
             self.assertEqual(record.levelno, logging.ERROR)
         record_iterator = iter(record_list)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 2)
         self.assertEqual(record.column_number, 5)
         self.assertEqual(record.cause, '1.5')
         return
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 5)
         self.assertEqual(record.column_number, 2)
         self.assertEqual(record.cause, '2.371393691351566')
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 7)
         self.assertEqual(record.column_number, 3)
         self.assertEqual(record.cause, '-12')
@@ -847,15 +847,15 @@ class FeatureWiseValuesTestCase(PostClinicalDataFileTestCase):
         for record in record_list:
             self.assertEqual(record.levelno, logging.ERROR)
         record_iterator = iter(record_list)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 4)
         self.assertEqual(record.column_number, 2)
         self.assertEqual(record.cause, '1.5')
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 6)
         self.assertEqual(record.column_number, 4)
         self.assertEqual(record.cause, '1e3')
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 8)
         self.assertEqual(record.column_number, 3)
         self.assertEqual(record.cause, '-0.00000000000000005')
@@ -876,11 +876,11 @@ class FeatureWiseValuesTestCase(PostClinicalDataFileTestCase):
         for record in record_list2:
             self.assertEqual(record.levelno, logging.ERROR)
         record_iterator = iter(record_list2)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 1)
         self.assertIn('headers', record.getMessage().lower())
         self.assertIn('different', record.getMessage().lower())
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertIn('invalid', record.getMessage().lower())
         self.assertIn('column', record.getMessage().lower())
         return
@@ -911,7 +911,7 @@ class FeatureWiseValuesTestCase(PostClinicalDataFileTestCase):
                                     validateData.GsvaScoreValidator)
         self.assertEqual(len(record_list), 1)
         record_iterator = iter(record_list)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 3)
         self.assertIn(record.cause, 'HYVE_TEST_GENE_SET')
         self.assertEqual('Gene set not found in database, please make sure to import gene sets prior to study loading',
@@ -934,11 +934,11 @@ class ContinuousValuesTestCase(PostClinicalDataFileTestCase):
         for record in record_list:
             self.assertEqual(record.levelno, logging.ERROR)
         record_iterator = iter(record_list)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.cause, 'n.a.')
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.cause, '')
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.cause, 'Na')
 
 
@@ -1001,55 +1001,55 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 11)
         record_iterator = iter(record_list)
         # expect error for bigger start than end position
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 2)
         self.assertIn('Start_Position should be smaller than or equal to End_Position.', record.getMessage())
         # expect error for not correct start and end position in INS
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 2)
         self.assertIn('Variant_Type indicates insertion, but difference in Start_Position and End_Position does '
                       'not equal to 1 or the length or the Reference_Allele.', record.getMessage())
         # expect error for incorrect length of reference allele with variant_type INS
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 3)
         self.assertIn('Variant_Type indicates insertion, but length of Reference_Allele is bigger than the length '
                       'of the Tumor_Seq_Allele1 and/or 2 and therefore indicates deletion.', record.getMessage())
         # expect error for not correct start and end position in DEL
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 4)
         self.assertIn('Variant_Type indicates deletion, but the difference between Start_Position and End_Position '
-                      'are not equal to the length of the Reference_Allele.',record.getMessage())
+                      'are not equal to the length of the Reference_Allele.', record.getMessage())
         # expect error for incorrect length of  allele with variant_type DEL
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 5)
         self.assertIn('Variant_Type indicates deletion, but length of Reference_Allele is smaller than the length '
                       'of Tumor_Seq_Allele1 and/or Tumor_Seq_Allele2, indicating an insertion.', record.getMessage())
         # expect error for incorrect length of allele with variant_type SNP
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 6)
         self.assertIn('Variant_Type indicates a SNP, but length of Reference_Allele, Tumor_Seq_Allele1 '
                       'and/or Tumor_Seq_Allele2 do not equal 1.', record.getMessage())
         # expect error for incorrect Allele with variant_type SNP
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 7)
         self.assertIn('Variant_Type indicates a SNP, but Reference_Allele, Tumor_Seq_Allele1 '
                       'and/or Tumor_Seq_Allele2 contain deletion (-).', record.getMessage())
         # expect error for incorrect length of allele with variant_type DNP
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 8)
         self.assertIn('Variant_Type indicates a DNP, but length of Reference_Allele, Tumor_Seq_Allele1 '
                       'and/or Tumor_Seq_Allele2 do not equal 2.', record.getMessage())
         # expect error for incorrect length of allele with variant_type TNP
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 9)
         self.assertIn('Variant_Type indicates a TNP, but length of Reference_Allele, Tumor_Seq_Allele1 '
                       'and/or Tumor_Seq_Allele2 do not equal 3.', record.getMessage())
         # expect error for incorrect length of allele with variant_type ONP
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 10)
         self.assertIn('Variant_Type indicates a ONP, but length of Reference_Allele, '
                       'Tumor_Seq_Allele1 and 2 are not bigger than 3 or are of unequal lengths.', record.getMessage())
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 11)
         self.assertIn('Allele Based column Reference_Allele contains invalid character.', record.getMessage())
         
@@ -1065,19 +1065,19 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 3)
         record_iterator = iter(record_list)
         # expect error for the same values in Reference_Allele, Tumor_Seq_Allele1 and Tumor_Seq_Allele2 columns
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 2)
         self.assertIn('All Values in columns Reference_Allele, Tumor_Seq_Allele1 and Tumor_Seq_Allele2 are equal.',
                       record.getMessage())
         # expect error for deletion, Tumor Seq allele columns do not contain -
         # even though the lengths of the sequences are equal
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 4)
         self.assertIn('Variant_Type indicates a deletion, Allele based columns are the same length, '
                       'but Tumor_Seq_Allele columns do not contain -, indicating a SNP.', record.getMessage())
         # expect error for ONP, lengths of sequences in Reference_Allele,
         # Tumor_Seq_Allele1 and Tumor_Seq_Allele2 are not equal
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 5)
         self.assertIn('Variant_Type indicates a ONP, but length of Reference_Allele, '
                       'Tumor_Seq_Allele1 and 2 are not bigger than 3 or are of unequal lengths.', record.getMessage())
@@ -1094,31 +1094,31 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 6)
         record_iterator = iter(record_list)
         # expect error for empty validation allele columns
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 2)
         self.assertIn('Validation Status is valid, but Validation Allele columns are empty.', record.getMessage())
         # expect error for invalid character in allele based column
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 3)
         self.assertIn('At least one of the Validation Allele Based columns (Tumor_Validation_Allele1, '
                       'Tumor_Validation_Allele2, Match_Norm_Validation_Allele1, Match_Norm_Validation_Allele2) '
                       'contains invalid character.', record.getMessage())
         # expect error for not equal tumor and normal allele columns when Validation_Status is invalid
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 4)
         self.assertIn('When Validation_Status is invalid the Tumor_Validation_Allele and Match_Norm_'
                       'Validation_Allele columns should be equal.', record.getMessage())
         # expect error for undefined Validation_Method when Validation_Status is valid or invalid
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 5)
         self.assertIn('Validation Status is invalid, but Validation_Method is not defined.', record.getMessage())
         # expect error for incorrect Validation Allele Columns when Mutation_Status is Germline
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 6)
         self.assertIn('When Validation_Status is valid and Mutation_Status is Germline, the Tumor_Validation_Allele '
                       'should be equal to the Match_Norm_Validation_Allele.', record.getMessage())
         # expect error for incorrect Validation Allele Columns when Mutation_Status is Germline
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 7)
         self.assertIn('When Validation_Status is valid and Mutation_Status is Somatic, the Match_Norm_Validation_Allele'
                       ' columns should be equal to the Reference Allele and one of the Tumor_Validation_Allele columns'
@@ -1148,13 +1148,13 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 2)
         record_iterator = iter(record_list)
         # used a name instead of an accession
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.WARNING)
         self.assertEqual(record.line_number, 3)
         self.assertEqual(record.cause, 'A1CF_HUMAN')
         self.assertNotIn('portal', record.getMessage().lower())
         # neither a name nor an accession
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.WARNING)
         self.assertEqual(record.line_number, 5)
         self.assertEqual(record.cause, 'P99999,Z9ZZZ9ZZZ9')
@@ -1188,13 +1188,13 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 2)
         record_iterator = iter(record_list)
         # used an accession instead of a name
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.WARNING)
         self.assertEqual(record.line_number, 3)
         self.assertEqual(record.cause, 'Q9NQ94')
         self.assertNotIn('portal', record.getMessage().lower())
         # neither a name nor an accession
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.WARNING)
         self.assertEqual(record.line_number, 5)
         self.assertEqual(record.cause, 'A1CF_HUMAN,HBB_YEAST')
@@ -1225,28 +1225,28 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 5)
         record_iterator = iter(record_list)
         # empty field (and no HGVSp_Short column)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.WARNING)
         self.assertIn('Amino_Acid_Change', record.getMessage())
         self.assertIn('HGVSp_Short', record.getMessage())
         self.assertEqual(record.line_number, 2)
         # multiple specifications
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertIn('p.', record.getMessage())
         self.assertEqual(record.cause, 'p.A195V;p.I167I')
         # comma in the string
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertIn('comma', record.getMessage().lower())
         self.assertEqual(record.cause, 'p.N851,Y1055delinsCC')
         # haplotype specification of multiple mutations
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertIn('allele', record.getMessage().lower())
         self.assertEqual(record.cause, 'p.[N851N];[Y1055C]')
         # NULL (and no HGVSp_Short column)
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.WARNING)
         self.assertIn('Amino_Acid_Change', record.getMessage())
         self.assertIn('HGVSp_Short', record.getMessage())
@@ -1264,11 +1264,11 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 2)
         record_iterator = iter(record_list)
         # first is a warning about wrong value:
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.WARNING)
         self.assertIn('not one of the expected values', record.getMessage())
         # second is an error about empty value (not allowed):
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertIn('is invalid', record.getMessage())
 
@@ -1355,22 +1355,22 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 4)
         record_iterator = iter(record_list)
         # first is an error about wrong value in Start_Position:
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertIn('The start position of this variant is not '
                       'an integer', record.getMessage())
         # second is an error about wrong value in End_Position:
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertIn('The end position of this variant is not '
                       'an integer', record.getMessage())
         # third is an error about no value in Start_Position:
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertIn('The start position of this variant is not '
                       'an integer', record.getMessage())
         # forth is an error about no value in End_Position:
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertIn('The end position of this variant is not '
                       'an integer', record.getMessage())
@@ -1540,13 +1540,13 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
 
         record_iterator = iter(record_list)
         # Validation Status error
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.WARNING)
         self.assertEqual(record.line_number, 2)
         self.assertEqual(record.cause, '---')
         self.assertEqual(record.getMessage(), "Value in 'Validation_Status' not in MAF format")
         # Verification status error
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.WARNING)
         self.assertEqual(record.line_number, 3)
         self.assertEqual(record.cause, 'Test')
@@ -1582,19 +1582,19 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 5)
         record_iterator = iter(record_list)
         # Expected info message due to value "None" in Mutation_Status
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.INFO)
         self.assertEqual(record.line_number, 3)
         self.assertEqual(record.cause, 'None')
         self.assertEqual(record.getMessage(), "Mutation will not be loaded due to value in Mutation_Status")
         # Expected info message due to value "loh" in Mutation_Status
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.INFO)
         self.assertEqual(record.line_number, 5)
         self.assertEqual(record.cause, 'loh')
         self.assertEqual(record.getMessage(), "Mutation will not be loaded due to value in Mutation_Status")
         # Expected info message due to value "Wildtype" in Mutation_Status
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.INFO)
         self.assertEqual(record.line_number, 9)
         self.assertEqual(record.cause, 'Wildtype')
@@ -1626,24 +1626,24 @@ class SegFileValidationTestCase(PostClinicalDataFileTestCase):
         @staticmethod
         def load_chromosome_lengths(genome_build, _):
             if genome_build == 'hg19':
-                return {u'1': 249250621, u'10': 135534747, u'11': 135006516,
-                        u'12': 133851895, u'13': 115169878, u'14': 107349540,
-                        u'15': 102531392, u'16': 90354753, u'17': 81195210,
-                        u'18': 78077248, u'19': 59128983, u'2': 243199373,
-                        u'20': 63025520, u'21': 48129895, u'22': 51304566,
-                        u'3': 198022430, u'4': 191154276, u'5': 180915260,
-                        u'6': 171115067, u'7': 159138663, u'8': 146364022,
-                        u'9': 141213431, u'X': 155270560, u'Y': 59373566}
+                return {'1': 249250621, '10': 135534747, '11': 135006516,
+                        '12': 133851895, '13': 115169878, '14': 107349540,
+                        '15': 102531392, '16': 90354753, '17': 81195210,
+                        '18': 78077248, '19': 59128983, '2': 243199373,
+                        '20': 63025520, '21': 48129895, '22': 51304566,
+                        '3': 198022430, '4': 191154276, '5': 180915260,
+                        '6': 171115067, '7': 159138663, '8': 146364022,
+                        '9': 141213431, 'X': 155270560, 'Y': 59373566}
             #Todo: Remove hg18 when all public data is liftOvered to hg18. See validator.
             elif genome_build == 'hg18':
-                return {u'1': 247249719, u'10': 135374737, u'11': 134452384,
-                        u'12': 132349534, u'13': 114142980, u'14': 106368585,
-                        u'15': 100338915, u'16': 88827254, u'17': 78774742,
-                        u'18': 76117153, u'19': 63811651, u'2': 242951149,
-                        u'20': 62435964, u'21': 46944323, u'22': 49691432,
-                        u'3': 199501827, u'4': 191273063, u'5': 180857866,
-                        u'6': 170899992, u'7': 158821424, u'8': 146274826,
-                        u'9': 140273252, u'X': 154913754, u'Y': 57772954}
+                return {'1': 247249719, '10': 135374737, '11': 134452384,
+                        '12': 132349534, '13': 114142980, '14': 106368585,
+                        '15': 100338915, '16': 88827254, '17': 78774742,
+                        '18': 76117153, '19': 63811651, '2': 242951149,
+                        '20': 62435964, '21': 46944323, '22': 49691432,
+                        '3': 199501827, '4': 191273063, '5': 180857866,
+                        '6': 170899992, '7': 158821424, '8': 146274826,
+                        '9': 140273252, 'X': 154913754, 'Y': 57772954}
             else:
                 raise ValueError(
                     "load_chromosome_lengths() called with genome build '{}'".format(
@@ -1707,11 +1707,11 @@ class SegFileValidationTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(len(record_list), 2)
         record_iterator = iter(record_list)
         # negative-length segment
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 11)
         # zero-length segment
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.levelno, logging.WARNING)
         self.assertEqual(record.line_number, 31)
 
@@ -1828,39 +1828,39 @@ class GisticGenesValidationTestCase(PostClinicalDataFileTestCase):
             self.assertEqual(record.levelno, logging.ERROR)
         record_iterator = iter(record_list)
         # invalid 'amp' value
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 2)
         self.assertEqual(record.column_number, 6)
         # mismatch between chromosome number in chromosome and cytoband cols
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 2)
-        self.assertEqual(record.cause,'(1p36.13, 2)')
+        self.assertEqual(record.cause, '(1p36.13, 2)')
         # q-value not a real number
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 3)
         self.assertEqual(record.column_number, 8)
         # reversed start and end positions
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 3)
         self.assertIn('not lower', record.getMessage())
         # incorrect 'amp' value
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 4)
         self.assertEqual(record.column_number, 6)
         # no p or q in cytoband
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 4)
         self.assertEqual(record.column_number, 7)
         # missing chromosome
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 5)
         self.assertEqual(record.column_number, 2)
         # missing chromosome in cytoband
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 5)
         self.assertEqual(record.column_number, 7)
         # blank gene in list
-        record = record_iterator.next()
+        record = next(record_iterator)
         self.assertEqual(record.line_number, 6)
         self.assertEqual(record.levelno, logging.WARNING)
         self.assertEqual(record.cause, '')
@@ -1913,7 +1913,7 @@ class StudyCompositionTestCase(LogBufferTestCase):
         # compare filenames mentioned in the 1st error independent of ordering
         filenames_in_cause_string = set(record_list[0].cause.split(', ', 1))
         self.assertEqual(filenames_in_cause_string,
-                         set(['cancer_type_luad.txt', 'cancer_type_lung.txt']))
+                         {'cancer_type_luad.txt', 'cancer_type_lung.txt'})
         # assert that the second error complains about the cancer type
         self.assertEqual(record_list[1].cause, 'luad')
 

--- a/docs/Data-Loading.md
+++ b/docs/Data-Loading.md
@@ -16,14 +16,15 @@ Getting your study data into cBioPortal requires four steps:
 If you have a git clone of cBioPortal, the relevant scripts can be found in the folder: `<your_cbioportal_dir>/core/src/main/scripts/importer`
 
 ### Dependencies
-The scripts run in `python 2`, and they require the module `requests`. You can use this command to install the module:
+The scripts run in Python 3.4 or newer, and they require the module `requests`.
+You can use this command to install the module:
 ```console
-$ sudo pip2 install requests
+$ sudo python3 -m pip install requests
 ```
 
-If you want the scripts to be able to generate html reports (recommended way for reading the validation errors, if any), then you will also need to install `jinja2`. You can use this command: 
+If you want the scripts to be able to generate html reports (recommended way for reading the validation errors, if any), then you will also need to install `Jinja2`. You can use this command:
 ```console
-$ sudo pip2 install jinja2
+$ sudo python3 -m pip install Jinja2
 ```
 
 ## Preparing Study Data 

--- a/docs/Updating-your-cBioPortal-installation.md
+++ b/docs/Updating-your-cBioPortal-installation.md
@@ -30,24 +30,20 @@ Compile your code again. After restarting the webserver the page should now stat
 
 First, make sure you have the DB connection properties correctly set in your portal.properties file (see [DB connection settings here](portal.properties-Reference.md#database-settings)).
 
-**Dependencies:** the migration script is a python script that depends on the `MySQL-python` library. If necessary, you can install it with the following commands (example for Ubuntu):
+**Dependencies:** the migration script is a Python script that depends on the `mysqlclient` library. If necessary, you can install it with the following commands (example for Ubuntu):
 ```console
-sudo apt-get install python-dev libmysqlclient-dev
-sudo pip2 install MySQL-python
+sudo apt-get install python3-dev default-libmysqlclient-dev
+sudo python3 -m pip install mysqlclient
 ```
 
-For Mac OS X, try the following:
+For macOS, try the following:
 
 ```
 brew install mysql-connector-c
-sudo pip2 install MySQL-python
+sudo python3 -m pip install mysqlclient
 ```
-
-For Mac OS X, you must also add the following to your .bash_profile:
-
-```
-export DYLD_LIBRARY_PATH=/usr/local/mysql/lib:$DYLD_LIBRARY_PATH
-```
+and see <https://github.com/PyMySQL/mysqlclient-python/blob/master/README.md#prerequisites>
+if problems occur during installation.
 
 To run the migration script first go to the scripts folder
 `<your_cbioportal_dir>/core/src/main/scripts` 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.10.0
 Jinja2==2.8
-MySQL-python==1.2.5
+mysqlclient==1.3.13


### PR DESCRIPTION
Python 2 has been deprecated for a decade now, and will reach its end of life in less than 1½ years. This PR ports the Python scripts we still document and support (`metaImport`, `validateStudies` and `migrate_db`) to Python 3.4, which is included even in the older long-term-support releases of Debian and Ubuntu that haven't already reached their end of life.

Main changes proposed in this pull request:
- Port the Python layer of the data import pipeline to Python 3.4+
- Make the automated tests for the ported layer run reproducibly across minor releases of Python 3.4+
- Port database migration script to Python 3.x
- Configure Travis CI to test the data import pipeline on Python 3.4, including validateStudies

# Checks
- [ ] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.
