### PR TITLE
remove travis slack notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,5 +97,3 @@ script:
       # screenshots of this portal loaded with the data from the amazon db
       bash test/end-to-end/test_make_screenshots.sh test/end-to-end/screenshots.yml
   fi
-notifications:
-  slack: cbioportal:S2qVTFTFMtizONhCOe8BYxS6


### PR DESCRIPTION
Revoked the token on slack as well, so people searching the git history won't find it. It was committed without encryption so other people could've used it to post messages