### PR TITLE
fix for skin.documentation.news

### DIFF
--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -26,7 +26,7 @@ skin.documentation.baseurl=https://raw.githubusercontent.com/cBioPortal/cbioport
 skin.documentation.markdown=true
 skin.documentation.faq=FAQ.md
 skin.documentation.about=About-Us.md
-skin.documentation.skin.news=News.md
+skin.documentation.news=News.md
 skin.documentation.oql=Onco-Query-Language.md
 
 # setting controlling the logos


### PR DESCRIPTION
Set correct property name for `skin.documentation.news`

Related to https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/cbioportal/m4l9nBOHO8k/OHRQeqQKAQAJ