### PR TITLE
For MUTATION_COUNT  include only MUTATION_EXTENDED

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
@@ -145,6 +145,7 @@ public final class DaoMutation {
                     "AND mutation.`MUTATION_EVENT_ID` = mutation_event.`MUTATION_EVENT_ID` " +
                     "AND mutation.`MUTATION_STATUS` <> 'GERMLINE' " +
                     "AND genetic_profile.`GENETIC_PROFILE_ID`=? " +
+                    "AND genetic_profile.`GENETIC_ALTERATION_TYPE` = 'MUTATION_EXTENDED' " +
                     "GROUP BY genetic_profile.`GENETIC_PROFILE_ID` , `SAMPLE_ID`;");
             pstmt.setInt(1, geneticProfile.getGeneticProfileId());
             Map<Integer, String> mutationCounts = new HashMap<Integer, String>();
@@ -186,6 +187,7 @@ public final class DaoMutation {
                     "GROUP BY g1.`GENETIC_PROFILE_ID` , m1.`ENTREZ_GENE_ID`) AS GENE_COUNT " +
                     "FROM `mutation` AS m2 , `genetic_profile` AS g2 , `mutation_event` " +
                     "WHERE m2.`GENETIC_PROFILE_ID` = g2.`GENETIC_PROFILE_ID` " +
+                    "AND g2.`GENETIC_ALTERATION_TYPE` = 'MUTATION_EXTENDED' " +
                     "AND m2.`MUTATION_EVENT_ID` = mutation_event.`MUTATION_EVENT_ID` " +
                     "AND g2.`GENETIC_PROFILE_ID`=? " +
                     "GROUP BY g2.`GENETIC_PROFILE_ID` , mutation_event.`KEYWORD` , m2.`ENTREZ_GENE_ID`;");

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
@@ -137,6 +137,8 @@ public final class DaoMutation {
         ResultSet rs = null;
         try {
             con = JdbcUtil.getDbConnection(DaoMutation.class);
+            // do not include germline and fusions (msk internal) when counting
+            // mutations
             pstmt = con.prepareStatement(
                     "SELECT `SAMPLE_ID`, COUNT(DISTINCT mutation_event.`CHR`, mutation_event.`START_POSITION`, " +
                     "mutation_event.`END_POSITION`, mutation_event.`REFERENCE_ALLELE`, mutation_event.`TUMOR_SEQ_ALLELE`) AS MUTATION_COUNT " +
@@ -144,6 +146,7 @@ public final class DaoMutation {
                     "WHERE mutation.`GENETIC_PROFILE_ID` = genetic_profile.`GENETIC_PROFILE_ID` " +
                     "AND mutation.`MUTATION_EVENT_ID` = mutation_event.`MUTATION_EVENT_ID` " +
                     "AND mutation.`MUTATION_STATUS` <> 'GERMLINE' " +
+                    "AND mutation.`MUTATION_TYPE` <> 'Fusion' " +
                     "AND genetic_profile.`GENETIC_PROFILE_ID`=? " +
                     "AND genetic_profile.`GENETIC_ALTERATION_TYPE` = 'MUTATION_EXTENDED' " +
                     "GROUP BY genetic_profile.`GENETIC_PROFILE_ID` , `SAMPLE_ID`;");
@@ -187,7 +190,6 @@ public final class DaoMutation {
                     "GROUP BY g1.`GENETIC_PROFILE_ID` , m1.`ENTREZ_GENE_ID`) AS GENE_COUNT " +
                     "FROM `mutation` AS m2 , `genetic_profile` AS g2 , `mutation_event` " +
                     "WHERE m2.`GENETIC_PROFILE_ID` = g2.`GENETIC_PROFILE_ID` " +
-                    "AND g2.`GENETIC_ALTERATION_TYPE` = 'MUTATION_EXTENDED' " +
                     "AND m2.`MUTATION_EVENT_ID` = mutation_event.`MUTATION_EVENT_ID` " +
                     "AND g2.`GENETIC_PROFILE_ID`=? " +
                     "GROUP BY g2.`GENETIC_PROFILE_ID` , mutation_event.`KEYWORD` , m2.`ENTREZ_GENE_ID`;");

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
@@ -146,7 +146,7 @@ public final class DaoMutation {
                     "WHERE mutation.`GENETIC_PROFILE_ID` = genetic_profile.`GENETIC_PROFILE_ID` " +
                     "AND mutation.`MUTATION_EVENT_ID` = mutation_event.`MUTATION_EVENT_ID` " +
                     "AND mutation.`MUTATION_STATUS` <> 'GERMLINE' " +
-                    "AND mutation.`MUTATION_TYPE` <> 'Fusion' " +
+                    "AND mutation_event.`MUTATION_TYPE` <> 'Fusion' " +
                     "AND genetic_profile.`GENETIC_PROFILE_ID`=? " +
                     "AND genetic_profile.`GENETIC_ALTERATION_TYPE` = 'MUTATION_EXTENDED' " +
                     "GROUP BY genetic_profile.`GENETIC_PROFILE_ID` , `SAMPLE_ID`;");

--- a/core/src/main/java/org/mskcc/cbio/portal/model/GeneticAlterationType.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/model/GeneticAlterationType.java
@@ -36,6 +36,9 @@ package org.mskcc.cbio.portal.model;
 // don't forget to change the other one too
 public enum GeneticAlterationType {
     MUTATION_EXTENDED,
+    // uncalled mutations (mskcc internal) for showing read counts even if
+    // mutation wasn't called
+    MUTATION_UNCALLED,
     FUSION,
     STRUCTURAL_VARIANT,
     COPY_NUMBER_ALTERATION,

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
@@ -452,7 +452,7 @@ public class ImportExtendedMutationData{
         }
 
         /*
-         * At MSKCC there are some MUTATION_EXTENDED_UNCALLED and FUSION
+         * At MSKCC there are some MUTATION_UNCALLED and FUSION
          * profiles that shouldn't be included when determining the number of
          * mutations for a sample
          */

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
@@ -458,8 +458,10 @@ public class ImportExtendedMutationData{
          */
         if (geneticProfile.getGeneticAlterationType().equals("MUTATION_EXTENDED")) {
             DaoMutation.createMutationCountClinicalData(geneticProfile);
-            DaoMutation.calculateMutationCountByKeyword(geneticProfileId);
         }
+        // the mutation count by keyword is on a per genetic profile basis so
+        // fine to calculate for any genetic profile
+        DaoMutation.calculateMutationCountByKeyword(geneticProfileId);
 
         if( MySQLbulkLoader.isBulkLoad()) {
             MySQLbulkLoader.flushAll();

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
@@ -456,7 +456,7 @@ public class ImportExtendedMutationData{
          * profiles that shouldn't be included when determining the number of
          * mutations for a sample
          */
-        if (geneticProfile.getGeneticAlterationType().equals("MUTATION_EXTENDED")) {
+        if (geneticProfile.getGeneticAlterationType().equals(GeneticAlterationType.MUTATION_EXTENDED)) {
             DaoMutation.createMutationCountClinicalData(geneticProfile);
         }
         // the mutation count by keyword is on a per genetic profile basis so

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
@@ -451,8 +451,15 @@ public class ImportExtendedMutationData{
             }
         }
 
-        DaoMutation.createMutationCountClinicalData(geneticProfile);
-        DaoMutation.calculateMutationCountByKeyword(geneticProfileId);
+        /*
+         * At MSKCC there are some MUTATION_EXTENDED_UNCALLED and FUSION
+         * profiles that shouldn't be included when determining the number of
+         * mutations for a sample
+         */
+        if (geneticProfile.getGeneticAlterationType().equals("MUTATION_EXTENDED")) {
+            DaoMutation.createMutationCountClinicalData(geneticProfile);
+            DaoMutation.calculateMutationCountByKeyword(geneticProfileId);
+        }
 
         if( MySQLbulkLoader.isBulkLoad()) {
             MySQLbulkLoader.flushAll();

--- a/db-scripts/src/main/resources/migration.sql
+++ b/db-scripts/src/main/resources/migration.sql
@@ -471,12 +471,14 @@ mutation_count.`GENETIC_PROFILE_ID` = genetic_profile.`GENETIC_PROFILE_ID` GROUP
 update genetic_profile set GENETIC_ALTERATION_TYPE = 'MUTATION_UNCALLED' where stable_id like '%_uncalled';
 
 -- recalculate mutation counts
+-- exclude germline and fusions (msk internal)
 DELETE FROM `clinical_sample` WHERE clinical_sample.`ATTR_ID` = 'MUTATION_COUNT';
 INSERT INTO `clinical_sample` SELECT `SAMPLE_ID`, 'MUTATION_COUNT', COUNT(DISTINCT mutation_event.`CHR`, mutation_event.`START_POSITION`, 
 mutation_event.`END_POSITION`, mutation_event.`REFERENCE_ALLELE`, mutation_event.`TUMOR_SEQ_ALLELE`) AS MUTATION_COUNT 
 FROM `mutation` , `genetic_profile`, `mutation_event` WHERE genetic_profile.`GENETIC_ALTERATION_TYPE` = 'MUTATION_EXTENDED'
 AND mutation.`GENETIC_PROFILE_ID` = genetic_profile.`GENETIC_PROFILE_ID`
 AND mutation.`MUTATION_EVENT_ID` = mutation_event.`MUTATION_EVENT_ID` AND mutation.`MUTATION_STATUS` <> 'GERMLINE' 
+AND mutation.`MUTATION_TYPE` <> 'Fusion'
 GROUP BY genetic_profile.`GENETIC_PROFILE_ID` , `SAMPLE_ID`;
 
 -- recalculate fraction genome altered

--- a/db-scripts/src/main/resources/migration.sql
+++ b/db-scripts/src/main/resources/migration.sql
@@ -478,7 +478,7 @@ mutation_event.`END_POSITION`, mutation_event.`REFERENCE_ALLELE`, mutation_event
 FROM `mutation` , `genetic_profile`, `mutation_event` WHERE genetic_profile.`GENETIC_ALTERATION_TYPE` = 'MUTATION_EXTENDED'
 AND mutation.`GENETIC_PROFILE_ID` = genetic_profile.`GENETIC_PROFILE_ID`
 AND mutation.`MUTATION_EVENT_ID` = mutation_event.`MUTATION_EVENT_ID` AND mutation.`MUTATION_STATUS` <> 'GERMLINE' 
-AND mutation.`MUTATION_TYPE` <> 'Fusion'
+AND mutation_event.`MUTATION_TYPE` <> 'Fusion'
 GROUP BY genetic_profile.`GENETIC_PROFILE_ID` , `SAMPLE_ID`;
 
 -- recalculate fraction genome altered

--- a/model/src/main/java/org/cbioportal/model/MolecularProfile.java
+++ b/model/src/main/java/org/cbioportal/model/MolecularProfile.java
@@ -9,6 +9,9 @@ public class MolecularProfile implements Serializable {
     // don't forget to change the original one too
     public enum MolecularAlterationType {
         MUTATION_EXTENDED,
+        // uncalled mutations (mskcc internal) for showing read counts even if
+        // mutation wasn't called
+        MUTATION_UNCALLED,
         FUSION,
         STRUCTURAL_VARIANT,
         COPY_NUMBER_ALTERATION,


### PR DESCRIPTION
At MSKCC there are some MUTATION_EXTENDED_UNCALLED and FUSION profiles that
shouldn't be included when determining the number of mutations for a sample

Partially solves https://github.com/cBioPortal/cbioportal/issues/4812. Also need to update the pipeline to actually give uncalled profiles the correct genetic_alteration_type