### PR TITLE
Allow changing config at runtime via $PORTAL_HOME/portal.properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,17 +42,16 @@ before_script:
       mysql --user root --password= <<< "flush privileges"
   fi
 script:
-- export PORTAL_HOME=$(pwd)
 - |
   if [[ "${TEST}" == python-validator ]]
   then
       source ~/python-env-validator/bin/activate
       trap 'deactivate' EXIT
-      export PYTHONPATH="$PORTAL_HOME/core/src/main/scripts:$PYTHONPATH" && \
-      pushd $PORTAL_HOME/core/src/test/scripts/ && \
-      python $PORTAL_HOME/core/src/test/scripts/unit_tests_validate_data.py && \
-      python $PORTAL_HOME/core/src/test/scripts/system_tests_validate_data.py && \
-      python $PORTAL_HOME/core/src/test/scripts/system_tests_validate_studies.py && \
+      export PYTHONPATH="$PWD/core/src/main/scripts:$PYTHONPATH" && \
+      pushd core/src/test/scripts/ && \
+      python unit_tests_validate_data.py && \
+      python system_tests_validate_data.py && \
+      python system_tests_validate_studies.py && \
       popd
   fi
 - |
@@ -66,20 +65,16 @@ script:
   then
       ~/maven/$MAVEN_VERSION/bin/mvn \
           -e \
-          -DPORTAL_HOME=$PORTAL_HOME \
           -Ppublic \
           -Dfinal.war.name=cbioportal \
           -Ddb.user=cbio_user \
           -Ddb.password=somepassword \
-          -Ddb.host=127.0.0.1 \
-          -Ddb.connection_string=jdbc:mysql://127.0.0.1:3306/ \
           clean integration-test
   fi
 - |
   if [[ "${TEST}" == end-to-end ]]
   then
       ~/maven/$MAVEN_VERSION/bin/mvn \
-          -e -DPORTAL_HOME=$PORTAL_HOME \
           -Ppublic -DskipTests \
           -Dfinal.war.name=cbioportal \
           clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,11 +82,6 @@ script:
           -e -DPORTAL_HOME=$PORTAL_HOME \
           -Ppublic -DskipTests \
           -Dfinal.war.name=cbioportal \
-          -Ddb.user=cbio_user \
-          -Ddb.password=cbio_pass \
-          -Ddb.portal_db_name=public_test \
-          -Ddb.connection_string=jdbc:mysql://devdb.cbioportal.org:3306/ \
-          -Ddb.host=devdb.cbioportal.org \
           clean install
   fi
 - |

--- a/app.json
+++ b/app.json
@@ -17,12 +17,11 @@
     },
     "MAVEN_CUSTOM_OPTS": {
         "description":"set heroku profile for mvn",
-        "value":"-Pheroku,public -DskipTests -Dfinal.war.name=cbioportal -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test_small -Dtomcat.catalina.scope=runtime -Ddb.connection_string=jdbc:mysql://sm4sa6ozhn5ya6.cuooweljyhix.us-east-1.rds.amazonaws.com:3306/ -Ddb.host=sm4sa6ozhn5ya6.cuooweljyhix.us-east-1.rds.amazonaws.com"
+        "value":"-Pheroku,public -DskipTests -Dtomcat.catalina.scope=runtime -Dfinal.war.name=cbioportal"
     },
-    "FRONTEND_URL": {
-        "description":"set frontend URL to use (default: empty string, uses frontend inside war)",
-        "value":"",
-        "required":false
+    "SPRING_OPTS": {
+        "description":"set spring properties with e.g. -Dshow.civic=true (TODO: not all props work atm)",
+        "value":"-Dtomcat.catalina.scope=runtime -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test_small -Ddb.connection_string=jdbc:mysql://devdb.cbioportal.org:3306/ -Ddb.host=devdb.cbioportal.org -Dshow.civic=true -Ddbconnector=dbcp -Dsuppress_schema_version_mismatch_errors=true"
     }
   },
   "buildpacks": [

--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -16,9 +16,8 @@
             <property name="ignoreResourceNotFound" value="true" />
             <property name="locations">
                 <list>
-                    <value>file:///${PORTAL_HOME}/portal.properties</value>
                     <value>classpath:/portal.properties</value>
-                    <value>classpath:/maven.properties</value>
+                    <value>file:///#{systemEnvironment['PORTAL_HOME']}/portal.properties</value>
                 </list>
             </property>
         </bean>

--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -92,18 +92,8 @@
     </beans>
   
     <beans profile="dbcp">
-        <!-- business data source -->
-        <!-- setting minIdle/maxIdle to 1 doesn't limit the number of active -->
-        <bean id="businessDataSource" destroy-method="close" class="org.apache.commons.dbcp2.BasicDataSource">
-            <property name="driverClassName" value="${db.driver}"/>
-            <property name="url" value="${db.connection_string}${db.portal_db_name}?zeroDateTimeBehavior=convertToNull"/>
-            <property name="username" value="${db.user}"/>
-            <property name="password" value="${db.password}"/>
-            <property name="minIdle" value="0"/>
-            <property name="maxIdle" value="10"/>
-            <property name="maxTotal" value="100"/>
-            <property name="poolPreparedStatements" value="true"/>
-        </bean>
+        <bean id="businessDataSource" destroy-method="close"
+            class="org.mskcc.cbio.portal.dao.JdbcDataSource" />
         <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
             <property name="staticMethod" value="org.mskcc.cbio.portal.dao.JdbcUtil.setDataSource"/>
             <property name="arguments">

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
@@ -1,0 +1,28 @@
+package org.mskcc.cbio.portal.dao;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.mskcc.cbio.portal.util.DatabaseProperties;
+
+/**
+ * Data source that self-initializes based on cBioPortal configuration.
+ */
+public class JdbcDataSource extends BasicDataSource {
+    public JdbcDataSource () {
+        DatabaseProperties dbProperties = DatabaseProperties.getInstance();
+        String host = dbProperties.getDbHost();
+        String userName = dbProperties.getDbUser();
+        String password = dbProperties.getDbPassword();
+        String database = dbProperties.getDbName();
+        String url ="jdbc:mysql://" + host + "/" + database +
+                        "?user=" + userName + "&password=" + password +
+                        "&zeroDateTimeBehavior=convertToNull";
+        //  Set up poolable data source
+        this.setDriverClassName("com.mysql.jdbc.Driver");
+        this.setUsername(userName);
+        this.setPassword(password);
+        this.setUrl(url);
+        //  By pooling/reusing PreparedStatements, we get a major performance gain
+        this.setPoolPreparedStatements(true);
+        this.setMaxTotal(100);
+    }
+}

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcUtil.java
@@ -56,7 +56,7 @@ public class JdbcUtil {
      */
     public static DataSource getDataSource() {
         if (dataSource == null) {
-            dataSource = initDataSource();
+            dataSource = new JdbcDataSource();
         }
         return dataSource;
     }
@@ -67,28 +67,6 @@ public class JdbcUtil {
      */
     public static void setDataSource(DataSource value) {
         dataSource = value;
-    }
-
-    private static DataSource initDataSource() {
-        DatabaseProperties dbProperties = DatabaseProperties.getInstance();
-        String host = dbProperties.getDbHost();
-        String userName = dbProperties.getDbUser();
-        String password = dbProperties.getDbPassword();
-        String database = dbProperties.getDbName();
-        String url ="jdbc:mysql://" + host + "/" + database +
-                        "?user=" + userName + "&password=" + password +
-                        "&zeroDateTimeBehavior=convertToNull";
-        //  Set up poolable data source
-        BasicDataSource dataSource = new BasicDataSource();
-        dataSource.setDriverClassName("com.mysql.jdbc.Driver");
-        dataSource.setUsername(userName);
-        dataSource.setPassword(password);
-        dataSource.setUrl(url);
-        //  By pooling/reusing PreparedStatements, we get a major performance gain
-        dataSource.setPoolPreparedStatements(true);
-        dataSource.setMaxTotal(100);
-        activeConnectionCount = new HashMap<String,Integer>();
-        return dataSource;
     }
 
     /**

--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -563,8 +563,13 @@ public class GlobalProperties {
     public static String getEmailContact()
     {
         String emailAddress = portalProperties.getProperty(SKIN_EMAIL_CONTACT);
-        return (emailAddress == null) ? DEFAULT_EMAIL_CONTACT :
-            ("<span class=\"mailme\" title=\"Contact us\">" + emailAddress + "</span>");
+        if (emailAddress == null)
+            emailAddress = DEFAULT_EMAIL_CONTACT;
+        return (
+                "<span class=\"mailme\" title=\"Contact us\">" +
+                emailAddress +
+                "</span>"
+        );
     }
 
     public static boolean includeNetworks()

--- a/core/src/main/scripts/env.pl
+++ b/core/src/main/scripts/env.pl
@@ -1,5 +1,8 @@
 #  Set up Environment for Running cBio Portal Java Tools
 
+use File::Spec;
+use Cwd 'abs_path';
+
 # check for JAVA_HOME
 $JAVA_HOME = $ENV{JAVA_HOME};
 if ($JAVA_HOME eq "") {
@@ -36,9 +39,18 @@ if ($portalDataHome eq "") {
 }
 
 # Set up Classpath to use the scripts jar
-@jar_files = glob("$portalHome/scripts/target/scripts-*.jar");
+sub locate_src_root {
+    # isolate the directory this code file is in
+    my ($volume, $script_dir, undef) = File::Spec->splitpath(__FILE__);
+    # go up from cbioportal/core/src/main/scripts/ to cbioportal/
+    my $src_root_dir = File::Spec->catdir($script_dir, (File::Spec->updir()) x 4);
+    # reassamble the path and resolve updirs (/../)
+    return abs_path(File::Spec->catpath($volume, $src_root_dir));
+}
+$src_root = locate_src_root();
+@jar_files = glob("$src_root/scripts/target/scripts-*.jar");
 if (scalar @jar_files != 1) {
-	die "Expected to find 1 scripts-*.jar, but found: " . scalar @jar_files;
+    die "Expected to find 1 scripts-*.jar, but found: " . scalar @jar_files;
 }
 $cp = pop @jar_files;
 

--- a/core/src/main/scripts/envSimple.pl
+++ b/core/src/main/scripts/envSimple.pl
@@ -1,5 +1,8 @@
 #  Set up Environment for Running cBio Portal Java Tools
 
+use File::Spec;
+use Cwd 'abs_path';
+
 # check for JAVA_HOME
 $JAVA_HOME = $ENV{JAVA_HOME};
 if ($JAVA_HOME eq "") {
@@ -31,9 +34,18 @@ if ($portalHome eq "") {
 }
 
 # Set up Classpath to use the scripts jar
-@jar_files = glob("$portalHome/scripts/target/scripts-*.jar");
+sub locate_src_root {
+    # isolate the directory this code file is in
+    my ($volume, $script_dir, undef) = File::Spec->splitpath(__FILE__);
+    # go up from cbioportal/core/src/main/scripts/ to cbioportal/
+    my $src_root_dir = File::Spec->catdir($script_dir, (File::Spec->updir()) x 4);
+    # reassamble the path and resolve updirs (/../)
+    return abs_path(File::Spec->catpath($volume, $src_root_dir));
+}
+$src_root = locate_src_root();
+@jar_files = glob("$src_root/scripts/target/scripts-*.jar");
 if (scalar @jar_files != 1) {
-	die "Expected to find 1 scripts-*.jar, but found: " . scalar @jar_files;
+    die "Expected to find 1 scripts-*.jar, but found: " . scalar @jar_files;
 }
 $cp = pop @jar_files;
 

--- a/core/src/main/scripts/importer/metaImport.py
+++ b/core/src/main/scripts/importer/metaImport.py
@@ -74,7 +74,9 @@ def interface():
                         help='portal.properties file path (default: assumed hg19)',
                         required=False) 
     parser.add_argument('-jar', '--jar_path', type=str, required=False,
-                        help='Path to scripts JAR file (default: $PORTAL_HOME/scripts/target/scripts-*.jar)')
+                        help=(
+                            'Path to scripts JAR file (default: locate it '
+                            'relative to the import script)'))
     parser.add_argument('-html', '--html_table', type=str,
                         help='path to html report')
     parser.add_argument('-v', '--verbose', action='store_true',

--- a/docs/Build-from-Source.md
+++ b/docs/Build-from-Source.md
@@ -2,12 +2,22 @@
 
 ## Building with Maven
 
-To compile the cBioPortal source code run the following maven command:
+While building, you must point the environment variable `PORTAL_HOME` to
+the root directory containing the portal source code.
+
+For example, run a command like the following if on macOS:
+```
+export PORTAL_HOME=/Users/ecerami/dev/cbioportal
+```
+
+To compile the cBioPortal source code, move into the source directory and
+run the following maven command:
 
 ```
 mvn -DskipTests clean install
 ```
 
-After this command completes, you will find a `cbioportal.war` file suitable for Apache Tomcat deployment in `$PORTAL_HOME/portal/target/`.  
+After this command completes, you will find a `cbioportal.war` file
+suitable for Apache Tomcat deployment in `portal/target/`.
 
 [Next Step: Importing the Seed Database](Import-the-Seed-Database.md)

--- a/docs/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/Customizing-your-instance-of-cBioPortal.md
@@ -2,7 +2,14 @@
 
 cBioPortal contains a number of properties that allow you to customize your cBioPortal instance. 
 
-This page focuses on the skin properties, which allow you to customize the web page cosmetics, such as custom images, texts, which tabs are visible, etc. Nearly all the skins properties have defaults, which can be overwritten by changing the `portal.properties` file, located in `{PORTAL_HOME}/src/main/resources/portal.properties`. If your cBioPortal instance does not yet contain a `portal.properties` file, you can copy the `portal.properties.EXAMPLE` and edit it. 
+This page focuses on the skin properties, which allow you to
+customize the web page cosmetics, such as custom images,
+texts, which tabs are visible, etc.
+Nearly all the skins properties have defaults, which can be overwritten by
+changing the `portal.properties` file located in `$PORTAL_HOME`--see
+[the deployment manual](Deploying.md). If your cBioPortal instance
+does not yet contain a `portal.properties` file, you can copy
+`src/main/resources/portal.properties.EXAMPLE` and edit it.
 
 Below you can find the complete list of all the available skin properties.
 

--- a/docs/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/Customizing-your-instance-of-cBioPortal.md
@@ -224,7 +224,7 @@ Below you can find the complete list of all the available skin properties.
 
 Creating you own local news/about or FAQ page involves three steps. For example, to create your own news page:
 
-1. Copy `{PORTAL_HOME}/portal/src/main/webapp/content/news.html` to `news_XXXX.html`
+1. Copy `<cbioportal_source_folder>/portal/src/main/webapp/content/news.html` to `news_XXXX.html`
 2. Modify `news_XXXX.html` as needed.
 3. Edit the `portal.properties` file and change the `skin.documentation.news` property, giving it the name of your news HTML component.
 

--- a/docs/Data-Loading-For-Developers.md
+++ b/docs/Data-Loading-For-Developers.md
@@ -1,15 +1,15 @@
 # Importing single data files for development
 In some cases, for example during development, it may be useful to import a single data file into an existing study. To import one data file at a time, you can use the following command. Note that this process will not validate the data.
 
-This can be done by running `cbioportalImporter.py` from `$PORTAL_HOME/core/src/main/scripts/importer/`.
+This can be done by running `cbioportalImporter.py` from `<cbioportal_source_folder>/core/src/main/scripts/importer/`.
 
 ## Requirements
-This script requires `PORTAL_HOME` to point to your cBioPortal repository. This can be done with:
-```
-export PORTAL_HOME=<your_cbioportal_dir>
-```
 
-The script itself can be found in `$PORTAL_HOME/core/src/main/scripts/importer`.
+This script requires `$PORTAL_HOME` to point to the folder containing your
+cBioPortal configuration. This can be done with:
+```
+export PORTAL_HOME=<cbioportal_configuration_folder>
+```
 
 ## Workflow
 

--- a/docs/Data-Loading-Maintaining-Studies.md
+++ b/docs/Data-Loading-Maintaining-Studies.md
@@ -8,12 +8,13 @@ This script can also be used to delete studies.
 - [Deleting a study](#deleting-a-study)
 
 ## Requirements
-This script requires `$PORTAL_HOME` to point to your cBioPortal repository. This can be done with:
+This script requires `$PORTAL_HOME` to point to the folder containing your
+cBioPortal configuration. This can be done with:
 ```
-export PORTAL_HOME=<your_cbioportal_dir>
+export PORTAL_HOME=<cbioportal_configuration_folder>
 ```
 
-The script itself can be found in `$PORTAL_HOME/core/src/main/scripts/importer`.
+The script itself can be found in `<cbioportal_source_folder>/core/src/main/scripts/importer`.
 
 ## Importing a study without validation 
 To import a study without validation, run: 

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -12,11 +12,28 @@ To make it available to your bash shell, add the following to your `.bash_profil
 
 Note:  If you are following the [recommended Ubuntu instructions](https://www.digitalocean.com/community/tutorials/how-to-install-apache-tomcat-8-on-ubuntu-14-04):  you should set ```export CATALINA_HOME=/opt/tomcat```
 
+## Prepare the global configuration file
+
+The portal is configured using a global configuration file, `portal.properties`.
+An example file is available in the `src/main/resources` folder.
+Use it as a template to create your own:
+
+    cd src/main/resources
+    cp portal.properties.EXAMPLE $HOME/cbioportal/portal.properties
+
+For more information about the `portal.properties` file,
+see the [reference](portal.properties-Reference.md) page.
+
 ## Add PORTAL_HOME to Tomcat
 
-The `PORTAL_HOME` environment variable needs to be available to the `cbioportal.war` file which runs within the Tomcat server. To make it available to Tomcat, edit your Tomcat startup file (typically `$CATALINA_HOME/bin/catalina.sh`) and add the following line anywhere within this file (we typically add it near the `JAVA_OPTS` statements):
+The `PORTAL_HOME` environment variable needs to be available to
+the `cbioportal.war` file which runs within the Tomcat server,
+so that it can find the configuration file. To make it available to Tomcat,
+edit your Tomcat startup file (typically `$CATALINA_HOME/bin/setenv.sh`)
+and add a line like the following, pointing it to the folder containing
+`portal.properties`:
 
-    export PORTAL_HOME= $CATALINA_HOME + "/webapps/cbioportal/WEB-INF/classes/"
+    export PORTAL_HOME=/Users/johndoe/cbioportal
 
 ## Add the MySQL JDBC Driver to Apache Tomcat
 
@@ -70,7 +87,7 @@ Lastly, open a browser and go to:
 ## Important
 
 - Each time you modify any java code, you must recompile and redeploy the WAR file.
-- Each time you modify any properties (see customization options), you must recompile and redeploy the WAR file.
+- Each time you modify any properties (see customization options), you must restart tomcat.
 - Each time you add new data, you must restart tomcat.
 
 ## Developer Tip

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -54,8 +54,9 @@ or, if you are following the [recommended Ubuntu instructions](https://www.digit
 
 After the tomcat server has been started, to deploy the WAR file, run the following command:
 
-    sudo cp portal/target/cbioportal-*-SNAPSHOT.war $CATALINA_HOME/webapps/cbioportal.war
-    
+```
+sudo cp portal/target/cbioportal-*-SNAPSHOT.war $CATALINA_HOME/webapps/cbioportal.war
+```
 
 After doing this, you can look in the tomcat log file (`$CATALINA_HOME/logs/catalina.out`) to see if the portal has been proper deployed.  You should see something like:
 
@@ -64,8 +65,7 @@ After doing this, you can look in the tomcat log file (`$CATALINA_HOME/logs/cata
 ## Verify the Web Application
 
 Lastly, open a browser and go to:  
-
-[http://localhost:8080/cbioportal/](http://localhost:8080/cbioportal/)
+<http://localhost:8080/cbioportal/>
 
 ## Important
 
@@ -96,4 +96,4 @@ According to the stack overflow answer:
 
 The default JNDI settings above therefore include `testOnBorrow` and `validationQuery`, and you should therefore not see any broken pipe errors.  Should you see these errors, despite the settings, best to consult [here](http://juststuffreally.blogspot.com/2007/10/broken-pipes-with-tomcat-and-dbcp.html), and [here](http://stackoverflow.com/questions/20848219/tomcat-mysql-java-servlet-application-getting-500-error-after-some-hours-of-inac).
 
-[Steps Complete: Return Home](README.md)
+[Next Step: Loading a Sample Study](Load-Sample-Cancer-Study.md)

--- a/docs/Import-Gene-Panels.md
+++ b/docs/Import-Gene-Panels.md
@@ -4,14 +4,14 @@ This page describes how to import a gene panel into the cBioPortal database.  It
 
 1. The cBioPortal software has been correctly [built from source](Build-from-Source.md).
 2. The gene panel to import is in the proper file format.  See [File Format](File-Formats.md#gene-panel-data) for more information.
-3. The `PORTAL_HOME` environment variable has been properly defined.  See [Pre-Build-Steps](Pre-Build-Steps.md#set-the-portal-home-variable) for more information.
+3. The `PORTAL_HOME` environment variable has been properly defined.  See [Loading a Sample Study](Load-Sample-Cancer-Study.md#set-the-portal_home-environment-variable) for more information.
 
 #### Import command
 
 In this example, we are loading the example gene panel which resides in the sample dataset `study_es_0`.
 
 ```
-cd $PORTAL_HOME/core/src/main/scripts
+cd <cbioportal_source_folder>/core/src/main/scripts
 ./importGenePanel.pl --data ../../test/scripts/test_data/study_es_0/gene_panel_example.txt
 ```
 

--- a/docs/Import-Gene-Sets.md
+++ b/docs/Import-Gene-Sets.md
@@ -23,7 +23,7 @@ This example shows how the process of importing gene set data using test data.
 1. Navigate to scripts folder:
 
 ```
-cd $PORTAL_HOME/core/src/main/scripts
+cd <cbioportal_source_folder>/core/src/main/scripts
 ```
 
 2. Import gene sets and supplementary data:
@@ -90,7 +90,7 @@ E2F1_UP.V1_DN<TAB>E2F1 upregulated v1 down genes<TAB>Identification of E2F1-regu
 The importer for gene sets can be run with a perl wrapper, which is located at the following location and requires the following arguments:
 
 ```
-cd $PORTAL_HOME/core/src/main/scripts
+cd <cbioportal_source_folder>/core/src/main/scripts
 perl importGenesetData.pl
 
 required:     --data <data_file.gmt>
@@ -133,7 +133,7 @@ To make your own hierarchy, make sure every branchname ends with `:`. Every bran
 
 ### Running the gene set hierarchy importer
 ```
-cd $PORTAL_HOME/core/src/main/scripts
+cd <cbioportal_source_folder>/core/src/main/scripts
 perl importGenesetHierarchy.pl
 
 required:     --data <data_file.yaml>

--- a/docs/Import-the-Seed-Database.md
+++ b/docs/Import-the-Seed-Database.md
@@ -45,4 +45,4 @@ If the database is older than what cBioPortal is expecting, the system will ask 
 
 Due to data provider specific restrictions on data re-distribution, the database setup, as outlined above, will lack some of the drug-gene relationships from specific data-resources. If you would like to obtain the complete the data sets from these resources, we encourage you to take advantage of [PiHelper](http://bitbucket.org/armish/pihelper) for aggregating drug-target associations and use the corresponding data importer `importPiHelperData.sh` which is distributed as part of cBioPortal.
 
-[Next Step: Loading a Sample Study](Load-Sample-Cancer-Study.md)
+[Next Step: Deploying the Web Application](Deploying.md)

--- a/docs/Load-Sample-Cancer-Study.md
+++ b/docs/Load-Sample-Cancer-Study.md
@@ -58,4 +58,4 @@ Done.
 Total time:  7742 ms
 ```
 
-[Next Step: Deploying the Web Application](Deploying.md)
+[Steps Complete: Return Home](README.md)

--- a/docs/Load-Sample-Cancer-Study.md
+++ b/docs/Load-Sample-Cancer-Study.md
@@ -1,10 +1,27 @@
 # Loading a Sample Study
 
-Once you have initialized MySQL with the seed database, you are ready to import a sample cancer study. This is recommended to verify that everything is working correctly.
+Once you have confirmed that the cBioPortal server is installed,
+you are ready to import data. Importing a sample study is recommended
+to verify that everything is working correctly.
 
 The cBioPortal distribution includes a [small dummy study, `study_es_0`](https://github.com/cBioPortal/cbioportal/tree/master/core/src/test/scripts/test_data/study_es_0), which contains all datatypes supported by cBioPortal. This document describes how to import the prerequisites for the sample study and how to import the study itself.
 
-#### Import Gene Panel for Sample Study
+## Set the PORTAL_HOME environment variable
+
+Most cBioPortal command-line tools, including the data loading pipeline,
+expect the environment variable `$PORTAL_HOME` to point to a folder
+containing the `portal.properties` configuration file,
+as explained during [the previous step](Deployment.md).
+
+Configure your shell to keep the variable set to the right folder.
+On GNU/Linux and macOS this usually means appending a line
+like the following to `.bash_profile` in your home directory:
+
+```
+export PORTAL_HOME=/Users/johndoe/cbioportal
+```
+
+## Import Gene Panel for Sample Study
 
 The sample gene panel has to be imported before gene panel study data can be added to the database.
 
@@ -15,7 +32,7 @@ cd <your_cbioportal_dir>/core/src/main/scripts
 
 More details to load your own gene panel and gene set data can be found here: [Import Gene Panels](Import-Gene-Panels.md).
 
-#### Validating the Sample Study
+## Validating the Sample Study
 
 First it's useful to validate the study `study_es_0`, to check if the data is formatted correctly.
 
@@ -37,7 +54,7 @@ If all goes well, you should see the final output message:
 Validation of study succeeded with warnings.
 ```
 
-#### Importing the Sample Study
+## Importing the Sample Study
 
 To import the sample study:
 

--- a/docs/Pre-Build-Steps.md
+++ b/docs/Pre-Build-Steps.md
@@ -7,19 +7,15 @@ Make sure that you have cloned the last code, and make sure you are on the ```ma
 	git clone https://github.com/cBioPortal/cbioportal.git
 	git checkout master
 
-## Prepare Property Files
-
-The portal requires two properties files:  one for global configuration (`portal.properties`) and one for logging (`log4j.properties`).  Example files are available within GitHub, but you must take the following steps to prepare them.
-
-    cd src/main/resources
-    cp portal.properties.EXAMPLE portal.properties
-    cp log4j.properties.EXAMPLE log4j.properties
-
-For more information about the `portal.properties` file, see the following [reference](portal.properties-Reference.md) page.
-
 ## Prepare the log4j.properties File
 
-Update the following lines with paths that make sense for your local system.
+This file configures logging for the portal.
+An example file is available within GitHub:
+
+    cd src/main/resources
+    cp log4j.properties.EXAMPLE log4j.properties
+
+But you must update the following lines with paths that make sense for the systems your build should target.
 
     log4j.appender.a.rollingPolicy.FileNamePattern = ${catalina.base}/logs/public-portal.log.%d.gz
     log4j.appender.a.File = ${catalina.base}/logs/public-portal.log
@@ -72,14 +68,5 @@ A sample file is shown below:
         </server>
       </servers>
     </settings>
-
-## Set the PORTAL_HOME Variable
-
-Prior to building, you must specify an environment variable for `PORTAL_HOME`.  This must point to the root directory containing the portal source code.
-
-For example, add the following to your `.bash_profile`:
-
-    export PORTAL_HOME=/Users/ecerami/dev/cbioportal
-
 
 [Next Step: Building From Source](Build-from-Source.md)

--- a/docs/Updating-gene-and-gene_alias-tables.md
+++ b/docs/Updating-gene-and-gene_alias-tables.md
@@ -43,9 +43,9 @@ ALTER TABLE `geneset` AUTO_INCREMENT = 1;
 
 After downloading, go to your downloads directory, decompress the file and add it as an argument (--gtf) in the next step.
 
-6- To import gene data type the following commands when in the folder `<your_cbioportal_dir>/core/src/main/scripts`:
+6- To import gene data type the following commands when in the folder `<cbioportal_source_folder>/core/src/main/scripts`:
 ```
- export PORTAL_HOME=<your_cbioportal_dir>
+export PORTAL_HOME=<cbioportal_configuration_folder>
 ./importGenes.pl --genes <ncbi_species.gene_info> --gtf <gencode.v25.annotation.gtf>
 ```
 
@@ -84,7 +84,7 @@ ALTER TABLE uniprot_id_mapping
 
 11- You can import new gene sets using the gene set importer. These gene sets are currently only used for gene set scoring. See [Import-Gene-Sets.md](Import-Gene-Sets.md) and [File-Formats.md#gene-set-data].
 
-For example, run in folder `<your_cbioportal_dir>/core/src/main/scripts`:
+For example, run in folder `<cbioportal_source_folder>/core/src/main/scripts`:
 ```bash
 ./importGenesetData.pl --data ~/Desktop/msigdb.v6.1.entrez.gmt --new-version msigdb_6.1
 ```

--- a/docs/Using-the-dataset-validator.md
+++ b/docs/Using-the-dataset-validator.md
@@ -11,7 +11,7 @@ To facilitate the loading of new studies into its database, cBioPortal [provides
 ## Running the validator
 
 To run the validator first go to the importer folder
-`<your_cbioportal_dir>/core/src/main/scripts/importer` 
+`<cbioportal_source_folder>/core/src/main/scripts/importer`
 and then run the following command:
 ```bash
 ./validateData.py --help
@@ -70,7 +70,7 @@ When running the validator with parameter `-m` the validator will run the valida
 when the validator encounters these validation checks it will report them as an error instead of a warning.
 
 ### Example 1: test study_es_0
-As an example, you can try the validator with one of the test studies found in  `<your_cbioportal_dir>/core/src/test/scripts/test_data`. Example, assuming port 8080 and using -v option to also see the progress:
+As an example, you can try the validator with one of the test studies found in  `<cbioportal_source_folder>/core/src/test/scripts/test_data`. Example, assuming port 8080 and using -v option to also see the progress:
 ```bash
 ./validateData.py -s ../../../test/scripts/test_data/study_es_0/ -u http://localhost:8080/cbioportal -v
 ```
@@ -172,7 +172,7 @@ When using the `-html` option, a report will be generated, which looks like this
 ![Screenshot of a successful validation report](images/scripts/report.png)
 
 ### Example 2: test study_es_1
-More test studies for trying the validator (`study_es_1` and `study_es_3`) are available in  `<your_cbioportal_dir>/core/src/test/scripts/test_data`. Example, assuming port 8080 and using -v option:
+More test studies for trying the validator (`study_es_1` and `study_es_3`) are available in  `<cbioportal_source_folder>/core/src/test/scripts/test_data`. Example, assuming port 8080 and using -v option:
 ```bash
 ./validateData.py -s ../../../test/scripts/test_data/study_es_1/ -u http://localhost:8080/cbioportal -v
 ```
@@ -316,10 +316,10 @@ Validation of study succeeded.
 ```
 
 ### Example 4: generating the portal info folder ###
-The portal information files can be generated on the server, using the dumpPortalInfo script. Go to `<your cbioportal dir>/core/src/main/scripts`, make sure the environment variables `$JAVA_HOME` and `$PORTAL_HOME` are set, and run dumpPortalInfo.pl with the name of the directory you want to create:
+The portal information files can be generated on the server, using the dumpPortalInfo script. Go to `<cbioportal_source_folder>/core/src/main/scripts`, make sure the environment variables `$JAVA_HOME` and `$PORTAL_HOME` are set, and run dumpPortalInfo.pl with the name of the directory you want to create:
 ```bash
 export JAVA_HOME='/usr/lib/jvm/default-java'
-export PORTAL_HOME='../../../..'
+export PORTAL_HOME=<cbioportal_configuration_folder>
 ./dumpPortalInfo.pl /home/johndoe/my_portal_info_folder/
 ```
 
@@ -443,7 +443,7 @@ As an example, the command for the "Example 1" listed above incorporating the `-
 ```
 
 ## Running the validator for multiple studies
-The importer folder `<your_cbioportal_dir>/core/src/main/scripts/importer` also contains a script for running the validator for multiple studies:
+The importer folder `<cbioportal_source_folder>/core/src/main/scripts/importer` also contains a script for running the validator for multiple studies:
 ```bash
 ./validateStudies.py --help
 ```

--- a/docs/Using-the-metaImport-script.md
+++ b/docs/Using-the-metaImport-script.md
@@ -8,12 +8,13 @@ and then run the following command:
 ```
 ./metaImport.py -h
 ```
-This will tell you the parameters you can use: 
+This will tell you the parameters you can use:
 ```
-./metaImport.py -h
+$ ./metaImport.py -h
 usage: metaImport.py [-h] -s STUDY_DIRECTORY
-                     [-u URL_SERVER | -p PORTAL_INFO_DIR] -jar JAR_PATH
-                     [-html HTML_TABLE] [-v] [-o]
+                     [-u URL_SERVER | -p PORTAL_INFO_DIR | -n]
+                     [-P PORTAL_PROPERTIES] [-jar JAR_PATH] [-html HTML_TABLE]
+                     [-v] [-o] [-r] [-m] [-a MAX_REPORTED_VALUES]
 
 cBioPortal meta Importer
 
@@ -27,28 +28,36 @@ optional arguments:
   -p PORTAL_INFO_DIR, --portal_info_dir PORTAL_INFO_DIR
                         Path to a directory of cBioPortal info files to be
                         used instead of contacting the web API
+  -n, --no_portal_checks
+                        Skip tests requiring information from the cBioPortal
+                        installation
   -P PORTAL_PROPERTIES, --portal_properties PORTAL_PROPERTIES
                         portal.properties file path (default: assumed hg19)
   -jar JAR_PATH, --jar_path JAR_PATH
-                        path to core jar file. You can set PORTAL_HOME variable instead.
+                        Path to scripts JAR file (default: locate it relative
+                        to the import script)
   -html HTML_TABLE, --html_table HTML_TABLE
                         path to html report
   -v, --verbose         report status info messages while validating
   -o, --override_warning
                         override warnings and continue importing
-  -r, --relaxed-clinical_definitions
-                        Option to enable relaxed mode for validator when validating
-                        clinical data without header definitions
   -m, --strict_maf_checks
-                        Option to enable strict mode for validator when validating
-                        mutation data
+                        Option to enable strict mode for validator when
+                        validating mutation data
+  -a MAX_REPORTED_VALUES, --max_reported_values MAX_REPORTED_VALUES
+                        Cutoff in report for the maximum number of line
+                        numbers and values encountered to report for each
+                        message in the HTML report. For example, set this to a
+                        high number to report all genes that could not be
+                        loaded, instead of reporting "(GeneA, GeneB, GeneC,
+                        213 more)".
 ```
 
 #### Example of Importing a study
-Export PORTAL_HOME, e.g.
+Export `PORTAL_HOME` as explained [here](Load-Sample-Cancer-Study.md), e.g.
 
 ```
-export PORTAL_HOME=<your_cbioportal_home_dir>
+export PORTAL_HOME=<cbioportal_configuration_folder>
 ```
 
 and then run (this simple command only works if your cBioPortal is running at http://localhost/cbioportal - if this is not the case, follow the advanced example):

--- a/docs/Z-Score-normalization-script.md
+++ b/docs/Z-Score-normalization-script.md
@@ -77,10 +77,10 @@ Note: this implies that your full dataset does not have average=0, std=1
 ## Running the script
 
 
-To run the script type the following commands when in the folder `<your_cbioportal_dir>/core/src/main/scripts`: 
+To run the script type the following commands when in the folder `<cbioportal_source_folder>/core/src/main/scripts`:
 
 ```
- export PORTAL_HOME=<your_cbioportal_dir>
+export PORTAL_HOME=<cbioportal_configuration_folder>
 ```
 
 and then 

--- a/heroku/Procfile
+++ b/heroku/Procfile
@@ -1,1 +1,1 @@
-web: java $JAVA_OPTS -Dfrontend.url=$FRONTEND_URL -Dshow.civic=true -Ddb.suppress_schema_version_mismatch_errors=true -Dsession.service.url=https://cbioportal-session-service.herokuapp.com/api/sessions/heroku_portal/ -Ddbconnector=dbcp -jar portal/target/dependency/webapp-runner.jar --enable-compression --expand-war --port $PORT portal/target/cbioportal.war
+web: java $JAVA_OPTS $SPRING_OPTS -jar portal/target/dependency/webapp-runner.jar --enable-compression --expand-war --port $PORT portal/target/cbioportal.war

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -131,7 +131,8 @@
             <resource>
               <directory>${project.parent.basedir}/business/src/main/resources</directory>
               <targetPath>WEB-INF/classes</targetPath>
-              <filtering>true</filtering>
+              <!-- do not hard-set portal.properties config at build-time -->
+              <filtering>false</filtering>
             </resource>
             <resource>
               <directory>${project.parent.basedir}/web/src/main/resources</directory>

--- a/test/end-to-end/docker-compose.yml
+++ b/test/end-to-end/docker-compose.yml
@@ -6,7 +6,7 @@ cbioportal:
     - $PWD/../../:/cbioportal
   command: java -Ddbconnector=dbcp -jar portal/target/dependency/webapp-runner.jar --expand-war portal/target/cbioportal.war
   environment:
-    PORTAL_HOME: /cbioportal
+    PORTAL_HOME: /cbioportal/test/end-to-end/runtime-config
   working_dir: /cbioportal
 hub:
   image: selenium/hub:2.53.0

--- a/test/end-to-end/runtime-config/portal.properties
+++ b/test/end-to-end/runtime-config/portal.properties
@@ -1,0 +1,5 @@
+db.user=cbio_user
+db.password=cbio_pass
+db.portal_db_name=public_test
+db.connection_string=jdbc:mysql://devdb.cbioportal.org:3306/
+db.host=devdb.cbioportal.org


### PR DESCRIPTION
Allow changing the configuration from portal.properties, including the database credentials, by pointing `$PORTAL_HOME` at a folder containing a `portal.properties` config file when running from any entrypoint (including command-line tools/scripts). This should greatly simplify and clarify deployment.

This approach should retain compatibility with existing deployments, by using the existing `$PORTAL_HOME` variable. If no `$PORTAL_HOME/portal.properties` file exists, it still falls back to the compiled-in defaults from `<cbioportal_source_folder>/src/main/resources/` and `GlobalProperties.java`.

Caveat: the web server still requires database credentials to be duplicated in the Tomcat resource.

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [x] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.