### PR TITLE
MUTATION_UNCALLED valid /mutations/fetch profile

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
@@ -216,6 +216,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
         MolecularProfile molecularProfile = molecularProfileService.getMolecularProfile(molecularProfileId);
 
         if (molecularProfile.getMolecularAlterationType().equals(MolecularAlterationType.MUTATION_EXTENDED) || 
+            molecularProfile.getMolecularAlterationType().equals(MolecularAlterationType.MUTATION_UNCALLED) ||
             molecularProfile.getMolecularAlterationType().equals(MolecularAlterationType.FUSION)) {
 
             throw new MolecularProfileNotFoundException(molecularProfileId);

--- a/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
@@ -164,8 +164,9 @@ public class MutationServiceImpl implements MutationService {
 
         MolecularProfile molecularProfile = molecularProfileService.getMolecularProfile(molecularProfileId);
 
-        if (!molecularProfile.getMolecularAlterationType()
-            .equals(MolecularProfile.MolecularAlterationType.MUTATION_EXTENDED)) {
+        if (!(molecularProfile.getMolecularAlterationType()
+            .equals(MolecularProfile.MolecularAlterationType.MUTATION_EXTENDED) || molecularProfile.getMolecularAlterationType()
+            .equals(MolecularProfile.MolecularAlterationType.MUTATION_UNCALLED))) {
 
             throw new MolecularProfileNotFoundException(molecularProfileId);
         }

--- a/service/src/main/java/org/cbioportal/service/impl/VariantCountServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/VariantCountServiceImpl.java
@@ -58,8 +58,9 @@ public class VariantCountServiceImpl implements VariantCountService {
 
         MolecularProfile molecularProfile = molecularProfileService.getMolecularProfile(molecularProfileId);
 
-        if (!molecularProfile.getMolecularAlterationType()
-            .equals(MolecularProfile.MolecularAlterationType.MUTATION_EXTENDED)) {
+        if (!(molecularProfile.getMolecularAlterationType()
+            .equals(MolecularProfile.MolecularAlterationType.MUTATION_EXTENDED) || !molecularProfile.getMolecularAlterationType()
+            .equals(MolecularProfile.MolecularAlterationType.MUTATION_UNCALLED))) {
 
             throw new MolecularProfileNotFoundException(molecularProfileId);
         }


### PR DESCRIPTION
This fixed the problem that the migration caused for msk internal %_uncalled
profiles to now be of genetic alteration type MUTATION_UNCALLED. It was no longer possible to retrieve those mutations on the patient view page.