### PR TITLE
Add netlify as another place for loading frontend

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -98,6 +98,9 @@ if (window.localdist || window.localdev) {
 } else if (localStorage.heroku) {
 	var herokuInstance = '//' + localStorage.getItem('heroku') + '.herokuapp.com/';
 	window.frontendConfig.frontendUrl = herokuInstance;
+} else if (localStorage.netlify) {
+	var netlifyInstance = '//' + localStorage.getItem('netlify') + '.netlify.com/';
+	window.frontendConfig.frontendUrl = netlifyInstance;
 }
 // clean userEmailAddress config
 if (!window.frontendConfig.userEmailAddress || window.frontendConfig.userEmailAddress === 'anonymousUser') {

--- a/portal/src/main/webapp/index.jsp
+++ b/portal/src/main/webapp/index.jsp
@@ -38,12 +38,16 @@
         window.localdev = localStorage.localdev === 'true';
         window.localdist = localStorage.localdist === 'true';
         window.heroku = localStorage.heroku;
+        window.netlify = localStorage.netlify;
         
         if (window.localdev || window.localdist) {
             window.frontendConfig.frontendUrl = "//localhost:3000/"
             localStorage.setItem("e2etest", "true");
         } else if (window.heroku) {
             window.frontendConfig.frontendUrl = ['//',localStorage.heroku,'.herokuapp.com','/'].join('');
+            localStorage.setItem("e2etest", "true");
+        } else if (window.netlify) {
+            window.frontendConfig.frontendUrl = ['//',localStorage.netlify,'.netlify.com','/'].join('');
             localStorage.setItem("e2etest", "true");
         } else if('<%=GlobalProperties.getFrontendUrl()%>'){
             window.frontendConfig.frontendUrl = '<%=GlobalProperties.getFrontendUrl()%>';

--- a/portal/src/main/webapp/js/src/load-frontend.js
+++ b/portal/src/main/webapp/js/src/load-frontend.js
@@ -3,6 +3,7 @@ function clearDevState(e){
     localStorage.removeItem('localdev');
     localStorage.removeItem('localdist');
     localStorage.removeItem('heroku');
+    localStorage.removeItem('netlify');
     window.location.reload();
 }
 
@@ -35,7 +36,7 @@ window.loadReactApp = function(config) {
             console.log('ERROR: No frontend URL defined, should at least be empty string');
         }
     }
-    if (window.localdev || window.localdist || localStorage.heroku) {
+    if (window.localdev || window.localdist || localStorage.heroku || localStorage.netlify) {
         showFrontendPopup(window.frontendConfig.frontendUrl);
     }
     document.write('<link rel="stylesheet" type="text/css" href="' + window.frontendConfig.frontendUrl + 'reactapp/prefixed-bootstrap.min.css?'+ window.frontendConfig.appVersion +'" />');


### PR DESCRIPTION
Similar to Heroku, but use Netlify. Netlify builds frontend artifacts
automatically, so it will save some time having to wait for heroku deployments
to build. The instances don't sleep either, so this makes the testing
experience a little smoother.