### PR TITLE
Fix the properties to set defaults for Oncoprint mutation annotations

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -294,8 +294,8 @@ public class GlobalProperties {
     
     public static final String BINARY_CUSTOM_DRIVER_ANNOTATION_MENU_LABEL = "oncoprint.custom_driver_annotation.binary.menu_label";
     public static final String TIERS_CUSTOM_DRIVER_ANNOTATION_MENU_LABEL = "oncoprint.custom_driver_annotation.tiers.menu_label";
-    public static final String ENABLE_DRIVER_ANNOTATIONS = "oncoprint.custom_driver_annotation.default";
-    public static final String ENABLE_TIERS = "oncoprint.custom_driver_tiers_annotation.default";
+    public static final String ENABLE_DRIVER_ANNOTATIONS = "oncoprint.custom_driver_annotation.binary.default";
+    public static final String ENABLE_TIERS = "oncoprint.custom_driver_annotation.tiers.default";
     public static final String ENABLE_ONCOKB_AND_HOTSPOTS_ANNOTATIONS = "oncoprint.oncokb_hotspots.default";
     public static final String HIDE_PASSENGER_MUTATIONS = "oncoprint.hide_vus.default";
 

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -176,17 +176,17 @@ oncoprint.custom_driver_annotation.binary.menu_label=Custom driver annotation
 oncoprint.custom_driver_annotation.tiers.menu_label=Custom driver tiers
 ```
 
-#### Automatic selection of custom annotations
-OncoKB and Hotspots are by default automatically selected as annotation source. To add automatic selection of custom driver or custom driver tiers annotations, set the respective property to `true`. Default is `false`.
+#### Automatic selection of OncoKB, hotspots and custom annotations
+OncoKB and Hotspots are by default automatically selected as annotation source, if `show.oncokb` and `show.hotspots` are set to `true`. To add automatic selection of custom driver or custom driver tiers annotations, set the respective property to `true`. Default is `false`.
 ```
-oncoprint.custom_driver_annotation.default=true|false
-oncoprint.custom_driver_tiers_annotation.default=true|false
+oncoprint.custom_driver_annotation.binary.default=true|false
+oncoprint.custom_driver_annotation.tiers.default=true|false
 ```
 
-#### Automatic selection of OncoKB annotations
-OncoKB and Hotspots are by default automatically selected as annotation source. To disable this, set the following property to `false`. To only select OncoKB and Hotspots when there are no custom driver mutation annotations, set this property to `custom`. Default is `true`.
+If you want to disable the automatic selection of OncoKB and hotspots as annotation source, set these properties to `false`:
 ```
-oncoprint.oncokb_hotspots.default=true|false|custom
+oncoprint.oncokb.default=true|false
+oncoprint.hotspots.default=true|false
 ``` 
 
 #### Automatic hiding of variants of unknown significance (VUS)

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -33,8 +33,9 @@
             "oncoprint.custom_driver_annotation.binary.menu_label",
             "disabled_tabs",            
             "civic.url",
-            "oncoprint.custom_driver_annotation.default",
-            "oncoprint.oncokb_hotspots.default",
+            "oncoprint.custom_driver_annotation.binary.default",
+            "oncoprint.oncokb.default",
+            "oncoprint.hotspots.default",
             "genomenexus.url",
             "google_analytics_profile_id",
             "oncoprint.hide_vus.default",
@@ -90,7 +91,8 @@
             "session.url_length_threshold",
             "bitly.api_key",
             "bitly.user",
-            "bitly.access.token"
+            "bitly.access.token",
+            "oncoprint.custom_driver_annotation.tiers.default"
            
         }; 
     

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -201,12 +201,13 @@ ucsc.build=hg19
 oncoprint.defaultview=patient
 
 # OncoPrint driver mutation annotations
-# oncoprint.custom_driver_annotation.binary.menu_label=Custom driver annotation
-# oncoprint.custom_driver_annotation.tiers.menu_label=Custom driver tiers
-# oncoprint.custom_driver_annotation.default=true
-# oncoprint.custom_driver_tiers_annotation.default=true
-# oncoprint.oncokb_hotspots.default=custom
-# oncoprint.hide_vus.default=false
+#   oncoprint.custom_driver_annotation.binary.menu_label=Custom driver annotation
+#   oncoprint.custom_driver_annotation.tiers.menu_label=Custom driver tiers
+#   oncoprint.custom_driver_annotation.binary.default=true
+#   oncoprint.custom_driver_annotation.tiers.default=true
+  oncoprint.oncokb.default=true
+  oncoprint.hotspots.default=true
+#  oncoprint.hide_vus.default=true
 
 # Custom gene sets
 # querypage.setsofgenes.location=file:/<path>


### PR DESCRIPTION
The current properties `oncoprint.custom_driver_annotation.default`, `oncoprint.custom_driver_tiers_annotation.default` and `oncoprint.oncokb_hotspots.default` do not work as expected in the [documentation](https://github.com/cBioPortal/cbioportal/blob/master/docs/portal.properties-Reference.md). 

This PR proposes to fix this and change some of the name properties so that it is more clear what they do. All properties are boolean, if they are set to `true`, then the checkbox in the "Mutations" menu of the Oncoprint will be checked by default:

- `oncoprint.custom_driver_annotation.binary.default`: referring to the "binary" custom annotations.
- `oncoprint.custom_driver_annotation.tiers.default`: referring to the tiers custom annotations.
- `oncoprint.oncokb.default`: referring to the OncoKB annotations.
- `oncoprint.hotspots.default`: referring to Hotspots annotations.

This PR goes together with cBioPortal/cbioportal-frontend#2074.
