### PR TITLE
Change classes to be serializable for Redis compatibility

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/model/DownloadLink.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/model/DownloadLink.java
@@ -32,12 +32,13 @@
 
 package org.mskcc.cbio.portal.model;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 
 /**
  * Encapsulates a Download Link.
  */
-public class DownloadLink {
+public class DownloadLink implements Serializable {
     private GeneticProfile profile;
     private ArrayList<String> geneList;
     private String caseIds;

--- a/core/src/main/java/org/mskcc/cbio/portal/model/GeneticProfile.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/model/GeneticProfile.java
@@ -32,6 +32,7 @@
 
 package org.mskcc.cbio.portal.model;
 
+import java.io.Serializable;
 import java.util.Properties;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -39,7 +40,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 /**
  * Class for genetic profile
  */
-public class GeneticProfile {
+public class GeneticProfile implements Serializable {
     private int geneticProfileId;
     private String stableId;
     private int cancerStudyId;


### PR DESCRIPTION
# What? Why?
Recent changes to the backend to use Redis to store sessions created bugs in the portal. Information stored in the session were not serializable and resulted in an exception being thrown when downloading data.

i.e Message java.io.IOException: java.lang.RuntimeException: Class org.mskcc.cbio.portal.model.DownloadLink does not implement Serializable or externalizable (also with GeneticProfile)

Changes proposed in this pull request:
- Change classes to implement Serializable

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).