### PR TITLE
Fix Molecular Data API sort issue

### DIFF
--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
@@ -33,7 +33,9 @@
                 </foreach>
             </if>
         </where>
-        ORDER BY genetic_profile.STABLE_ID ASC
+        <!-- It seems like in Java, `_` comes before letters when sorted, but in MySQL it comes after. 
+        The code depends on them being the same order, so this is done to make the MySQL ordering same with Java. -->
+        ORDER BY REPLACE(genetic_profile.STABLE_ID, '_', ' '), genetic_profile.STABLE_ID ASC
     </select>
     
     <select id="getGeneMolecularAlterations" resultType="org.cbioportal.model.GeneMolecularAlteration">

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepositoryTest.java
@@ -35,10 +35,10 @@ public class MolecularDataMyBatisRepositoryTest {
     public void getCommaSeparatedSampleIdsOfMolecularProfiles() throws Exception {
 
         List<String> result = molecularDataMyBatisRepository
-            .getCommaSeparatedSampleIdsOfMolecularProfiles(Arrays.asList("study_tcga_pub_gistic", "study_tcga_pub_mrna"));
+            .getCommaSeparatedSampleIdsOfMolecularProfiles(Arrays.asList("study_tcga_pub_mrna", "study_tcga_pub_m_na"));
 
         Assert.assertEquals(2, result.size());
-        Assert.assertEquals("1,2,3,4,5,6,7,8,9,10,11,12,13,14,", result.get(0));
+        Assert.assertEquals("1,2,3,4,5,6,7,8,9,10,11,", result.get(0));
         Assert.assertEquals("2,3,6,8,9,10,12,13,", result.get(1));
     }
 

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularProfileMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularProfileMyBatisRepositoryTest.java
@@ -28,7 +28,7 @@ public class MolecularProfileMyBatisRepositoryTest {
         List<MolecularProfile> result = molecularProfileMyBatisRepository.getAllMolecularProfiles("ID", null, null, 
             null, null);
 
-        Assert.assertEquals(8, result.size());
+        Assert.assertEquals(9, result.size());
         MolecularProfile molecularProfile = result.get(0);
         Assert.assertEquals((Integer) 8, molecularProfile.getMolecularProfileId());
         Assert.assertEquals("acc_tcga_mutations", molecularProfile.getStableId());
@@ -41,7 +41,7 @@ public class MolecularProfileMyBatisRepositoryTest {
         List<MolecularProfile> result = molecularProfileMyBatisRepository.getAllMolecularProfiles("SUMMARY", null, null, 
             null, null);
 
-        Assert.assertEquals(8, result.size());
+        Assert.assertEquals(9, result.size());
         MolecularProfile molecularProfile = result.get(0);
         Assert.assertEquals((Integer) 2, molecularProfile.getMolecularProfileId());
         Assert.assertEquals("study_tcga_pub_gistic", molecularProfile.getStableId());
@@ -64,7 +64,7 @@ public class MolecularProfileMyBatisRepositoryTest {
         List<MolecularProfile> result = molecularProfileMyBatisRepository.getAllMolecularProfiles("DETAILED", null, 
             null, null, null);
 
-        Assert.assertEquals(8, result.size());
+        Assert.assertEquals(9, result.size());
         MolecularProfile molecularProfile = result.get(0);
         Assert.assertEquals((Integer) 2, molecularProfile.getMolecularProfileId());
         Assert.assertEquals("study_tcga_pub_gistic", molecularProfile.getStableId());
@@ -109,15 +109,15 @@ public class MolecularProfileMyBatisRepositoryTest {
         List<MolecularProfile> result = molecularProfileMyBatisRepository.getAllMolecularProfiles("SUMMARY", null, null,
                 "stableId", "ASC");
 
-        Assert.assertEquals(8, result.size());
+        Assert.assertEquals(9, result.size());
         Assert.assertEquals("acc_tcga_mutations", result.get(0).getStableId());
         Assert.assertEquals("study_tcga_pub_gistic", result.get(1).getStableId());
         Assert.assertEquals("study_tcga_pub_gsva_scores", result.get(2).getStableId());
         Assert.assertEquals("study_tcga_pub_log2CNA", result.get(3).getStableId());
-        Assert.assertEquals("study_tcga_pub_methylation_hm27", result.get(4).getStableId());
-        Assert.assertEquals("study_tcga_pub_mrna", result.get(5).getStableId());
-        Assert.assertEquals("study_tcga_pub_mutations", result.get(6).getStableId());
-        Assert.assertEquals("study_tcga_pub_sv", result.get(7).getStableId());
+        Assert.assertEquals("study_tcga_pub_methylation_hm27", result.get(5).getStableId());
+        Assert.assertEquals("study_tcga_pub_mrna", result.get(6).getStableId());
+        Assert.assertEquals("study_tcga_pub_mutations", result.get(7).getStableId());
+        Assert.assertEquals("study_tcga_pub_sv", result.get(8).getStableId());
     }
 
     @Test
@@ -125,7 +125,7 @@ public class MolecularProfileMyBatisRepositoryTest {
 
         BaseMeta result = molecularProfileMyBatisRepository.getMetaMolecularProfiles();
 
-        Assert.assertEquals((Integer) 8, result.getTotalCount());
+        Assert.assertEquals((Integer) 9, result.getTotalCount());
     }
 
     @Test
@@ -197,7 +197,7 @@ public class MolecularProfileMyBatisRepositoryTest {
         List<MolecularProfile> result = molecularProfileMyBatisRepository
             .getAllMolecularProfilesInStudy("study_tcga_pub", "SUMMARY", null, null, null, null);
 
-        Assert.assertEquals(7, result.size());
+        Assert.assertEquals(8, result.size());
         MolecularProfile molecularProfile = result.get(0);
         Assert.assertEquals((Integer) 2, molecularProfile.getMolecularProfileId());
         Assert.assertEquals("study_tcga_pub_gistic", molecularProfile.getStableId());
@@ -219,7 +219,7 @@ public class MolecularProfileMyBatisRepositoryTest {
 
         BaseMeta result = molecularProfileMyBatisRepository.getMetaMolecularProfilesInStudy("study_tcga_pub");
 
-        Assert.assertEquals((Integer) 7, result.getTotalCount());
+        Assert.assertEquals((Integer) 8, result.getTotalCount());
     }
 
     @Test
@@ -228,7 +228,7 @@ public class MolecularProfileMyBatisRepositoryTest {
         List<MolecularProfile> result = molecularProfileMyBatisRepository
             .getMolecularProfilesInStudies(Arrays.asList("study_tcga_pub", "acc_tcga"), "SUMMARY");
 
-        Assert.assertEquals(8, result.size());
+        Assert.assertEquals(9, result.size());
         MolecularProfile molecularProfile = result.get(0);
         Assert.assertEquals((Integer) 8, molecularProfile.getMolecularProfileId());
         Assert.assertEquals("acc_tcga_mutations", molecularProfile.getStableId());
@@ -250,6 +250,6 @@ public class MolecularProfileMyBatisRepositoryTest {
         BaseMeta result = molecularProfileMyBatisRepository.getMetaMolecularProfilesInStudies(
             Arrays.asList("study_tcga_pub", "acc_tcga"));
 
-        Assert.assertEquals((Integer) 8, result.getTotalCount());
+        Assert.assertEquals((Integer) 9, result.getTotalCount());
     }
 }

--- a/persistence/persistence-mybatis/src/test/resources/testSql.sql
+++ b/persistence/persistence-mybatis/src/test/resources/testSql.sql
@@ -62,6 +62,7 @@ INSERT INTO reference_genome_gene (ENTREZ_GENE_ID,CYTOBAND,EXONIC_LENGTH,START,E
 
 INSERT INTO genetic_profile (GENETIC_PROFILE_ID,STABLE_ID,CANCER_STUDY_ID,GENETIC_ALTERATION_TYPE,DATATYPE,NAME,DESCRIPTION,SHOW_PROFILE_IN_ANALYSIS_TAB) VALUES(2,'study_tcga_pub_gistic',1,'COPY_NUMBER_ALTERATION','DISCRETE','Putative copy-number alterations from GISTIC','Putative copy-number from GISTIC 2.0. Values: -2 = homozygous deletion; -1 = hemizygous deletion; 0 = neutral / no change; 1 = gain; 2 = high level amplification.',1);
 INSERT INTO genetic_profile (GENETIC_PROFILE_ID,STABLE_ID,CANCER_STUDY_ID,GENETIC_ALTERATION_TYPE,DATATYPE,NAME,DESCRIPTION,SHOW_PROFILE_IN_ANALYSIS_TAB) VALUES(3,'study_tcga_pub_mrna',1,'MRNA_EXPRESSION','Z-SCORE','mRNA expression (microarray)','Expression levels (Agilent microarray).',0);
+INSERT INTO genetic_profile (GENETIC_PROFILE_ID,STABLE_ID,CANCER_STUDY_ID,GENETIC_ALTERATION_TYPE,DATATYPE,NAME,DESCRIPTION,SHOW_PROFILE_IN_ANALYSIS_TAB) VALUES(10,'study_tcga_pub_m_na',1,'MRNA_EXPRESSION','Z-SCORE','mRNA expression (microarray)','Expression levels (Agilent microarray).',0);
 INSERT INTO genetic_profile (GENETIC_PROFILE_ID,STABLE_ID,CANCER_STUDY_ID,GENETIC_ALTERATION_TYPE,DATATYPE,NAME,DESCRIPTION,SHOW_PROFILE_IN_ANALYSIS_TAB) VALUES(4,'study_tcga_pub_log2CNA',1,'COPY_NUMBER_ALTERATION','LOG2-VALUE','Log2 copy-number values','Log2 copy-number VALUESfor each gene (from Affymetrix SNP6).',0);
 INSERT INTO genetic_profile (GENETIC_PROFILE_ID,STABLE_ID,CANCER_STUDY_ID,GENETIC_ALTERATION_TYPE,DATATYPE,NAME,DESCRIPTION,SHOW_PROFILE_IN_ANALYSIS_TAB) VALUES(5,'study_tcga_pub_methylation_hm27',1,'METHYLATION','CONTINUOUS','Methylation (HM27)','Methylation beta-VALUES(HM27 platform). For genes with multiple methylation probes, the probe least correlated with expression is selected.',0);
 INSERT INTO genetic_profile (GENETIC_PROFILE_ID,STABLE_ID,CANCER_STUDY_ID,GENETIC_ALTERATION_TYPE,DATATYPE,NAME,DESCRIPTION,SHOW_PROFILE_IN_ANALYSIS_TAB) VALUES(6,'study_tcga_pub_mutations',1,'MUTATION_EXTENDED','MAF','Mutations','Mutation data from whole exome sequencing.',1);
@@ -73,6 +74,7 @@ INSERT INTO genetic_profile_samples (GENETIC_PROFILE_ID,ORDERED_SAMPLE_LIST) VAL
 INSERT INTO genetic_profile_samples (GENETIC_PROFILE_ID,ORDERED_SAMPLE_LIST) VALUES(3,'2,3,6,8,9,10,12,13,');
 INSERT INTO genetic_profile_samples (GENETIC_PROFILE_ID,ORDERED_SAMPLE_LIST) VALUES(4,'1,2,3,4,5,6,7,8,9,10,11,12,13,14,');
 INSERT INTO genetic_profile_samples (GENETIC_PROFILE_ID,ORDERED_SAMPLE_LIST) VALUES(5,'2,');
+INSERT INTO genetic_profile_samples (GENETIC_PROFILE_ID,ORDERED_SAMPLE_LIST) VALUES(10,'1,2,3,4,5,6,7,8,9,10,11,');
 
 INSERT INTO patient (INTERNAL_ID,STABLE_ID,CANCER_STUDY_ID) VALUES(1,'TCGA-A1-A0SB',1);
 INSERT INTO patient (INTERNAL_ID,STABLE_ID,CANCER_STUDY_ID) VALUES(2,'TCGA-A1-A0SD',1);


### PR DESCRIPTION
It seems like in Java, `_` comes before letters when sorted, but in MySQL it comes after. The code was depending on them being the same order, so had to do this trick.