### PR TITLE
change darwin auth check to construct ddp url for ddp patient viewer

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/CheckDarwinAccessServlet.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/CheckDarwinAccessServlet.java
@@ -64,10 +64,12 @@ import javax.servlet.ServletException;
 @JsonPropertyOrder({
 "darwinAuthResponse",
 "p_userName",
-"p_dmp_pid"
+"p_dmp_pid",
+"deidentification_id"
 })
 public class CheckDarwinAccessServlet extends HttpServlet {
     private static Logger logger = Logger.getLogger(CheckDarwinAccessServlet.class);
+    private static final String DDP_INFO_ENDPOINT = "/info";
 
     @Override
     public void init(ServletConfig config) throws ServletException {
@@ -78,7 +80,7 @@ public class CheckDarwinAccessServlet extends HttpServlet {
     
     public static class CheckDarwinAccess {
         private static String darwinAuthUrl = GlobalProperties.getDarwinAuthCheckUrl();
-        private static String darwinResponseUrl = GlobalProperties.getDarwinResponseUrl();
+        private static String ddpResponseUrl = GlobalProperties.getDdpResponseUrl();
         private static String cisUser = GlobalProperties.getCisUser();
         public static Pattern sampleIdRegex = Pattern.compile(GlobalProperties.getDarwinRegex());
 
@@ -104,7 +106,15 @@ public class CheckDarwinAccessServlet extends HttpServlet {
             HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = getRequestEntity(userName, patientId);
             ResponseEntity<DarwinAccess> responseEntity = restTemplate.exchange(darwinAuthUrl, HttpMethod.POST, requestEntity, DarwinAccess.class);
             String darwinResponse = responseEntity.getBody().getDarwinAuthResponse();
-            return darwinResponse.equals("valid")?darwinResponseUrl+patientId:"";
+            String deidentificationId = responseEntity.getBody().getDeidentification_Id();
+            if (!darwinResponse.equals("valid")) {
+                return "";
+            }
+            if (deidentificationId.isEmpty()) {
+                return "";
+            }
+            // construct URL 
+            return ddpResponseUrl + deidentificationId + DDP_INFO_ENDPOINT;
         }
 
         private static HttpEntity<LinkedMultiValueMap<String, Object>> getRequestEntity(String userName, String patientId) {
@@ -117,7 +127,7 @@ public class CheckDarwinAccessServlet extends HttpServlet {
         }
         
         public static boolean existsDarwinProperties() {
-            return (!darwinAuthUrl.isEmpty() && !darwinResponseUrl.isEmpty() && !cisUser.isEmpty() && !GlobalProperties.getDarwinRegex().isEmpty());
+            return (!darwinAuthUrl.isEmpty() && !ddpResponseUrl.isEmpty() && !cisUser.isEmpty() && !GlobalProperties.getDarwinRegex().isEmpty());
         }
     }   
 
@@ -137,6 +147,11 @@ public class CheckDarwinAccessServlet extends HttpServlet {
         **/
         @JsonProperty("p_dmp_pid")
         private String p_dmp_pid;
+        /**
+        * (Required)
+        **/
+        @JsonProperty("deidentification_id")
+        private String deidentification_id;
 
         @JsonIgnore
         private Map<String, Object> additionalProperties = new HashMap<String, Object>();
@@ -150,11 +165,13 @@ public class CheckDarwinAccessServlet extends HttpServlet {
         * @param darwinAuthResponse
         * @param p_userName
         * @param p_dmp_pid
+        * @param deidentification_id
         **/
-        public DarwinAccess(String darwinAuthResponse, String p_userName, String p_dmp_pid) {
-        this.darwinAuthResponse = darwinAuthResponse;
-        this.p_userName = p_userName;
-        this.p_dmp_pid = p_dmp_pid;
+        public DarwinAccess(String darwinAuthResponse, String p_userName, String p_dmp_pid, String deidentification_id) {
+            this.darwinAuthResponse = darwinAuthResponse;
+            this.p_userName = p_userName;
+            this.p_dmp_pid = p_dmp_pid;
+            this.deidentification_id = deidentification_id;
         }
 
         /**
@@ -164,7 +181,7 @@ public class CheckDarwinAccessServlet extends HttpServlet {
         **/
         @JsonProperty("darwinAuthResponse")
         public String getDarwinAuthResponse() {
-        return darwinAuthResponse;
+            return darwinAuthResponse;
         }
 
         /**
@@ -174,12 +191,12 @@ public class CheckDarwinAccessServlet extends HttpServlet {
         **/
         @JsonProperty("darwinAuthResponse")
         public void setDarwinAuthResponse(String darwinAuthResponse) {
-        this.darwinAuthResponse = darwinAuthResponse;
+            this.darwinAuthResponse = darwinAuthResponse;
         }
 
         public DarwinAccess withDarwinAuthResponse(String darwinAuthResponse) {
-        this.darwinAuthResponse = darwinAuthResponse;
-        return this;
+            this.darwinAuthResponse = darwinAuthResponse;
+            return this;
         }
 
         /**
@@ -189,7 +206,7 @@ public class CheckDarwinAccessServlet extends HttpServlet {
         **/
         @JsonProperty("p_userName")
         public String getP_UserName() {
-        return p_userName;
+            return p_userName;
         }
 
         /**
@@ -199,12 +216,12 @@ public class CheckDarwinAccessServlet extends HttpServlet {
         **/
         @JsonProperty("p_userName")
         public void setP_UserName(String p_userName) {
-        this.p_userName = p_userName;
+            this.p_userName = p_userName;
         }
 
         public DarwinAccess withP_UserName(String p_userName) {
-        this.p_userName = p_userName;
-        return this;
+            this.p_userName = p_userName;
+            return this;
         }
 
         /**
@@ -214,7 +231,7 @@ public class CheckDarwinAccessServlet extends HttpServlet {
         **/
         @JsonProperty("p_dmp_pid")
         public String getP_Dmp_Pid() {
-        return p_dmp_pid;
+            return p_dmp_pid;
         }
 
         /**
@@ -224,32 +241,52 @@ public class CheckDarwinAccessServlet extends HttpServlet {
         **/
         @JsonProperty("p_dmp_pid")
         public void setP_Dmp_Pid(String p_dmp_pid) {
-        this.p_dmp_pid = p_dmp_pid;
+            this.p_dmp_pid = p_dmp_pid;
+        }
+
+        /**
+        * (Required)
+        * @return
+        * The deidentification_id
+        **/
+        @JsonProperty("deidentification_id")
+        public String getDeidentification_Id() {
+            return deidentification_id;
+        }
+
+        /**
+        * (Required)
+        * @param deidentification_id
+        * The deidentification_id
+        **/
+        @JsonProperty("deidentification_id")
+        public void setDeidentification_Id(String deidentification_id) {
+            this.deidentification_id = deidentification_id;
         }
 
         public DarwinAccess withP_Dmp_Pid(String p_dmp_pid) {
-        this.p_dmp_pid = p_dmp_pid;
-        return this;
+            this.p_dmp_pid = p_dmp_pid;
+            return this;
         }
 
         @Override
         public String toString() {
-        return ToStringBuilder.reflectionToString(this);
+            return ToStringBuilder.reflectionToString(this);
         }
 
         @JsonAnyGetter
         public Map<String, Object> getAdditionalProperties() {
-        return this.additionalProperties;
+            return this.additionalProperties;
         }
 
         @JsonAnySetter
         public void setAdditionalProperty(String name, Object value) {
-        this.additionalProperties.put(name, value);
+            this.additionalProperties.put(name, value);
         }
 
         public DarwinAccess withAdditionalProperty(String name, Object value) {
-        this.additionalProperties.put(name, value);
-        return this;
+            this.additionalProperties.put(name, value);
+            return this;
         }
     }    
     

--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -242,7 +242,7 @@ public class GlobalProperties {
     public void setSuppressSchemaVersionMismatchErrors(String property) { suppressSchemaVersionMismatchErrors = Boolean.parseBoolean(property); }
     
     public static final String DARWIN_AUTH_URL = "darwin.auth_url";
-    public static final String DARWIN_RESPONSE_URL = "darwin.response_url";
+    public static final String DDP_RESPONSE_URL = "ddp.response_url";
     public static final String CIS_USER = "cis.user";
     public static final String DISABLED_TABS = "disabled_tabs";
     public static final String BITLY_USER = "bitly.user";
@@ -1022,15 +1022,15 @@ public class GlobalProperties {
         return darwinAuthUrl;
     }
     
-    public static String getDarwinResponseUrl() {
-        String darwinResponseUrl = "";
-        if (portalProperties.containsKey(DARWIN_RESPONSE_URL)) {
+    public static String getDdpResponseUrl() {
+        String ddpResponseUrl = "";
+        if (portalProperties.containsKey(DDP_RESPONSE_URL)) {
             try{
-                darwinResponseUrl = portalProperties.getProperty(DARWIN_RESPONSE_URL);
+                ddpResponseUrl = portalProperties.getProperty(DDP_RESPONSE_URL);
             }
             catch (NullPointerException e) {}
         }
-        return darwinResponseUrl;
+        return ddpResponseUrl;
     }
     
     public static List<String[]> getPriorityStudies() {


### PR DESCRIPTION
# What? Why?
Darwin patient viewer is being taken out - link will instead point to patient view in DDP

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
