### PR TITLE
Fix #4895 MUTATION_COUNT germline/fusion only

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
@@ -144,11 +144,11 @@ public final class DaoMutation {
                     "mutation_event.`END_POSITION`, mutation_event.`REFERENCE_ALLELE`, mutation_event.`TUMOR_SEQ_ALLELE`) AS MUTATION_COUNT " +
                     "FROM `sample_profile` " +
                     "LEFT JOIN mutation ON mutation.`SAMPLE_ID` = sample_profile.`SAMPLE_ID` " +
+                    "AND ( mutation.`MUTATION_STATUS` <> 'GERMLINE' OR mutation.`MUTATION_STATUS` IS NULL ) " +
                     "LEFT JOIN mutation_event ON mutation.`MUTATION_EVENT_ID` = mutation_event.`MUTATION_EVENT_ID` " +
+                    "AND ( mutation_event.`MUTATION_TYPE` <> 'Fusion' OR mutation_event.`MUTATION_TYPE` IS NULL ) " +
                     "INNER JOIN genetic_profile ON genetic_profile.`GENETIC_PROFILE_ID` = sample_profile.`GENETIC_PROFILE_ID` " +
                     "WHERE genetic_profile.`GENETIC_ALTERATION_TYPE` = 'MUTATION_EXTENDED' " +
-                    "AND ( mutation.`MUTATION_STATUS` <> 'GERMLINE' OR mutation.`MUTATION_STATUS` IS NULL ) " +
-                    "AND ( mutation_event.`MUTATION_TYPE` <> 'Fusion' OR mutation_event.`MUTATION_TYPE` IS NULL ) " +
                     "AND genetic_profile.`GENETIC_PROFILE_ID`=? " +
                     "GROUP BY sample_profile.`GENETIC_PROFILE_ID` , sample_profile.`SAMPLE_ID`;");
             pstmt.setInt(1, geneticProfile.getGeneticProfileId());

--- a/core/src/test/java/org/mskcc/cbio/portal/scripts/TestImportProfileData.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/scripts/TestImportProfileData.java
@@ -24,6 +24,7 @@
 package org.mskcc.cbio.portal.scripts;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +36,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mskcc.cbio.portal.dao.DaoCancerStudy;
+import org.mskcc.cbio.portal.dao.DaoClinicalAttributeMeta;
 import org.mskcc.cbio.portal.dao.DaoClinicalData;
 import org.mskcc.cbio.portal.dao.DaoCnaEvent;
 import org.mskcc.cbio.portal.dao.DaoException;
@@ -45,8 +47,11 @@ import org.mskcc.cbio.portal.dao.DaoSample;
 import org.mskcc.cbio.portal.dao.MySQLbulkLoader;
 import org.mskcc.cbio.portal.model.CancerStudy;
 import org.mskcc.cbio.portal.model.CanonicalGene;
+import org.mskcc.cbio.portal.model.ClinicalAttribute;
+import org.mskcc.cbio.portal.model.ClinicalData;
 import org.mskcc.cbio.portal.model.CnaEvent;
 import org.mskcc.cbio.portal.model.ExtendedMutation;
+import org.mskcc.cbio.portal.model.GeneticProfile;
 import org.mskcc.cbio.portal.util.ConsoleUtil;
 import org.mskcc.cbio.portal.util.ImportDataUtil;
 import org.mskcc.cbio.portal.util.ProgressMonitor;
@@ -106,6 +111,42 @@ public class TestImportProfileData {
         ImportProfileData secondRunner = new ImportProfileData(secondArgs);
         secondRunner.run();
         validateMutationAminoAcid (geneticProfileId, secondSampleId, 2842, "L113P");
+    }
+
+    @Test
+    public void testImportGermlineOnlyFile() throws Exception {
+        /* Mutations file split over two files with same stable id */
+        String[] args = {
+                "--data","src/test/resources/germlineOnlyMutationsData/data_mutations_extended.txt",
+                "--meta","src/test/resources/germlineOnlyMutationsData/meta_mutations_extended.txt",
+                "--loadMode", "bulkLoad"
+        };
+        ImportProfileData runner = new ImportProfileData(args);
+        runner.run();
+        String studyStableId = "study_tcga_pub";
+        CancerStudy study = DaoCancerStudy.getCancerStudyByStableId(studyStableId);
+        studyId = study.getInternalId();
+        int sampleId = DaoSample.getSampleByCancerStudyAndSampleId(studyId, "TCGA-AA-3664-01").getInternalId();
+        GeneticProfile geneticProfile = DaoGeneticProfile.getGeneticProfileByStableId(studyStableId + "_breast_mutations");
+        geneticProfileId = geneticProfile.getGeneticProfileId();
+
+        // assume clinical data for MUTATION_COUNT was created
+        ClinicalAttribute clinicalAttribute = DaoClinicalAttributeMeta.getDatum("MUTATION_COUNT", studyId);
+        assertNotNull(clinicalAttribute);
+
+        // assume a MUTATION_COUNT record has been added for one sample and the count is zero
+        List<ClinicalData> clinicalData = DaoClinicalData.getSampleData(study.getInternalId(), new ArrayList<String>(Arrays.asList("TCGA-AA-3664-01")), clinicalAttribute);
+        assert(clinicalData.size() == 1);
+        assertEquals("0", clinicalData.get(0).getAttrVal());
+
+        // check if the three germline mutations have been inserted
+        validateMutationAminoAcid (geneticProfileId, sampleId, 64581, "T209A");
+        validateMutationAminoAcid (geneticProfileId, sampleId, 50839, "G78S");
+        validateMutationAminoAcid (geneticProfileId, sampleId, 2842, "L113P");
+
+        // remove profile at the end
+        DaoGeneticProfile.deleteGeneticProfile(geneticProfile);
+        assertNull(DaoGeneticProfile.getGeneticProfileByStableId(studyStableId + "_breast_mutations"));
     }
 
     @Test

--- a/core/src/test/java/org/mskcc/cbio/portal/scripts/TestIntegrationTest.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/scripts/TestIntegrationTest.java
@@ -24,6 +24,7 @@
 package org.mskcc.cbio.portal.scripts;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -205,6 +206,20 @@ public class TestIntegrationTest {
             assertEquals(3, clinicalAttributes.size());
             clinicalAttributes = apiService.getPatientClinicalAttributes();
             assertEquals(4, clinicalAttributes.size());
+            List<DBClinicalSampleData> clinicalComputedSampleData = apiService.getSampleClinicalData("study_es_0", Arrays.asList("MUTATION_COUNT","FRACTION_GENOME_ALTERED"), Arrays.asList("TCGA-A2-A04P-01"));
+            Boolean mutationCountExists = false;
+            Boolean fractionGenomeAlteredExists = false;
+            for (DBClinicalSampleData dbClinicalSampleData: clinicalComputedSampleData) {
+                if (dbClinicalSampleData.attr_id.equals("MUTATION_COUNT")) {
+                    mutationCountExists = true;
+                    assertEquals("TCGA-A2-A04P-01 should have one mutation in MUTATION_COUNT", "1", dbClinicalSampleData.attr_val);
+                } else if (dbClinicalSampleData.attr_id.equals("FRACTION_GENOME_ALTERED")) {
+                    fractionGenomeAlteredExists = true;
+                    assertEquals("TCGA-A2-A04P-01 should have 0.0 FRACTION_GENOME_ALTERED (the imported segment file spans a very small part of the genome)", 0.0, Float.parseFloat(dbClinicalSampleData.attr_val), 0.01);
+                }
+            }
+            assertTrue("MUTATION_COUNT sample clinical attribute should have been added for TCGA-A2-A04P-01", mutationCountExists);
+            assertTrue("FRACTION_GENOME_ALTERED sample clinical attribute should have been added for TCGA-A2-A04P-01", fractionGenomeAlteredExists);
             
             //===== Check EXPRESSION data ========
             geneticProfileStableIds = new ArrayList<String>();

--- a/core/src/test/resources/germlineOnlyMutationsData/data_mutations_extended.txt
+++ b/core/src/test/resources/germlineOnlyMutationsData/data_mutations_extended.txt
@@ -1,0 +1,5 @@
+#sequenced_samples: TCGA-AA-3664-01
+Hugo_Symbol	Entrez_Gene_Id	Center	Tumor_Sample_Barcode	Verification_Status	Validation_Status	Mutation_Status	Sequencer	Chromosome	Start_position	End_position	Variant_Classification	HGVSp_Short	MA:FImpact	MA:link.MSA	MA:link.PDB
+CLEC7A	64581	broad.mit.edu	TCGA-AA-3664-01	Unknown	Unknown	Germline	Illumina GAIIx	chr12	10162443	10162443	Missense_Mutation	T209A	neutral	mutationassessor.org/?cm=msa&ty=f&p=CLC7A_HUMAN&rb=137&re=243&var=T209A	mutationassessor.org/pdb.php?prot=CLC7A_HUMAN&from=137&to=243&var=T209A
+TAS2R10	50839	broad.mit.edu	TCGA-AA-3664-01	Unknown	valid	Germline	Illumina GAIIx	chr12	10869904	10869904	Missense_Mutation	G78S	medium	mutationassessor.org/?cm=msa&ty=f&p=T2R10_HUMAN&rb=1&re=296&var=G78S	
+GPR19	2842	broad.mit.edu	TCGA-AA-3664-01	Unknown	valid	Germline	Illumina GAIIx	chr12	12706312	12706312	Nonsense_Mutation	L113P	high	mutationassessor.org/?cm=msa&ty=f&p=GPR19_HUMAN&rb=82&re=330&var=L113P	mutationassessor.org/pdb.php?prot=GPR19_HUMAN&from=82&to=330&var=L113P

--- a/core/src/test/resources/germlineOnlyMutationsData/meta_mutations_extended.txt
+++ b/core/src/test/resources/germlineOnlyMutationsData/meta_mutations_extended.txt
@@ -1,0 +1,8 @@
+cancer_study_identifier: study_tcga_pub
+cancer_type_id: breast
+genetic_alteration_type: MUTATION_EXTENDED
+datatype: MAF
+stable_id: breast_mutations
+show_profile_in_analysis_tab: true
+profile_description: Mutation data from whole exome sequencing.
+profile_name: Mutations

--- a/db-scripts/src/main/resources/migration.sql
+++ b/db-scripts/src/main/resources/migration.sql
@@ -515,3 +515,27 @@ AND ( mutation_event.`MUTATION_TYPE` <> 'Fusion' OR mutation_event.`MUTATION_TYP
 GROUP BY sample_profile.`GENETIC_PROFILE_ID` , sample_profile.`SAMPLE_ID`;
 
 UPDATE `info` SET `DB_SCHEMA_VERSION`="2.7.1";
+
+##version: 2.7.2
+DELETE FROM `clinical_sample` WHERE clinical_sample.`ATTR_ID` = 'MUTATION_COUNT';
+INSERT INTO `clinical_sample` SELECT sample_profile.`SAMPLE_ID`, 'MUTATION_COUNT', COUNT(DISTINCT mutation_event.`CHR`, mutation_event.`START_POSITION`,
+mutation_event.`END_POSITION`, mutation_event.`REFERENCE_ALLELE`, mutation_event.`TUMOR_SEQ_ALLELE`) AS MUTATION_COUNT
+FROM `sample_profile`
+LEFT JOIN mutation ON mutation.`SAMPLE_ID` = sample_profile.`SAMPLE_ID`
+AND ( mutation.`MUTATION_STATUS` <> 'GERMLINE' OR mutation.`MUTATION_STATUS` IS NULL )
+LEFT JOIN mutation_event ON mutation.`MUTATION_EVENT_ID` = mutation_event.`MUTATION_EVENT_ID`
+AND ( mutation_event.`MUTATION_TYPE` <> 'Fusion' OR mutation_event.`MUTATION_TYPE` IS NULL )
+INNER JOIN genetic_profile ON genetic_profile.`GENETIC_PROFILE_ID` = sample_profile.`GENETIC_PROFILE_ID`
+WHERE genetic_profile.`GENETIC_ALTERATION_TYPE` = 'MUTATION_EXTENDED'
+GROUP BY sample_profile.`GENETIC_PROFILE_ID` , sample_profile.`SAMPLE_ID`;
+
+DELETE FROM `clinical_sample` WHERE clinical_sample.`ATTR_ID` = 'FRACTION_GENOME_ALTERED';
+INSERT INTO `clinical_sample` SELECT `SAMPLE_ID`, 'FRACTION_GENOME_ALTERED', IF((SELECT SUM(`END`-`START`) 
+FROM copy_number_seg AS c2 WHERE c2.`CANCER_STUDY_ID` = c1.`CANCER_STUDY_ID` AND c2.`SAMPLE_ID` = c1.`SAMPLE_ID`
+AND ABS(c2.`SEGMENT_MEAN`) >= 0.2) IS NULL, 0, (SELECT SUM(`END`-`START`) FROM copy_number_seg AS c2
+WHERE c2.`CANCER_STUDY_ID` = c1.`CANCER_STUDY_ID` AND c2.`SAMPLE_ID` = c1.`SAMPLE_ID`
+AND ABS(c2.`SEGMENT_MEAN`) >= 0.2) / SUM(`END`-`START`)) AS `VALUE` FROM `copy_number_seg` AS c1 , `cancer_study`
+WHERE c1.`CANCER_STUDY_ID` = cancer_study.`CANCER_STUDY_ID` GROUP BY cancer_study.`CANCER_STUDY_ID` , `SAMPLE_ID`
+HAVING SUM(`END`-`START`) > 0;
+
+UPDATE `info` SET `DB_SCHEMA_VERSION`="2.7.2";


### PR DESCRIPTION
If a sample has only germline or fusion events it would not get 0 count. By
including the criteria in the left join this is solved