### PR TITLE
Add documentation describing release + deployment

### DIFF
--- a/docs/Deployment-Procedure.md
+++ b/docs/Deployment-Procedure.md
@@ -25,8 +25,10 @@ events that can require a new deployment:
 ## New frontend commit in master
 Currently we are auto-deploying the frontend master branch to netlify:
 https://cbioportal-frontend.netlify.com. So any change should be automatically
-deployed to the relevant portals if the frontend configuration has been set up
-properly.
+built and deployed to the relevant portals if the frontend configuration has
+been set up properly. Do note that the current build time for the frontend
+project is ~15 minutes or so. To see what frontend commit is deployed, check
+`window.FRONTEND_COMMIT` in the console of the browser.
 
 ### Public Portal Frontend URL
 The public portal is on AWS and running inside a Kubernetes cluster.

--- a/docs/Deployment-Procedure.md
+++ b/docs/Deployment-Procedure.md
@@ -1,0 +1,188 @@
+# Deployment Procedure
+This describes our internal deployment procedure. Shared publicly, in case it
+may be of use. Instructions on how to deploy cBioPortal can be found elsewhere,
+see e.g. [Deploying the web application](Deploying.md) and [Deploy using
+Docker](Deploy-Using-Docker.md).
+
+We deploy the master branch of backend and the master branch of frontend to
+production. The public portal (https://www.cbioportal.org) runs on AWS inside
+kubernetes. The configuration can be found in the knowledgesystems repo:
+
+https://github.com/knowledgesystems/knowledgesystems-k8s-deployment 
+
+Other portals run at MSKCC on two internal machines called dashi and dashi2.
+Since we're running several apps in several tomcats internally the procedure
+for updating them is different from the public portal on AWS. The configuration
+is in the mercurial portal-configuration repo. To make changes, ask Ben for
+access. 
+
+The frontend and backend can be upgraded independently. We have the following
+events that can require a new deployment:
+
+1. [New frontend commit in master](new-frontend-commit-in-master)
+1. [New backend commit in master](new-backend-commit-in-master)
+
+## New frontend commit in master
+Currently we are auto-deploying the frontend master branch to netlify:
+https://cbioportal-frontend.netlify.com. So any change should be automatically
+deployed to the relevant portals if the frontend configuration has been set up
+properly.
+
+### Public Portal Frontend URL
+The public portal is on AWS and running inside a Kubernetes cluster.
+The URL that it gets the frontend version from is here:
+
+https://github.com/knowledgesystems/knowledgesystems-k8s-deployment/search?q=-Dfrontend.url&unscoped_q=-Dfrontend.url
+
+This should be a URL pointing to netlify.
+
+### Internal Portal Frontend URL
+For the internally runnning portals the frontend.url is defined in the
+portal.properties file in the mercurial portal-configuration repo. If set up
+correctly, this should point to a file on both dashi and dashi2 that in turn
+points to a netlify frontend URL. The reason we have a separate file with the
+URL in it is that it allows us to update the frontend URL without redeploying
+the backend.
+
+## New backend commit in master
+A new backend commit usually also means a new frontend change is necessary. For
+this reason the following sections assume that's the case.
+
+### Public Portal Backend Upgrade
+For a backend upgrade a new docker image needs to be generated. You will need
+to have access to the cbioportal org account. Currently we are using a
+different docker image in production then the default one provided with the
+repo. This is an open issue that we're trying to solve. For now we generate the
+docker image like this. Make sure you have the following Dockerfile in the root
+of where you checked out the cbioportal repo:
+
+```
+$ cat norebuild.Dockerfile
+FROM shipilev/openjdk-shenandoah:8
+# copy application WAR (with libraries inside)
+COPY portal/target/cbioportal*.war /app.war
+COPY portal/target/dependency/webapp-runner.jar /webapp-runner.jar
+# specify default command
+CMD ["/usr/bin/java", "-Dspring.data.mongodb.uri=${MONGODB_URI}", "-jar", "/webapp-runner.jar", "/app.war"]
+```
+
+Then generate the image like this (pick a sensible CBIOPORTAL_DOCKER_TAG):
+
+```
+export CBIOPORTAL_DOCKER_TAG=release-2.1.0-rc6 && cp src/main/resources/portal.properties.EXAMPLE src/main/resources/portal.properties && mvn  -DskipTests clean install && docker build -f norebuild.Dockerfile -t cbioportal/cbioportal:${CBIOPORTAL_DOCKER_TAG} . && docker  push cbioportal/cbioportal:${CBIOPORTAL_DOCKER_TAG}
+```	
+
+After that, if you have access to the kubernetes cluster you can change the image in the configuration of the kubernetes cluster:
+
+
+https://github.com/knowledgesystems/knowledgesystems-k8s-deployment/blob/master/cbioportal/cbioportal_spring_boot.yaml
+
+point this line, to the new `CBIOPORTAL_DOCKER_TAG` you pushed to docker hub:
+
+```
+image: cbioportal/cbioportal:release-2.1.0-rc5
+```
+
+Also remove the `-Dfrontend.url` parameter such that the frontend version inside the war will be used:
+
+```
+"-Dfrontend.url=https://cbioportal-frontend.netlify.com/"
+```
+
+Then running this command applies the changes to the cluster:
+
+```
+kubectl apply -f cbioportal/cbioportal_spring_boot.yaml
+```
+
+You can keep track of what's happening by looking at the pods:
+
+```
+kubectl get po
+```
+
+If you have the watch command installed you can also use that to see the output
+of this every 2s:
+
+```
+watch kubectl get po
+```
+
+Another thing to look at is the events:
+
+```
+kubectl get events --sort-by='{.lastTimestamp}'
+```
+
+If there are any issues, point the image back to what it was, set
+`-Dfrontend.url` and run `kubectl apply -f filename` again.
+
+If everything went ok, you can re-enable auto deployment on netlify, set
+`-Dfrontend.url` in the kubernetes file and run `kubectl apply -f filename`
+again.
+
+Make sure to commit your changes to the knowledgesystems-k8s-deployment repo
+and push them to the main repo, so that other people making changes to the
+kubernetes config will be using the latest version. 
+
+### Private Portal Backend Upgrade
+First update the frontend portal configuration to point to a new file. It's
+fine if this file does not exist yet, because if it doesn't the frontend
+bundled with the war will be used. We can later point the file to netlify, once
+we've determined everything looks ok.
+
+You can use this for loop to update the frontend url in all properties files
+(set it to a file that doesn't exist yet and give it a sensible name e.g. `frontend_url_version_x_y_z.txt`):
+
+```
+for f in $(grep frontend.url.runtime properties/*/portal.properties | grep -v beta | cut -d: -f1); do sed -i 's|frontend.url.runtime=/srv/www/msk-tomcat/frontend_url_version_2_0_0.txt|frontend.url.runtime=/srv/www/msk-tomcat/frontend_url_version_2_1_0.txt|g' $f; done
+```
+Same for triage-tomcat (agin set the correct file name)::
+
+```
+ for f in $(grep frontend.url.runtime properties/*/portal.properties | grep -v beta | cut -d: -f1); do sed -i 's|frontend.url.runtime=/srv/www/triage-tomcat/frontend_url_version_2_0_0.txt|frontend.url.runtime=/srv/www/triage-tomcat/frontend_url_version_2_1_0.txt|g' $f; done
+```	
+Make sure you see the frontend url file updated correctly:
+
+```
+hg diff
+```
+
+Then commit and push your changes to the mercurial repo:
+```
+hg commit -u username -m 'update frontend url files for new release'
+hg push
+```
+
+If you have your public key added for the relevant deploy scripts you should be able to deploy with the following command on dashi-dev:
+
+```
+# set PROJECT_CONFIG_HOME and PORTAL_HOME to your own directory
+unset PROJECT_VERSION && export PORTAL_HOME=/data/debruiji/git/cbioportal && export PORTAL_CONFIG_HOME=/data/debruiji/hg/portal-configuration && cd ${PORTAL_CONFIG_HOME}/buildwars && hg pull && hg update && export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk.x86_64 && bash buildproductionwars.sh master && bash ${PORTAL_CONFIG_HOME}/deploywars-remotely/deployproductionportals.sh
+```
+
+If you don't have a SSH key set up to run the deploy script ask Ino.
+
+If everything looks ok you can update the frontend url file to point to
+netlify. Log in to dashi and become msk-tomcat with `sudo su - msk-tomcat`.
+Then change the update script:
+
+```
+vi /data/cbio-portal-data/portal-configuration/deploy-scripts/updatefrontendurl.sh
+```
+to point `oldurlfile=/srv/www/msk-tomcat/frontend_url_version_2_0_0.txt` to the
+new frontend url file you supplied above.
+
+Then update the url like:
+
+```
+./updatefrontendurl.sh "https://cbioportal-frontend.netlify.com"
+```
+
+Do the same thing on dashi2. Then log in to pipelines machine, log in as
+triage-tomcat user: `sudo su - triage-tomcat`, and update the frontend url file
+there:
+
+```
+echo 'https://cbioportal-frontend.netlify.com' > /srv/www/triage-tomcat/frontend_url_version_2_1_0.txt
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,8 @@ We also maintain an active [list of RFCs (Requests for Comments)](RFC-List.md) w
    * [API and API Client](The-API-and-API-Client-[Beta].md)
 * [Providing cBioPortal Parameters](providing-cBioPortal-parameters.md)
 * [Manual test cases](manual-test-cases.md)
+* [Release-Procedure](Release-Procedure.md)
+* [Deployment-Procedure](Deployment-Procedure.md)
 
 ## 5. Data Loading
 ### 5.1 Data Loading

--- a/docs/Release-Procedure.md
+++ b/docs/Release-Procedure.md
@@ -1,0 +1,73 @@
+# Release Procedure
+We have release procedures for the following scenarios:
+
+1. [cBioPortal community release of code already in production](#cbioportal-community-release-of-code-already-in-production)
+2. [New Feature Release](#new-feature-release)
+
+## cBioPortal community release of code already in production
+We often run code in production that is not ready yet for use by the wider
+cBioPortal community. We deploy to production what's in the master branch of
+the backend repo and the frontend repo. Often times this is not a tagged
+release. At some point this code should be released for the wider community.
+These are the steps we follow:
+
+1. Create a new frontend tag. The releases can be found here:
+   https://github.com/cBioPortal/cbioportal-frontend/releases. We usually
+   already have a MAJOR.MINOR number for this release. Increment the PATCH
+   number, i.e. MAJOR.MINOR.PATCH. Look at what new commits are in this release
+   compared to the old release by using e.g.:
+   https://github.com/cBioPortal/cbioportal-frontend/compare/v2.1.0...master.
+   Adjust the tag and branch name in between the `...` of the link accordingly
+   to see the new commits. Add significant PRs and issues to the release log:
+   https://github.com/cBioPortal/cbioportal-frontend/releases/new. Follow the
+   same style as the other releases shown in:
+   https://github.com/cBioPortal/cbioportal-frontend/releases. You can save
+   your work as a draft if necessary.
+2. Once the frontend code is tagged, create a pull request to the backend repo
+   where the frontend version is incremented in `portal/pom.xml`:
+   ```
+	  <groupId>com.github.cbioportal</groupId>
+	  <artifactId>cbioportal-frontend</artifactId>
+	  <version>CHANGE_THIS_TO_THE_FRONTEND_TAG</version>
+   ```
+3. Once that PR is merged, one can create a tag for the backend repo with the
+   same tag as the frontend repo. Copy over the release log from the frontend
+   repo. You can look at backend specific commits in the same manner:
+   https://github.com/cBioPortal/cbioportal/compare/v2.1.0...master. Note that
+   the release log of frontend and backend should be identical. Both list the
+   significant frontend and backend changes. You can update existing release
+   logs using the github interface.
+
+## New Feature Release
+For new feature releases, we increase the MINOR number in MAJOR.MINOR.PATCH.
+For those releases we have a separate branch (see
+https://github.com/cBioPortal/cbioportal/blob/master/CONTRIBUTING.md#branches-within-cbioportal),
+which needs to be merged to master on both backend and frontend:
+
+1. Make sure no auto deployment is running for frontend from netlify
+2. Merge frontend release-x.y.z branch to frontend master
+3. Follow same procedure as for [a PATCH
+   release](#cbioportal-community-release-of-code-already-in-production),
+   but instead of having a separate PR to update the frontend (step 2) one can
+   add it to the already existing backend branch release-x.y.z and open the PR
+   from there to backend's master. This is merely for convenience to avoid
+   having to create another branch just to update the frontend version.
+
+## A note on versioning
+We follow the following logic when deciding how/when to increment the version
+of cBioPortal. It's a complete modification of semantic versioning
+(MAJOR.MINOR.PATCH) more suitable for our purposes:
+
+MAJOR
+: A big change in how cBioPortal works. We changed the major version from 1 to
+2 when we completely moved from using JSPs to a Single Page App written in
+React calling a REST service.
+
+MINOR
+: Backwards incompatible features that requires both backend and frontend
+changes. If the frontend change is very significant we can increase the MINOR
+version as well.
+
+PATCH
+: Backwards compatible fixes. Can be e.g. frontend only changes or fixes to
+backend.


### PR DESCRIPTION
This describes our internal release and deployment procedures.

Note that this is very much a work in progress. It describes how we are doing deployments now, but obviously there is a lot of room for automation and improvement. We can update the document while we're automating more of these steps