### PR TITLE
Add endpoint to retrieve study tags from multiple studies in one request

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/StudyRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/StudyRepository.java
@@ -20,4 +20,6 @@ public interface StudyRepository {
     BaseMeta fetchMetaStudies(List<String> studyIds);
     
     CancerStudyTags getTags(String studyId);
+
+    List<CancerStudyTags> getTagsForMultipleStudies(List<String> studyIds);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StudyMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StudyMapper.java
@@ -16,4 +16,6 @@ public interface StudyMapper {
     CancerStudy getStudy(String studyId, String projection);
 
     CancerStudyTags getTags(String studyId);
+
+    List<CancerStudyTags> getTagsForMultipleStudies(List<String> studyIds);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepository.java
@@ -52,4 +52,10 @@ public class StudyMyBatisRepository implements StudyRepository {
     public CancerStudyTags getTags(String studyId) {
         return studyMapper.getTags(studyId);
     }
+
+    @Override
+    public List<CancerStudyTags> getTagsForMultipleStudies(List<String> studyIds) {
+
+        return studyMapper.getTagsForMultipleStudies(studyIds);
+    }
 }

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
@@ -131,4 +131,18 @@
         WHERE cancer_study.CANCER_STUDY_IDENTIFIER = #{studyId}        
     </select>
 
+    <select id="getTagsForMultipleStudies" resultType="org.cbioportal.model.CancerStudyTags">
+        SELECT
+        cancer_study_tags.CANCER_STUDY_ID AS cancerStudyId,
+        cancer_study_tags.TAGS AS tags
+        FROM cancer_study_tags
+        JOIN cancer_study ON cancer_study_tags.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
+        <where>
+                cancer_study.CANCER_STUDY_IDENTIFIER IN
+                <foreach item="item" collection="list" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+        </where>
+    </select>
+
 </mapper>

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepositoryTest.java
@@ -245,4 +245,17 @@ public class StudyMyBatisRepositoryTest {
 
         Assert.assertEquals((Integer) 2, result.getTotalCount());
     }
+    
+    public void getMultipleTags() throws Exception {
+
+        List<CancerStudyTags> result = studyMyBatisRepository.getTagsForMultipleStudies(Arrays.asList("study_tcga_pub", "acc_tcga"));
+
+        Assert.assertEquals(2, result.size());
+        CancerStudyTags cancerStudyTags1 = result.get(1);
+        Assert.assertEquals((Integer) 1, cancerStudyTags1.getCancerStudyId());
+        Assert.assertEquals("{\"Analyst\": {\"Name\": \"Jack\", \"Email\": \"jack@something.com\"}, \"Load id\": 35}", cancerStudyTags1.getTags());
+        CancerStudyTags cancerStudyTags2 = result.get(0);
+        Assert.assertEquals((Integer) 2, cancerStudyTags2.getCancerStudyId());
+        Assert.assertEquals("{\"Load id\": 36}", cancerStudyTags2.getTags()); 
+    }
 }

--- a/service/src/main/java/org/cbioportal/service/StudyService.java
+++ b/service/src/main/java/org/cbioportal/service/StudyService.java
@@ -20,5 +20,7 @@ public interface StudyService {
 
 	BaseMeta fetchMetaStudies(List<String> studyIds);
 
-	CancerStudyTags getTags(String studyId);
+    CancerStudyTags getTags(String studyId);
+    
+    List<CancerStudyTags> getTagsForMultipleStudies(List<String> studyIds);
 }

--- a/service/src/main/java/org/cbioportal/service/impl/StudyServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/StudyServiceImpl.java
@@ -65,4 +65,10 @@ public class StudyServiceImpl implements StudyService {
 
         return studyRepository.getTags(studyId);
     }
+
+    @Override
+    public List<CancerStudyTags> getTagsForMultipleStudies(List<String> studyIds) {
+
+        return studyRepository.getTagsForMultipleStudies(studyIds);
+    }
 }

--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -133,4 +133,17 @@ public class StudyController {
         
         return new ResponseEntity<>(map, HttpStatus.OK);
     }
+
+    @PreAuthorize("hasPermission(#studyIds, 'List<CancerStudyId>', 'read')")
+    @RequestMapping(value = "/studies/tags", method = RequestMethod.POST,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Get the study tags by IDs")
+    public ResponseEntity<List<CancerStudyTags>> getTagsForMultipleStudies(
+        @ApiParam(required = true, value = "List of Study IDs")
+        @RequestBody List<String> studyIds) {
+        
+        List<CancerStudyTags> cancerStudyTags = studyService.getTagsForMultipleStudies(studyIds);
+        
+        return new ResponseEntity<>(cancerStudyTags, HttpStatus.OK);
+    }
 }

--- a/web/src/test/java/org/cbioportal/web/StudyControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StudyControllerTest.java
@@ -69,6 +69,7 @@ public class StudyControllerTest {
     private static final String TEST_DEDICATED_COLOR = "test_dedicated_color";
     private static final String TEST_TYPE_OF_CANCER_SHORT_NAME = "test_type_of_cancer_short_name";
     private static final String TEST_PARENT = "test_parent";
+    private static final String TEST_TAGS_3 = "{\"Analyst\":{\"Name\":\"Frank\",\"Email\":\"frank@something.com\"},\"Load id\":43}";
 
     @Autowired
     private WebApplicationContext wac;
@@ -321,5 +322,37 @@ public class StudyControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.content().string(TEST_TAGS_2));
+    }
+
+    @Test
+    public void getAllTags() throws Exception {
+
+        List<CancerStudyTags> cancerStudyTagsList = new ArrayList<>();
+        CancerStudyTags cancerStudyTags1 = new CancerStudyTags();
+        cancerStudyTags1.setCancerStudyId(TEST_CANCER_STUDY_ID_1);
+        cancerStudyTags1.setTags(TEST_TAGS_1);
+        cancerStudyTagsList.add(cancerStudyTags1);
+
+        CancerStudyTags cancerStudyTags2 = new CancerStudyTags();
+        cancerStudyTags2.setCancerStudyId(TEST_CANCER_STUDY_ID_2);
+        cancerStudyTags2.setTags(TEST_TAGS_3);
+        cancerStudyTagsList.add(cancerStudyTags2);
+
+        Mockito.when(studyService.getTagsForMultipleStudies(Mockito.anyList())).thenReturn(cancerStudyTagsList);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/studies/tags")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(Arrays.asList(TEST_CANCER_STUDY_IDENTIFIER_1, 
+                TEST_CANCER_STUDY_IDENTIFIER_2))))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].cancerStudyId")
+                    .value(TEST_CANCER_STUDY_ID_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].tags").value(TEST_TAGS_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].cancerStudyId")
+                    .value(TEST_CANCER_STUDY_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].tags").value(TEST_TAGS_3));
     }
 }


### PR DESCRIPTION
Related to #4563, add an endpoint which retrieves all study tags from a list of study ids.
