### PR TITLE
Warning instead of error for some incorrectly placed clinical attributes

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1883,7 +1883,8 @@ class ClinicalValidator(Validator):
                       'datatype',
                       'priority')
 
-    # Only a core set of attributes must be either specific in the patient or sample clinical data.
+    # A core set of attributes must be either specific in the patient or sample clinical data.
+    # See GET /api/ at http://oncotree.mskcc.org/cdd/swagger-ui.html#/
     PREDEFINED_ATTRIBUTES = {
         'AGE': {
             'is_patient_attribute': '1',
@@ -1984,6 +1985,12 @@ class ClinicalValidator(Validator):
             'datatype': 'STRING'
         },
     }
+
+    # For some attributes, only a warning should be reported when they are in the wrong data file.
+    # This was added to successfully validate old study data.
+    WARNING_ATTRIBUTES = ['PRIMARY_SITE', 'METASTATIC_SITE', 'TUMOR_TISSUE_SITE']
+
+    # Invalid characters in attributes
     INVALID_ID_CHARACTERS = r'[^A-Za-z0-9._-]'
 
 
@@ -2135,12 +2142,22 @@ class ClinicalValidator(Validator):
                     if attr_property == 'is_patient_attribute':
                         expected_level = self.PREDEFINED_ATTRIBUTES[col_name][attr_property]
                         if self.PROP_IS_PATIENT_ATTRIBUTE != expected_level:
-                            self.logger.error(
-                                'Attribute must to be a %s-level attribute',
-                                {'0': 'sample', '1': 'patient'}[expected_level],
-                                extra={'line_number': self.line_number,
-                                       'column_number': col_index + 1,
-                                       'cause': col_name})
+                            if col_name in self.WARNING_ATTRIBUTES:
+                                self.logger.warning(
+                                    'Clinical Data Dictionary defines this as a %s-level attribute. '
+                                    'See GET /api/ at http://oncotree.mskcc.org/cdd/swagger-ui.html#/',
+                                    {'0': 'sample', '1': 'patient'}[expected_level],
+                                    extra={'line_number': self.line_number,
+                                           'column_number': col_index + 1,
+                                           'cause': col_name})
+                            else:
+                                self.logger.error(
+                                    'According to Clinical Data Dictionary, this attribute must to be a %s-level '
+                                    'attribute. See GET /api/ at http://oncotree.mskcc.org/cdd/swagger-ui.html#/',
+                                    {'0': 'sample', '1': 'patient'}[expected_level],
+                                    extra={'line_number': self.line_number,
+                                           'column_number': col_index + 1,
+                                           'cause': col_name})
                     # check pre-header datatype property:
                     if attr_property == 'datatype':
                         # check pre-header metadata if applicable -- if these were

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -254,7 +254,7 @@ class ClinicalColumnDefsTestCase(PostClinicalDataFileTestCase):
         self.assertEqual(record.column_number, 2)
         self.assertIn(record.cause, 'STRING')
 
-        # Expect warning for sample attribute in patient clinical data
+        # Expect error for sample attribute in patient clinical data
         record = next(record_iterator)
         self.assertEqual(record.levelno, logging.ERROR)
         self.assertEqual(record.line_number, 5)
@@ -263,7 +263,7 @@ class ClinicalColumnDefsTestCase(PostClinicalDataFileTestCase):
 
         # Expect warning for sample attribute in patient clinical data
         record = next(record_iterator)
-        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertEqual(record.levelno, logging.WARNING)
         self.assertEqual(record.line_number, 5)
         self.assertEqual(record.column_number, 7)
         self.assertIn(record.cause, 'METASTATIC_SITE')


### PR DESCRIPTION
Recently we changed the validation of whether clinical attributes should be in the sample or patient file (https://github.com/cBioPortal/cbioportal/pull/3910). This PR makes this validation less strict. 

This is required to load old study data (all TCGA provisional studies) that can't be migrated to the new format.