### PR TITLE
Add git-commit-id-plugin, show git in /api/info

### DIFF
--- a/business/pom.xml
+++ b/business/pom.xml
@@ -61,6 +61,7 @@
                     <exclude>**/portal.properties.*</exclude>
                     <exclude>**/log4j.properties.*</exclude>
                     <exclude>**/maven.properties.*</exclude>
+                    <exclude>**/git.properties</exclude>
                     <exclude>**/*.EXAMPLE</exclude>
                   </excludes>
                 </resource>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -445,6 +445,7 @@
                     <exclude>**/portal.properties.*</exclude>
                     <exclude>**/log4j.properties.*</exclude>
                     <exclude>**/maven.properties.*</exclude>
+                    <exclude>**/git.properties.*</exclude>
                     <exclude>**/*.EXAMPLE</exclude>
                   </excludes>
                 </resource>

--- a/model/src/main/java/org/cbioportal/model/Info.java
+++ b/model/src/main/java/org/cbioportal/model/Info.java
@@ -9,6 +9,107 @@ public class Info implements Serializable {
     private String portalVersion;
     @NotNull
     private String dbVersion;
+    @NotNull
+    private String gitBranch;
+    @NotNull
+    private String gitCommitId;
+    @NotNull
+    private String gitCommitIdAbbrev;
+    @NotNull
+    private String gitCommitIdDescribe;
+    @NotNull
+    private String gitCommitIdDescribeShort;
+    @NotNull
+    private String gitCommitMessageFull;
+    @NotNull
+    private String gitCommitMessageShort;
+    @NotNull
+    private String gitCommitMessageUserEmail;
+    @NotNull
+    private String gitCommitMessageUserName;
+    @NotNull
+    private Boolean gitDirty;
+
+    public String getGitBranch() {
+        return this.gitBranch;
+    }
+
+    public void setGitBranch(String gitBranch) {
+        this.gitBranch = gitBranch;
+    }
+
+    public String getGitCommitId() {
+        return this.gitCommitId;
+    }
+
+    public void setGitCommitId(String gitCommitId) {
+        this.gitCommitId = gitCommitId;
+    }
+
+    public String getGitCommitIdAbbrev() {
+        return this.gitCommitIdAbbrev;
+    }
+
+    public void setGitCommitIdAbbrev(String gitCommitIdAbbrev) {
+        this.gitCommitIdAbbrev = gitCommitIdAbbrev;
+    }
+
+    public String getGitCommitIdDescribe() {
+        return this.gitCommitIdDescribe;
+    }
+
+    public void setGitCommitIdDescribe(String gitCommitIdDescribe) {
+        this.gitCommitIdDescribe = gitCommitIdDescribe;
+    }
+
+    public String getGitCommitIdDescribeShort() {
+        return this.gitCommitIdDescribeShort;
+    }
+
+    public void setGitCommitIdDescribeShort(String gitCommitIdDescribeShort) {
+        this.gitCommitIdDescribeShort = gitCommitIdDescribeShort;
+    }
+
+    public String getGitCommitMessageFull() {
+        return this.gitCommitMessageFull;
+    }
+
+    public void setGitCommitMessageFull(String gitCommitMessageFull) {
+        this.gitCommitMessageFull = gitCommitMessageFull;
+    }
+
+    public String getGitCommitMessageShort() {
+        return this.gitCommitMessageShort;
+    }
+
+    public void setGitCommitMessageShort(String gitCommitMessageShort) {
+        this.gitCommitMessageShort = gitCommitMessageShort;
+    }
+
+    public String getGitCommitMessageUserEmail() {
+        return this.gitCommitMessageUserEmail;
+    }
+
+    public void setGitCommitMessageUserEmail(String gitCommitMessageUserEmail) {
+        this.gitCommitMessageUserEmail = gitCommitMessageUserEmail;
+    }
+
+    public String getGitCommitMessageUserName() {
+        return this.gitCommitMessageUserName;
+    }
+
+    public void setGitCommitMessageUserName(String gitCommitMessageUserName) {
+        this.gitCommitMessageUserName = gitCommitMessageUserName;
+    }
+
+    public Boolean getGitDirty() {
+        return this.gitDirty;
+    }
+
+    public void isGitDirty(Boolean gitDirty) {
+        this.gitDirty = gitDirty;
+    }
+
 
     public String getPortalVersion() {
         return portalVersion;

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,22 @@
               </execution>
             </executions>
           </plugin>
+		  <!-- don't generate git.properties on heroku (unf doesn't work, since
+			   .git directory is not accessible during build) -->
+          <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+						<phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>validate-the-git-infos</id>
+						<phase>none</phase>
+                    </execution>
+                </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,31 @@
               </dependency>
             </dependencies>
           </plugin>
+          <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <!-- *NOTE*: The default phase of revision is initialize, but in case you want to change it, you can do so by adding the phase here -->
+                        <phase>initialize</phase>
+                    </execution>
+                    <execution>
+                        <id>validate-the-git-infos</id>
+                        <goals>
+                            <goal>validateRevision</goal>
+                        </goals>
+                        <!-- *NOTE*: The default phase of validateRevision is verify, but in case you want to change it, you can do so by adding the phase here -->
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            <configuration>
+                <generateGitPropertiesFile>true</generateGitPropertiesFile>
+            </configuration>
+          </plugin>
     </plugins>
     </build>
     </profile>
@@ -439,6 +464,7 @@
         <includes>
           <include>**/portal.properties</include>
           <include>**/maven.properties</include>
+          <include>**/git.properties</include>
         </includes>
       </resource>
       <resource>
@@ -447,6 +473,7 @@
         <excludes>
           <exclude>**/portal.properties</exclude>
           <exclude>**/maven.properties</exclude>
+          <exclude>**/git.properties</exclude>
         </excludes>
       </resource>
     </resources>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -198,6 +198,7 @@
                     <exclude>**/portal.properties.*</exclude>
                     <exclude>**/log4j.properties.*</exclude>
                     <exclude>**/maven.properties.*</exclude>
+                    <exclude>**/git.properties.*</exclude>
                     <exclude>**/*.EXAMPLE</exclude>
                   </excludes>
                 </resource>

--- a/web/src/main/java/org/cbioportal/web/InfoController.java
+++ b/web/src/main/java/org/cbioportal/web/InfoController.java
@@ -25,6 +25,36 @@ public class InfoController {
     @Value("${db.version}")
     private String dbVersion;
 
+    @Value("${git.branch}")
+    private String gitBranch;
+
+    @Value("${git.commit.id}")
+    private String gitCommitId;
+
+    @Value("${git.commit.id.abbrev}")
+    private String gitCommitIdAbbrev;
+
+    @Value("${git.commit.id.describe}")
+    private String gitCommitIdDescribe;
+
+    @Value("${git.commit.id.describe-short}")
+    private String gitCommitIdDescribeShort;
+
+    @Value("${git.commit.message.full}")
+    private String gitCommitMessageFull;
+
+    @Value("${git.commit.message.short}")
+    private String gitCommitMessageShort;
+
+    @Value("${git.commit.user.email}")
+    private String gitCommitMessageUserEmail;
+
+    @Value("${git.commit.user.name}")
+    private String gitCommitMessageUserName;
+
+    @Value("${git.dirty}")
+    private String gitDirty;
+
     @RequestMapping(value = "/info", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get information about the running instance")
     public ResponseEntity<Info> getInfo() {
@@ -32,6 +62,15 @@ public class InfoController {
         Info info = new Info();
         info.setPortalVersion(portalVersion);
         info.setDbVersion(dbVersion);
+        info.setGitBranch(gitBranch);
+        info.setGitCommitId(gitCommitId);
+        info.setGitCommitIdDescribe(gitCommitIdDescribe);
+        info.setGitCommitIdDescribeShort(gitCommitIdDescribeShort);
+        info.setGitCommitMessageShort(gitCommitMessageShort);
+        info.setGitCommitMessageFull(gitCommitMessageFull);
+        info.setGitCommitMessageUserEmail(gitCommitMessageUserEmail);
+        info.setGitCommitMessageUserName(gitCommitMessageUserName);
+        info.isGitDirty(Boolean.valueOf(gitDirty));
         return new ResponseEntity<>(info, HttpStatus.OK);
     }
 }

--- a/web/src/main/resources/applicationContext-web.xml
+++ b/web/src/main/resources/applicationContext-web.xml
@@ -21,6 +21,7 @@
                 <value>file:///${PORTAL_HOME}/portal.properties</value>
                 <value>classpath:portal.properties</value>
                 <value>classpath:maven.properties</value>
+                <value>classpath:git.properties</value>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
```
{
    "portalVersion": "1.17.0-SNAPSHOT",
    "dbVersion": "2.7.0",
    "gitBranch": "add-git-to-info-endpoint",
    "gitCommitId": "36cf0cedd480f64b0a2579634b0473a29c9d9d13",
    "gitCommitIdDescribe": "36cf0ce-dirty",
    "gitCommitIdDescribeShort": "85c3206-dirty",
    "gitCommitMessageFull": "Merge pull request #4776 from ersinciftci/mutation-sample-count-fix\n\nFix sample-count response header for mutation endpoints",
    "gitCommitMessageShort": "Merge pull request #4776 from ersinciftci/mutation-sample-count-fix",
    "gitCommitMessageUserEmail": "arseniusthegreat@gmail.com",
    "gitCommitMessageUserName": "Ersin Ciftci",
    "gitDirty": true
}
```