### PR TITLE
fix api parameter description in 2 swagger endpoints

### DIFF
--- a/web/src/main/java/org/cbioportal/web/GenePanelController.java
+++ b/web/src/main/java/org/cbioportal/web/GenePanelController.java
@@ -128,8 +128,7 @@ public class GenePanelController {
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch gene panel data")
     public ResponseEntity<List<GenePanelData>> fetchGenePanelDataInMultipleMolecularProfiles(
-        @ApiParam(required = true, value = "List of Molecular Profile ID and Sample ID pairs or List of Molecular" + 
-            "Profile IDs and Entrez Gene IDs")
+        @ApiParam(required = true, value = "List of Molecular Profile ID and Sample ID pairs")
         @Valid @RequestBody GenePanelMultipleStudyFilter genePanelMultipleStudyFilter) {
         
         List<String> molecularProfileIds = new ArrayList<>();

--- a/web/src/main/java/org/cbioportal/web/MutationController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationController.java
@@ -156,7 +156,8 @@ public class MutationController {
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch mutations in multiple molecular profiles by sample IDs")
     public ResponseEntity<List<Mutation>> fetchMutationsInMultipleMolecularProfiles(
-        @ApiParam(required = true, value = "List of Molecular Profile ID and Sample ID pairs and Entrez Gene IDs")
+        @ApiParam(required = true, value = "List of Molecular Profile IDs or List of Molecular Profile ID / Sample ID pairs," +
+            " and List of Entrez Gene IDs")
         @Valid @RequestBody MutationMultipleStudyFilter mutationMultipleStudyFilter,
         @ApiParam("Level of detail of the response")
         @RequestParam(defaultValue = "SUMMARY") Projection projection,


### PR DESCRIPTION
# What? Why?
Swagger API Documentation for gene-panel-data/fetch endpoint and mutations/fetch contain incorrect descriptions

fix api parameter description in gene-panel-data and mutations endpoint
    - gene-panel-data/fetch description refers to request supplying Gene IDs, but no such ability remains in the service interface
    - mutations/fetch description does not mention mode where sampleIds are not supplied (only molecularProfileId)

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.
