### PR TITLE
Allow frontend version configured as maven argument

### DIFF
--- a/docs/Build-Different-Frontend.md
+++ b/docs/Build-Different-Frontend.md
@@ -1,0 +1,19 @@
+# Build with different frontend versions
+
+Maven will build cBioPortal with a cBioPortal-frontend version and git repository url as determined by respectively the _frontend.version_ and _frontend.groupId_ parameters in the root POM.xml.
+
+```
+  <properties>
+    <frontend.version>v2.1.0_/frontend.version>
+    <frontend.groupId>com.github.cbioportal</frontend.groupId>
+    ...
+```
+To build cBioPortal with a different frontend version different values for  _frontend.version_ and _frontend.groupId_ parameters can be specified as part of the maven install command. For example:
+
+```
+mvn clean -DskipTests install -Dfrontend.version=93d9cbcbf007ff620ab51ef5af5927a0eb1ebed4 -Dfrontend.groupId=com.github.thehyve
+```
+
+Remarks:
+- The _frontend.version_ parameter allows release tags (e.g. 'v2.1.0') and commit sha-hashes (e.g., '93d9cbcb').
+- The _frontend.groupId_ is a reversed, dot-separated derivative of the git url. Git repository location _github.com/cbioportal_ is represented by the _com.github.cbioportal_ groupId.

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ We also maintain an active [list of RFCs (Requests for Comments)](RFC-List.md) w
    * [API and API Client](The-API-and-API-Client-[Beta].md)
 * [Providing cBioPortal Parameters](providing-cBioPortal-parameters.md)
 * [Manual test cases](manual-test-cases.md)
+* [Build cBioPortal with a different frontend version](Build-Different-Frontend.md)
 
 ## 5. Data Loading
 ### 5.1 Data Loading

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,8 @@
   </profiles>
 
   <properties>
+    <frontend.version>v2.1.0</frontend.version>
+    <frontend.groupId>com.github.cbioportal</frontend.groupId>
     <slf4j.version>1.6.6</slf4j.version>
     <spring.version>4.3.14.RELEASE</spring.version>
     <spring.context.support.version>4.3.14.RELEASE</spring.context.support.version>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -107,9 +107,9 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>com.github.cbioportal</groupId>
+                  <groupId>${frontend.groupId}</groupId>
                   <artifactId>cbioportal-frontend</artifactId>
-                  <version>v2.1.0</version>
+                  <version>${frontend.version}</version>
                   <type>jar</type>
                   <outputDirectory>.</outputDirectory>
                   <excludes>*index*</excludes>


### PR DESCRIPTION
# Why
For implementation of cbioportal-frontend screenshot tests it is required that a cBioPortal docker image can be built with cBioPortal-frontend versions specified by the testing environment. This PR will make the _frontend version_ (e.g., v2.1.0, commit hash such as 93d9cbcbf) and repository location (e.g., github.com/cbioportal, github.com/thehyve) a parameter defined in the ./POM.xml that can be specified on built time with f.i:

>  mvn clean install -DskipTests **-Dfrontend.version=93d9cbcbf007ff620ab51ef5af5927a0eb1ebed4 -Dfrontend.groupId=com.github.thehyve**

A short explanation is added to the docs in the _development_ section.

Note: 
- These values were previously a hard coded value in portal/POM.xml.