### PR TITLE
Added prefixes to the swagger endpoint tags

### DIFF
--- a/web/src/main/java/org/cbioportal/web/CancerTypeController.java
+++ b/web/src/main/java/org/cbioportal/web/CancerTypeController.java
@@ -31,7 +31,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Cancer Types", description = " ")
+@Api(tags = "A. Cancer Types", description = " ")
 public class CancerTypeController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/ClinicalAttributeController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalAttributeController.java
@@ -41,7 +41,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Clinical Attributes", description = " ")
+@Api(tags = "F. Clinical Attributes", description = " ")
 public class ClinicalAttributeController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/ClinicalDataController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalDataController.java
@@ -41,7 +41,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Clinical Data", description = " ")
+@Api(tags = "G. Clinical Data", description = " ")
 public class ClinicalDataController {
 
     public static final int CLINICAL_DATA_MAX_PAGE_SIZE = 10000000;

--- a/web/src/main/java/org/cbioportal/web/ClinicalEventController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalEventController.java
@@ -33,7 +33,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Clinical Events", description = " ")
+@Api(tags = "H. Clinical Events", description = " ")
 public class ClinicalEventController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/CopyNumberSegmentController.java
+++ b/web/src/main/java/org/cbioportal/web/CopyNumberSegmentController.java
@@ -37,7 +37,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Copy Number Segments", description = " ")
+@Api(tags = "M. Copy Number Segments", description = " ")
 public class CopyNumberSegmentController {
 
     private static final int COPY_NUMBER_SEGMENT_MAX_PAGE_SIZE = 20000;

--- a/web/src/main/java/org/cbioportal/web/DiscreteCopyNumberController.java
+++ b/web/src/main/java/org/cbioportal/web/DiscreteCopyNumberController.java
@@ -36,7 +36,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Discrete Copy Number Alterations", description = " ")
+@Api(tags = "L. Discrete Copy Number Alterations", description = " ")
 public class DiscreteCopyNumberController {
 
     private static final int COPY_NUMBER_COUNT_MAX_PAGE_SIZE = 50000;

--- a/web/src/main/java/org/cbioportal/web/GeneController.java
+++ b/web/src/main/java/org/cbioportal/web/GeneController.java
@@ -34,7 +34,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Genes", description = " ")
+@Api(tags = "N. Genes", description = " ")
 public class GeneController {
 
     private static final int GENE_MAX_PAGE_SIZE = 100000;

--- a/web/src/main/java/org/cbioportal/web/GenePanelController.java
+++ b/web/src/main/java/org/cbioportal/web/GenePanelController.java
@@ -42,7 +42,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Gene Panels", description = " ")
+@Api(tags = "O. Gene Panels", description = " ")
 public class GenePanelController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/MolecularDataController.java
+++ b/web/src/main/java/org/cbioportal/web/MolecularDataController.java
@@ -40,7 +40,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Molecular Data", description = " ")
+@Api(tags = "I. Molecular Data", description = " ")
 public class MolecularDataController {
     
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/MolecularProfileController.java
+++ b/web/src/main/java/org/cbioportal/web/MolecularProfileController.java
@@ -36,7 +36,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Molecular Profiles", description = " ")
+@Api(tags = "J. Molecular Profiles", description = " ")
 public class MolecularProfileController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/MutationController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationController.java
@@ -47,7 +47,7 @@ import javax.validation.constraints.Size;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Mutations", description = " ")
+@Api(tags = "K. Mutations", description = " ")
 public class MutationController {
 
     public static final int MUTATION_MAX_PAGE_SIZE = 10000000;

--- a/web/src/main/java/org/cbioportal/web/PatientController.java
+++ b/web/src/main/java/org/cbioportal/web/PatientController.java
@@ -33,7 +33,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Patients", description = " ")
+@Api(tags = "C. Patients", description = " ")
 public class PatientController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/SampleController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleController.java
@@ -35,7 +35,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Samples", description = " ")
+@Api(tags = "D. Samples", description = " ")
 public class SampleController {
 
     public static final int SAMPLE_MAX_PAGE_SIZE = 10000000;

--- a/web/src/main/java/org/cbioportal/web/SampleListController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleListController.java
@@ -35,7 +35,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Sample Lists", description = " ")
+@Api(tags = "E. Sample Lists", description = " ")
 public class SampleListController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -44,7 +44,7 @@ import java.util.Map;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Studies", description = " ")
+@Api(tags = "B. Studies", description = " ")
 public class StudyController {
 
     @Autowired


### PR DESCRIPTION
This will enforce a visual sorting when viewed in the UI.

Fix: https://github.com/cBioPortal/cbioportal/issues/4570
