### PR TITLE
Disable bot indexing when sitemaps are not configured on

### DIFF
--- a/portal/src/main/webapp/index.jsp
+++ b/portal/src/main/webapp/index.jsp
@@ -3,12 +3,17 @@
     String baseUrl = url.substring(0, url.length() - request.getRequestURI().length()) + request.getContextPath();
     baseUrl = baseUrl.replace("https://", "").replace("http://", "");
 %>
-
+<%@ taglib prefix = "c" uri = "http://java.sun.com/jsp/jstl/core" %>
 <%@ page import="org.mskcc.cbio.portal.util.GlobalProperties" %>
 <!DOCTYPE html>
 <html class="cbioportal-frontend">
 <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+        
+    <c:if test = "${GlobalProperties.showSitemaps()==false}">
+       <meta name="robots" content="noindex" />
+    </c:if>
+    
     <link rel="icon" href="/images/cbioportal_icon.png"/>
     <title>cBioPortal for Cancer Genomics</title>
     

--- a/portal/src/main/webapp/robots.jsp
+++ b/portal/src/main/webapp/robots.jsp
@@ -13,3 +13,10 @@ if (!GlobalProperties.showSitemaps()) {
 <c:if test = "${GlobalProperties.showSitemaps()}">
 Sitemap: <%=protocol%>://<%=request.getServerName()%>/sitemap_index.xml
 </c:if>
+
+<c:if test = "${GlobalProperties.showSitemaps()==false}">
+User-agent: *
+Disallow: /
+</c:if>
+
+

--- a/portal/src/main/webapp/sitemap_index.jsp
+++ b/portal/src/main/webapp/sitemap_index.jsp
@@ -11,6 +11,11 @@
 <%
 String protocol = (request.isSecure()) ? "https" : "http";
 pageContext.setAttribute("serverRoot", protocol + "://" + request.getServerName());
+
+if (GlobalProperties.showSitemaps() == false) {
+    response.setStatus(404);
+} else {
+
 %>
 
 <c:if test = "${GlobalProperties.showSitemaps()}">
@@ -39,3 +44,6 @@ if (GlobalProperties.showSitemaps()) {
    </sitemapindex>
 
 </c:if>
+
+<% } %>
+

--- a/portal/src/main/webapp/sitemap_study.jsp
+++ b/portal/src/main/webapp/sitemap_study.jsp
@@ -10,6 +10,10 @@
 
 <%
 
+if (GlobalProperties.showSitemaps() == false) {
+    response.setStatus(404);
+} else {
+
 String protocol = (request.isSecure()) ? "https" : "http";
 String studyId = request.getParameter("studyId");
 pageContext.setAttribute("studyId", request.getParameter("studyId"));
@@ -45,3 +49,5 @@ if (GlobalProperties.showSitemaps()) {
     </c:forEach>
 </urlset>
 </c:if>
+
+<% } %>


### PR DESCRIPTION
We only want search engines to index our public site.  Add noindex to sitemap and page meta tags when sitemap is configured off 