### PR TITLE
Fix redirection of case.do and index.do legacy urls to SPA urls

### DIFF
--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -454,10 +454,6 @@
         <servlet-name>patient_view</servlet-name>
         <servlet-class>org.mskcc.cbio.portal.servlet.PatientView</servlet-class>
     </servlet>
-    <servlet-mapping>
-        <servlet-name>patient_view</servlet-name>
-        <url-pattern>/case.do</url-pattern>
-    </servlet-mapping>
 
     <servlet>
         <servlet-name>CrossCancerJSON</servlet-name>
@@ -674,6 +670,7 @@
         <url-pattern>/newstudy/*</url-pattern>
         <url-pattern>/mutation_mapper/*</url-pattern>
         <url-pattern>/index.do/*</url-pattern>
+        <url-pattern>/case.do/*</url-pattern>
     </servlet-mapping>
     
     <servlet>

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -89,8 +89,7 @@
             "session.url_length_threshold",
             "bitly.api_key",
             "bitly.user",
-            "bitly.access.token",
-            "bitly.url"
+            "bitly.access.token"
            
         }; 
     

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -163,8 +163,6 @@ broad.bam.checking.url=
 include_networks=true
 pathway_commons.url=http://www.pathwaycommons.org/pc2
 
-# bitly, please use your bitly user and apiKey
-bitly.url=http://api.bit.ly/shorten?login=[bitly.user]&apiKey=[bitly.apiKey]&
 # the new API uses the v3 of bitly API, and a java library to make the API call, so you only need to provide the access token  
 bitly.access.token=
 

--- a/web/src/main/java/org/mskcc/cbio/portal/web/ProxyController.java
+++ b/web/src/main/java/org/mskcc/cbio/portal/web/ProxyController.java
@@ -65,7 +65,7 @@ public class ProxyController
   public void setHotspotsURL(String property) { this.hotspotsURL = property; }
   
   private String bitlyURL;
-  @Value("${bitly.url}")
+  @Value("${bitly.url:''}")
   public void setBitlyURL(String property) { this.bitlyURL = property; }
 
   private String sessionServiceURL;


### PR DESCRIPTION
# What? Why?
Fix # .

Changes proposed in this pull request:
- a
- b

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
