### PR TITLE
Replace list.indexOf() with map.get() speeds up MolecularDataServiceImpl.getMolecularDataInMultipleProfiles()

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
@@ -139,13 +139,17 @@ public class MolecularDataServiceImpl implements MolecularDataService {
         List<String> commaSeparatedSampleIdsOfMolecularProfiles = molecularDataRepository
             .getCommaSeparatedSampleIdsOfMolecularProfiles(distinctMolecularProfileIds);
 
-        Map<String, List<Integer>> internalSampleIdsMap = new HashMap<>();
+        Map<String, Map<Integer, Integer>> internalSampleIdsMap = new HashMap<>();
         List<Integer> allInternalSampleIds = new ArrayList<>();
         
         for (int i = 0; i < distinctMolecularProfileIds.size(); i++) {
             List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfiles.get(i).split(","))
                 .mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
-            internalSampleIdsMap.put(distinctMolecularProfileIds.get(i), internalSampleIds);
+            HashMap<Integer, Integer> molecularProfileSampleMap = new HashMap<Integer, Integer>();
+            for (int lc = 0; lc < internalSampleIds.size(); lc++) {
+                molecularProfileSampleMap.put(internalSampleIds.get(lc), lc);
+            }
+            internalSampleIdsMap.put(distinctMolecularProfileIds.get(i), molecularProfileSampleMap);
             allInternalSampleIds.addAll(internalSampleIds);
         }
 
@@ -160,7 +164,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
         if (sampleIds == null) {
             samples = sampleService.getSamplesByInternalIds(allInternalSampleIds);
             for (String molecularProfileId : distinctMolecularProfileIds) {
-                internalSampleIdsMap.get(molecularProfileId).forEach(s -> molecularProfiles.add(molecularProfileMapById
+                internalSampleIdsMap.get(molecularProfileId).keySet().forEach(s -> molecularProfiles.add(molecularProfileMapById
                     .get(molecularProfileId)));
             }
         } else {
@@ -180,8 +184,8 @@ public class MolecularDataServiceImpl implements MolecularDataService {
         for (Sample sample : samples) {
             for (MolecularProfile molecularProfile : molecularProfileMapByStudyId.get(sample.getCancerStudyIdentifier())) {
                 String molecularProfileId = molecularProfile.getStableId();
-                int indexOfSampleId = internalSampleIdsMap.get(molecularProfileId).indexOf(sample.getInternalId());
-                if (indexOfSampleId != -1 && molecularAlterationsMap.containsKey(molecularProfileId)) {
+                Integer indexOfSampleId = internalSampleIdsMap.get(molecularProfileId).get(sample.getInternalId());
+                if (indexOfSampleId != null && molecularAlterationsMap.containsKey(molecularProfileId)) {
                     for (GeneMolecularAlteration molecularAlteration : molecularAlterationsMap.get(molecularProfileId)) {
                         GeneMolecularData molecularData = new GeneMolecularData();
                         molecularData.setMolecularProfileId(molecularProfileId);


### PR DESCRIPTION
Profiled with GENIE Cohort v6.1-consortium (~70,000 samples) on internal MSK machine - dashi dev (map eliminates ~4.5 seconds spent finding indices for samples of interest - as sample list size increases over time, more gain will be realized)

Using list.indexOf():
![7AEEAC63-07F9-4F07-92AB-D35C896E769E](https://user-images.githubusercontent.com/366003/54615038-caefa000-4a33-11e9-8f30-e13338e4f667.png)

Using map.get():
![4BF170AB-EE70-4681-B729-9974B6226965](https://user-images.githubusercontent.com/366003/54614970-af849500-4a33-11e9-87f2-4a56d54a6711.png)
