### PR TITLE
Add in missing line to update db version schema

### DIFF
--- a/db-scripts/src/main/resources/migration.sql
+++ b/db-scripts/src/main/resources/migration.sql
@@ -452,6 +452,7 @@ UPDATE info SET DB_SCHEMA_VERSION="2.5.0";
 -- modify fkc for gistic_to_gene
 ALTER TABLE gistic_to_gene DROP FOREIGN KEY gistic_to_gene_ibfk_2;
 ALTER TABLE gistic_to_gene ADD CONSTRAINT `gistic_to_gene_ibfk_2` FOREIGN KEY (`GISTIC_ROI_ID`) REFERENCES `gistic` (`GISTIC_ROI_ID`) ON DELETE CASCADE;
+UPDATE info SET DB_SCHEMA_VERSION="2.6.0";
 
 ##version: 2.6.1
 ALTER TABLE `mutation_event` MODIFY COLUMN `KEYWORD` VARCHAR(255);


### PR DESCRIPTION
# What? Why?
The migration.sql script is missing the line which updates the schema version in table info after the changes that are made in version 2.6.0.

Changes proposed in this pull request:
The appropriate line is added

It seems to me that even if someone has migrated their database to 2.6.0, it is harmless for the script to re-apply the changes between 2.6.0 and 2.6.1, so we probably do not need to warn users who may have applied the migration.sql script on a database without getting the bump to 2.6.1 in the info table.

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
