### PR TITLE
Add frontend release version to sentry

### DIFF
--- a/portal/src/main/webapp/index.jsp
+++ b/portal/src/main/webapp/index.jsp
@@ -17,8 +17,6 @@
     <link rel="icon" href="/images/cbioportal_icon.png"/>
     <title>cBioPortal for Cancer Genomics</title>
     
-    <%@include file="./tracking_include.jsp" %>
-
     <script>
         window.frontendConfig = {
             configurationServiceUrl:"//" + '<%=baseUrl%>' +  "/config_service.jsp",
@@ -57,7 +55,10 @@
 
     </script>
      
-    <script type="text/javascript" src="//<%=baseUrl%>/js/src/load-frontend.js?<%=GlobalProperties.getAppVersion()%>"></script>       
+    <script type="text/javascript" src="//<%=baseUrl%>/js/src/load-frontend.js?<%=GlobalProperties.getAppVersion()%>"></script> 
+    
+    
+          
     <script>
         window.frontendConfig.customTabs && window.frontendConfig.customTabs.forEach(function(tab){
             if (tab.pathsToJs) {
@@ -68,9 +69,12 @@
         });
     </script>
 
+
     <script>
             loadReactApp(window.frontendConfig);
     </script>
+    
+    <%@include file="./tracking_include.jsp" %>
 
 </head>
 

--- a/portal/src/main/webapp/tracking_include.jsp
+++ b/portal/src/main/webapp/tracking_include.jsp
@@ -5,6 +5,7 @@
 <% if (!sentryEndpoint.equals("null")) { %>
 <script src="https://browser.sentry-cdn.com/4.1.1/bundle.min.js" crossorigin="anonymous"></script>
 <script>
-Sentry.init({ dsn: '<%=sentryEndpoint.trim()%>',   ignoreErrors: [/document\.registerElement is deprecated and will be removed/]  });
+var release = (typeof FRONTEND_COMMIT === "undefined") ? "norelease" : FRONTEND_COMMIT;
+Sentry.init({ dsn: '<%=sentryEndpoint.trim()%>', release:release, ignoreErrors: [/document\.registerElement is deprecated and will be removed/]  });
 </script>   
 <% } %> 


### PR DESCRIPTION
We need to add our release version (git hash) to sentry so that we can associate errors with releases and also improve source map resolution 