### PR TITLE
Adjust doc index to match order of deploying steps

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,8 @@ We also maintain an active [list of RFCs (Requests for Comments)](RFC-List.md) w
 * [Pre-Build Steps](Pre-Build-Steps.md)
 * [Building from Source](Build-from-Source.md)
 * [Importing the Seed Database](Import-the-Seed-Database.md)
-* [Loading a Sample Study](Load-Sample-Cancer-Study.md)  
 * [Deploying the Web Application](Deploying.md)
+* [Loading a Sample Study](Load-Sample-Cancer-Study.md)
 
 ### 2.2 Authorization and Authentication
 * [User Authorization](User-Authorization.md)


### PR DESCRIPTION
In commit 7046477de08eea59790331829aaf1d889c94b7fe of PR #4787 I changed the order in which the steps of the deployment manual reference each other, but I forgot to update the index in README.md.