### PR TITLE
Sentry.js: Ignore "request terminated" errors

### DIFF
--- a/portal/src/main/webapp/tracking_include.jsp
+++ b/portal/src/main/webapp/tracking_include.jsp
@@ -6,6 +6,6 @@
 <script src="https://browser.sentry-cdn.com/4.1.1/bundle.min.js" crossorigin="anonymous"></script>
 <script>
 var release = (typeof FRONTEND_COMMIT === "undefined") ? "norelease" : FRONTEND_COMMIT;
-Sentry.init({ dsn: '<%=sentryEndpoint.trim()%>', release:release, ignoreErrors: [/document\.registerElement is deprecated and will be removed/]  });
+Sentry.init({ dsn: '<%=sentryEndpoint.trim()%>', release:release, ignoreErrors: [/Request has been terminated/,/document\.registerElement is deprecated and will be removed/]  });
 </script>   
 <% } %> 


### PR DESCRIPTION
These errors result when a user navigates to a new page while requests are in progress.  They are noise.