### PR TITLE
Replace list.indexOf() with map.get() speeds up MolecularDataServiceImpl.fetchMolecularData

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
@@ -74,6 +74,10 @@ public class MolecularDataServiceImpl implements MolecularDataService {
         }
         List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfile.split(","))
             .mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
+        Map<Integer, Integer> internalSampleIdsMap = new HashMap<>();
+        for (int lc = 0; lc < internalSampleIds.size(); lc++) {
+            internalSampleIdsMap.put(internalSampleIds.get(lc), lc);
+        }
 
         List<Sample> samples;
         if (sampleIds == null) {
@@ -89,8 +93,8 @@ public class MolecularDataServiceImpl implements MolecularDataService {
             molecularProfileId, entrezGeneIds, projection);
         
         for (Sample sample : samples) {
-            int indexOfSampleId = internalSampleIds.indexOf(sample.getInternalId());
-            if (indexOfSampleId != -1) {
+            Integer indexOfSampleId = internalSampleIdsMap.get(sample.getInternalId());
+            if (indexOfSampleId != null) {
                 for (GeneMolecularAlteration molecularAlteration : molecularAlterations) {
                     GeneMolecularData molecularData = new GeneMolecularData();
                     molecularData.setMolecularProfileId(molecularProfileId);


### PR DESCRIPTION
Profiled with GENIE Cohort v6.1-consortium (~70,000 samples) on internal MSK machine - dashi dev (map eliminates ~4.5 seconds spent finding indices for samples of interest - as sample list size increases over time, more gain will be realized)

(Similar to optimization merged in [5871](https://github.com/cBioPortal/cbioportal/pull/5871))

Using list.indexOf():
![2473D296-9355-4BB3-9FEE-C3B57B0793F6](https://user-images.githubusercontent.com/366003/54711332-11bac400-4b20-11e9-9018-07c9be576e24.png)

Using map.get():
![9E2FBEFE-1487-41A9-8195-6A73512533F6](https://user-images.githubusercontent.com/366003/54711359-1d0def80-4b20-11e9-8f07-94a4e88ffe42.png)
