### PR TITLE
Add missing exposed CORS header sample-count

### DIFF
--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -76,9 +76,10 @@
             <param-name>cors.allowed.headers</param-name>
             <param-value>Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers</param-value>
         </init-param>
+        <!-- expose cors headers defined in HeaderKeyConstants.java -->
         <init-param>
             <param-name>cors.exposed.headers</param-name>
-            <param-value>total-count</param-value>
+            <param-value>total-count,sample-count</param-value>
         </init-param>
         <init-param>
             <param-name>cors.support.credentials</param-name>

--- a/web/src/main/java/org/cbioportal/web/parameter/HeaderKeyConstants.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/HeaderKeyConstants.java
@@ -1,5 +1,7 @@
 package org.cbioportal.web.parameter;
 
+/* When changing these edit them in portal/src/main/webapp/WEB-INF/web.xml as
+ * well to expose the CORS headers */
 public class HeaderKeyConstants {
 
     public static final String TOTAL_COUNT = "total-count";


### PR DESCRIPTION
This fixes the issue of mutations not showing up in the coexpression tab when
using the AWS apiRoot hack to point to a different backend api then the one
that the user is visiting.