### PR TITLE
Authenticates any request with an authorization bearer header 

### DIFF
--- a/model/src/main/java/org/cbioportal/model/DataAccessToken.java
+++ b/model/src/main/java/org/cbioportal/model/DataAccessToken.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.model;
+
+import java.io.Serializable;
+import java.util.Date;
+import javax.validation.constraints.NotNull;
+
+public class DataAccessToken implements Serializable {
+
+    @NotNull
+    private String userId;
+    private Date expiresAt;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public Date getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Date expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+}

--- a/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/token/TokenAuthenticationFilter.java
+++ b/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/token/TokenAuthenticationFilter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.security.spring.authentication.token;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+
+/**
+ *
+ * @author Manda Wilson
+ */
+public class TokenAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    private static final String BEARER = "Bearer";
+
+    private static final Log log = LogFactory.getLog(TokenAuthenticationFilter.class);
+
+    public TokenAuthenticationFilter() {
+        // allow any request to contain an authorization header
+        super("/**");
+    }
+
+    @Override
+    protected boolean requiresAuthentication(HttpServletRequest request, HttpServletResponse response) {
+        // only required if we do see an authorization header
+        String param = request.getHeader(AUTHORIZATION);
+        if (param == null) {
+            log.debug("attemptAuthentication(), authorization header is null, continue on to other security filters");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public Authentication attemptAuthentication (
+        final HttpServletRequest request,
+        final HttpServletResponse response) {
+
+        String param = request.getHeader(AUTHORIZATION);
+
+        log.debug("attemptAuthentication(), header - " + param);
+
+        // TODO strip out token
+        //String token = param;
+        //Authentication auth = new UsernamePasswordAuthenticationToken(token, token);
+
+        // when DaoAuthenticationProvider does authentication on user returned by PortalUserDetailsService
+        // which has password "unused", this password won't match, and then there is a BadCredentials exception thrown
+        // this is a good way to catch that the wrong authetication provider is being used
+        Authentication auth = new UsernamePasswordAuthenticationToken("fakeuser@mskcc.org", "does not match unused");
+        return getAuthenticationManager().authenticate(auth);
+    }
+
+    @Override
+    protected void successfulAuthentication (
+        final HttpServletRequest request,
+        final HttpServletResponse response,
+        final FilterChain chain,
+        final Authentication authResult) throws IOException, ServletException {
+        super.successfulAuthentication(request, response, chain, authResult);
+        chain.doFilter(request, response);
+    }
+}

--- a/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/token/TokenAuthenticationSuccessHandler.java
+++ b/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/token/TokenAuthenticationSuccessHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.security.spring.authentication.token;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+public class TokenAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        // We do not need to do anything extra on REST authentication success, because there is no page to redirect to
+    }
+
+}

--- a/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/token/TokenUserDetailsAuthenticationProvider.java
+++ b/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/token/TokenUserDetailsAuthenticationProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.security.spring.authentication.token;
+
+import java.util.ArrayList;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.cbioportal.security.spring.authentication.googleplus.PortalUserDetailsService;
+
+import org.springframework.security.authentication.dao.AbstractUserDetailsAuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ *
+ * @author Manda Wilson
+ */
+public class TokenUserDetailsAuthenticationProvider extends AbstractUserDetailsAuthenticationProvider {
+
+    private PortalUserDetailsService userDetailsService;
+
+    public TokenUserDetailsAuthenticationProvider(PortalUserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
+
+    private static final Log log = LogFactory.getLog(TokenUserDetailsAuthenticationProvider.class);
+
+    @Override
+    protected void additionalAuthenticationChecks(UserDetails userDetails, UsernamePasswordAuthenticationToken authentication) 
+        throws AuthenticationException {
+        // TODO?
+    }
+
+    @Override
+    protected UserDetails retrieveUser(String username, UsernamePasswordAuthenticationToken authentication) 
+        throws AuthenticationException {
+        log.debug("retrieveUser(), username - " + username);
+        return this.userDetailsService.loadUserByUsername(username); 
+    }
+
+}

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -53,14 +53,38 @@
     <http pattern="/reactapp/**" security="none"/>
     <http pattern="/api/swagger-resources/**" security="none"/>
     <http pattern="/api/swagger-ui.html" security="none"/>
-        
+
     <!-- This must come before the default entry point which will capture everything not matched by pattern -->
     <http use-expressions="true" pattern="/api/**" entry-point-ref="restAuthenticationEntryPoint" create-session="never">
         <intercept-url pattern="/**" access="isAuthenticated()"/>
         <csrf disabled="true"/>
+        <custom-filter ref="tokenAuthenticationFilter" before="FORM_LOGIN_FILTER"/>
     </http>
 
     <b:bean id="restAuthenticationEntryPoint" class="org.cbioportal.security.spring.sessionservice.RestAuthenticationEntryPoint"/>
+
+    <b:bean id="tokenAuthenticationFilter" class="org.cbioportal.security.spring.authentication.token.TokenAuthenticationFilter">
+        <b:property name="authenticationManager" ref="tokenAuthenticationManager" />
+        <b:property name="authenticationSuccessHandler" ref="tokenSuccessRedirectHandler"/>
+    </b:bean>
+
+    <!-- WARNING: if you define another authentication-manager AFTER this one, this one
+        will be overridden, even if you use <http ... pattern="/api/**" ... authentication-manager-ref="tokenAuthenticationManager">
+        AND even though the authenticationManager is defined as a property of tokenAuthenticationFilter
+        so you must add <authentication-provider ref="tokenUserDetailsAuthenticationProvider"/> to your
+        other authentication-manager, and tokenUserDetailsAuthenticationProvider should come before other authentication-providers -->
+    <authentication-manager alias="tokenAuthenticationManager">
+        <authentication-provider ref="tokenUserDetailsAuthenticationProvider"/>
+    </authentication-manager>
+
+    <b:bean id="tokenSuccessRedirectHandler" class="org.cbioportal.security.spring.authentication.token.TokenAuthenticationSuccessHandler"/>
+
+    <b:bean id="tokenUserDetailsAuthenticationProvider" class="org.cbioportal.security.spring.authentication.token.TokenUserDetailsAuthenticationProvider">
+        <b:constructor-arg index="0" ref="tokenUserDetailsService" />
+    </b:bean>
+
+    <!-- Used to compare token returned by authentication-provider against portal user db tables -->
+    <b:bean id="tokenUserDetailsService" class="org.cbioportal.security.spring.authentication.googleplus.PortalUserDetailsService"/>
 
     <!-- Handler deciding where to redirect user after successful login -->
     <b:bean id="successRedirectHandler" class="org.cbioportal.security.spring.PortalSavedRequestAwareAuthenticationSuccessHandler">
@@ -75,7 +99,7 @@
     <!-- googleplus beans -->
     <b:beans profile="googleplus">
 
-    <http entry-point-ref="authenticationEntryPoint" use-expressions="true"> 
+    <http entry-point-ref="authenticationEntryPoint" use-expressions="true">
         <intercept-url pattern="/auth/*" access="permitAll"/>
         <intercept-url pattern="/favicon.ico" access="permitAll"/>
         <intercept-url pattern="/login.jsp*" access="permitAll"/>
@@ -83,7 +107,7 @@
         <intercept-url pattern="/webservice.do*" access="isAuthenticated() or hasIpAddress('127.0.0.1')"/>
         <intercept-url pattern="/**" access="isAuthenticated()"/>
         <!-- used for google+ authentication (spring social) -->
-        <custom-filter ref="socialAuthenticationFilter" before="PRE_AUTH_FILTER" />
+        <custom-filter ref="socialAuthenticationFilter" before="PRE_AUTH_FILTER"/>
 
         <!--  logout actions -->      
         <logout logout-url="/j_spring_security_logout" logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID"/>
@@ -110,12 +134,14 @@
         <b:property name="allowSessionCreation" value="true" />
     </b:bean>
 
+    <!-- You can use multiple authentication-provider elements, in which case they will be
+         checked in the order they are declared when attempting to authenticate a user. -->
     <authentication-manager alias="authenticationManager">
-        <authentication-provider user-service-ref="userDetailsService">
-        </authentication-provider>
+        <!-- token access for the API -->
+        <authentication-provider ref="tokenUserDetailsAuthenticationProvider"/>
         <authentication-provider ref="socialAuthenticationProvider"/>
     </authentication-manager>
-    
+
     <!-- beans used to compare token returned by authentication-provider against portal user db tables -->
     <b:bean id="userDetailsService" class="org.cbioportal.security.spring.authentication.googleplus.PortalUserDetailsService">
     </b:bean>
@@ -125,7 +151,7 @@
         <b:constructor-arg index="0" ref="usersConnectionRepository" />
         <b:constructor-arg index="1" ref="socialUserDetailsService" />
     </b:bean>
-    
+
     <b:bean id="socialUserDetailsService" class="org.cbioportal.security.spring.authentication.googleplus.GoogleplusUserDetailsService">
         <b:constructor-arg index="0" ref="userDetailsService" />
     </b:bean>
@@ -134,7 +160,7 @@
     <!--Implementation of UserIdSource that returns the Spring Security Authentication's name as the user ID -->
     <b:bean id="userIdSource" class="org.springframework.social.security.AuthenticationNameUserIdSource"/>
 
-    <b:bean id="usersConnectionRepository" 
+    <b:bean id="usersConnectionRepository"
             class="org.springframework.social.connect.mem.InMemoryUsersConnectionRepository">
         <b:constructor-arg ref="connectionFactoryLocator" />
         <b:property name="connectionSignUp" ref="connectionSignUp"/>
@@ -157,14 +183,14 @@
         <b:constructor-arg value="${googleplus.consumer.key}" />
         <b:constructor-arg value="${googleplus.consumer.secret}" />
     </b:bean>
-   
+ 
     <!-- end googleplus beans -->
     </b:beans>
 
     <!-- openid beans -->
     <b:beans profile="openid">
 
-    <http use-expressions="true"> 
+    <http use-expressions="true">
 
         <openid-login login-page="/login.jsp" default-target-url="/index.do" user-service-ref="customUserService" authentication-failure-url="/login.jsp?login_error=true">
             <attribute-exchange identifier-match="https://www.google.com/.*">
@@ -189,7 +215,10 @@
         <csrf disabled="true"/>
     </http>
 
-    <authentication-manager alias="authenticationManager"/>
+    <authentication-manager alias="authenticationManager">
+        <!-- token access for the API -->
+        <authentication-provider ref="tokenUserDetailsAuthenticationProvider"/>
+    </authentication-manager>
 
     <b:bean id="customUserService" class="org.cbioportal.security.spring.authentication.openID.PortalUserDetailsService">
     </b:bean>
@@ -228,7 +257,6 @@
         </filter-chain-map>
     </b:bean>
 
-
     <!-- Handler deciding where to redirect user after failed login -->
     <b:bean id="failureRedirectHandler" class="org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler">
         <!--<b:property name="useForward" value="true"/>-->
@@ -241,6 +269,8 @@
     </b:bean>
 
     <authentication-manager alias="authenticationManager">
+        <!-- token access for the API -->
+        <authentication-provider ref="tokenUserDetailsAuthenticationProvider"/>
         <authentication-provider ref="samlAuthenticationProvider"/>
     </authentication-manager>
 
@@ -266,7 +296,7 @@
     <b:bean id="defaultBinding" class="org.springframework.security.saml.websso.WebSSOProfileOptions">
 	<b:property name="includeScoping" value="false"/>
     </b:bean>
-    
+
     <b:bean id="specificBinding" class="org.springframework.security.saml.websso.WebSSOProfileOptions">
 	<b:property name="includeScoping" value="false"/>
 	<b:property name="binding" value="urn:oasis:names:tc:SAML:2.0:${saml.idp.comm.binding.type}"/>
@@ -458,7 +488,7 @@
     <b:beans profile="ad">
         <http use-expressions="true" auto-config="true">
             <form-login login-page="/login.jsp"
-                login-processing-url="/j_spring_security_check" 
+                login-processing-url="/j_spring_security_check"
                 default-target-url="/index.do"
                 authentication-success-handler-ref="successRedirectHandler" />
             <logout logout-url="/j_spring_security_logout" logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID" />
@@ -475,6 +505,8 @@
 
         <!-- Add Authentication Manager -->
         <authentication-manager>
+            <!-- token access for the API -->
+            <authentication-provider ref="tokenUserDetailsAuthenticationProvider"/>
             <authentication-provider ref="adAuthenticationProvider" />
         </authentication-manager>
 
@@ -521,6 +553,8 @@
         </b:bean>
 
         <authentication-manager>
+            <!-- token access for the API -->
+            <authentication-provider ref="tokenUserDetailsAuthenticationProvider"/>
             <ldap-authentication-provider
                 server-ref="ldapServer" user-search-filter="(${ldap.attributes.username}={0})"
                 user-search-base="${ldap.user_search_base}"
@@ -530,7 +564,7 @@
         <!-- end ldap beans -->
     </b:beans>
 
-    <!-- authenticate is off beans --> 
+    <!-- authenticate is off beans -->
     <b:beans profile="false">
         <global-method-security pre-post-annotations="disabled"/>
         <http pattern="/**" security="none"/>
@@ -539,6 +573,7 @@
     <!-- authenticate is off but we have session-service beans -->
     <b:beans profile="noauthsessionservice">
         <global-method-security pre-post-annotations="disabled"/>
+        <b:bean id="restAuthenticationEntryPoint" class="org.cbioportal.security.spring.sessionservice.RestAuthenticationEntryPoint"/>
         <b:bean id="sessionSecurity" class="org.cbioportal.security.spring.sessionservice.SessionServiceSecurity"/>
         <!-- create-session is never so spring security will not create the session,
             this relies on the app creating the session -->
@@ -549,7 +584,7 @@
         </http>
         <authentication-manager alias="authenticationManager"/>
     </b:beans>
-    
+
     <b:beans profile="social_auth">
 
 	    <b:bean id="propertyPlaceholderConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
@@ -564,12 +599,12 @@
 	            </b:list>
 	        </b:property>
 	    </b:bean>
-	    
+
 	    <global-method-security pre-post-annotations="disabled"/>
 	
 	    <!-- support for general annotations within class definitions (used in AccessControl) -->
 	    <context:annotation-config/>
-	        
+
 	    <!-- Handler deciding where to redirect user after successful login -->
 	    <b:bean id="successRedirectHandler" class="org.cbioportal.security.spring.PortalSavedRequestAwareAuthenticationSuccessHandler">
 	        <b:property name="defaultTargetUrl" value="/index.do"/>
@@ -577,17 +612,17 @@
 	        <b:property name="targetUrlParameter" value="spring-security-redirect"/>
 	    </b:bean>
 	
-	
 	    <http entry-point-ref="authenticationEntryPoint"  use-expressions="true">
 	        <intercept-url pattern="/**" access="permitAll"/>
 	        <custom-filter ref="socialAuthenticationFilter" before="PRE_AUTH_FILTER" />
-	            <!--  logout actions -->      
+
+	        <!--  logout actions -->      
 	        <logout logout-url="/j_spring_security_logout" logout-success-url="/" delete-cookies="JSESSIONID"/>
 	        <!-- to enable access from matlab, r, python, etc clients -->
 	        <session-management session-fixation-protection="none"/>
             <csrf disabled="true"/>
 	        </http>
-	        
+
 	        <b:bean id="authenticationEntryPoint" class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
 	            <b:constructor-arg value="/index.do" />
 	        </b:bean>
@@ -607,22 +642,24 @@
 	    </b:bean>
 	
 	    <authentication-manager alias="authenticationManager">
+            <!-- token access for the API -->
+            <authentication-provider ref="tokenUserDetailsAuthenticationProvider"/>
 	        <authentication-provider ref="socialAuthenticationProvider"/>
 	    </authentication-manager>
-	    
+
 	     <!-- configure the social authentication provider which processes authentication requests -->
 	    <b:bean id="socialAuthenticationProvider" class="org.springframework.social.security.SocialAuthenticationProvider">
 	        <b:constructor-arg index="0" ref="usersConnectionRepository" />
 	        <b:constructor-arg index="1" ref="socialUserDetailsService" />
 	    </b:bean>
-	    
+
 	    <b:bean id="socialUserDetailsService" class="org.cbioportal.security.spring.authentication.googleplus.CustomUserDetailsService" />
 	
 	    <!-- returns the spring security account id for the user -->
 	    <!--Implementation of UserIdSource that returns the Spring Security Authentication's name as the user ID -->
 	    <b:bean id="userIdSource" class="org.springframework.social.security.AuthenticationNameUserIdSource"/>
 	
-	    <b:bean id="usersConnectionRepository" 
+	    <b:bean id="usersConnectionRepository"
 	            class="org.springframework.social.connect.mem.InMemoryUsersConnectionRepository">
 	        <b:constructor-arg ref="connectionFactoryLocator" />
 	        <b:property name="connectionSignUp" ref="connectionSignUp"/>
@@ -645,7 +682,7 @@
 	        <b:constructor-arg value="${googleplus.consumer.key}" />
 	        <b:constructor-arg value="${googleplus.consumer.secret}" />
 	    </b:bean>
-	   
+
 	    <!-- end googleplus beans -->
 	</b:beans>
 

--- a/service/src/main/java/org/cbioportal/service/DataAccessTokenService.java
+++ b/service/src/main/java/org/cbioportal/service/DataAccessTokenService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.service;
+
+import java.util.*;
+import org.cbioportal.model.DataAccessToken;
+
+public interface DataAccessTokenService {
+
+    public String getDataAccessToken(String username);
+    public List<String> getAllDataAccessTokens(String username);
+    public void revokeAllDataAccessTokens(String username);
+
+    /** tests token validity
+     *  token is valid if not yet expired and not revoked and can be verfied as issued through this service via signature
+     */
+    public Boolean isValid(String dataAccessToken);
+
+}

--- a/service/src/main/java/org/cbioportal/service/impl/DataAccessTokenServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/DataAccessTokenServiceImpl.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.service.impl;
+
+import java.util.*;
+import org.cbioportal.model.DataAccessToken;
+//import org.cbioportal.persistence.DataAccessTokenRepository; // Maybe this is a different package? we do not plan to persist in database .. so need to configure another bean maybe
+import org.cbioportal.service.DataAccessTokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DataAccessTokenServiceImpl implements DataAccessTokenService {
+
+//    @Autowired
+//    private DataAccessTokenRepository dataAccessTokenRepository;
+
+    public final String VALID_DATA_ACCESS_TOKEN_USER1 = "d12b5d23-72ce-4c9d-a0d3-04297b7b8811";
+    public final String VALID_DATA_ACCESS_TOKEN_USER2 = "8ff83cb6-d691-4c24-b974-18f627c2c979";
+    public final String VALID_DATA_ACCESS_TOKEN_NEW = "6716ef71-fbbc-4a6a-b1c7-c02b7cb67e48";
+    public final String UNKNOWN_DATA_ACCESS_TOKEN = "7d2c2fa7-f949-4a38-b8dc-9ab2a6b1a488";
+    public final String EXPIRED_DATA_ACCESS_TOKEN = "ad70d755-41d1-42c5-a9d0-28961aa72326";
+    public final String REVOKED_DATA_ACCESS_TOKEN = "9cbdd669-fc9a-458d-8202-e8641db06b71";
+
+    private Set<String> usersWhoRevoked = new HashSet<>();
+
+
+    @Override
+    public String getDataAccessToken(String username) {
+    // old args: (String username, Boolean allowNewlyGeneratedToken, Boolean allowRevocationOfOtherTokens, Long minimumTimeBeforeExpiration) {
+        if ("user1".equals(username)) {
+            return VALID_DATA_ACCESS_TOKEN_USER1;
+        }
+        if ("user2".equals(username)) {
+            return VALID_DATA_ACCESS_TOKEN_USER2;
+        }
+        // no need to check if user is "valid" ... a valid session means a valid user ... some users are not in the users table
+        return VALID_DATA_ACCESS_TOKEN_NEW;
+    }
+
+    @Override
+    public List<String> getAllDataAccessTokens(String username) {
+        List<String> tokenList = new ArrayList<>();
+        tokenList.add(getDataAccessToken(username));
+        return tokenList;
+    }
+
+    @Override
+    public void revokeAllDataAccessTokens(String username) {
+        usersWhoRevoked.add(username); 
+    }
+
+    @Override
+    public Boolean isValid(String dataAccessToken) {
+        if (!isAuthenticAndUnrevoked(dataAccessToken)) {
+            return Boolean.FALSE;
+        }
+        if (hasExpired(dataAccessToken)) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    private boolean isAuthenticAndUnrevoked(String dataAccessToken) {
+        if (UNKNOWN_DATA_ACCESS_TOKEN.equals(dataAccessToken)) {
+            return false;
+        }
+        if (REVOKED_DATA_ACCESS_TOKEN.equals(dataAccessToken)) {
+            return false;
+        }
+        if (VALID_DATA_ACCESS_TOKEN_USER1.equals(dataAccessToken)) {
+            return !usersWhoRevoked.contains("user1");
+        }
+        if (VALID_DATA_ACCESS_TOKEN_USER2.equals(dataAccessToken)) {
+            return !usersWhoRevoked.contains("user2");
+        }
+        if (REVOKED_DATA_ACCESS_TOKEN.equals(dataAccessToken)) {
+            Set<String> otherUsers = new HashSet<>(usersWhoRevoked);
+            otherUsers.remove("user1");
+            otherUsers.remove("user2");
+            return otherUsers.isEmpty();
+        }
+        return true; // replace with a call to the repository layer (and maybe a crytographic check)
+    }
+
+    private boolean hasExpired(String dataAccessToken) {
+        if (EXPIRED_DATA_ACCESS_TOKEN.equals(dataAccessToken)) {
+            return true;
+        }
+        return false;
+        //Date now = new Date();
+        //return now.before(dataAccessToken.getExpiresAt());
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/weblegacy/DataAccessTokenController.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/DataAccessTokenController.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.weblegacy;
+
+import java.util.*;
+import org.cbioportal.model.DataAccessToken;
+import org.cbioportal.service.DataAccessTokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpClientErrorException;
+
+@RestController
+public class DataAccessTokenController {
+
+    @Autowired
+    private DataAccessTokenService dataAccessTokenService;
+
+//      TODO: figure out how to read this from the properties file
+//    @Value("${security.data_tokens.unauth_users}")
+//    private String[] USERS_WHO_CANNOT_USE_TOKENS = {"anonymousUser", "servcbioportal";
+    private String[] USERS_WHO_CANNOT_USE_TOKENS = {"anonymousUser", "servcbioportal"};
+    private Set<String> usersWhoCannotUseTokenSet = null;
+
+    @Autowired
+    private void initializeUsersWhoCannotUseTokenSet() {
+        usersWhoCannotUseTokenSet = new HashSet<>(Arrays.asList(USERS_WHO_CANNOT_USE_TOKENS));
+    }
+
+    @RequestMapping(method = RequestMethod.GET, value = "/dataAccessToken")
+    public String getDataAccessToken(Authentication authentication,
+                                    @RequestParam(required = false) Boolean allowNewlyGeneratedToken,
+                                    @RequestParam(required = false) Boolean allowRevocationOfOtherTokens,
+                                    @RequestParam(required = false) Long minimumTimeBeforeExpiration) {
+        return dataAccessTokenService.getDataAccessToken(getAuthenticatedUser(authentication));
+    }
+
+    @RequestMapping(method = RequestMethod.GET, value = "/dataAccessToken/all")
+    public List<String> getDataAccessTokenAll(Authentication authentication) {
+        return dataAccessTokenService.getAllDataAccessTokens(getAuthenticatedUser(authentication));
+    }
+
+    @RequestMapping(method = RequestMethod.GET, value = "/dataAccessToken/revokeAll")
+    public void getDataAccessTokenRevokeAll(Authentication authentication) {
+        dataAccessTokenService.revokeAllDataAccessTokens(getAuthenticatedUser(authentication));
+    }
+
+    private String getAuthenticatedUser(Authentication authentication) {
+        if (authentication == null) {
+            //TODO: this gets converted into a server error (when the exception propagates up to the the REST response generation) .. so figure out how to actually with 401 status
+            throw new HttpClientErrorException(HttpStatus.UNAUTHORIZED, "user authentication not available");
+        }
+        if (!authentication.isAuthenticated()) {
+            throw new HttpClientErrorException(HttpStatus.UNAUTHORIZED, "current user is not authenticated");
+        }
+        String username = authentication.getName();
+        if (usersWhoCannotUseTokenSet.contains(username)) {
+            throw new HttpClientErrorException(HttpStatus.UNAUTHORIZED, "you are not authorized to use data access tokens");
+        }
+        return username;
+    }
+
+}


### PR DESCRIPTION
Currently authenticates user to be "fakeuser@mskcc.org", which obviously needs changing.  Only tested with "googleplus" security profile.

# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
