### PR TITLE
Make security-spring respect runtime configuration

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,7 +21,7 @@
     },
     "SPRING_OPTS": {
         "description":"set spring properties with e.g. -Dshow.civic=true (TODO: not all props work atm)",
-        "value":"-Dtomcat.catalina.scope=runtime -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test_small -Ddb.connection_string=jdbc:mysql://devdb.cbioportal.org:3306/ -Ddb.host=devdb.cbioportal.org -Dshow.civic=true -Ddbconnector=dbcp -Dsuppress_schema_version_mismatch_errors=true"
+        "value":"-Dauthenticate=false -Dtomcat.catalina.scope=runtime -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test_small -Ddb.connection_string=jdbc:mysql://devdb.cbioportal.org:3306/ -Ddb.host=devdb.cbioportal.org -Dshow.civic=true -Ddbconnector=dbcp -Dsuppress_schema_version_mismatch_errors=true"
     }
   },
   "buildpacks": [

--- a/docs/Authenticating-Users-via-LDAP.md
+++ b/docs/Authenticating-Users-via-LDAP.md
@@ -23,13 +23,15 @@ The cBioPortal code has no means of storing user name and passwords and no means
 # Configuring LDAP within cBioPortal
 
 
-## Modifying portal.properties
+## Modifying configuration
 
-Within portal.properties, modify the section labeled `authentication`.  For example:
+Make Tomcat pass the authentication method as a JVM argument
+by adding this line to `$CATALINA_HOME/bin/setenv.sh`:
 
-    # authentication
-    authenticate=ldap
-    
+    CATALINA_OPTS='-Dauthenticate=ldap'
+
+In portal.properties, modify the section labeled `authentication`.  For example:
+
     ## configuration for the LDAP access
     ldap.user_search_base=DC=example,DC=com
     ldap.url=ldap://ldap.example.com:389

--- a/docs/Authenticating-Users-via-SAML.md
+++ b/docs/Authenticating-Users-via-SAML.md
@@ -121,7 +121,12 @@ See [this Tomcat documentation page](https://tomcat.apache.org/tomcat-8.0-doc/ss
 both keystore and secure-key. This seems to be an extra restriction by Tomcat.
 
 
-## Modifying portal.properties
+## Modifying configuration
+
+Make Tomcat pass the authentication method as a JVM argument
+by adding this line to `$CATALINA_HOME/bin/setenv.sh`:
+
+    CATALINA_OPTS='-Dauthenticate=saml'
 
 Within portal.properties, make sure that:
 
@@ -130,7 +135,6 @@ Within portal.properties, make sure that:
 Then, modify the section labeled `authentication`. See SAML parameters shown in example below:
 
     # authentication
-    authenticate=saml
     authorization=true
     saml.sp.metadata.entityid=cbioportal
     saml.idp.metadata.location=classpath:/onelogin_metadata_620035.xml

--- a/docs/Authenticating-and-Authorizing-Users-via-keycloak.md
+++ b/docs/Authenticating-and-Authorizing-Users-via-keycloak.md
@@ -96,7 +96,7 @@ installed. Keycloak may not give an indication of successful
 completion, but when navigating to the **SAML Keys** tab again you
 should now see the certificate and no private key.
 
-## Modifying portal.properties
+## Modifying configuration
 
 1. Within the portal.properties file , make sure that this line is present:
 ```
@@ -108,7 +108,6 @@ should now see the certificate and no private key.
 ```properties
     # authentication
     authorization=true
-    authenticate=saml
     filter_groups_by_appname=false
     saml.sp.metadata.entityid=cbioportal
     saml.idp.metadata.location=classpath:/client-tailored-saml-idp-metadata.xml
@@ -126,6 +125,13 @@ should now see the certificate and no private key.
     # global logout (as opposed to local logout):
     saml.logout.local=false
     saml.logout.url=/
+```
+
+3. Finally, make Tomcat pass the authentication method as a JVM argument
+   by adding this line to `$CATALINA_HOME/bin/setenv.sh`:
+
+```sh
+CATALINA_OPTS='-Dauthenticate=saml'
 ```
 
 ## Obtain user identities

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -24,7 +24,7 @@ Use it as a template to create your own:
 For more information about the `portal.properties` file,
 see the [reference](portal.properties-Reference.md) page.
 
-## Add PORTAL_HOME to Tomcat
+## Set environment variables for Tomcat
 
 The `PORTAL_HOME` environment variable needs to be available to
 the `cbioportal.war` file which runs within the Tomcat server,
@@ -34,6 +34,11 @@ and add a line like the following, pointing it to the folder containing
 `portal.properties`:
 
     export PORTAL_HOME=/Users/johndoe/cbioportal
+
+In additon, add a line to make Tomcat pass `-Dauthenticate=false`
+as a JVM argument, or replace the word ‘false’ by the method to use:
+
+    CATALINA_OPTS='-Dauthenticate=false'
 
 ## Add the MySQL JDBC Driver to Apache Tomcat
 

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -73,11 +73,17 @@ googleplus.consumer.secret=2jCfg4SPWdGfXF44WC588dK
 ```
 (note: these are just examples, you need to get your own) You will also need to go to "Google+ API" and click Enable button. In case of problems make sure to enable DEBUG logging for org.springframework.social and org.springframework.security.web.authentication.
 
-
-To active password authentication, then the following properties are required:
+To activate password authentication,
+pass the `-Dauthenticate=googleplus` argument to the web server JVM.
+This can be done by adding the following line to the Tomcat config file
+`$CATALINA_HOME/bin/setenv.sh`:
+```sh
+CATALINA_OPTS='-Dauthenticate=googleplus'
 ```
-app.name=
-authenticate=googleplus
+
+In addition, set these properties in `portal.properties`:
+```
+app.name=cbioportal
 authorization=true
 ```
 app.name should be set to the name of the portal instance referenced in the "AUTHORITY" column of the "AUTHORITIES" table.  See the [User Authorization](User-Authorization.md) for more information.

--- a/security/security-spring/pom.xml
+++ b/security/security-spring/pom.xml
@@ -102,19 +102,4 @@
         <scope>provided</scope>
       </dependency>
     </dependencies>
-    <build>
-      <filters>
-        <filter>../../src/main/resources/portal.properties</filter>
-        <filter>../../src/main/resources/maven.properties</filter>
-      </filters>
-      <resources>
-        <resource>
-          <directory>src/main/resources</directory>
-          <filtering>true</filtering>
-          <includes>
-            <include>applicationContext-security.xml</include>
-          </includes>
-        </resource>
-      </resources>
-    </build>
 </project>

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -17,9 +17,8 @@
            <b:property name="ignoreResourceNotFound" value="true" />
            <b:property name="locations">
              <b:list>
-               <b:value>file:///${PORTAL_HOME}/portal.properties</b:value>
                <b:value>classpath:portal.properties</b:value>
-               <b:value>classpath:maven.properties</b:value>
+               <b:value>file:///#{systemEnvironment['PORTAL_HOME']}/portal.properties</b:value>
              </b:list>
            </b:property>
         </b:bean>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -71,8 +71,10 @@ skin.study_view.link_text=To build your own case set, try out our enhanced Study
 authorization=false
 ## enable and set this property to specify a study group to be used to identify public studies for which no specific authorization entries are needed in the `authorities` table
 # always_show_study_group=
+
+## change the `-Dauthenticate=` JVM argument to configure
 ## which method of authentication to use (false, googleplus, social_auth, saml, openid, ad, ldap, noauthsessionservice)
-authenticate=false
+
 ## Should the permissions for groups and users be filtered by this instance's app.name?
 ## (true means the system only handles "CBIOPORTAL:someGroupPermission" groups, false means "someGroupPermission" works)
 filter_groups_by_appname=true
@@ -179,8 +181,8 @@ recache_study_after_update=false
 # example session-service url: http://localhost:8080/session_service/api/sessions/public_portal/
 # see: https://github.com/cBioPortal/session-service
 # excluding this value or setting it to an empty string will revert to the previous bookmarking method
-# WARNING: do not use session service with authenticate=false
-#  either use authentication or change to authenticate=noauthsessionservice
+# WARNING: do not use session service with -Dauthenticate=false
+#  either use authentication or change to -Dauthenticate=noauthsessionservice
 session.service.url=
 
 # disabled tabs, | delimited

--- a/test/end-to-end/docker-compose.yml
+++ b/test/end-to-end/docker-compose.yml
@@ -4,7 +4,7 @@ cbioportal:
     - "8080:8080"
   volumes:
     - $PWD/../../:/cbioportal
-  command: java -Ddbconnector=dbcp -jar portal/target/dependency/webapp-runner.jar --expand-war portal/target/cbioportal.war
+  command: java -Ddbconnector=dbcp -Dauthenticate=false -jar portal/target/dependency/webapp-runner.jar --expand-war portal/target/cbioportal.war
   environment:
     PORTAL_HOME: /cbioportal/test/end-to-end/runtime-config
   working_dir: /cbioportal


### PR DESCRIPTION
In PR #4787, I adjusted the central logic on reading configuration files, as
well as the deployment manual, moving the main way to supply
configuration to $PORTAL_HOME/portal.properties at runtime. Later, I
found out that the security-spring applicationContext uses its own logic to read the same
files, and this logic was broken.

As a quick fix to make configuration of auth settings work again, adjust
security-spring's duplicate logic to behave like GlobalProperties at
least when these settings are actually listed in the runtime
portal.properties.

Turn `authenticate=` into a required JVM system property (`-D` arg) when using runtime configuration, as it's used before `portal.properties` is read.

Fix #4905. The main issue, at least; the remaining maintainability and deployability issue I logged as #4916.

I pointed this pull request to `rc` rather than `master` even though it's a bugfix, because it only really matters after #4787.

# Checks
- [x] Runs on Heroku.
- [x] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.