### PR TITLE
Add portal/images to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ portal/Portal.iml
 portal/portal.log
 portal/nbproject
 portal/build
+portal/images
 portal/.idea
 portal/.DS_Store
 portal/Portal.ipr


### PR DESCRIPTION
Changes proposed in this pull request:
- Add `portal/images` to gitignore. This is created when running maven.