### PR TITLE
Add version to git-commit-id-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
           <plugin>
             <groupId>pl.project13.maven</groupId>
             <artifactId>git-commit-id-plugin</artifactId>
+            <version>2.2.4</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>


### PR DESCRIPTION
removes warnings when building with mvn