### PR TITLE
Change db parameters dbcp for production

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
@@ -23,6 +23,13 @@ public class JdbcDataSource extends BasicDataSource {
         this.setUrl(url);
         //  By pooling/reusing PreparedStatements, we get a major performance gain
         this.setPoolPreparedStatements(true);
-        this.setMaxTotal(100);
+        // these are the values cbioportal has been using in their production
+        // context.xml files when using jndi
+        this.setMaxTotal(500);
+        this.setMaxIdle(30);
+        this.setMaxWaitMillis(10000);
+        this.setMinEvictableIdleTimeMillis(30000);
+        this.setTestOnBorrow(true);
+        this.setValidationQuery("SELECT 1");
     }
 }


### PR DESCRIPTION
We want to use dbcp on k8s/AWS. This copies over the db parameters we are currently
using in production in our context.xml when using jndi instead of dbcp