### PR TITLE
Fix problem with AD authentication after upgrade of Spring security

### DIFF
--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -458,7 +458,9 @@
         <http use-expressions="true" auto-config="true">
             <form-login login-page="/login.jsp"
                 login-processing-url="/j_spring_security_check" 
-                default-target-url="/index.do"
+                username-parameter="j_username" 
+                password-parameter="j_password"                 
+		default-target-url="/index.do"
                 authentication-success-handler-ref="successRedirectHandler" />
             <logout logout-url="/j_spring_security_logout" logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID" />
             <intercept-url pattern="/auth/*" access="permitAll"/>

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -460,7 +460,7 @@
                 login-processing-url="/j_spring_security_check" 
                 username-parameter="j_username" 
                 password-parameter="j_password"                 
-		default-target-url="/index.do"
+                default-target-url="/index.do"
                 authentication-success-handler-ref="successRedirectHandler" />
             <logout logout-url="/j_spring_security_logout" logout-success-url="/login.jsp?logout_success=true" delete-cookies="JSESSIONID" />
             <intercept-url pattern="/auth/*" access="permitAll"/>


### PR DESCRIPTION
After the upgrade to spring-security 4.*, authentication with AD was not working anymore. In the log message we can read that the "username" is emtpy.

To fix it, I add the username-parameter to the security configuration as suggested in https://stackoverflow.com/a/31607334

