### PR TITLE
Use OAuth2Operations to fetch User email.

### DIFF
--- a/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/googleplus/GoogleplusConnectionFactory.java
+++ b/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/googleplus/GoogleplusConnectionFactory.java
@@ -32,35 +32,33 @@
 
 package org.cbioportal.security.spring.authentication.googleplus;
 
-import org.springframework.social.connect.UserProfile;
 import org.springframework.social.connect.support.OAuth2ConnectionFactory;
 import org.springframework.social.google.api.Google;
 import org.springframework.social.google.connect.GoogleAdapter;
 import org.springframework.social.google.connect.GoogleServiceProvider;
 import org.springframework.social.oauth2.AccessGrant;
+import org.springframework.social.google.api.oauth2.OAuth2Operations;
+
 /**
  * @author criscuof
  *
  */
 public class GoogleplusConnectionFactory extends OAuth2ConnectionFactory<Google> {
-	
 
+    public GoogleplusConnectionFactory(String clientId, String clientSecret) {
+            super("google", new GoogleServiceProvider(clientId, clientSecret),
+                            new GoogleAdapter());
+    }
 
-	public GoogleplusConnectionFactory(String clientId, String clientSecret) {
-		super("google", new GoogleServiceProvider(clientId, clientSecret),
-				new GoogleAdapter());
-	}
-
-	/*
-	 * modification of original factory class to support using the user's email address as his/her id
-	 * original method utilized the google id, a numeric string
-	 */
-	@Override
-	protected String extractProviderUserId(AccessGrant accessGrant) {
-		Google api = ((GoogleServiceProvider)getServiceProvider()).getApi(accessGrant.getAccessToken());
-	    UserProfile userProfile = getApiAdapter().fetchUserProfile(api);
-	    return userProfile.getEmail();
-	}
-
+    /**
+     * modification of original factory class to support using the user's email address as his/her id
+     * original method utilized the google id, a numeric string
+    */
+    @Override
+    protected String extractProviderUserId(AccessGrant accessGrant) {
+        Google api = ((GoogleServiceProvider)getServiceProvider()).getApi(accessGrant.getAccessToken());
+        OAuth2Operations op = api.oauth2Operations();
+        return op.getUserinfo().getEmail();
+    }
 
 }


### PR DESCRIPTION
Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>

# What? Why?
Google is sunsetting Google+. We can fetch the user email directly from `OAuth2Operations` instead of the Google `UserProfile`

See `spring-social-google` issue [#115](https://github.com/spring-social/spring-social-google/issues/115) for reference.

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.
