### PR TITLE
Co-expression memory optimization

### DIFF
--- a/service/src/main/java/org/cbioportal/service/MolecularDataService.java
+++ b/service/src/main/java/org/cbioportal/service/MolecularDataService.java
@@ -1,5 +1,6 @@
 package org.cbioportal.service;
 
+import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GeneMolecularData;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
@@ -20,6 +21,10 @@ public interface MolecularDataService {
         throws MolecularProfileNotFoundException;
 
     BaseMeta fetchMetaMolecularData(String molecularProfileId, List<String> sampleIds, List<Integer> entrezGeneIds) 
+        throws MolecularProfileNotFoundException;
+
+    List<GeneMolecularAlteration> getMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds, 
+                                                          String projection) 
         throws MolecularProfileNotFoundException;
     
     Integer getNumberOfSamplesInMolecularProfile(String molecularProfileId);

--- a/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java
@@ -6,19 +6,30 @@ import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.stat.correlation.SpearmansCorrelation;
 import org.cbioportal.model.CoExpression;
 import org.cbioportal.model.Gene;
-import org.cbioportal.model.GeneMolecularData;
+import org.cbioportal.model.GeneMolecularAlteration;
+import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.Sample;
+import org.cbioportal.persistence.MolecularDataRepository;
+import org.cbioportal.persistence.SampleListRepository;
 import org.cbioportal.service.CoExpressionService;
 import org.cbioportal.service.GeneService;
 import org.cbioportal.service.MolecularDataService;
+import org.cbioportal.service.MolecularProfileService;
+import org.cbioportal.service.SampleService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,54 +39,83 @@ public class CoExpressionServiceImpl implements CoExpressionService {
     private MolecularDataService molecularDataService;
     @Autowired
     private GeneService geneService;
+    @Autowired
+    private SampleListRepository sampleListRepository;
+    @Autowired
+    private MolecularDataRepository molecularDataRepository;
+    @Autowired
+    private MolecularProfileService molecularProfileService;
+    @Autowired
+    private SampleService sampleService;
     
     @Override
     public List<CoExpression> getCoExpressions(String molecularProfileId, String sampleListId, Integer entrezGeneId, 
                                               Double threshold) throws MolecularProfileNotFoundException {
 
-        List<GeneMolecularData> molecularDataList = molecularDataService.getMolecularData(molecularProfileId, 
-            sampleListId, null, "SUMMARY");
+        List<String> sampleIds = sampleListRepository.getAllSampleIdsInSampleList(sampleListId);
+        if (sampleIds.isEmpty()) {
+            return Collections.emptyList();
+        }
         
-        return createCoExpressions(molecularDataList, entrezGeneId, threshold);
+        return fetchCoExpressions(molecularProfileId, sampleIds, entrezGeneId, threshold);
     }
 
     @Override
-    public List<CoExpression> fetchCoExpressions(String molecularProfileId, List<String> sampleIds, Integer entrezGeneId, 
-                                                Double threshold) throws MolecularProfileNotFoundException {
-
-        List<GeneMolecularData> molecularDataList = molecularDataService.fetchMolecularData(molecularProfileId, 
-            sampleIds, null, "SUMMARY");
+    public List<CoExpression> fetchCoExpressions(String molecularProfileId, List<String> sampleIds, 
+                                                 Integer queryEntrezGeneId, Double threshold) 
+        throws MolecularProfileNotFoundException {
         
-        return createCoExpressions(molecularDataList, entrezGeneId, threshold);
-    }
-    
-    private List<CoExpression> createCoExpressions(List<GeneMolecularData> molecularDataList, Integer queryEntrezGeneId,
-                                                   Double threshold) {
+        List<GeneMolecularAlteration> molecularAlterations = molecularDataService.getMolecularAlterations(
+            molecularProfileId, null, "SUMMARY");
 
-        Map<Integer, List<GeneMolecularData>> molecularDataMap = molecularDataList.stream()
-                .collect(Collectors.groupingBy(GeneMolecularData::getEntrezGeneId));
-        List<GeneMolecularData> queryMolecularDataList = molecularDataMap.remove(queryEntrezGeneId);
+        Map<Integer, GeneMolecularAlteration> molecularDataMap = molecularAlterations.stream()
+                .collect(Collectors.toMap(GeneMolecularAlteration::getEntrezGeneId, Function.identity()));
+        GeneMolecularAlteration queryMolecularDataList = molecularDataMap.remove(queryEntrezGeneId);
 
         Map<Integer, List<Gene>> genes = geneService.fetchGenes(molecularDataMap.keySet().stream()
             .map(String::valueOf).collect(Collectors.toList()), "ENTREZ_GENE_ID", "SUMMARY").stream()
             .collect(Collectors.groupingBy(Gene::getEntrezGeneId));
         
         List<CoExpression> coExpressionList = new ArrayList<>();
-
         if (queryMolecularDataList == null) {
             return coExpressionList;
         }
 
-        List<String> queryValues = queryMolecularDataList.stream().map(g -> g.getValue()).collect(Collectors.toList());
+        String commaSeparatedSampleIdsOfMolecularProfile = molecularDataRepository
+            .getCommaSeparatedSampleIdsOfMolecularProfile(molecularProfileId);
+        List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfile.split(","))
+            .mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
+        Map<Integer, Integer> internalSampleIdsMap = new HashMap<>();
+        for (int lc = 0; lc < internalSampleIds.size(); lc++) {
+            internalSampleIdsMap.put(internalSampleIds.get(lc), lc);
+        }
+
+        MolecularProfile molecularProfile = molecularProfileService.getMolecularProfile(molecularProfileId);
+        List<String> studyIds = new ArrayList<>();
+        sampleIds.forEach(s -> studyIds.add(molecularProfile.getCancerStudyIdentifier()));
+        List<Sample> samples = sampleService.fetchSamples(studyIds, sampleIds, "ID");
+        Map<Integer, Integer> selectedSampleIdsMap = new HashMap<>();
+        for (int lc = 0; lc < samples.size(); lc++) {
+            selectedSampleIdsMap.put(samples.get(lc).getInternalId(), lc);
+        }
+
+        Set<Integer> excludedIndexes = new HashSet<>();
+        for (Integer internalSampleId : internalSampleIds) {
+            if (!selectedSampleIdsMap.containsKey(internalSampleId)) {
+                excludedIndexes.add(internalSampleIdsMap.get(internalSampleId));
+            }
+        }
+
+        List<String> queryValues = Arrays.asList(queryMolecularDataList.getSplitValues());
         for (Integer entrezGeneId : molecularDataMap.keySet()) {
             
-            List<String> values = molecularDataMap.get(entrezGeneId).stream().map(g -> g.getValue())
-                .collect(Collectors.toList());
+            List<String> values = new ArrayList<>(Arrays.asList(molecularDataMap.get(entrezGeneId).getSplitValues()));
             List<String> queryValuesCopy = new ArrayList<>(queryValues);
 
             List<Integer> valuesToRemove = new ArrayList<>();
             for (int i = 0; i < queryValuesCopy.size(); i++) {
-                if (!NumberUtils.isNumber(queryValuesCopy.get(i)) || !NumberUtils.isNumber(values.get(i))) {
+                if (!NumberUtils.isNumber(queryValuesCopy.get(i)) || !NumberUtils.isNumber(values.get(i)) 
+                    || excludedIndexes.contains(i)) {
                     valuesToRemove.add(i);
                 }
             }
@@ -99,13 +139,10 @@ public class CoExpressionServiceImpl implements CoExpressionService {
                 continue;
             }
             
-            double[][] arrays = new double[valuesNumber.length][2];
-            for (int i = 0; i < valuesNumber.length; i++) {
-                arrays[i][0] = queryValuesNumber[i];
-                arrays[i][1] = valuesNumber[i];
-            }
-
-            SpearmansCorrelation spearmansCorrelation = new SpearmansCorrelation(new Array2DRowRealMatrix(arrays, false));
+            double[][] arrays = new double[2][valuesNumber.length];
+            arrays[0] = queryValuesNumber;
+            arrays[1] = valuesNumber;
+            SpearmansCorrelation spearmansCorrelation = new SpearmansCorrelation((new Array2DRowRealMatrix(arrays, false)).transpose());
 
             double spearmansValue = spearmansCorrelation.correlation(queryValuesNumber, valuesNumber);
             if (Double.isNaN(spearmansValue) || Math.abs(spearmansValue) < threshold) {

--- a/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
@@ -122,6 +122,15 @@ public class MolecularDataServiceImpl implements MolecularDataService {
     }
 
     @Override
+    public List<GeneMolecularAlteration> getMolecularAlterations(String molecularProfileId, 
+                                                                 List<Integer> entrezGeneIds, String projection)
+        throws MolecularProfileNotFoundException {
+        
+        validateMolecularProfile(molecularProfileId);
+        return molecularDataRepository.getGeneMolecularAlterations(molecularProfileId, entrezGeneIds, projection);
+    }
+
+    @Override
     public Integer getNumberOfSamplesInMolecularProfile(String molecularProfileId) {
 
         String commaSeparatedSampleIdsOfMolecularProfile = molecularDataRepository

--- a/service/src/test/java/org/cbioportal/service/impl/CoExpressionServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/CoExpressionServiceImplTest.java
@@ -2,9 +2,16 @@ package org.cbioportal.service.impl;
 
 import org.cbioportal.model.CoExpression;
 import org.cbioportal.model.Gene;
+import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GeneMolecularData;
+import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.Sample;
+import org.cbioportal.persistence.MolecularDataRepository;
+import org.cbioportal.persistence.SampleListRepository;
 import org.cbioportal.service.GeneService;
 import org.cbioportal.service.MolecularDataService;
+import org.cbioportal.service.MolecularProfileService;
+import org.cbioportal.service.SampleService;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,18 +37,49 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
     private MolecularDataService molecularDataService;
     @Mock
     private GeneService geneService;
+    @Mock
+    private SampleListRepository sampleListRepository;
+    @Mock
+    private MolecularDataRepository molecularDataRepository;
+    @Mock
+    private MolecularProfileService molecularProfileService;
+    @Mock
+    private SampleService sampleService;
     
     @Test
     public void getCoExpressions() throws Exception {
 
-        List<GeneMolecularData> molecularDataList = createGeneMolecularData();
-        Mockito.when(molecularDataService.getMolecularData(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, null, "SUMMARY"))
-            .thenReturn(molecularDataList);
+        Mockito.when(sampleListRepository.getAllSampleIdsInSampleList(SAMPLE_LIST_ID))
+            .thenReturn(Arrays.asList(SAMPLE_ID1, SAMPLE_ID2, SAMPLE_ID3));
+
+        List<GeneMolecularAlteration> molecularAlterations = createGeneAlterations();
+        Mockito.when(molecularDataService.getMolecularAlterations(MOLECULAR_PROFILE_ID, null, "SUMMARY"))
+            .thenReturn(molecularAlterations);
 
         List<Gene> genes = createGenes();
 
         Mockito.when(geneService.fetchGenes(Arrays.asList("2", "3", "4"), "ENTREZ_GENE_ID", "SUMMARY"))
             .thenReturn(genes);
+
+        Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
+            .thenReturn("1,2,3");
+
+        MolecularProfile molecularProfile = new MolecularProfile();
+        molecularProfile.setCancerStudyIdentifier(STUDY_ID);
+        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
+
+        List<Sample> samples = new ArrayList<>();
+        Sample sample1 = new Sample();
+        sample1.setInternalId(1);
+        samples.add(sample1);
+        Sample sample2 = new Sample();
+        sample2.setInternalId(2);
+        samples.add(sample2);
+        Sample sample3 = new Sample();
+        sample3.setInternalId(3);
+        samples.add(sample3);
+        Mockito.when(sampleService.fetchSamples(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID), 
+            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2, SAMPLE_ID3), "ID")).thenReturn(samples);
 
         List<CoExpression> result = coExpressionService.getCoExpressions(MOLECULAR_PROFILE_ID,
             SAMPLE_LIST_ID, ENTREZ_GENE_ID_1, THRESHOLD);
@@ -64,17 +102,37 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
     @Test
     public void fetchCoExpressions() throws Exception {
 
-        List<GeneMolecularData> molecularDataList = createGeneMolecularData();
-        Mockito.when(molecularDataService.fetchMolecularData(MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), 
-            null, "SUMMARY")).thenReturn(molecularDataList);
+        List<GeneMolecularAlteration> molecularAlterations = createGeneAlterations();
+        Mockito.when(molecularDataService.getMolecularAlterations(MOLECULAR_PROFILE_ID, null, "SUMMARY"))
+            .thenReturn(molecularAlterations);
 
         List<Gene> genes = createGenes();
 
         Mockito.when(geneService.fetchGenes(Arrays.asList("2", "3", "4"), "ENTREZ_GENE_ID", "SUMMARY"))
             .thenReturn(genes);
 
+        Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
+            .thenReturn("1,2,3");
+
+        MolecularProfile molecularProfile = new MolecularProfile();
+        molecularProfile.setCancerStudyIdentifier(STUDY_ID);
+        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
+
+        List<Sample> samples = new ArrayList<>();
+        Sample sample1 = new Sample();
+        sample1.setInternalId(1);
+        samples.add(sample1);
+        Sample sample2 = new Sample();
+        sample2.setInternalId(2);
+        samples.add(sample2);
+        Sample sample3 = new Sample();
+        sample3.setInternalId(3);
+        samples.add(sample3);
+        Mockito.when(sampleService.fetchSamples(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID), 
+            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2, SAMPLE_ID3), "ID")).thenReturn(samples);
+
         List<CoExpression> result = coExpressionService.fetchCoExpressions(MOLECULAR_PROFILE_ID,
-            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), ENTREZ_GENE_ID_1, THRESHOLD);
+            Arrays.asList(SAMPLE_ID1, SAMPLE_ID2, SAMPLE_ID3), ENTREZ_GENE_ID_1, THRESHOLD);
 
         Assert.assertEquals(2, result.size());
         CoExpression coExpression1 = result.get(0);
@@ -91,57 +149,27 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(new BigDecimal("0.3333333333333333"), coExpression2.getpValue());
     }
 
-    private List<GeneMolecularData> createGeneMolecularData() {
-        List<GeneMolecularData> molecularDataList = new ArrayList<>();
-        GeneMolecularData geneMolecularData1 = new GeneMolecularData();
-        geneMolecularData1.setEntrezGeneId(ENTREZ_GENE_ID_1);
-        geneMolecularData1.setValue("2.1");
-        molecularDataList.add(geneMolecularData1);
-        GeneMolecularData geneMolecularData2 = new GeneMolecularData();
-        geneMolecularData2.setEntrezGeneId(ENTREZ_GENE_ID_1);
-        geneMolecularData2.setValue("3");
-        molecularDataList.add(geneMolecularData2);
-        GeneMolecularData geneMolecularData3 = new GeneMolecularData();
-        geneMolecularData3.setEntrezGeneId(ENTREZ_GENE_ID_1);
-        geneMolecularData3.setValue("3");
-        molecularDataList.add(geneMolecularData3);
-        GeneMolecularData geneMolecularData4 = new GeneMolecularData();
-        geneMolecularData4.setEntrezGeneId(2);
-        geneMolecularData4.setValue("2");
-        molecularDataList.add(geneMolecularData4);
-        GeneMolecularData geneMolecularData5 = new GeneMolecularData();
-        geneMolecularData5.setEntrezGeneId(2);
-        geneMolecularData5.setValue("3");
-        molecularDataList.add(geneMolecularData5);
-        GeneMolecularData geneMolecularData6 = new GeneMolecularData();
-        geneMolecularData6.setEntrezGeneId(2);
-        geneMolecularData6.setValue("2");
-        molecularDataList.add(geneMolecularData6);
-        GeneMolecularData geneMolecularData7 = new GeneMolecularData();
-        geneMolecularData7.setEntrezGeneId(3);
-        geneMolecularData7.setValue("1.1");
-        molecularDataList.add(geneMolecularData7);
-        GeneMolecularData geneMolecularData8 = new GeneMolecularData();
-        geneMolecularData8.setEntrezGeneId(3);
-        geneMolecularData8.setValue("5");
-        molecularDataList.add(geneMolecularData8);
-        GeneMolecularData geneMolecularData9 = new GeneMolecularData();
-        geneMolecularData9.setEntrezGeneId(3);
-        geneMolecularData9.setValue("3");
-        molecularDataList.add(geneMolecularData9);
-        GeneMolecularData geneMolecularData10 = new GeneMolecularData();
-        geneMolecularData10.setEntrezGeneId(4);
-        geneMolecularData10.setValue("1");
-        molecularDataList.add(geneMolecularData10);
-        GeneMolecularData geneMolecularData11 = new GeneMolecularData();
-        geneMolecularData11.setEntrezGeneId(4);
-        geneMolecularData11.setValue("4");
-        molecularDataList.add(geneMolecularData11);
-        GeneMolecularData geneMolecularData12 = new GeneMolecularData();
-        geneMolecularData12.setEntrezGeneId(4);
-        geneMolecularData12.setValue("0");
-        molecularDataList.add(geneMolecularData12);
-        return molecularDataList;
+    private List<GeneMolecularAlteration> createGeneAlterations() {
+
+        List<GeneMolecularAlteration> molecularAlterations = new ArrayList<>();
+        GeneMolecularAlteration geneMolecularAlteration1 = new GeneMolecularAlteration();
+        geneMolecularAlteration1.setEntrezGeneId(1);
+        geneMolecularAlteration1.setValues("2.1,3,3");
+        molecularAlterations.add(geneMolecularAlteration1);
+        GeneMolecularAlteration geneMolecularAlteration2 = new GeneMolecularAlteration();
+        geneMolecularAlteration2.setEntrezGeneId(2);
+        geneMolecularAlteration2.setValues("2,3,2");
+        molecularAlterations.add(geneMolecularAlteration2);
+        GeneMolecularAlteration geneMolecularAlteration3 = new GeneMolecularAlteration();
+        geneMolecularAlteration3.setEntrezGeneId(3);
+        geneMolecularAlteration3.setValues("1.1,5,3");
+        molecularAlterations.add(geneMolecularAlteration3);
+        GeneMolecularAlteration geneMolecularAlteration4 = new GeneMolecularAlteration();
+        geneMolecularAlteration4.setEntrezGeneId(4);
+        geneMolecularAlteration4.setValues("1,4,0");
+        molecularAlterations.add(geneMolecularAlteration4);
+
+        return molecularAlterations;
     }
 
     private List<Gene> createGenes() {


### PR DESCRIPTION
It's a memory optimization for Co-expression API, instead of creating a list of millions of `GeneMolecularData` objects to calculate the co-expression, we do the calculation on the raw `GeneMolecularAlteration` objects.