### PR TITLE
Replacing old static list by link to RFC folder

### DIFF
--- a/docs/RFC-List.md
+++ b/docs/RFC-List.md
@@ -2,22 +2,8 @@
 
 We maintain an active set of RFCs (Requests for Comments) where we spec out new features and solicit community feedback.
 
-* [RFC1:  Multiple Transcripts in cBioPortal](https://docs.google.com/document/d/1OwfSNAHHvB7hO2rn5GlYlX-YUQIe0GE7baACstfpoZA/edit) [Active]
-* [RFC2:   Landscape View](https://docs.google.com/document/d/1uJ-dgbTW2JzJyzgO885xxdGNgl1nJWTB01ku2kWb7is/edit) [Active]
-* [RFC3:  Genome Nexus](https://docs.google.com/document/d/19O7qJIhISA_YPZ3EMx9Vpfo8Pc4C1Q8t8KzbSqW7jic/edit) [Active]
-* [RFC4:  Support sessions in cBioPortal](https://docs.google.com/document/d/19Mdwxyrcn30JGgb2JM5vowCoK8oc4qeIp6_LhtyBfw8/edit) [Active]
-* [RFC5:  Dynamic Z-Score Calculation](https://docs.google.com/document/d/1yNYDZhrC1qLrjogoS5M6BOW4A313D5u_Or6jhe5pNtc/edit) [Active]
-* [RFC6: cBioPortal Architecture Evolution](https://docs.google.com/document/d/1wIUpo0lRpGurb6SG6h1k10HP4MIsvqlEj1d58U3MugQ/edit) [Active]
-* [RFC7: Layout](https://docs.google.com/document/d/1D2WDjiEhIS_kMYxuno0MJNvr_m7b1wKKYqe7sB3IIvA/edit) [Active]
-* [RFC8: Genome Nexus Annotation](https://docs.google.com/document/d/1yRnN0P52oUknbVcENi6UNLi6-vx5-x8IS9YzgUdwLgM/edit) [Active]
-* [RFC9: Staging Repository](https://docs.google.com/document/d/11HSZn2nKO-1V2RgRLZznDFdStE9Qusf-ttoTti9Np5w/edit) [Active]
-* [RFC10: ETL framework + reference implementation for TCGA](https://docs.google.com/document/d/1kxkXG-lRDX429eWmtUi5_b76XDxMuv14lNFAfR2vO4g/edit) [Active]
-* [RFC11: Release Procedure](https://docs.google.com/document/d/179Slo8_Q2UMjLEvppi5KOQAxBbmJjpDDmHKXi31dIjo/edit) [Active]
-* [RFC12: Cross Study Query](https://docs.google.com/document/d/1kHDC7kImduWJzhKz7THO7QKo83e8k0QD4NeYBj8SI0Q/edit) [Active]
-* [RFC13: Clinical Attributes Ontology](https://docs.google.com/document/d/17FkD03vxEM39pdDTo8ZN1nehu5yr4cMt-M8v9LMQLyE/edit) [Active]
-* [RFC14: Improve Study View Performance](https://docs.google.com/document/d/19xaYBvciCCYjY1j244Dl1wCpiQn6f0r4DzmKajdWE04/edit) [Active]
-* [RFC17: Alteration Frequency Service](https://docs.google.com/document/d/1V--MU2-vQMhWhTF1oy-FAOE0hFoT7WXf1ft4mR443U0/edit) [Active]
-* [RFC20: Patient View Clinical Attributes Template](https://docs.google.com/document/d/1LcSUT1eCsNtoxCLowX4VEyqnQFaihiN0YgqoOfmMDo0) [Active]
+See this [shared google folder](https://drive.google.com/drive/folders/0B6z8AlO4d-qMT0Zpd0J4cW5LbHc) for the list of RFCs.
+
 
 # For Developers Creating new RFCs
 


### PR DESCRIPTION
One of our users ignored this page because he saw that the list of 20 RFCs was never changing. 
This PR solves this issue by pointing to the RFCs folder directly.


