### PR TITLE
Use of hashset instead of list speeds up SampleServiceImpl.processSam…

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
@@ -161,12 +161,12 @@ public class SampleServiceImpl implements SampleService {
     private void processSamples(List<Sample> samples, String projection) {
 
         if (projection.equals("DETAILED")) {
-            Map<String, List<String>> sequencedSampleIdsMap = new HashMap<>();
+            Map<String, Set<String>> sequencedSampleIdsMap = new HashMap<>();
             List<String> distinctStudyIds = samples.stream().map(Sample::getCancerStudyIdentifier).distinct()
                 .collect(Collectors.toList());
             for (String studyId : distinctStudyIds) {
-                sequencedSampleIdsMap.put(studyId, sampleListRepository
-                    .getAllSampleIdsInSampleList(studyId + SEQUENCED));
+                sequencedSampleIdsMap.put(studyId,
+                                          new HashSet<String>(sampleListRepository.getAllSampleIdsInSampleList(studyId + SEQUENCED)));
             }
 
             List<Integer> samplesWithCopyNumberSeg = copyNumberSegmentRepository.fetchSamplesWithCopyNumberSegments(


### PR DESCRIPTION
Profiled with GENIE Cohort v5.0-public (~60,000 samples) on internal MSK machine - dashi dev (numbers will probably not be so dramatic going forward, but list sizes will continue to grow, so its a good change going forward).

Using list -

![6BF2ACF1-E680-4AF2-A2D4-0EC57139795F](https://user-images.githubusercontent.com/366003/54216630-63c86d80-44c0-11e9-85a3-e17275755d34.png)

Using set -

![AF9211B3-C10C-4787-B038-1F82CE556FB6](https://user-images.githubusercontent.com/366003/54216642-688d2180-44c0-11e9-8ee9-58e021b240d8.png)
