### PR TITLE
attempt to fix DaoPatient stall during reCache()

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2017 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2015 - 2018 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -340,7 +340,7 @@ public final class DaoCancerStudy {
      * @param cancerStudyID     Internal (int) Cancer Study ID.
      * @return Cancer Study Object, or null if there's no such study.
      */
-    public static CancerStudy getCancerStudyByInternalId(int internalId) throws DaoException {
+    public static CancerStudy getCancerStudyByInternalId(int internalId) {
         return byInternalId.get(internalId);
     }
 
@@ -350,7 +350,7 @@ public final class DaoCancerStudy {
      * @param cancerStudyStableId Cancer Study Stable ID.
      * @return the CancerStudy, or null if there's no such study.
      */
-    public static CancerStudy getCancerStudyByStableId(String stableId) throws DaoException {
+    public static CancerStudy getCancerStudyByStableId(String stableId) {
         return byStableId.get(stableId);
     }
 

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
@@ -32,13 +32,15 @@
 
 package org.mskcc.cbio.portal.dao;
 
-import java.sql.*;
-import java.text.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.*;
 import org.apache.commons.lang.StringUtils;
-import org.mskcc.cbio.portal.model.*;
-import org.mskcc.cbio.portal.util.*;
+import org.mskcc.cbio.portal.model.CancerStudy;
+import org.mskcc.cbio.portal.util.SpringUtil;
 
 /**
  * Analogous to and replaces the old DaoCancerType. A CancerStudy has a NAME and
@@ -56,8 +58,6 @@ public final class DaoCancerStudy {
         AVAILABLE
     }
 
-    private static final Map<String, java.util.Date> cacheDateByStableId = new HashMap<String, java.util.Date>();
-    private static final Map<Integer, java.util.Date> cacheDateByInternalId = new HashMap<Integer, java.util.Date>();
     private static final Map<String,CancerStudy> byStableId = new HashMap<String,CancerStudy>();
     private static final Map<Integer,CancerStudy> byInternalId = new HashMap<Integer,CancerStudy>();
     private static final long THREAD_SLEEP_AFTER_ADD_STUDY_MILLISECONDS = 5000L;
@@ -81,8 +81,6 @@ public final class DaoCancerStudy {
     }
 
     private static synchronized void reCache() {
-        cacheDateByStableId.clear();
-        cacheDateByInternalId.clear();
         byStableId.clear();
         byInternalId.clear();
         Connection con = null;
@@ -94,7 +92,7 @@ public final class DaoCancerStudy {
             rs = pstmt.executeQuery();
             while (rs.next()) {
                 CancerStudy cancerStudy = extractCancerStudy(rs);
-                cacheCancerStudy(cancerStudy, new java.util.Date());
+                cacheCancerStudy(cancerStudy);
             }
         } catch (SQLException e) {
             e.printStackTrace();
@@ -103,23 +101,9 @@ public final class DaoCancerStudy {
         }
     }
 
-    private static void cacheCancerStudy(CancerStudy study, java.util.Date importDate) {
-        cacheDateByStableId.put(study.getCancerStudyStableId(), importDate);
-        cacheDateByInternalId.put(study.getInternalId(), importDate);
+    private static void cacheCancerStudy(CancerStudy study) {
         byStableId.put(study.getCancerStudyStableId(), study);
         byInternalId.put(study.getInternalId(), study);
-    }
-
-    /**
-     * Removes the cancer study from cache
-     * @param internalCancerStudyId Internal cancer study ID
-     */
-    private static void removeCancerStudyFromCache(int internalCancerStudyId) {
-        String stableId = byInternalId.get(internalCancerStudyId).getCancerStudyStableId();
-        cacheDateByStableId.remove(stableId);
-        cacheDateByInternalId.remove(internalCancerStudyId);
-        byStableId.remove(stableId);
-        byInternalId.remove(internalCancerStudyId);
     }
 
     public static void setStatus(Status status, String stableCancerStudyId, Integer ... internalId) throws DaoException {
@@ -163,90 +147,12 @@ public final class DaoCancerStudy {
             rs = pstmt.executeQuery();
             if (rs.next()) {
                 Integer status = rs.getInt(1);
-                if (rs.wasNull()) {
-                    return Status.AVAILABLE;
+                if (!rs.wasNull() && status == Status.UNAVAILABLE.ordinal()) {
+                    return Status.UNAVAILABLE;
                 }
-                if (status>=Status.values().length) {
-                    return Status.AVAILABLE;
-                }
-                return Status.values()[status];
-            } else {
-                return Status.AVAILABLE;
             }
+            return Status.AVAILABLE; // anything other than UNAVAILABLE (even null) is returned as AVAILABLE
         } catch (SQLException e) {
-            throw new DaoException(e);
-        } finally {
-            JdbcUtil.closeAll(DaoCancerStudy.class, con, pstmt, rs);
-        }
-    }
-
-    private static Integer getStudyCount() throws DaoException {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
-        try {
-            con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
-            pstmt = con.prepareStatement("SELECT count(*) from cancer_study");
-            rs = pstmt.executeQuery();
-            if (rs.next()) {
-                return rs.getInt(1);
-            } else {
-                return 0;
-            }
-        } catch (SQLException e) {
-            throw new DaoException(e);
-        } finally {
-            JdbcUtil.closeAll(DaoCancerStudy.class, con, pstmt, rs);
-        }
-    }
-
-    public static void setImportDate(Integer internalId) throws DaoException {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
-        try {
-            con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
-            pstmt = con.prepareStatement("UPDATE cancer_study set IMPORT_DATE = NOW() where cancer_study_id = ?");
-            pstmt.setInt(1, internalId);
-            pstmt.executeUpdate();
-        } catch (SQLException e) {
-            if (e.getMessage().toLowerCase().contains("unknown column")) {
-                return;
-            }
-            throw new DaoException(e);
-        } finally {
-            JdbcUtil.closeAll(DaoCancerStudy.class, con, pstmt, rs);
-        }
-    }
-
-    public static java.util.Date getImportDate(String stableCancerStudyId, Integer ... internalId) throws DaoException, ParseException {
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
-        try {
-            con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
-            if (internalId.length > 0) {
-                pstmt = con.prepareStatement("SELECT IMPORT_DATE FROM cancer_study where cancer_study_id = ?");
-                pstmt.setInt(1, internalId[0]);
-            } else {
-                pstmt = con.prepareStatement("SELECT IMPORT_DATE FROM cancer_study where cancer_study_identifier = ?");
-                pstmt.setString(1, stableCancerStudyId);
-            }
-            rs = pstmt.executeQuery();
-            if (rs.next()) {
-                java.sql.Timestamp importDate = rs.getTimestamp(1);
-                if (rs.wasNull()) {
-                    return new SimpleDateFormat("yyyyMMdd").parse("19180511");
-                } else {
-                    return importDate;
-                }
-            } else {
-                return new SimpleDateFormat("yyyyMMdd").parse("19180511");
-            }
-        } catch (SQLException e) {
-            if (e.getMessage().toLowerCase().contains("unknown column")) {
-                return new SimpleDateFormat("yyyyMMdd").parse("19180511");
-            }
             throw new DaoException(e);
         } finally {
             JdbcUtil.closeAll(DaoCancerStudy.class, con, pstmt, rs);
@@ -287,15 +193,14 @@ public final class DaoCancerStudy {
      * @throws DaoException
      */
     public static void addCancerStudy(CancerStudy cancerStudy, boolean overwrite) throws DaoException {
-        // CANCER_STUDY_IDENTIFIER cannot be null
         String stableId = cancerStudy.getCancerStudyStableId();
         if (stableId == null) {
             throw new DaoException("Cancer study stable ID cannot be null.");
         }
-        CancerStudy existing = getCancerStudyByStableId(stableId);
-        if (existing != null) {
+        CancerStudy existingCancerStudy = getCancerStudyByStableId(stableId);
+        if (existingCancerStudy != null) {
             if (overwrite) {
-                deleteCancerStudy(existing.getInternalId());
+                deleteCancerStudy(existingCancerStudy.getInternalId());
             } else {
                 throw new DaoException("Cancer study " + stableId + "is already imported.");
             }
@@ -309,7 +214,7 @@ public final class DaoCancerStudy {
                     "( `CANCER_STUDY_IDENTIFIER`, `NAME`, "
                     + "`DESCRIPTION`, `PUBLIC`, `TYPE_OF_CANCER_ID`, "
                     + "`PMID`, `CITATION`, `GROUPS`, `SHORT_NAME`, `STATUS`, `IMPORT_DATE` ) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
-                    Statement.RETURN_GENERATED_KEYS);
+                    PreparedStatement.RETURN_GENERATED_KEYS);
             pstmt.setString(1, stableId);
             pstmt.setString(2, cancerStudy.getName());
             pstmt.setString(3, cancerStudy.getDescription());
@@ -407,8 +312,6 @@ public final class DaoCancerStudy {
      * @deprecated this should not be used. Use deleteCancerStudy(cancerStudyStableId) instead
      */
     public static void deleteAllRecords() throws DaoException {
-        cacheDateByStableId.clear();
-        cacheDateByInternalId.clear();
         byStableId.clear();
         byInternalId.clear();
         Connection con = null;
@@ -436,7 +339,6 @@ public final class DaoCancerStudy {
     public static void deleteCancerStudy(String cancerStudyStableId) throws DaoException {
         CancerStudy study = getCancerStudyByStableId(cancerStudyStableId);
         if (study != null){
-            //setStatus(Status.UNAVAILABLE, cancerStudyStableId);
             deleteCancerStudy(study.getInternalId());
         }
     }
@@ -493,7 +395,6 @@ public final class DaoCancerStudy {
             if (rows == 0) {
                 throw new DaoException("deleteCancerStudyByCascade() failed: No rows affected");
             }
-            removeCancerStudyFromCache(internalCancerStudyId);
         } catch (SQLException e) {
             throw new DaoException(e);
         } finally {
@@ -563,7 +464,6 @@ public final class DaoCancerStudy {
                 pstmt.executeUpdate();
                 pstmt.close();
             }
-            removeCancerStudyFromCache(internalCancerStudyId);
         } catch (SQLException e) {
             throw new DaoException(e);
         } finally {
@@ -618,36 +518,4 @@ public final class DaoCancerStudy {
         return cancerStudy;
     }
 
-    private static boolean studyNeedsRecaching(String stableId, Integer ... internalId) {
-        if (cacheOutOfSyncWithDb()) {
-            return true;
-        }
-        try {
-            java.util.Date importDate = null;
-            java.util.Date cacheDate = null;
-            if (internalId.length > 0) {
-                importDate = getImportDate(null, internalId[0]);
-                cacheDate = cacheDateByInternalId.get(internalId[0]);
-            } else {
-                if (stableId.equals(org.mskcc.cbio.portal.util.AccessControl.ALL_CANCER_STUDIES_ID)) {
-                    return false;
-                }
-                importDate = getImportDate(stableId);
-                cacheDate = cacheDateByStableId.get(stableId);
-            }
-            return (importDate == null || cacheDate == null) ? false : cacheDate.before(importDate);
-        } catch (ParseException e) {
-            return false;
-        } catch (DaoException e) {
-            return false;
-        }
-    }
-
-    private static boolean cacheOutOfSyncWithDb() {
-        try {
-            return getStudyCount() != byStableId.size();
-        } catch (DaoException e) {
-        }
-        return false;
-    }
 }

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGeneticProfile.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGeneticProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2015 - 2018 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -50,11 +50,6 @@ public final class DaoGeneticProfile {
     private static final Map<String,GeneticProfile> byStableId = new HashMap<String,GeneticProfile>();
     private static final Map<Integer,GeneticProfile> byInternalId = new HashMap<Integer,GeneticProfile>();
     private static final Map<Integer,List<GeneticProfile>> byStudy = new HashMap<Integer,List<GeneticProfile>>();
-
-    static {
-        SpringUtil.initDataSource();
-        reCache();
-    }
 
     public static synchronized void reCache() {
         byStableId.clear();

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/QueryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2015 - 2018 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -794,28 +794,24 @@ public class QueryBuilder extends HttpServlet {
         Set<VirtualStudy> studies = new HashSet<>();
         SessionServiceUtil sessionServiceUtil = new SessionServiceUtil();
         for (String inputCohortId: inputCohortIds) {
-            try {
-                CancerStudy cancerStudy = DaoCancerStudy.getCancerStudyByStableId(inputCohortId);
-                // is virtual study
-                if (cancerStudy == null) {
-                    VirtualStudy virtualStudy = sessionServiceUtil.getVirtualStudyData(inputCohortId);
-                    if (virtualStudy != null && virtualStudy.getData().getStudies().size() > 0) {
-                        studies.add(virtualStudy);
-                    }
-                    // is regular study
-                } else {
-                    VirtualStudy study = new VirtualStudy();
-                    VirtualStudySamples studySamples = new VirtualStudySamples();
-                    studySamples.setId(inputCohortId);
-                    studySamples.setSamples(new HashSet<>());
-                    VirtualStudyData studyData = new VirtualStudyData();
-                    studyData.setStudies(Collections.singleton(studySamples));
-                    study.setId(cancerStudy.getCancerStudyStableId());
-                    study.setData(studyData);
-                    studies.add(study);
+            CancerStudy cancerStudy = DaoCancerStudy.getCancerStudyByStableId(inputCohortId);
+            // is virtual study
+            if (cancerStudy == null) {
+                VirtualStudy virtualStudy = sessionServiceUtil.getVirtualStudyData(inputCohortId);
+                if (virtualStudy != null && virtualStudy.getData().getStudies().size() > 0) {
+                    studies.add(virtualStudy);
                 }
-            } catch (DaoException e) {
-                throw e;
+                // is regular study
+            } else {
+                VirtualStudy study = new VirtualStudy();
+                VirtualStudySamples studySamples = new VirtualStudySamples();
+                studySamples.setId(inputCohortId);
+                studySamples.setSamples(new HashSet<>());
+                VirtualStudyData studyData = new VirtualStudyData();
+                studyData.setStudies(Collections.singleton(studySamples));
+                study.setId(cancerStudy.getCancerStudyStableId());
+                study.setData(studyData);
+                studies.add(study);
             }
         }
         return studies;

--- a/core/src/main/java/org/mskcc/cbio/portal/util/CoExpUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/CoExpUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2015 - 2018 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -42,8 +42,8 @@ import org.mskcc.cbio.portal.dao.*;
 public class CoExpUtil {
 
     public static ArrayList<String> getSampleIds(String sampleSetId, String sampleIdsKeys) {
-		try {
-			DaoSampleList daoSampleList = new DaoSampleList();
+        try {
+            DaoSampleList daoSampleList = new DaoSampleList();
             SampleList sampleList;
             ArrayList<String> sampleIdList = new ArrayList<String>();
             if (sampleSetId.equals("-1")) {
@@ -56,36 +56,31 @@ public class CoExpUtil {
                 sampleList = daoSampleList.getSampleListByStableId(sampleSetId);
                 sampleIdList = sampleList.getSampleList();
             }
-			return sampleIdList;
+            return sampleIdList;
         } catch (DaoException e) {
             System.out.println("Caught Dao Exception: " + e.getMessage());
-			return null;
+            return null;
         }
     }
 
-	public static GeneticProfile getPreferedGeneticProfile(String cancerStudyIdentifier) {
-		try {
-			CancerStudy cs = DaoCancerStudy.getCancerStudyByStableId(cancerStudyIdentifier);
-			ArrayList<GeneticProfile> gps = DaoGeneticProfile.getAllGeneticProfiles(cs.getInternalId());
-			GeneticProfile final_gp = null;
-			for (GeneticProfile gp : gps) {
-				// TODO: support miRNA later
-				if (gp.getGeneticAlterationType() == GeneticAlterationType.MRNA_EXPRESSION) {
-					//rna seq profile (no z-scores applied) holds the highest priority)
-					if (gp.getStableId().toLowerCase().contains("rna_seq") &&
-					   !gp.getStableId().toLowerCase().contains("zscores")) {
-						final_gp = gp;
-						break;
-					} else if (!gp.getStableId().toLowerCase().contains("zscores")) {
-						final_gp = gp;
-					}
-				}
-			}
-			return final_gp;
-		}
-		catch (DaoException e) {
-			return null;
-		}
+    public static GeneticProfile getPreferedGeneticProfile(String cancerStudyIdentifier) {
+        CancerStudy cs = DaoCancerStudy.getCancerStudyByStableId(cancerStudyIdentifier);
+        ArrayList<GeneticProfile> gps = DaoGeneticProfile.getAllGeneticProfiles(cs.getInternalId());
+        GeneticProfile final_gp = null;
+        for (GeneticProfile gp : gps) {
+            // TODO: support miRNA later
+            if (gp.getGeneticAlterationType() == GeneticAlterationType.MRNA_EXPRESSION) {
+                //rna seq profile (no z-scores applied) holds the highest priority)
+                if (gp.getStableId().toLowerCase().contains("rna_seq") &&
+                   !gp.getStableId().toLowerCase().contains("zscores")) {
+                    final_gp = gp;
+                    break;
+                } else if (!gp.getStableId().toLowerCase().contains("zscores")) {
+                    final_gp = gp;
+                }
+            }
+        }
+        return final_gp;
     }
 
     public static Map<Long,double[]> getExpressionMap(int profileId, String sampleSetId, String sampleIdsKeys) throws DaoException {
@@ -123,5 +118,5 @@ public class CoExpUtil {
 
         return map;
     }
-	
+
 }


### PR DESCRIPTION
- all primitive patient records extracted from record set before cancer studies are retrieved
- primitive patient records are processed after recordset/connection is closed (cancer study objects are retrieved and Patient model objects are created)
- also removed apparently unnecessary static initializer block in DaoGeneticProfile
- removed "throws DaoException" specifier from DaoCancerStudy.getCancerStudyByInternalId() (exception is no longer possible)
- unnecessary try/catch blocks removed in related classes
- cleaned up cachePatient() function to use only the passed Patient object, which contains the needed studyId in the CancerStudy member

These fixes, and this new branch is to attempt to resolve an intermittent stalling of the import process during the recaching step when using the jdbc datasource. This branch (importer-daopatient-stall-fix) will be kept current with master (rebasing as necessary) and will be used to build the import pipeline. When it appears that the intermittent stalling has been resolved, the code will be tested for use in the production web service portals and a PR for a merge into a release branch will be opened.

Changes proposed in this pull request: