### PR TITLE
Get project version from git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ cache:
   - $HOME/maven
 env:
   matrix:
-  - MAVEN_VERSION=3.3.9 TEST=core
-  - MAVEN_VERSION=3.3.9 TEST=python-validator
-  - MAVEN_VERSION=3.3.9 TEST=sanity-checks
-  - MAVEN_VERSION=3.3.9 TEST=end-to-end
+  - MAVEN_VERSION=3.5.4 TEST=core
+  - MAVEN_VERSION=3.5.4 TEST=python-validator
+  - MAVEN_VERSION=3.5.4 TEST=sanity-checks
+  - MAVEN_VERSION=3.5.4 TEST=end-to-end
 install:
 - |
   if [[ "${TEST}" == core || "${TEST}" == end-to-end ]]
@@ -71,18 +71,19 @@ script:
   then
       ~/maven/$MAVEN_VERSION/bin/mvn \
           -e \
-          -Ppublic \
-          -Dfinal.war.name=cbioportal \
+          -U \
           -Ddb.user=cbio_user \
           -Ddb.password=somepassword \
-          clean integration-test
+          clean \
+          install \
+          integration-test
   fi
 - |
   if [[ "${TEST}" == end-to-end ]]
   then
       ~/maven/$MAVEN_VERSION/bin/mvn \
-          -Ppublic -DskipTests \
-          -Dfinal.war.name=cbioportal \
+          -U \
+          -DskipTests \
           clean install
   fi
 - |

--- a/app.json
+++ b/app.json
@@ -21,7 +21,7 @@
     },
     "SPRING_OPTS": {
         "description":"set spring properties with e.g. -Dshow.civic=true (TODO: not all props work atm)",
-        "value":"-Dauthenticate=false -Dtomcat.catalina.scope=runtime -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test_small -Ddb.connection_string=jdbc:mysql://devdb.cbioportal.org:3306/ -Ddb.host=devdb.cbioportal.org -Dshow.civic=true -Ddbconnector=dbcp -Dsuppress_schema_version_mismatch_errors=true"
+        "value":"-Dauthenticate=false -Dtomcat.catalina.scope=runtime -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test -Ddb.connection_string=jdbc:mysql://devdb.cbioportal.org:3306/ -Ddb.host=devdb.cbioportal.org -Dshow.civic=true -Ddbconnector=dbcp -Dsuppress_schema_version_mismatch_errors=true"
     }
   },
   "buildpacks": [

--- a/business/pom.xml
+++ b/business/pom.xml
@@ -4,7 +4,9 @@
   <parent>
     <artifactId>master</artifactId>
     <groupId>org.mskcc.cbio</groupId>
-    <version>1.18.2-SNAPSHOT</version>
+    <!-- project version is generated through git or can be passed as
+         PROJECT_VERSION env variable (see version.sh) -->
+    <version>0-unknown-version-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>business</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -292,38 +292,6 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>heroku</id>
-      <build>
-        <plugins>
-          <!-- remove core temp build files -->
-          <plugin>
-            <artifactId>maven-clean-plugin</artifactId>
-            <version>2.5</version>
-            <executions>
-              <execution>
-                <id>clean-artifacts</id>
-                <phase>install</phase>
-                <goals>
-                  <goal>clean</goal>
-                </goals>
-                <configuration>
-                  <excludeDefaultDirectories>true</excludeDefaultDirectories>
-                  <filesets>
-                    <fileset>
-                      <directory>target</directory>
-                    </fileset>
-                  </filesets>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
       <!-- surefire (test) config -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,9 @@
   <parent>
     <artifactId>master</artifactId>
     <groupId>org.mskcc.cbio</groupId>
-    <version>1.18.2-SNAPSHOT</version>
+    <!-- project version is generated through git or can be passed as
+         PROJECT_VERSION env variable (see version.sh) -->
+    <version>0-unknown-version-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>core</artifactId>

--- a/db-scripts/pom.xml
+++ b/db-scripts/pom.xml
@@ -3,7 +3,9 @@
     <parent>
         <artifactId>master</artifactId>
         <groupId>org.mskcc.cbio</groupId>
-        <version>1.18.2-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/docs/System-Requirements.md
+++ b/docs/System-Requirements.md
@@ -27,7 +27,7 @@ On Ubuntu:  [See Recommended Installation Instructions](https://www.digitalocean
 
 ## Apache Maven
 
-The cBioPortal source code is an [Apache Maven](https://maven.apache.org/) driven project.  The software needs to be downloaded and installed prior to building the application from source code.  It can be found on the [Apache Maven](https://maven.apache.org/download.cgi) website.
+The cBioPortal source code is an [Apache Maven](https://maven.apache.org/) driven project.  The software needs to be downloaded and installed prior to building the application from source code.  It can be found on the [Apache Maven](https://maven.apache.org/download.cgi) website. We are currently using version 3.5.4.
 
 On Ubuntu:  ```sudo apt-get install maven```
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -3,7 +3,9 @@
     <parent>
         <artifactId>master</artifactId>
         <groupId>org.mskcc.cbio</groupId>
-        <version>1.18.2-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/persistence/persistence-api/pom.xml
+++ b/persistence/persistence-api/pom.xml
@@ -3,7 +3,9 @@
     <parent>
         <artifactId>persistence</artifactId>
         <groupId>org.mskcc.cbio</groupId>
-        <version>1.18.2-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/persistence/persistence-mybatis/pom.xml
+++ b/persistence/persistence-mybatis/pom.xml
@@ -3,7 +3,9 @@
     <parent>
         <artifactId>persistence</artifactId>
         <groupId>org.mskcc.cbio</groupId>
-        <version>1.18.2-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -3,7 +3,9 @@
     <parent>
         <artifactId>master</artifactId>
         <groupId>org.mskcc.cbio</groupId>
-        <version>1.18.2-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
     <build>
     <plugins>
           <plugin>
-            <groupId>com.github.inodb.maven-external-version</groupId>
+            <groupId>com.github.cbioportal.maven-external-version</groupId>
             <artifactId>maven-external-version-plugin</artifactId>
-            <version>b7bc6a6ff7d51295089d5dc7ff64084063440cc6</version>
+            <version>67e9fc4ebb17333b119ab10e1b521fe8391b7ff2</version>
             <extensions>true</extensions>
             <configuration>
               <strategy hint="script">

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,9 @@
   <artifactId>master</artifactId>
   <packaging>pom</packaging>
   <name>Portal Master</name>
-  <version>1.18.2-SNAPSHOT</version>
+  <!-- project version is generated through git or can be passed as
+	   PROJECT_VERSION env variable (see version.sh) -->
+  <version>0-unknown-version-SNAPSHOT</version>
   <description>master maven module</description>
 
   <scm>
@@ -23,6 +25,12 @@
       </snapshots>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <profiles>
     <profile>
@@ -35,6 +43,17 @@
       </properties>
     <build>
     <plugins>
+          <plugin>
+            <groupId>com.github.inodb.maven-external-version</groupId>
+            <artifactId>maven-external-version-plugin</artifactId>
+            <version>b7bc6a6ff7d51295089d5dc7ff64084063440cc6</version>
+            <extensions>true</extensions>
+            <configuration>
+              <strategy hint="script">
+                <script>./version.sh</script>
+              </strategy>
+            </configuration>
+          </plugin>
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
@@ -250,7 +269,7 @@
     <jacoco-maven-plugin.version>0.7.6.201602180812</jacoco-maven-plugin.version>
     <mockito.version>1.10.19</mockito.version>
 
-    <final.war.name>cbioportal-${project.version}</final.war.name>
+    <final.war.name>cbioportal</final.war.name>
 
   <db.test.driver>com.mysql.jdbc.Driver</db.test.driver>
     <!-- For MySQL < 5.5 change 'default_storage_engine' to 'storage_engine' -->

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
           <plugin>
             <groupId>com.github.cbioportal.maven-external-version</groupId>
             <artifactId>maven-external-version-plugin</artifactId>
-            <version>67e9fc4ebb17333b119ab10e1b521fe8391b7ff2</version>
+            <version>f09c2b9608744881111f24e55d55a91e54e6cb5f</version>
             <extensions>true</extensions>
             <configuration>
               <strategy hint="script">

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -4,7 +4,9 @@
   <parent>
     <artifactId>master</artifactId>
     <groupId>org.mskcc.cbio</groupId>
-    <version>1.18.2-SNAPSHOT</version>
+    <!-- project version is generated through git or can be passed as
+         PROJECT_VERSION env variable (see version.sh) -->
+    <version>0-unknown-version-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cbioportal</artifactId>

--- a/scripts/pom.xml
+++ b/scripts/pom.xml
@@ -67,6 +67,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <artifactSet>
                 <excludes>
                   <exclude>org.bouncycastle:bcprov-jdk15</exclude>

--- a/scripts/pom.xml
+++ b/scripts/pom.xml
@@ -4,7 +4,9 @@
   <parent>
         <artifactId>master</artifactId>
         <groupId>org.mskcc.cbio</groupId>
-        <version>1.18.2-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>scripts</artifactId>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -3,7 +3,9 @@
     <parent>
         <artifactId>master</artifactId>
         <groupId>org.mskcc.cbio</groupId>
-        <version>1.18.2-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/security/security-spring/pom.xml
+++ b/security/security-spring/pom.xml
@@ -3,7 +3,9 @@
     <parent>
         <artifactId>security</artifactId>
         <groupId>org.mskcc.cbio</groupId>
-        <version>1.18.2-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -3,7 +3,9 @@
     <parent>
         <artifactId>master</artifactId>
         <groupId>org.mskcc.cbio</groupId>
-        <version>1.18.2-SNAPSHOT</version>
+        <!-- project version is generated through git or can be passed as
+             PROJECT_VERSION env variable (see version.sh) -->
+        <version>0-unknown-version-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/version.sh
+++ b/version.sh
@@ -2,8 +2,8 @@
 if [ -n "$PROJECT_VERSION" ]; then
     # use env variable PROJECT_VERSION if defined
     echo $PROJECT_VERSION
-elif ! [ -x "$(command -v git)" ]; then
-    # git is not installed, 
+elif ! [ -x "$(command -v git)" ] || ! [ -d .git ]; then
+	# git is not installed, or not in a git repo
     echo '0-unknown-version'
 else
 	# get human readable commit id from git

--- a/version.sh
+++ b/version.sh
@@ -6,6 +6,8 @@ elif ! [ -x "$(command -v git)" ] || ! [ -d .git ]; then
 	# git is not installed, or not in a git repo
     echo '0-unknown-version'
 else
+	# fetch all tags silently
+	git fetch --tags --quiet > /dev/null 2> /dev/null
 	# get human readable commit id from git
 	git describe --tags --always --dirty | sed 's/^v//'
 fi

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+if [ -n "$PROJECT_VERSION" ]; then
+    # use env variable PROJECT_VERSION if defined
+    echo $PROJECT_VERSION
+elif ! [ -x "$(command -v git)" ]; then
+    # git is not installed, 
+    echo '0-unknown-version'
+else
+	# get human readable commit id from git
+	git describe --tags --always --dirty | sed 's/^v//'
+fi

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -4,7 +4,9 @@
   <parent>
     <artifactId>master</artifactId>
     <groupId>org.mskcc.cbio</groupId>
-    <version>1.18.2-SNAPSHOT</version>
+    <!-- project version is generated through git or can be passed as
+         PROJECT_VERSION env variable (see version.sh) -->
+    <version>0-unknown-version-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>web</artifactId>


### PR DESCRIPTION
Normally for each new release we have to create a PR just to update the version in the pom. Then afterwards we get conflicts when we try n merge master branch back into feature branches. Imagine updating master branch, now you will get conflicts in release-x branch and rc branch.

Maven should not keep track of the versioning at all, this is already managed by git. This maven-external-version plugin determines the version using a bash script, `version.sh`. This tries to get the version from git. If git is not available at compile time, one can also supply the version by setting an env variable `PROJECT_VERSION` instead.

I slightly modified maven-external-version plugin, so we can download that dependency from jitpack.

Unfortunately ${project.version} doesn't work in plugins, so we can't show the
version name in the actual war file name anymore (this is a known issue:
https://github.com/bdemers/maven-external-version/issues/7). Seems like an ok
trade-off though

Another issue I ran into was that `integration-test` didn't work anymore without running `install` first. Not sure if this is a reason for concern, but just wanted to notify @ersinciftci . There might be a way to update the plugin to avoid having to do this, but maybe it's not that big of a deal.