### PR TITLE
Clean up Tomcat 6 note from build docs

### DIFF
--- a/docs/Build-from-Source.md
+++ b/docs/Build-from-Source.md
@@ -10,22 +10,4 @@ mvn -DskipTests clean install
 
 After this command completes, you will find a `cbioportal.war` file suitable for Apache Tomcat deployment in `$PORTAL_HOME/portal/target/`.  
 
-#### Note for those running Tomcat6
-
-The current version of the code is using an optional feature which is only available if you are running Tomcat7. If you are not, you should remove the following lines from the file portal/src/main/webapp/WEB-INF/web.xml :
-
-```
-   <filter>
-     <filter-name>CorsFilter</filter-name>
-     <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>
-   </filter>
-
-   <filter-mapping>
-     <filter-name>CorsFilter</filter-name>
-     <url-pattern>/*</url-pattern>
-   </filter-mapping>
-```
-
-Then, rebuild with Maven.
-
 [Next Step: Importing the Seed Database](Import-the-Seed-Database.md)


### PR DESCRIPTION
Looking at https://github.com/cBioPortal/cbioportal/pull/3267,
I gather that suggesting to run the current release on Tomcat 6
would probably just result in a bad first impression when
the newer code doesn't work.