### PR TITLE
Update migration script

### DIFF
--- a/db-scripts/src/main/resources/migration.sql
+++ b/db-scripts/src/main/resources/migration.sql
@@ -558,4 +558,8 @@ CREATE TABLE `cancer_study_tags` (
   PRIMARY KEY (`CANCER_STUDY_ID`),
   FOREIGN KEY (`CANCER_STUDY_ID`) REFERENCES `cancer_study` (`CANCER_STUDY_ID`) ON DELETE CASCADE
 );
+
+-- Corresponding change in cgds.sql was missed, hence this duplicate migration statement from version 2.6.1 to ensure dbs installed after v 2.6.1 are in sync.
+ALTER TABLE `mutation_count_by_keyword` MODIFY COLUMN `KEYWORD` VARCHAR(255);
+
 UPDATE `info` SET `DB_SCHEMA_VERSION`="2.7.4";


### PR DESCRIPTION
# What? Why?
Duplicated migration statement increasing the keyword size in `mutation_count_by_keyword` from 2.6.1 to ensure databases installed after 2.6.1 are up-to-date.


# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.


Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>