### PR TITLE
Study tags

### DIFF
--- a/model/src/main/java/org/cbioportal/model/CancerStudyTags.java
+++ b/model/src/main/java/org/cbioportal/model/CancerStudyTags.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 public class CancerStudyTags implements Serializable {
 
     private Integer cancerStudyId;
+    private String cancerStudyIdentifier;
     private String tags;
 
     public Integer getCancerStudyId() {
@@ -13,6 +14,14 @@ public class CancerStudyTags implements Serializable {
 
     public void setCancerStudyId(Integer cancerStudyId) {
         this.cancerStudyId = cancerStudyId;
+    }
+
+    public String getCancerStudyIdentifier() {
+        return cancerStudyIdentifier;
+    }
+
+    public void setCancerStudyIdentifier(String cancerStudyIdentifier) {
+        this.cancerStudyIdentifier = cancerStudyIdentifier;
     }
 
     public String getTags() {

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
@@ -126,6 +126,7 @@
     <select id="getTags" resultType="org.cbioportal.model.CancerStudyTags">
         SELECT
         cancer_study_tags.CANCER_STUDY_ID AS cancerStudyId,
+        cancer_study.CANCER_STUDY_IDENTIFIER as cancerStudyIdentifier,
         cancer_study_tags.TAGS AS tags
         FROM cancer_study_tags
         JOIN cancer_study ON cancer_study_tags.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
@@ -135,6 +136,7 @@
     <select id="getTagsForMultipleStudies" resultType="org.cbioportal.model.CancerStudyTags">
         SELECT
         cancer_study_tags.CANCER_STUDY_ID AS cancerStudyId,
+        cancer_study.CANCER_STUDY_IDENTIFIER as cancerStudyIdentifier,
         cancer_study_tags.TAGS AS tags
         FROM cancer_study_tags
         JOIN cancer_study ON cancer_study_tags.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepositoryTest.java
@@ -232,12 +232,6 @@ public class StudyMyBatisRepositoryTest {
 
         List<CancerStudyTags> result = studyMyBatisRepository.getTagsForMultipleStudies(Arrays.asList("study_tcga_pub", "acc_tcga"));
 
-        Assert.assertEquals(2, result.size());
-        CancerStudyTags cancerStudyTags1 = result.get(1);
-        Assert.assertEquals((Integer) 1, cancerStudyTags1.getCancerStudyId());
-        Assert.assertEquals("{\"Analyst\": {\"Name\": \"Jack\", \"Email\": \"jack@something.com\"}, \"Load id\": 35}", cancerStudyTags1.getTags());
-        CancerStudyTags cancerStudyTags2 = result.get(0);
-        Assert.assertEquals((Integer) 2, cancerStudyTags2.getCancerStudyId());
-        Assert.assertEquals("{\"Load id\": 36}", cancerStudyTags2.getTags()); 
+        Assert.assertEquals("{\"study_tcga_pub\": {\"Analyst\": {\"Name\": \"Jack\", \"Email\": \"jack@something.com\"}, \"Load id\": 35}, \"acc_tcga\": {\"Load id\": 36}", result);
     }
 }

--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -138,12 +138,19 @@ public class StudyController {
     @RequestMapping(value = "/studies/tags/fetch", method = RequestMethod.POST,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get the study tags by IDs")
-    public ResponseEntity<List<CancerStudyTags>> getTagsForMultipleStudies(
+    public ResponseEntity<Map<String,Object>> getTagsForMultipleStudies(
         @ApiParam(required = true, value = "List of Study IDs")
-        @RequestBody List<String> studyIds) {
-        
-        List<CancerStudyTags> cancerStudyTags = studyService.getTagsForMultipleStudies(studyIds);
-        
-        return new ResponseEntity<>(cancerStudyTags, HttpStatus.OK);
+        @RequestBody List<String> studyIds) throws IOException {
+
+            Map<String,Object> map = new HashMap<String,Object>();
+            ObjectMapper mapper = new ObjectMapper();
+            List<CancerStudyTags> cancerStudyTags = studyService.getTagsForMultipleStudies(studyIds);
+            if (cancerStudyTags != null) { //If tags is null an empty map is returned
+                for (CancerStudyTags study : cancerStudyTags) {
+                    map.put(study.getCancerStudyIdentifier(), mapper.readValue(study.getTags(), Map.class));
+                }
+            }
+
+        return new ResponseEntity<>(map, HttpStatus.OK);
     }
 }

--- a/web/src/test/java/org/cbioportal/web/StudyControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StudyControllerTest.java
@@ -31,6 +31,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.Map;
+import java.util.HashMap;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
@@ -292,15 +294,21 @@ public class StudyControllerTest {
 
         List<CancerStudyTags> cancerStudyTagsList = new ArrayList<>();
         CancerStudyTags cancerStudyTags1 = new CancerStudyTags();
-        cancerStudyTags1.setCancerStudyId(TEST_CANCER_STUDY_ID_1);
         cancerStudyTags1.setTags(TEST_TAGS_1);
+        cancerStudyTags1.setCancerStudyId(TEST_CANCER_STUDY_ID_1);
+        cancerStudyTags1.setCancerStudyIdentifier(TEST_CANCER_STUDY_IDENTIFIER_1);
         cancerStudyTagsList.add(cancerStudyTags1);
 
         CancerStudyTags cancerStudyTags2 = new CancerStudyTags();
-        cancerStudyTags2.setCancerStudyId(TEST_CANCER_STUDY_ID_2);
         cancerStudyTags2.setTags(TEST_TAGS_3);
+        cancerStudyTags2.setCancerStudyId(TEST_CANCER_STUDY_ID_2);
+        cancerStudyTags2.setCancerStudyIdentifier(TEST_CANCER_STUDY_IDENTIFIER_2);
         cancerStudyTagsList.add(cancerStudyTags2);
-
+        
+        Map<String,Object> cancerStudyTagsResult = new HashMap<String,Object>();
+        cancerStudyTagsResult.put(TEST_CANCER_STUDY_IDENTIFIER_1, TEST_TAGS_1);
+        cancerStudyTagsResult.put(TEST_CANCER_STUDY_IDENTIFIER_2, TEST_TAGS_3);
+        
         Mockito.when(studyService.getTagsForMultipleStudies(Mockito.anyListOf(String.class))).thenReturn(cancerStudyTagsList);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/studies/tags/fetch")
@@ -310,13 +318,7 @@ public class StudyControllerTest {
                 TEST_CANCER_STUDY_IDENTIFIER_2))))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].cancerStudyId")
-                    .value(TEST_CANCER_STUDY_ID_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].tags").value(TEST_TAGS_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].cancerStudyId")
-                    .value(TEST_CANCER_STUDY_ID_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].tags").value(TEST_TAGS_3));
+            .andExpect(MockMvcResultMatchers.content().string("{\"test_study_1\":{\"Analyst\":{\"Name\":\"Jack\",\"Email\":\"jack@something.com\"},\"Load id\":35},\"test_study_2\":{\"Analyst\":{\"Name\":\"Frank\",\"Email\":\"frank@something.com\"},\"Load id\":43}}"));
     }
 
     private List<CancerStudy> createExampleStudies() throws ParseException {


### PR DESCRIPTION
Added the cancer study identifier as part of the `CancerStudyTags` model, so that the endpoint retrieving multiple studies returns the cancer study identifier instead of the cancer study ID (e.g. `{"brca_tcga":{"analyst":"Frank", "load":"45"}}` instead of `{3:{"analyst":"Frank", "load":"45"}}`.