### PR TITLE
Add endpoint to calculate coexpression in gene sets

### DIFF
--- a/model/src/main/java/org/cbioportal/model/CoExpression.java
+++ b/model/src/main/java/org/cbioportal/model/CoExpression.java
@@ -6,10 +6,18 @@ import javax.validation.constraints.NotNull;
 
 public class CoExpression implements Serializable {
 
+    public enum GeneticEntityType {
+
+        GENE,
+        GENESET
+    }
+
     @NotNull
-    private Integer entrezGeneId;
+    private String geneticEntityId;
     @NotNull
-    private String hugoGeneSymbol;
+    private String geneticEntityName;
+    @NotNull
+    private GeneticEntityType geneticEntityType;
     @NotNull
     private String cytoband;
     @NotNull
@@ -17,20 +25,28 @@ public class CoExpression implements Serializable {
     @NotNull
     private BigDecimal pValue;
 
-    public Integer getEntrezGeneId() {
-        return entrezGeneId;
+    public String getGeneticEntityId() {
+        return geneticEntityId;
     }
 
-    public void setEntrezGeneId(Integer entrezGeneId) {
-        this.entrezGeneId = entrezGeneId;
+    public void setGeneticEntityId(String geneticEntityId) {
+        this.geneticEntityId = geneticEntityId;
     }
 
-    public String getHugoGeneSymbol() {
-        return hugoGeneSymbol;
+    public String getGeneticEntityName() {
+        return geneticEntityName;
     }
 
-    public void setHugoGeneSymbol(String hugoGeneSymbol) {
-        this.hugoGeneSymbol = hugoGeneSymbol;
+    public void setGeneticEntityName(String geneticEntityName) {
+        this.geneticEntityName = geneticEntityName;
+    }
+    
+    public GeneticEntityType getGeneticEntityType() {
+        return geneticEntityType;
+    }
+
+    public void setGeneticEntityType(GeneticEntityType geneticEntityType) {
+        this.geneticEntityType = geneticEntityType;
     }
 
     public String getCytoband() {

--- a/model/src/main/java/org/cbioportal/model/GeneMolecularData.java
+++ b/model/src/main/java/org/cbioportal/model/GeneMolecularData.java
@@ -24,4 +24,9 @@ public class GeneMolecularData extends MolecularData implements Serializable {
     public void setGene(Gene gene) {
         this.gene = gene;
     }
+
+    @Override
+    public String getStableId() {
+        return entrezGeneId.toString();
+    }
 }

--- a/model/src/main/java/org/cbioportal/model/GenesetMolecularAlteration.java
+++ b/model/src/main/java/org/cbioportal/model/GenesetMolecularAlteration.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 public class GenesetMolecularAlteration extends MolecularAlteration implements Serializable {
     
     private String genesetId;
+    private Geneset geneset;
 
     public String getGenesetId() {
         return genesetId;
@@ -12,5 +13,13 @@ public class GenesetMolecularAlteration extends MolecularAlteration implements S
 
     public void setGenesetId(String genesetId) {
         this.genesetId = genesetId;
+    }
+    
+    public Geneset getGeneset() {
+        return geneset;
+    }
+
+    public void setGeneset(Geneset geneset) {
+        this.geneset = geneset;
     }
 }

--- a/model/src/main/java/org/cbioportal/model/GenesetMolecularData.java
+++ b/model/src/main/java/org/cbioportal/model/GenesetMolecularData.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 public class GenesetMolecularData extends MolecularData implements Serializable {
 
     private String genesetId;
+    private Geneset geneset;
     
     public String getGenesetId() {
         return genesetId;
@@ -12,5 +13,18 @@ public class GenesetMolecularData extends MolecularData implements Serializable 
 
     public void setGenesetId(String genesetId) {
         this.genesetId = genesetId;
+    }
+    
+    public Geneset getGeneset() {
+        return geneset;
+    }
+
+    public void setGeneset(Geneset geneset) {
+        this.geneset = geneset;
+    }
+
+    @Override
+    public String getStableId() {
+        return genesetId;
     }
 }

--- a/model/src/main/java/org/cbioportal/model/MolecularData.java
+++ b/model/src/main/java/org/cbioportal/model/MolecularData.java
@@ -31,6 +31,8 @@ public abstract class MolecularData extends UniqueKeyBase {
         this.sampleId = sampleId;
     }
 
+    public abstract String getStableId();
+
     public String getPatientId() {
         return patientId;
     }

--- a/service/src/main/java/org/cbioportal/service/CoExpressionService.java
+++ b/service/src/main/java/org/cbioportal/service/CoExpressionService.java
@@ -7,10 +7,10 @@ import java.util.List;
 
 public interface CoExpressionService {
     
-    List<CoExpression> getCoExpressions(String molecularProfileId, String sampleListId, Integer entrezGeneId, 
-                                       Double threshold) throws MolecularProfileNotFoundException;
+    List<CoExpression> getCoExpressions(String geneticEntityId, CoExpression.GeneticEntityType geneticEntityType, String sampleListId, String molecularProfileIdA, 
+                                       String molecularProfileIdB, Double threshold) throws MolecularProfileNotFoundException, Exception;
 
 
-    List<CoExpression> fetchCoExpressions(String molecularProfileId, List<String> sampleIds, Integer entrezGeneId, 
-                                         Double threshold) throws MolecularProfileNotFoundException;
+    List<CoExpression> fetchCoExpressions(String geneticEntityId, CoExpression.GeneticEntityType geneticEntityType, List<String> sampleIds, String molecularProfileIdA, 
+                                         String molecularProfileIdB, Double threshold) throws MolecularProfileNotFoundException, Exception;
 }

--- a/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java
@@ -4,21 +4,29 @@ import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.stat.correlation.SpearmansCorrelation;
-import org.cbioportal.model.CoExpression;
 import org.cbioportal.model.Gene;
 import org.cbioportal.model.GeneMolecularData;
-import org.cbioportal.service.CoExpressionService;
+import org.cbioportal.model.Geneset;
+import org.cbioportal.model.GenesetMolecularData;
+import org.cbioportal.model.MolecularData;
+import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.CoExpression.GeneticEntityType;
+import org.cbioportal.model.CoExpression;
 import org.cbioportal.service.GeneService;
+import org.cbioportal.service.GenesetDataService;
+import org.cbioportal.service.GenesetService;
 import org.cbioportal.service.MolecularDataService;
-import org.cbioportal.service.exception.MolecularProfileNotFoundException;
+import org.cbioportal.service.MolecularProfileService;
+import org.cbioportal.service.CoExpressionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,71 +36,125 @@ public class CoExpressionServiceImpl implements CoExpressionService {
     private MolecularDataService molecularDataService;
     @Autowired
     private GeneService geneService;
+    @Autowired
+    private GenesetService genesetService;
+    @Autowired
+    private GenesetDataService genesetDataService;
+    @Autowired
+    private MolecularProfileService molecularProfileService;
     
     @Override
-    public List<CoExpression> getCoExpressions(String molecularProfileId, String sampleListId, Integer entrezGeneId, 
-                                              Double threshold) throws MolecularProfileNotFoundException {
-
-        List<GeneMolecularData> molecularDataList = molecularDataService.getMolecularData(molecularProfileId, 
-            sampleListId, null, "SUMMARY");
+    public List<CoExpression> getCoExpressions(String geneticEntityId, CoExpression.GeneticEntityType geneticEntityType, String sampleListId, 
+                                              String molecularProfileIdA, String molecularProfileIdB, Double threshold) throws Exception {
         
-        return createCoExpressions(molecularDataList, entrezGeneId, threshold);
+        List<CoExpression> computedCoExpressions = null;
+        List<? extends MolecularData>  molecularDataListA = null;
+        List<? extends MolecularData>  molecularDataListB = null;
+        if (geneticEntityType.equals(GeneticEntityType.GENE)) {
+            molecularDataListA = molecularDataService.getMolecularData(molecularProfileIdA, sampleListId, null, "SUMMARY");
+        } else if (geneticEntityType.equals(GeneticEntityType.GENESET)) {
+            molecularDataListA = genesetDataService.fetchGenesetData(molecularProfileIdA, sampleListId, null);
+        }
+        MolecularProfile molecularProfileB = molecularProfileService.getMolecularProfile(molecularProfileIdB);
+        Boolean isMolecularProfileBOfGenesetType = molecularProfileB.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.GENESET_SCORE);
+        if (isMolecularProfileBOfGenesetType) {
+            molecularDataListB = genesetDataService.fetchGenesetData(molecularProfileIdB, sampleListId, null);
+        } else {
+            molecularDataListB = molecularDataService.getMolecularData(molecularProfileIdB, sampleListId, null, "SUMMARY");
+        }
+        Set<String> samplesA = new HashSet<String>((molecularDataListA.stream().map(g -> g.getSampleId()).collect(Collectors.toList())));
+        Set<String> samplesB = new HashSet<String>((molecularDataListB.stream().map(g -> g.getSampleId()).collect(Collectors.toList())));
+        Set<String> sharedSamples = new HashSet<String>(samplesA); // use the copy constructor
+        sharedSamples.retainAll(samplesB);
+        List<? extends MolecularData> finalmolecularDataListA = molecularDataListA.stream().filter(p -> sharedSamples.contains(p.getSampleId()))
+                .collect(Collectors.toList());
+        List<? extends MolecularData> finalmolecularDataListB = molecularDataListB.stream().filter(p -> sharedSamples.contains(p.getSampleId()))
+                .collect(Collectors.toList());
+
+        computedCoExpressions = computeCoExpressions(finalmolecularDataListB, isMolecularProfileBOfGenesetType, finalmolecularDataListA, geneticEntityId, threshold);
+        return computedCoExpressions;
     }
 
     @Override
-    public List<CoExpression> fetchCoExpressions(String molecularProfileId, List<String> sampleIds, Integer entrezGeneId, 
-                                                Double threshold) throws MolecularProfileNotFoundException {
+    public List<CoExpression> fetchCoExpressions(String geneticEntityId, CoExpression.GeneticEntityType geneticEntityType, List<String> sampleIds, 
+                                              String molecularProfileIdB, String molecularProfileIdA, Double threshold) throws Exception {
 
-        List<GeneMolecularData> molecularDataList = molecularDataService.fetchMolecularData(molecularProfileId, 
-            sampleIds, null, "SUMMARY");
-        
-        return createCoExpressions(molecularDataList, entrezGeneId, threshold);
+        List<CoExpression> computedCoExpressions = null;
+        List<? extends MolecularData>  molecularDataListA = null;
+        List<? extends MolecularData>  molecularDataListB = null;
+        if (geneticEntityType.equals(GeneticEntityType.GENE)) {
+            molecularDataListA = molecularDataService.fetchMolecularData(molecularProfileIdA, sampleIds, null, "SUMMARY");
+        } else if (geneticEntityType.equals(GeneticEntityType.GENESET)) {
+            molecularDataListA = genesetDataService.fetchGenesetData(molecularProfileIdB, sampleIds, null);
+        }
+        MolecularProfile molecularProfileB = molecularProfileService.getMolecularProfile(molecularProfileIdB);
+        Boolean isMolecularProfileBOfGenesetType = molecularProfileB.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.GENESET_SCORE);
+        if (isMolecularProfileBOfGenesetType) {
+            molecularDataListB = genesetDataService.fetchGenesetData(molecularProfileIdB, sampleIds, null).stream().collect(Collectors.toList());;
+        } else {
+            molecularDataListB = molecularDataService.fetchMolecularData(molecularProfileIdB, sampleIds, null, "SUMMARY").stream().collect(Collectors.toList());
+        }
+        computedCoExpressions = computeCoExpressions(molecularDataListB, isMolecularProfileBOfGenesetType, molecularDataListA, geneticEntityId, threshold);
+        return computedCoExpressions;
     }
     
-    private List<CoExpression> createCoExpressions(List<GeneMolecularData> molecularDataList, Integer queryEntrezGeneId,
-                                                   Double threshold) {
-
-        Map<Integer, List<GeneMolecularData>> molecularDataMap = molecularDataList.stream()
-                .collect(Collectors.groupingBy(GeneMolecularData::getEntrezGeneId));
-        List<GeneMolecularData> queryMolecularDataList = molecularDataMap.remove(queryEntrezGeneId);
-
-        Map<Integer, List<Gene>> genes = geneService.fetchGenes(molecularDataMap.keySet().stream()
-            .map(String::valueOf).collect(Collectors.toList()), "ENTREZ_GENE_ID", "SUMMARY").stream()
-            .collect(Collectors.groupingBy(Gene::getEntrezGeneId));
+    private List<CoExpression> computeCoExpressions(List<? extends MolecularData> molecularDataListB, Boolean isMolecularProfileBOfGenesetType,
+                                                    List<? extends MolecularData> molecularDataListA, String queryGeneticEntityId, Double threshold) 
+                                                    throws Exception {
+        
+        Map<String , List<MolecularData>> molecularDataMapA = molecularDataListA.stream()
+            .collect(Collectors.groupingBy(MolecularData::getStableId));
+        Map<String , List<MolecularData>> molecularDataMapB = molecularDataListB.stream()
+            .collect(Collectors.groupingBy(MolecularData::getStableId));
         
         List<CoExpression> coExpressionList = new ArrayList<>();
-
-        if (queryMolecularDataList == null) {
+        
+        if (!molecularDataMapA.keySet().contains(queryGeneticEntityId)) {
             return coExpressionList;
         }
 
-        List<String> queryValues = queryMolecularDataList.stream().map(g -> g.getValue()).collect(Collectors.toList());
-        for (Integer entrezGeneId : molecularDataMap.keySet()) {
+        List<? extends MolecularData> finalMolecularDataListA = (List<? extends MolecularData>)molecularDataMapA.remove(queryGeneticEntityId);
+        if (molecularDataMapB.get(queryGeneticEntityId) != null) {
+            List<? extends MolecularData> finalMolecularDataListB = (List<? extends MolecularData>)molecularDataMapB.remove(queryGeneticEntityId);
+            if (finalMolecularDataListB == null) {
+                return coExpressionList;
+            }
+        }
+
+        List<String> valuesB = finalMolecularDataListA.stream().map(g -> g.getValue()).collect(Collectors.toList());
+        for (String entityId : molecularDataMapB.keySet()) {
             
-            List<String> values = molecularDataMap.get(entrezGeneId).stream().map(g -> g.getValue())
+            List<String> values = molecularDataMapB.get(entityId).stream().map(g -> g.getValue())
                 .collect(Collectors.toList());
-            List<String> queryValuesCopy = new ArrayList<>(queryValues);
+            List<String> valuesBCopy = new ArrayList<>(valuesB);
 
             List<Integer> valuesToRemove = new ArrayList<>();
-            for (int i = 0; i < queryValuesCopy.size(); i++) {
-                if (!NumberUtils.isNumber(queryValuesCopy.get(i)) || !NumberUtils.isNumber(values.get(i))) {
+            for (int i = 0; i < valuesBCopy.size(); i++) {
+                if (!NumberUtils.isNumber(valuesBCopy.get(i)) || !NumberUtils.isNumber(values.get(i))) {
                     valuesToRemove.add(i);
                 }
             }
 
             for (int i = 0; i < valuesToRemove.size(); i++) {
                 int valueToRemove = valuesToRemove.get(i) - i;
-                queryValuesCopy.remove(valueToRemove);
+                valuesBCopy.remove(valueToRemove);
                 values.remove(valueToRemove);
             }
             
             CoExpression coExpression = new CoExpression();
-            coExpression.setEntrezGeneId(entrezGeneId);
-            Gene gene = genes.get(entrezGeneId).get(0);
-            coExpression.setCytoband(gene.getCytoband());
-            coExpression.setHugoGeneSymbol(gene.getHugoGeneSymbol());
+            coExpression.setGeneticEntityId(entityId);
+            if (isMolecularProfileBOfGenesetType) {
+                Geneset geneset = genesetService.getGeneset(entityId);
+                coExpression.setCytoband("-");
+                coExpression.setGeneticEntityName(geneset.getName());
+            } else {
+                Gene gene = geneService.getGene(entityId);
+                coExpression.setCytoband(gene.getCytoband());
+                coExpression.setGeneticEntityName(gene.getHugoGeneSymbol());
+            }
+            
 
-            double[] queryValuesNumber = queryValuesCopy.stream().mapToDouble(Double::parseDouble).toArray();
+            double[] valuesBNumber = valuesBCopy.stream().mapToDouble(Double::parseDouble).toArray();
             double[] valuesNumber = values.stream().mapToDouble(Double::parseDouble).toArray();
 
             if (valuesNumber.length <= 2) {
@@ -101,13 +163,13 @@ public class CoExpressionServiceImpl implements CoExpressionService {
             
             double[][] arrays = new double[valuesNumber.length][2];
             for (int i = 0; i < valuesNumber.length; i++) {
-                arrays[i][0] = queryValuesNumber[i];
+                arrays[i][0] = valuesBNumber[i];
                 arrays[i][1] = valuesNumber[i];
             }
 
             SpearmansCorrelation spearmansCorrelation = new SpearmansCorrelation(new Array2DRowRealMatrix(arrays, false));
 
-            double spearmansValue = spearmansCorrelation.correlation(queryValuesNumber, valuesNumber);
+            double spearmansValue = spearmansCorrelation.correlation(valuesBNumber, valuesNumber);
             if (Double.isNaN(spearmansValue) || Math.abs(spearmansValue) < threshold) {
                 continue;
             }

--- a/service/src/test/java/org/cbioportal/service/impl/CoExpressionServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/CoExpressionServiceImplTest.java
@@ -2,9 +2,15 @@ package org.cbioportal.service.impl;
 
 import org.cbioportal.model.CoExpression;
 import org.cbioportal.model.Gene;
+import org.cbioportal.model.Geneset;
 import org.cbioportal.model.GeneMolecularData;
+import org.cbioportal.model.GenesetMolecularData;
+import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.service.GeneService;
+import org.cbioportal.service.GenesetService;
 import org.cbioportal.service.MolecularDataService;
+import org.cbioportal.service.GenesetDataService;
+import org.cbioportal.service.MolecularProfileService;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,11 +34,17 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
     
     @Mock
     private MolecularDataService molecularDataService;
+    @Mock 
+    private GenesetDataService genesetDataService;
     @Mock
     private GeneService geneService;
+    @Mock
+    private GenesetService genesetService;
+    @Mock
+    private MolecularProfileService molecularProfileService;
     
     @Test
-    public void getCoExpressions() throws Exception {
+    public void getGeneCorrelationForQueriedGene() throws Exception {
 
         List<GeneMolecularData> molecularDataList = createGeneMolecularData();
         Mockito.when(molecularDataService.getMolecularData(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, null, "SUMMARY"))
@@ -40,29 +52,40 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
 
         List<Gene> genes = createGenes();
 
-        Mockito.when(geneService.fetchGenes(Arrays.asList("2", "3", "4"), "ENTREZ_GENE_ID", "SUMMARY"))
-            .thenReturn(genes);
+        Mockito.when(geneService.getGene("2"))
+            .thenReturn(genes.get(0));
 
-        List<CoExpression> result = coExpressionService.getCoExpressions(MOLECULAR_PROFILE_ID,
-            SAMPLE_LIST_ID, ENTREZ_GENE_ID_1, THRESHOLD);
+        Mockito.when(geneService.getGene("3"))
+            .thenReturn(genes.get(1));
+
+        Mockito.when(geneService.getGene("4"))
+            .thenReturn(genes.get(2));
+        
+        MolecularProfile geneMolecularProfile = createGeneMolecularProfile();
+        
+        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID))
+            .thenReturn(geneMolecularProfile);
+        
+        List<CoExpression> result = coExpressionService.getCoExpressions("1", CoExpression.GeneticEntityType.GENE, 
+        SAMPLE_LIST_ID, MOLECULAR_PROFILE_ID, MOLECULAR_PROFILE_ID, THRESHOLD);
 
         Assert.assertEquals(2, result.size());
         CoExpression coExpression1 = result.get(0);
-        Assert.assertEquals((Integer) 2, coExpression1.getEntrezGeneId());
-        Assert.assertEquals("HUGO2", coExpression1.getHugoGeneSymbol());
+        Assert.assertEquals("2", coExpression1.getGeneticEntityId());
+        Assert.assertEquals("HUGO2", coExpression1.getGeneticEntityName());
         Assert.assertEquals("CYTOBAND2", coExpression1.getCytoband());
         Assert.assertEquals(new BigDecimal("0.5"), coExpression1.getSpearmansCorrelation());
         Assert.assertEquals(new BigDecimal("0.6666666666666667"), coExpression1.getpValue());
         CoExpression coExpression2 = result.get(1);
-        Assert.assertEquals((Integer) 3, coExpression2.getEntrezGeneId());
-        Assert.assertEquals("HUGO3", coExpression2.getHugoGeneSymbol());
+        Assert.assertEquals("3", coExpression2.getGeneticEntityId());
+        Assert.assertEquals("HUGO3", coExpression2.getGeneticEntityName());
         Assert.assertEquals("CYTOBAND3", coExpression2.getCytoband());
         Assert.assertEquals(new BigDecimal("0.8660254037844386"), coExpression2.getSpearmansCorrelation());
         Assert.assertEquals(new BigDecimal("0.3333333333333333"), coExpression2.getpValue());
     }
 
     @Test
-    public void fetchCoExpressions() throws Exception {
+    public void fetchGeneCoExpressions() throws Exception {
 
         List<GeneMolecularData> molecularDataList = createGeneMolecularData();
         Mockito.when(molecularDataService.fetchMolecularData(MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), 
@@ -70,25 +93,121 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
 
         List<Gene> genes = createGenes();
 
-        Mockito.when(geneService.fetchGenes(Arrays.asList("2", "3", "4"), "ENTREZ_GENE_ID", "SUMMARY"))
-            .thenReturn(genes);
+        Mockito.when(geneService.getGene("2"))
+            .thenReturn(genes.get(0));
 
-        List<CoExpression> result = coExpressionService.fetchCoExpressions(MOLECULAR_PROFILE_ID,
-            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), ENTREZ_GENE_ID_1, THRESHOLD);
+        Mockito.when(geneService.getGene("3"))
+            .thenReturn(genes.get(1));
+
+        Mockito.when(geneService.getGene("4"))
+            .thenReturn(genes.get(2));
+
+        MolecularProfile geneMolecularProfile = createGeneMolecularProfile();
+
+        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID))
+            .thenReturn(geneMolecularProfile);
+
+        List<CoExpression> result = coExpressionService.fetchCoExpressions("1", CoExpression.GeneticEntityType.GENE,
+            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), MOLECULAR_PROFILE_ID, MOLECULAR_PROFILE_ID, THRESHOLD);
 
         Assert.assertEquals(2, result.size());
         CoExpression coExpression1 = result.get(0);
-        Assert.assertEquals((Integer) 2, coExpression1.getEntrezGeneId());
-        Assert.assertEquals("HUGO2", coExpression1.getHugoGeneSymbol());
+        Assert.assertEquals("2", coExpression1.getGeneticEntityId());
+        Assert.assertEquals("HUGO2", coExpression1.getGeneticEntityName());
         Assert.assertEquals("CYTOBAND2", coExpression1.getCytoband());
         Assert.assertEquals(new BigDecimal("0.5"), coExpression1.getSpearmansCorrelation());
         Assert.assertEquals(new BigDecimal("0.6666666666666667"), coExpression1.getpValue());
         CoExpression coExpression2 = result.get(1);
-        Assert.assertEquals((Integer) 3, coExpression2.getEntrezGeneId());
-        Assert.assertEquals("HUGO3", coExpression2.getHugoGeneSymbol());
+        Assert.assertEquals("3", coExpression2.getGeneticEntityId());
+        Assert.assertEquals("HUGO3", coExpression2.getGeneticEntityName());
         Assert.assertEquals("CYTOBAND3", coExpression2.getCytoband());
         Assert.assertEquals(new BigDecimal("0.8660254037844386"), coExpression2.getSpearmansCorrelation());
         Assert.assertEquals(new BigDecimal("0.3333333333333333"), coExpression2.getpValue());
+    }
+
+    @Test
+    public void getGenesetCoExpressions() throws Exception {
+
+        List<GenesetMolecularData> molecularDataList = createGenesetMolecularData();
+        Mockito.when(genesetDataService.fetchGenesetData("profile_id_gsva_scores", SAMPLE_LIST_ID, null))
+            .thenReturn(molecularDataList);
+
+        List<Geneset> genesets = createGenesets();
+
+        Mockito.when(genesetService.getGeneset("BIOCARTA_ASBCELL_PATHWAY"))
+            .thenReturn(genesets.get(0));
+
+        Mockito.when(genesetService.getGeneset("KEGG_DNA_REPLICATION"))
+            .thenReturn(genesets.get(1));
+
+        Mockito.when(genesetService.getGeneset("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE"))
+            .thenReturn(genesets.get(2));
+        
+        MolecularProfile genesetMolecularProfile = createGenesetMolecularProfile();
+
+        Mockito.when(molecularProfileService.getMolecularProfile("profile_id_gsva_scores"))
+            .thenReturn(genesetMolecularProfile);
+
+        List<CoExpression> result = coExpressionService.getCoExpressions("GENESET_ID_TEST", CoExpression.GeneticEntityType.GENESET, 
+        SAMPLE_LIST_ID, "profile_id_gsva_scores", "profile_id_gsva_scores", THRESHOLD);
+
+        Assert.assertEquals(2, result.size());
+        CoExpression coExpression1 = result.get(0);
+        Assert.assertEquals("KEGG_DNA_REPLICATION", coExpression1.getGeneticEntityId());
+        Assert.assertEquals("KEGG_DNA_REPLICATION", coExpression1.getGeneticEntityName());
+        Assert.assertEquals("-", coExpression1.getCytoband());
+        Assert.assertEquals(new BigDecimal("0.8660254037844386"), coExpression1.getSpearmansCorrelation());
+        Assert.assertEquals(new BigDecimal("0.3333333333333333"), coExpression1.getpValue());
+        CoExpression coExpression2 = result.get(1);
+        Assert.assertEquals("BIOCARTA_ASBCELL_PATHWAY", coExpression2.getGeneticEntityId());
+        Assert.assertEquals("BIOCARTA_ASBCELL_PATHWAY", coExpression2.getGeneticEntityName());
+        Assert.assertEquals("-", coExpression2.getCytoband());
+        Assert.assertEquals(new BigDecimal("0.5"), coExpression2.getSpearmansCorrelation());
+        Assert.assertEquals(new BigDecimal("0.6666666666666667"), coExpression2.getpValue());
+    }
+
+    @Test
+    public void fetchGenesetCoExpressions() throws Exception {
+
+        List<GenesetMolecularData> molecularDataList = createGenesetMolecularData();
+        Mockito.when(genesetDataService.fetchGenesetData("profile_id_gsva_scores", Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), 
+            null)).thenReturn(molecularDataList);
+
+        List<Geneset> genesets = createGenesets();
+
+        Mockito.when(genesetService.getGeneset("BIOCARTA_ASBCELL_PATHWAY"))
+            .thenReturn(genesets.get(0));
+    
+        Mockito.when(genesetService.getGeneset("KEGG_DNA_REPLICATION"))
+            .thenReturn(genesets.get(1));
+
+        Mockito.when(genesetService.getGeneset("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE"))
+            .thenReturn(genesets.get(2));
+        
+        Mockito.when(genesetService.getGeneset("BIOCARTA_ASBCELL_PATHWAY"))
+            .thenReturn(genesets.get(0));
+        
+        MolecularProfile genesetMolecularProfile = createGenesetMolecularProfile();
+
+        Mockito.when(molecularProfileService.getMolecularProfile("profile_id_gsva_scores"))
+            .thenReturn(genesetMolecularProfile);
+
+        List<CoExpression> result = coExpressionService.fetchCoExpressions("GENESET_ID_TEST", CoExpression.GeneticEntityType.GENESET,
+            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), "profile_id_gsva_scores", "profile_id_gsva_scores", THRESHOLD);
+
+        Assert.assertEquals(2, result.size());
+        CoExpression coExpression1 = result.get(0);
+        Assert.assertEquals("KEGG_DNA_REPLICATION", coExpression1.getGeneticEntityId());
+        Assert.assertEquals("KEGG_DNA_REPLICATION", coExpression1.getGeneticEntityName());
+        Assert.assertEquals("-", coExpression1.getCytoband());
+        Assert.assertEquals(new BigDecimal("0.8660254037844386"), coExpression1.getSpearmansCorrelation());
+        Assert.assertEquals(new BigDecimal("0.3333333333333333"), coExpression1.getpValue());
+        CoExpression coExpression2 = result.get(1);
+        Assert.assertEquals("BIOCARTA_ASBCELL_PATHWAY", coExpression2.getGeneticEntityId());
+        Assert.assertEquals("BIOCARTA_ASBCELL_PATHWAY", coExpression2.getGeneticEntityName());
+        Assert.assertEquals("-", coExpression2.getCytoband());
+        Assert.assertEquals(new BigDecimal("0.5"), coExpression2.getSpearmansCorrelation());
+        Assert.assertEquals(new BigDecimal("0.6666666666666667"), coExpression2.getpValue());
     }
 
     private List<GeneMolecularData> createGeneMolecularData() {
@@ -162,5 +281,87 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
         gene3.setCytoband("CYTOBAND4");
         genes.add(gene3);
         return genes;
+    }
+
+    private List<GenesetMolecularData> createGenesetMolecularData() {
+        List<GenesetMolecularData> molecularDataList = new ArrayList<>();
+        GenesetMolecularData genesetMolecularData1 = new GenesetMolecularData();
+        genesetMolecularData1.setGenesetId("GENESET_ID_TEST");
+        genesetMolecularData1.setValue("2.1");
+        molecularDataList.add(genesetMolecularData1);
+        GenesetMolecularData genesetMolecularData2 = new GenesetMolecularData();
+        genesetMolecularData2.setGenesetId("GENESET_ID_TEST");
+        genesetMolecularData2.setValue("3");
+        molecularDataList.add(genesetMolecularData2);
+        GenesetMolecularData genesetMolecularData3 = new GenesetMolecularData();
+        genesetMolecularData3.setGenesetId("GENESET_ID_TEST");
+        genesetMolecularData3.setValue("3");
+        molecularDataList.add(genesetMolecularData3);
+        GenesetMolecularData genesetMolecularData4 = new GenesetMolecularData();
+        genesetMolecularData4.setGenesetId("BIOCARTA_ASBCELL_PATHWAY");
+        genesetMolecularData4.setValue("2");
+        molecularDataList.add(genesetMolecularData4);
+        GenesetMolecularData genesetMolecularData5 = new GenesetMolecularData();
+        genesetMolecularData5.setGenesetId("BIOCARTA_ASBCELL_PATHWAY");
+        genesetMolecularData5.setValue("3");
+        molecularDataList.add(genesetMolecularData5);
+        GenesetMolecularData genesetMolecularData6 = new GenesetMolecularData();
+        genesetMolecularData6.setGenesetId("BIOCARTA_ASBCELL_PATHWAY");
+        genesetMolecularData6.setValue("2");
+        molecularDataList.add(genesetMolecularData6);
+        GenesetMolecularData genesetMolecularData7 = new GenesetMolecularData();
+        genesetMolecularData7.setGenesetId("KEGG_DNA_REPLICATION");
+        genesetMolecularData7.setValue("1.1");
+        molecularDataList.add(genesetMolecularData7);
+        GenesetMolecularData genesetMolecularData8 = new GenesetMolecularData();
+        genesetMolecularData8.setGenesetId("KEGG_DNA_REPLICATION");
+        genesetMolecularData8.setValue("5");
+        molecularDataList.add(genesetMolecularData8);
+        GenesetMolecularData genesetMolecularData9 = new GenesetMolecularData();
+        genesetMolecularData9.setGenesetId("KEGG_DNA_REPLICATION");
+        genesetMolecularData9.setValue("3");
+        molecularDataList.add(genesetMolecularData9);
+        GenesetMolecularData genesetMolecularData10 = new GenesetMolecularData();
+        genesetMolecularData10.setGenesetId("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE");
+        genesetMolecularData10.setValue("1");
+        molecularDataList.add(genesetMolecularData10);
+        GenesetMolecularData genesetMolecularData11 = new GenesetMolecularData();
+        genesetMolecularData11.setGenesetId("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE");
+        genesetMolecularData11.setValue("4");
+        molecularDataList.add(genesetMolecularData11);
+        GenesetMolecularData genesetMolecularData12 = new GenesetMolecularData();
+        genesetMolecularData12.setGenesetId("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE");
+        genesetMolecularData12.setValue("0");
+        molecularDataList.add(genesetMolecularData12);
+        return molecularDataList;
+    }
+
+    private List<Geneset> createGenesets() {
+        List<Geneset> genesets = new ArrayList<>();
+        Geneset geneset1 = new Geneset();
+        geneset1.setGenesetId("BIOCARTA_ASBCELL_PATHWAY");
+        geneset1.setName("BIOCARTA_ASBCELL_PATHWAY");
+        genesets.add(geneset1);
+        Geneset geneset2 = new Geneset();
+        geneset2.setGenesetId("KEGG_DNA_REPLICATION");
+        geneset2.setName("KEGG_DNA_REPLICATION");
+        genesets.add(geneset2);
+        Geneset geneset3 = new Geneset();
+        geneset3.setGenesetId("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE");
+        geneset3.setName("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE");
+        genesets.add(geneset3);
+        return genesets;
+    }
+
+    private MolecularProfile createGeneMolecularProfile() {
+        MolecularProfile geneMolecularProfile = new MolecularProfile();
+        geneMolecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.MRNA_EXPRESSION);
+        return geneMolecularProfile;
+    }
+
+    private MolecularProfile createGenesetMolecularProfile() {
+        MolecularProfile genesetMolecularProfile = new MolecularProfile();
+        genesetMolecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.GENESET_SCORE);
+        return genesetMolecularProfile;
     }
 }

--- a/web/src/main/java/org/cbioportal/web/CoExpressionController.java
+++ b/web/src/main/java/org/cbioportal/web/CoExpressionController.java
@@ -5,7 +5,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.CoExpression;
 import org.cbioportal.service.CoExpressionService;
-import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.web.config.annotation.InternalApi;
 import org.cbioportal.web.parameter.CoExpressionFilter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -33,28 +31,41 @@ public class CoExpressionController {
     @Autowired
     private CoExpressionService coExpressionService;
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
-    @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/co-expressions/fetch",
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfile', 'read')")
+    @RequestMapping(value = "/molecular-profiles/co-expressions/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation("Fetch co-expressions in a molecular profile")
+    @ApiOperation("Calculates correlations between a genetic entity from a specific profile and another profile from the same study")
     public ResponseEntity<List<CoExpression>> fetchCoExpressions(
-        @ApiParam(required = true, value = "Molecular Profile ID e.g. acc_tcga_rna_seq_v2_mrna")
-        @PathVariable String molecularProfileId,
-        @ApiParam(required = true, value = "List of Sample IDs/Sample List ID")
+        @ApiParam(required = true, value = "Molecular Profile ID from the Genetic Entity referenced in the co-expression filter e.g. acc_tcga_rna_seq_v2_mrna")
+        @RequestParam String molecularProfileIdA,
+        @ApiParam(required = true, value = "Molecular Profile ID (can be the same as molecularProfileIdA) e.g. acc_tcga_rna_seq_v2_mrna")
+        @RequestParam String molecularProfileIdB,
+        @ApiParam(required = true, value = "List of Sample IDs/Sample List ID and Entrez Gene ID/Gene set ID")
         @Valid @RequestBody CoExpressionFilter coExpressionFilter,
-        @ApiParam(required = true, value = "Entrez Gene ID")
-        @RequestParam Integer entrezGeneId,
         @ApiParam("Threshold")
-        @RequestParam(defaultValue = "0.3") Double threshold) throws MolecularProfileNotFoundException {
+        @RequestParam(defaultValue = "0.3") Double threshold) throws Exception {
 
         List<CoExpression> coExpressionList;
-        if (coExpressionFilter.getSampleListId() != null) {
-            coExpressionList = coExpressionService.getCoExpressions(molecularProfileId,
-                coExpressionFilter.getSampleListId(), entrezGeneId, threshold);
+        String geneticEntityId = null;
+        CoExpression.GeneticEntityType geneticEntityType = null;
+
+        if (coExpressionFilter.getEntrezGeneId() != null) {
+            geneticEntityId = coExpressionFilter.getEntrezGeneId().toString();
+            geneticEntityType = CoExpression.GeneticEntityType.GENE;
         } else {
-            coExpressionList = coExpressionService.fetchCoExpressions(molecularProfileId,
-                coExpressionFilter.getSampleIds(), entrezGeneId, threshold);
+            geneticEntityId = coExpressionFilter.getGenesetId();
+            geneticEntityType = CoExpression.GeneticEntityType.GENESET;
+        }
+
+        if (coExpressionFilter.getSampleListId() != null) {
+            coExpressionList = coExpressionService.getCoExpressions(geneticEntityId,
+                    geneticEntityType, coExpressionFilter.getSampleListId(), molecularProfileIdA, molecularProfileIdB,
+                    threshold);
+        } else {
+            coExpressionList = coExpressionService.fetchCoExpressions(geneticEntityId,
+                    geneticEntityType, coExpressionFilter.getSampleIds(), molecularProfileIdA, molecularProfileIdB,
+                    threshold);
         }
 
         return new ResponseEntity<>(coExpressionList, HttpStatus.OK);

--- a/web/src/main/java/org/cbioportal/web/parameter/CoExpressionFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/CoExpressionFilter.java
@@ -9,10 +9,17 @@ public class CoExpressionFilter {
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> sampleIds;
     private String sampleListId;
+    private Integer entrezGeneId;
+    private String genesetId;
 
     @AssertTrue
     private boolean isEitherSampleListIdOrSampleIdsPresent() {
         return sampleListId != null ^ sampleIds != null;
+    }
+
+    @AssertTrue
+    private boolean isEitherEntrezGeneIdOrGenesetIdPresent() {
+        return entrezGeneId != null ^ genesetId != null;
     }
 
     public List<String> getSampleIds() {
@@ -29,5 +36,21 @@ public class CoExpressionFilter {
 
     public void setSampleListId(String sampleListId) {
         this.sampleListId = sampleListId;
+    }
+    
+    public Integer getEntrezGeneId() {
+        return entrezGeneId;
+    }
+
+    public void setEntrezGeneId(Integer entrezGeneId) {
+        this.entrezGeneId = entrezGeneId;
+    }
+
+    public String getGenesetId() {
+        return genesetId;
+    }
+
+    public void setGenesetId(String genesetId) {
+        this.genesetId = genesetId;
     }
 }

--- a/web/src/test/java/org/cbioportal/web/CoExpressionControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CoExpressionControllerTest.java
@@ -33,12 +33,12 @@ import java.util.List;
 @Configuration
 public class CoExpressionControllerTest {
 
-    private static final int TEST_ENTREZ_GENE_ID_1 = 1;
+    private static final String TEST_ENTREZ_GENE_ID_1 = "1";
     private static final String TEST_HUGO_GENE_SYMBOL_1 = "test_hugo_gene_symbol_1";
     private static final String TEST_CYTOBAND_1 = "test_cytoband_1";
     private static final BigDecimal TEST_SPEARMANS_CORRELATION_1 = new BigDecimal(2.1);
     private static final BigDecimal TEST_P_VALUE_1 = new BigDecimal(0.33);
-    private static final int TEST_ENTREZ_GENE_ID_2 = 2;
+    private static final String TEST_ENTREZ_GENE_ID_2 = "2";
     private static final String TEST_HUGO_GENE_SYMBOL_2 = "test_hugo_gene_symbol_2";
     private static final String TEST_CYTOBAND_2 = "test_cytoband_2";
     private static final BigDecimal TEST_SPEARMANS_CORRELATION_2 = new BigDecimal(4.1);
@@ -68,47 +68,51 @@ public class CoExpressionControllerTest {
     }
     
     @Test
-    public void fetchCoExpressions() throws Exception {
+    public void fetchMolecularProfileCoExpressions() throws Exception {
 
         List<CoExpression> coExpressionList = new ArrayList<>();
         CoExpression coExpression1 = new CoExpression();
-        coExpression1.setEntrezGeneId(TEST_ENTREZ_GENE_ID_1);
-        coExpression1.setHugoGeneSymbol(TEST_HUGO_GENE_SYMBOL_1);
+        coExpression1.setGeneticEntityId(TEST_ENTREZ_GENE_ID_1);
+        coExpression1.setGeneticEntityName(TEST_HUGO_GENE_SYMBOL_1);
         coExpression1.setCytoband(TEST_CYTOBAND_1);
         coExpression1.setSpearmansCorrelation(TEST_SPEARMANS_CORRELATION_1);
         coExpression1.setpValue(TEST_P_VALUE_1);
         coExpressionList.add(coExpression1);
         CoExpression coExpression2 = new CoExpression();
-        coExpression2.setEntrezGeneId(TEST_ENTREZ_GENE_ID_2);
-        coExpression2.setHugoGeneSymbol(TEST_HUGO_GENE_SYMBOL_2);
+        coExpression2.setGeneticEntityId(TEST_ENTREZ_GENE_ID_2);
+        coExpression2.setGeneticEntityName(TEST_HUGO_GENE_SYMBOL_2);
         coExpression2.setCytoband(TEST_CYTOBAND_2);
         coExpression2.setSpearmansCorrelation(TEST_SPEARMANS_CORRELATION_2);
         coExpression2.setpValue(TEST_P_VALUE_2);
         coExpressionList.add(coExpression2);
 
+
         Mockito.when(coExpressionService.fetchCoExpressions(Mockito.anyString(),
-            Mockito.anyListOf(String.class), Mockito.anyInt(), Mockito.anyDouble()))
+        Mockito.any(CoExpression.GeneticEntityType.class), Mockito.anyListOf(String.class), Mockito.anyString(), Mockito.anyString(), 
+        Mockito.anyDouble()))
             .thenReturn(coExpressionList);
 
         CoExpressionFilter coExpressionFilter = new CoExpressionFilter();
         coExpressionFilter.setSampleIds(Arrays.asList("test_sample_id"));
+        coExpressionFilter.setEntrezGeneId(1);
 
         mockMvc.perform(MockMvcRequestBuilders.post(
-            "/molecular-profiles/test_molecular_profile_id/co-expressions/fetch")
-            .param("entrezGeneId", "1")
+            "/molecular-profiles/co-expressions/fetch")
+            .param("molecularProfileIdA", "test_molecular_profile_id")
+            .param("molecularProfileIdB", "test_molecular_profile_id")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(coExpressionFilter)))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneId").value(TEST_ENTREZ_GENE_ID_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].hugoGeneSymbol").value(TEST_HUGO_GENE_SYMBOL_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].geneticEntityId").value(TEST_ENTREZ_GENE_ID_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].geneticEntityName").value(TEST_HUGO_GENE_SYMBOL_1))
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].cytoband").value(TEST_CYTOBAND_1))
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].spearmansCorrelation").value(TEST_SPEARMANS_CORRELATION_1))
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].pValue").value(TEST_P_VALUE_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneId").value(TEST_ENTREZ_GENE_ID_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].hugoGeneSymbol").value(TEST_HUGO_GENE_SYMBOL_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].geneticEntityId").value(TEST_ENTREZ_GENE_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].geneticEntityName").value(TEST_HUGO_GENE_SYMBOL_2))
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].cytoband").value(TEST_CYTOBAND_2))
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].spearmansCorrelation").value(TEST_SPEARMANS_CORRELATION_2))
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].pValue").value(TEST_P_VALUE_2));


### PR DESCRIPTION
This PR adds a new endpoint which allows to calculate the correlations between one gene (or gene set) from a specific profile (e.g. mRNA expression) against the genes / gene sets of another profile (mRNA expression, RPPA, GSVA scores). This endpoint is going to be used in the new co-expression tab, you can check (and find out where to test) the functionality here: https://github.com/cBioPortal/cbioportal-frontend/pull/1786.