### PR TITLE
Add HRRS filter to log web requests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,7 +36,6 @@
         <artifactId>service</artifactId>
         <version>${project.version}</version>
     </dependency>
-
     <!-- antisamy -->
     <dependency>
       <groupId>org.owasp</groupId>

--- a/core/src/main/java/org/mskcc/cbio/portal/util/DebugHrrsFilter.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/DebugHrrsFilter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.mskcc.cbio.portal.util;
+
+import java.io.*;
+import java.util.*;
+import org.apache.commons.logging.*;
+import org.cbioportal.model.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import com.vlkan.hrrs.servlet.base64.Base64HrrsFilter;
+import com.vlkan.rfos.RotationConfig;
+import com.vlkan.rfos.policy.DailyRotationPolicy;
+import javax.servlet.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DebugHrrsFilter extends Base64HrrsFilter {
+
+    private static RotationConfig createRotationConfig() {
+        String hrrsLoggingFilePath = GlobalProperties.getProperty("hrrs.logging.filepath");
+        String file = new File(hrrsLoggingFilePath).getAbsolutePath();
+        String filePattern = new File(hrrsLoggingFilePath + "-%d{yyyyMMdd-HHmmss-SSS}.csv").getAbsolutePath();
+        RotationConfig rotationConfig = RotationConfig
+                .builder()
+                .file(file)
+                .filePattern(filePattern)
+                .policy(DailyRotationPolicy.getInstance())
+                .build();
+        return rotationConfig;
+    }
+ 
+    public DebugHrrsFilter() {
+        super(createRotationConfig());
+        boolean enableHrrsLogging = Boolean.valueOf(GlobalProperties.getProperty("hrrs.enable.logging"));
+        this.setEnabled(enableHrrsLogging);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -486,11 +486,17 @@
       <artifactId>mybatis</artifactId>
       <version>${mybatis.version}</version>
     </dependency>
+
+    <dependency>
+        <groupId>com.vlkan.hrrs</groupId>
+        <artifactId>hrrs-servlet-filter-base64</artifactId>
+        <version>0.5</version>
+    </dependency>
     <!-- guava -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>23.6-jre</version>
     </dependency>
     <dependency>
         <groupId>org.apache.commons</groupId>

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -101,6 +101,16 @@
     </filter-mapping>
 
     <filter>
+        <filter-name>DebugHrrsFilter</filter-name>
+        <filter-class>org.mskcc.cbio.portal.util.DebugHrrsFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>DebugHrrsFilter</filter-name>
+        <url-pattern>*</url-pattern>
+    </filter-mapping>
+
+    <filter>
         <filter-name>springSecurityFilterChain</filter-name>
         <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
     </filter>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -246,3 +246,9 @@ oncoprint.defaultview=patient
 
 # Enable/Disable quick search (currently in beta, default is false)
 # quick_search.enabled=true
+
+# enable/disable hrrs logging
+# filter which logs incoming web requests to specified logging directory
+# logs must be decrypted for more in-depth information
+hrrs.logging.filepath=
+hrrs.enable.logging=


### PR DESCRIPTION
TODO:
figure out pipeline for decoding and replaying requests

# What? Why?
Adding hrrs library to log incoming web requests - potentially useful for debugging memory leak
Logging can be turned on and off by sending a PUT request to the hrrs servlet (this might not work as easily on a password protected instance of the portal)

Changes proposed in this pull request:
Add hrrs servlet filter 
new property `hrrs.logging.directory` in portal.properties - decide logging output directory

TODO:
Integrate in the `replayer` hrrs tool
Workaround for turning hrrs logging on/off on password protected portal

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
