### PR TITLE
add timestamp to the msk slide viewer token information

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -1195,11 +1195,15 @@ public class GlobalProperties {
 
     public static String getMskWholeSlideViewerToken()
     {
+        // this token is for the msk portal 
+        // the token is generated based on users' timestamp to let the slide viewer know whether the token is expired and then decide whether to allow the user to login the viewer
+        // every time when we refresh the page or goto the new page, a new token should be generated
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String secretKey = portalProperties.getProperty(MSK_WHOLE_SLIDE_VIEWER_SECRET_KEY);
+        String timeStamp = String.valueOf(System.currentTimeMillis());
         
-        if(authentication != null && authentication.isAuthenticated() && secretKey != null && !secretKey.isEmpty()) {
-            return MskWholeSlideViewerTokenGenerator.generateTokenByHmacSHA256(authentication.getName(), secretKey);
+        if(authentication != null && authentication.isAuthenticated() && secretKey != null && !secretKey.isEmpty()) {           
+            return "{ \"token\":\"" + MskWholeSlideViewerTokenGenerator.generateTokenByHmacSHA256(authentication.getName(), secretKey, timeStamp) + "\", \"time\":\"" + timeStamp + "\"}";
         } else {
             return null;
         }

--- a/core/src/main/java/org/mskcc/cbio/portal/util/MskWholeSlideViewerTokenGenerator.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/MskWholeSlideViewerTokenGenerator.java
@@ -1,32 +1,35 @@
 
 package org.mskcc.cbio.portal.util;
-
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.apache.commons.codec.binary.Base64;
 
 public class MskWholeSlideViewerTokenGenerator {
 	// ~ Static fields
-	// ========================================================================================================
-
-	public static final String PORTAL_NAME = "cbioportal";
+    // ========================================================================================================
+    
+    private static Log LOG = LogFactory.getLog(MskWholeSlideViewerTokenGenerator.class);
+	private static final String PORTAL_NAME = "cbioportal";
 
 	// ~ Methods
 	// ========================================================================================================
 
-	public static String generateTokenByHmacSHA256(String username, String secretKey) {
+	public static String generateTokenByHmacSHA256(String username, String secretKey, String timeStamp) {
         try {
-            String timeStamp = String.valueOf(System.currentTimeMillis());
             String message = PORTAL_NAME + "?" + "user=" + username + "&t=" + timeStamp;
 
             Mac sha256_HMAC = Mac.getInstance("HmacSHA256");
             SecretKeySpec secret_key = new SecretKeySpec(secretKey.getBytes(), "HmacSHA256");
             sha256_HMAC.init(secret_key);
             String hash = Base64.encodeBase64String(sha256_HMAC.doFinal(message.getBytes()));
-
             return hash;
         }
         catch (Exception e) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error("Error generate msk Whole slide viewer token: " + e.getMessage());
+            }
             return null;
         }
 	}


### PR DESCRIPTION
The back-end should return the token generation time together with the token. The front-end url should have the same time when we generate the token.
Partial fix https://github.com/cBioPortal/cbioportal/issues/5624.