### PR TITLE
Support add/retrieve groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ portal/reactapp/*
 package.json
 .vscode/
 *.tramp_history
+pom.xml.*

--- a/business/src/main/java/org/mskcc/cbio/portal/model/virtualstudy/VirtualStudy.java
+++ b/business/src/main/java/org/mskcc/cbio/portal/model/virtualstudy/VirtualStudy.java
@@ -3,7 +3,8 @@ package org.mskcc.cbio.portal.model.virtualstudy;
 public class VirtualStudy {
 
 	private String id;
-	
+	private String source;
+	private String type;
 	private VirtualStudyData data;
 
 	public String getId() {
@@ -22,6 +23,22 @@ public class VirtualStudy {
 		this.data = data;
 	}
 
+	public String getSource() {
+		return source;
+	}
+
+	public void setSource(String source) {
+		this.source = source;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+	
 }
 
 

--- a/docs/Authenticating-and-Authorizing-Users-via-keycloak.md
+++ b/docs/Authenticating-and-Authorizing-Users-via-keycloak.md
@@ -33,7 +33,7 @@ Keycloak offers three types of roles:
 Keycloak supports both OpenID-Connect and SAML authentication. When you use SAML authentication, the Keycloak server exchanges XML documents with a web application. XML signatures and encryption are then used to verify requests from the application.
 
 ## Configure Keycloak to authenticate your cbioportal instance
-1. Log in to your Keycloak Identity Provider, e.g. <http://localhost:8080/auth>, as an admin user.
+1. Log in to your Keycloak Identity Provider, e.g. <http://localhost:8080/auth>, as an admin user. :warning: when setting this up on something else than localhost (e.g. production), you will need to use/enable https on your Keycloak server. For simplicity, the rest of the documentation below continues on http://localhost.
 2. Hover over the top-left–corner drop down menu (titled ‘**Master**’) to create a new realm.
 ![](images/previews/add-realm.png)
 Please note if you are logged in the master realm, this drop-down menu lists all the realms created. The last entry of this drop-down menu is always **Add Realm**. Click this to add a realm. Then type '_demo_' in the name field and click the **Create** button.

--- a/web/src/main/java/org/cbioportal/weblegacy/mixin/VirtualStudyMixin.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/mixin/VirtualStudyMixin.java
@@ -1,0 +1,12 @@
+package org.cbioportal.weblegacy.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class VirtualStudyMixin {
+
+	@JsonIgnore
+	private String source;
+	@JsonIgnore
+	private String type;
+	
+}

--- a/web/src/main/java/org/mskcc/cbio/portal/web/ProxySessionServiceController.java
+++ b/web/src/main/java/org/mskcc/cbio/portal/web/ProxySessionServiceController.java
@@ -12,45 +12,45 @@ import java.util.Optional;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.Size;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.cbioportal.web.parameter.PagingConstants;
 import org.json.simple.JSONObject;
 import org.mskcc.cbio.portal.model.virtualstudy.VirtualStudy;
 import org.mskcc.cbio.portal.model.virtualstudy.VirtualStudyData;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 
-import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.apache.commons.logging.LogFactory;
-import org.apache.commons.logging.Log;
 
 @Controller
 @RequestMapping("/proxy/session")
 public class ProxySessionServiceController {
+	
+	private static final Log LOG = LogFactory.getLog(ProxySessionServiceController.class);
+
 
     @Value("${session.service.url:}")
     private String sessionServiceURL;
@@ -63,7 +63,7 @@ public class ProxySessionServiceController {
     
     
     @RequestMapping(value = "/{type}/{id}", method = RequestMethod.GET)
-    public @ResponseBody Object getSessionService(
+    public @ResponseBody Object getSession(
             @PathVariable SessionType type, 
             @PathVariable String      id,
             HttpServletResponse       response) throws IOException {
@@ -78,7 +78,7 @@ public class ProxySessionServiceController {
                                                                         headers,
                                                                         HashMap.class);
             
-            if (type.equals(SessionType.virtual_study)) {
+            if (type.equals(SessionType.virtual_study) || type.equals(SessionType.group)) {
                 ObjectMapper mapper = new ObjectMapper()
                         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
                 
@@ -94,11 +94,15 @@ public class ProxySessionServiceController {
         return null;
     }
 
-    public Boolean isBasicAuthEnabled() {
+    private Boolean isBasicAuthEnabled() {
         return sessionServiceUser != null && !sessionServiceUser.equals("") && sessionServicePassword != null && !sessionServicePassword.equals("");
     }
+    
+    private Boolean isSessionServiceEnabled() {
+    	return !StringUtils.isEmpty(sessionServiceURL);
+    }
 
-    public HttpHeaders getHttpHeaders() {
+    private HttpHeaders getHttpHeaders() {
         return new HttpHeaders() {{
             if (isBasicAuthEnabled()) {
                 String auth = sessionServiceUser + ":" + sessionServicePassword;
@@ -111,148 +115,221 @@ public class ProxySessionServiceController {
      }
     
     @RequestMapping(value = "/virtual_study", method = RequestMethod.GET)
-    public @ResponseBody List<VirtualStudy> getUserStudies() {
-        List<VirtualStudy> virtualStudies = new ArrayList<>();
+    public @ResponseBody List<VirtualStudy> getUserStudies() throws JsonProcessingException {
+        List<VirtualStudy> virtualStudies = new ArrayList<VirtualStudy>();
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (!StringUtils.isEmpty(sessionServiceURL) && authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
+        if (isSessionServiceEnabled()
+                && !(authentication == null || authentication instanceof AnonymousAuthenticationToken)) {
+
+            Map<String, String> map = new HashMap<>();
+            map.put("data.users", ((UserDetails) authentication.getPrincipal()).getUsername());
+
+            ObjectMapper mapper = new ObjectMapper();
+            String query = mapper.writeValueAsString(map);
+
             RestTemplate restTemplate = new RestTemplate();
-            HttpEntity<Object> headers = new HttpEntity<Object>(getHttpHeaders());
-            ResponseEntity<VirtualStudy[]> responseEntity = restTemplate.exchange(
-                    sessionServiceURL + "virtual_study/query?field=data.users&value=" + 
-                    ((UserDetails)authentication.getPrincipal()).getUsername(),
-                    HttpMethod.GET,
-                    headers,
-                    VirtualStudy[].class);
-            virtualStudies = Arrays.asList(responseEntity.getBody());
+
+            HttpEntity<Object> httpEntity = new HttpEntity<Object>(query, getHttpHeaders());
+
+            ResponseEntity<List<VirtualStudy>> responseEntity = restTemplate.exchange(
+                    sessionServiceURL + "virtual_study/query?field=data.users&value="
+                            + ((UserDetails) authentication.getPrincipal()).getUsername(),
+                    HttpMethod.GET, httpEntity, new ParameterizedTypeReference<List<VirtualStudy>>() {
+                    });
+
+            virtualStudies = responseEntity.getBody();
         }
         return virtualStudies;
-        
+
     }
     
     @RequestMapping(value = "/{type}", method = RequestMethod.POST)
-    public @ResponseBody Map addSessionService(@PathVariable SessionType type,
+    public ResponseEntity<HashMap> addSession(@PathVariable SessionType type,
                                                @RequestBody  JSONObject  body) throws IOException {
         
         return addSession(type, Optional.empty(), body);
-
     }
     
     @RequestMapping(value = "/virtual_study/save", method = RequestMethod.POST)
-    public @ResponseBody Map addUserSavedVirtualStudy(@RequestBody  JSONObject body) throws IOException {
+    public ResponseEntity<HashMap> addUserSavedVirtualStudy(@RequestBody  JSONObject body) throws IOException {
         
         return addSession(SessionType.virtual_study, Optional.of(SessionOperation.save), body);
-
     }
 
-    @RequestMapping(value = "/virtual_study/add/{id}", method = RequestMethod.GET)
-    public void addUsertoVirtualStudy(@PathVariable String   id, 
-                                      HttpServletResponse    response) throws IOException {
-        
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        
-        if (!StringUtils.isEmpty(sessionServiceURL) && authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
-                updateVirtualStudyUser(id,
-                                       ((UserDetails)authentication.getPrincipal()).getUsername(),
-                                       Operation.add,
-                                       response);
-        } else {
-            response.sendError(HttpStatus.SERVICE_UNAVAILABLE.value());
-        }
-        
-    }
+	@RequestMapping(value = "/virtual_study/add/{id}", method = RequestMethod.GET)
+	public void addUsertoVirtualStudy(@PathVariable String id, HttpServletResponse response) throws IOException {
+
+		updateVirtualStudyUsers(id, Operation.add, response);
+	}
+
+	@RequestMapping(value = "/virtual_study/delete/{id}", method = RequestMethod.GET)
+	public void removeUserFromVirtualStudy(@PathVariable String id, HttpServletResponse response) throws IOException {
+
+		updateVirtualStudyUsers(id, Operation.delete, response);
+
+	}
     
-    @RequestMapping(value = "/virtual_study/delete/{id}", method = RequestMethod.GET)
-    public void removeUserFromVirtualStudy(@PathVariable String id,
-                                           HttpServletResponse  response) throws IOException {
-        
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        
-        if (!StringUtils.isEmpty(sessionServiceURL) && authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
-            updateVirtualStudyUser(id,
-                                   ((UserDetails)authentication.getPrincipal()).getUsername(),
-                                   Operation.delete,
-                                   response);
-        } else {
-            response.sendError(HttpStatus.SERVICE_UNAVAILABLE.value());
-        }
-        
-    }
-    
-    private Map addSession(SessionType type, 
-                           Optional<SessionOperation> operation,
-                           JSONObject body) throws IOException, JsonParseException, JsonMappingException {
-        
-        HttpEntity httpEntity = null;
-        if (type.equals(SessionType.virtual_study)) {
-            ObjectMapper mapper = new ObjectMapper();
-            // JSON from file to Object
-            VirtualStudyData virtualStudyData = mapper.readValue(body.toString(), VirtualStudyData.class);
-            
-            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-            
-            if (authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
-                    String userName = ((UserDetails)authentication.getPrincipal()).getUsername();
-                virtualStudyData.setOwner(userName);
-                if(operation.isPresent() && operation.get().equals(SessionOperation.save)) {
-                    virtualStudyData.setUsers(Collections.singleton(userName));
-                }
-            }
+	private ResponseEntity<HashMap> addSession(SessionType type, Optional<SessionOperation> operation, JSONObject body) {
+		try {
+			HttpEntity httpEntity = null;
+			if (type.equals(SessionType.virtual_study) || type.equals(SessionType.group)) {
+				ObjectMapper mapper = new ObjectMapper();
+				// JSON from file to Object
+				VirtualStudyData virtualStudyData = mapper.readValue(body.toString(), VirtualStudyData.class);
 
-            // use basic authentication for session service if set
-            httpEntity = new HttpEntity<VirtualStudyData>(virtualStudyData, getHttpHeaders());
-        } else {
-            httpEntity = new HttpEntity<JSONObject>(body, getHttpHeaders());
-        }
-        // returns {"id":"5799648eef86c0e807a2e965"}
-        // using HashMap because converter is MappingJackson2HttpMessageConverter
-        // (Jackson 2 is on classpath)
-        // was String when default converter StringHttpMessageConverter was used
-        RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity<HashMap> responseEntity = restTemplate.exchange(sessionServiceURL + type, HttpMethod.POST, httpEntity, HashMap.class);
+				Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        return responseEntity.getBody();
-    }
+				if (authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
+					String userName = ((UserDetails) authentication.getPrincipal()).getUsername();
+					virtualStudyData.setOwner(userName);
+					if ((operation.isPresent() && operation.get().equals(SessionOperation.save))
+							|| type.equals(SessionType.group)) {
+						virtualStudyData.setUsers(Collections.singleton(userName));
+					}
+				}
+				
+				// use basic authentication for session service if set
+				httpEntity = new HttpEntity<VirtualStudyData>(virtualStudyData, getHttpHeaders());
+			} else {
+				httpEntity = new HttpEntity<JSONObject>(body, getHttpHeaders());
+			}
+			// returns {"id":"5799648eef86c0e807a2e965"}
+			// using HashMap because converter is MappingJackson2HttpMessageConverter
+			// (Jackson 2 is on classpath)
+			// was String when default converter StringHttpMessageConverter was used
+			RestTemplate restTemplate = new RestTemplate();
+			return restTemplate.exchange(sessionServiceURL + type, HttpMethod.POST,
+					httpEntity, HashMap.class);
+
+		} catch (IOException e) {
+			LOG.error(e);
+			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+		}
+	}
     
     
-    private void updateVirtualStudyUser(String              id,
-                                        String              user,
-                                        Operation           operation,
-                                        HttpServletResponse response) throws IOException {
-        
-        try {
-            ObjectMapper mapper = new ObjectMapper()
-                                           .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,false);
-            String virtualStudyStr = mapper
-                    .writeValueAsString(getSessionService(SessionType.virtual_study, id, response));
-            VirtualStudy virtualStudy = mapper.readValue(virtualStudyStr, VirtualStudy.class);
-            Set<String> users = virtualStudy.getData().getUsers();
-            switch (operation) {
-                case add: {
-                    users.add(user);
-                    break;
-                }
-                case delete: {
-                    users.remove(user);
-                    break;
-                }
-            }
-            virtualStudy.getData().setUsers(users);
-            RestTemplate restTemplate = new RestTemplate();
-            HttpEntity<Object> httpEntity = new HttpEntity<Object>(virtualStudy.getData(), getHttpHeaders());
+	private void updateVirtualStudyUsers(String id, Operation operation, HttpServletResponse response)
+			throws IOException {
 
-            restTemplate.exchange(sessionServiceURL + SessionType.virtual_study + "/" + id, HttpMethod.PUT, httpEntity, HashMap.class);
+		try {
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value());
-        }
-        
-    }
+			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+			if (isSessionServiceEnabled()
+					&& !(authentication == null || authentication instanceof AnonymousAuthenticationToken)) {
+
+				String user = ((UserDetails) authentication.getPrincipal()).getUsername();
+
+				ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+						false);
+				String virtualStudyStr = mapper.writeValueAsString(getSession(SessionType.virtual_study, id, response));
+				VirtualStudy virtualStudy = mapper.readValue(virtualStudyStr, VirtualStudy.class);
+				Set<String> users = virtualStudy.getData().getUsers();
+				
+				switch (operation) {
+					case add: {
+						users.add(user);
+						break;
+					}
+					case delete: {
+						users.remove(user);
+						break;
+					}
+				}
+				virtualStudy.getData().setUsers(users);
+				RestTemplate restTemplate = new RestTemplate();
+				HttpEntity<Object> httpEntity = new HttpEntity<Object>(virtualStudy.getData(), getHttpHeaders());
+
+				restTemplate.exchange(sessionServiceURL + SessionType.virtual_study + "/" + id, HttpMethod.PUT,
+						httpEntity, HashMap.class);
+			} else {
+				response.sendError(HttpStatus.SERVICE_UNAVAILABLE.value());
+			}
+
+		} catch (Exception e) {
+			LOG.error(e);
+			response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value());
+		}
+
+	}
+
+	@RequestMapping(value = "/groups/fetch", method = RequestMethod.POST)
+	public ResponseEntity<List<VirtualStudy>> fetchUserGroups(
+			@Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE) @RequestBody List<String> studyIds,
+			HttpServletResponse response) throws IOException {
+
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (isSessionServiceEnabled() && !(authentication == null
+				|| (authentication instanceof AnonymousAuthenticationToken))) {
+
+			Map<String, Object> map = new HashMap<>();
+			map.put("data.users", ((UserDetails) authentication.getPrincipal()).getUsername());
+			map.put("data.origin", studyIds);
+
+			ObjectMapper mapper = new ObjectMapper();
+			String query = mapper.writeValueAsString(map);
+
+			RestTemplate restTemplate = new RestTemplate();
+
+			HttpEntity<String> httpEntity = new HttpEntity<String>(query, getHttpHeaders());
+
+			return restTemplate.exchange(
+					sessionServiceURL + SessionType.group + "/query/fetch",
+					HttpMethod.POST,
+					httpEntity,
+					new ParameterizedTypeReference<List<VirtualStudy>>() {});
+
+		}
+		return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
+	}
+	
+	@RequestMapping(value = "/{type}/{id}", method = RequestMethod.POST)
+	public void updateSession(
+			@PathVariable SessionType type,
+			@PathVariable String id,
+            @RequestBody  JSONObject  body,
+			HttpServletResponse response) throws IOException {
+
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		// updates only allowed for type group for now
+		List<SessionType> validSessionTypes = Arrays.asList(SessionType.group);
+
+		if (validSessionTypes.contains(type) && isSessionServiceEnabled() || !(authentication == null
+				|| (authentication instanceof AnonymousAuthenticationToken))) {
+
+			ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+					false);
+			String virtualStudyStr = mapper.writeValueAsString(getSession(type, id, response));
+			VirtualStudy virtualStudy = mapper.readValue(virtualStudyStr, VirtualStudy.class);
+
+			String user = ((UserDetails) authentication.getPrincipal()).getUsername();
+			if (user == virtualStudy.getData().getOwner() && virtualStudy.getType() == type.toString()) {
+
+				VirtualStudyData updatedVirtualStudyData = mapper.readValue(body.toString(), VirtualStudyData.class);
+				updatedVirtualStudyData.setCreated(virtualStudy.getData().getCreated());
+				updatedVirtualStudyData.setOwner(virtualStudy.getData().getOwner());
+				updatedVirtualStudyData.setUsers(virtualStudy.getData().getUsers());
+
+				virtualStudy.setData(updatedVirtualStudyData);
+				RestTemplate restTemplate = new RestTemplate();
+				HttpEntity<Object> httpEntity = new HttpEntity<Object>(updatedVirtualStudyData, getHttpHeaders());
+				
+				restTemplate.put(sessionServiceURL + type + "/" + id, httpEntity);
+				
+			} else {
+				response.setStatus(HttpStatus.UNAUTHORIZED.value());
+			}
+		}
+		response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
+	}
 }
 
 enum SessionType {
     main_session,
-    virtual_study;
+    virtual_study,
+    group,
+    comparison_session;
 }
 
 enum Operation {

--- a/web/src/main/java/org/mskcc/cbio/portal/web/config/CustomObjectMapper.java
+++ b/web/src/main/java/org/mskcc/cbio/portal/web/config/CustomObjectMapper.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.cbioportal.weblegacy.mixin.VirtualStudyDataMixin;
+import org.cbioportal.weblegacy.mixin.VirtualStudyMixin;
+import org.mskcc.cbio.portal.model.virtualstudy.VirtualStudy;
 import org.mskcc.cbio.portal.model.virtualstudy.VirtualStudyData;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -18,7 +20,8 @@ public class CustomObjectMapper extends ObjectMapper {
         super.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         super.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
         Map<Class<?>, Class<?>> mixinMap = new HashMap<>();
+        mixinMap.put(VirtualStudy.class, VirtualStudyMixin.class);
         mixinMap.put(VirtualStudyData.class, VirtualStudyDataMixin.class);
-        super.setMixInAnnotations(mixinMap);
+        super.setMixIns(mixinMap);
     }
 }


### PR DESCRIPTION
# What? Why?
Fix https://github.com/cBioPortal/cbioportal/issues/5542

API's used for group comparison
```
1. POST  -->  /api-legacy/proxy/session/group         --> add new group(pass virtual study object in request body)
2. GET   -->  /api-legacy/proxy/session/group/{id}    --> get group by id
3. POST  -->  /api-legacy/proxy/session/group/{id}    --> updated group(pass virtual study object in request body)
4. POST  -->  /api-legacy/proxy/session/groups/fetch  --> retrieve groups for queried ids(pass list of id in request body)

```

Supported session API's in general
```
type can be main_session|virtual_study|group|comparison_session

1. GET   -->  /api-legacy/proxy/session/{type}/{id}  -->  get particular session by type and id
2. POST  -->  /api-legacy/proxy/session/{type}  -->  add a new session
3. POST  -->  /api-legacy/proxy/session/{type}/{id}  -->  update particular session(for now only type=group is enabled)

Special API's
1. GET   -->  /api-legacy/proxy/session/virtual_study
2. POST  -->  /api-legacy/proxy/session/virtual_study/save
3. GET   -->  /api-legacy/proxy/session/virtual_study/delete/{ID}
4. GET   -->  /api-legacy/proxy/session/virtual_study/add/{ID}
5. POST  -->  /api-legacy/proxy/session/groups/fetch
```
