### PR TITLE
Fix evaluation of sessionServiceEnabled flag

### DIFF
--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -140,7 +140,8 @@
              
         obj.put("oncoprintOncoKbHotspotsDefault",enableOncoKBandHotspots);    
         
-        obj.put("sessionServiceEnabled",GlobalProperties.getSessionServiceUrl()!= "");        
+        // we don't want to expose session service url to frontend so we need this flag
+        obj.put("sessionServiceEnabled",!GlobalProperties.getSessionServiceUrl().equals(""));      
                 
         out.println(obj.toJSONString());       
                       


### PR DESCRIPTION
We weren't evaluating sessionServiceEnabled properly.  An empty string (corresponding to example properties file) was interpreted as sessionService = true.  