### PR TITLE
Add new session api's to support user preference in study-view

### DIFF
--- a/web/src/main/java/org/cbioportal/web/parameter/ChartType.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ChartType.java
@@ -1,0 +1,12 @@
+package org.cbioportal.web.parameter;
+
+public enum ChartType {
+    PIE_CHART,
+    BAR_CHART,
+    SURVIVAL,
+    TABLE,
+    SCATTER,
+    MUTATED_GENES_TABLE,
+    CNA_GENES_TABLE,
+    NONE;
+}

--- a/web/src/main/java/org/cbioportal/web/parameter/PageSession.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/PageSession.java
@@ -8,17 +8,19 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
-public class VirtualStudy implements Serializable {
+public class PageSession implements Serializable {
 
     /**
      * 
      */
     private static final long serialVersionUID = 1L;
-
     private String id;
     private String source;
-    private String type;
-    private VirtualStudyData data;
+    private SessionType type;
+
+    // replace Object with SessionData once model for main_session and
+    // comparison_session are finalized
+    private StudyPageSettings data;
 
     public String getId() {
         return id;
@@ -26,14 +28,6 @@ public class VirtualStudy implements Serializable {
 
     public void setId(String id) {
         this.id = id;
-    }
-
-    public VirtualStudyData getData() {
-        return data;
-    }
-
-    public void setData(VirtualStudyData data) {
-        this.data = data;
     }
 
     public String getSource() {
@@ -44,14 +38,19 @@ public class VirtualStudy implements Serializable {
         this.source = source;
     }
 
-    public String getType() {
+    public SessionType getType() {
         return type;
     }
 
-    public void setType(String type) {
+    public void setType(SessionType type) {
         this.type = type;
     }
-    
+
+    public StudyPageSettings getData() {
+        return data;
+    }
+
+    public void setData(StudyPageSettings data) {
+        this.data = data;
+    }
 }
-
-

--- a/web/src/main/java/org/cbioportal/web/parameter/SessionPage.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/SessionPage.java
@@ -1,0 +1,6 @@
+package org.cbioportal.web.parameter;
+
+public enum SessionPage {
+    study_view;
+
+}

--- a/web/src/main/java/org/cbioportal/web/parameter/SessionType.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/SessionType.java
@@ -1,0 +1,9 @@
+package org.cbioportal.web.parameter;
+
+public enum SessionType {
+    main_session,
+    virtual_study,
+    group,
+    comparison_session,
+    settings;
+}

--- a/web/src/main/java/org/cbioportal/web/parameter/SettingsIdentifier.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/SettingsIdentifier.java
@@ -1,0 +1,38 @@
+package org.cbioportal.web.parameter;
+
+import java.io.Serializable;
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class SettingsIdentifier implements Serializable {
+
+    /**
+    * 
+    */
+    private static final long serialVersionUID = 1L;
+
+    @NotNull
+    private SessionPage page;
+
+    @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
+    List<String> origin;
+
+    public SessionPage getPage() {
+        return page;
+    }
+
+    public void setPage(SessionPage page) {
+        this.page = page;
+    }
+
+    public List<String> getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(List<String> origin) {
+        this.origin = origin;
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/web/parameter/StudyPageSettings.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/StudyPageSettings.java
@@ -1,0 +1,284 @@
+package org.cbioportal.web.parameter;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * @author kalletlak
+ *
+ */
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class StudyPageSettings implements Serializable {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(Include.NON_NULL)
+    static class ChartSetting implements Serializable {
+
+        /**
+         * 
+         */
+        private static final long serialVersionUID = 1L;
+
+        static class Layout implements Serializable {
+
+            /**
+             * 
+             */
+            private static final long serialVersionUID = 1L;
+
+            private Integer x;
+            private Integer y;
+            private Integer w;
+            private Integer h;
+
+            public Integer getX() {
+                return x;
+            }
+
+            public void setX(Integer x) {
+                this.x = x;
+            }
+
+            public Integer getY() {
+                return y;
+            }
+
+            public void setY(Integer y) {
+                this.y = y;
+            }
+
+            public Integer getW() {
+                return w;
+            }
+
+            public void setW(Integer w) {
+                this.w = w;
+            }
+
+            public Integer getH() {
+                return h;
+            }
+
+            public void setH(Integer h) {
+                this.h = h;
+            }
+        }
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        @JsonInclude(Include.NON_NULL)
+        static class PatientSampleIdentifier extends SampleIdentifier implements Serializable {
+            /**
+             * 
+             */
+            private static final long serialVersionUID = 1L;
+            private String patientId;
+
+            public String getPatientId() {
+                return patientId;
+            }
+
+            public void setPatientId(String patientId) {
+                this.patientId = patientId;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (o == this)
+                    return true;
+                if (!(o instanceof PatientSampleIdentifier)) {
+                    return false;
+                }
+                PatientSampleIdentifier patientSampleIdentifier = (PatientSampleIdentifier) o;
+                return Objects.equals(getSampleId(), patientSampleIdentifier.getSampleId())
+                        && Objects.equals(getPatientId(), patientSampleIdentifier.getPatientId())
+                        && Objects.equals(getStudyId(), patientSampleIdentifier.getStudyId());
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(getSampleId(), getPatientId(), getStudyId());
+            }
+        }
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        @JsonInclude(Include.NON_NULL)
+        static class Group implements Serializable {
+
+            /**
+             * 
+             */
+            private static final long serialVersionUID = 1L;
+
+            @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
+            private List<PatientSampleIdentifier> sampleIdentifiers;
+
+            private String name;
+
+            public List<PatientSampleIdentifier> getSampleIdentifiers() {
+                return sampleIdentifiers;
+            }
+
+            public void setSampleIdentifiers(List<PatientSampleIdentifier> sampleIdentifiers) {
+                this.sampleIdentifiers = sampleIdentifiers;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+        }
+
+        private String id;
+        private String name;
+        private ChartType chartType;
+        private List<Group> groups;
+        private Layout layout;
+        private Boolean patientAttribute;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public ChartType getChartType() {
+            return chartType;
+        }
+
+        public void setChartType(ChartType chartType) {
+            this.chartType = chartType;
+        }
+
+        public List<Group> getGroups() {
+            return groups;
+        }
+
+        public void setGroups(List<Group> groups) {
+            this.groups = groups;
+        }
+
+        public Layout getLayout() {
+            return layout;
+        }
+
+        public void setLayout(Layout layout) {
+            this.layout = layout;
+        }
+
+        public Boolean getPatientAttribute() {
+            return patientAttribute;
+        }
+
+        public void setPatientAttribute(Boolean patientAttribute) {
+            this.patientAttribute = patientAttribute;
+        }
+
+    }
+
+    @NotNull
+    private SessionPage page;
+
+    @NotNull
+    private List<ChartSetting> chartSettings = new ArrayList<ChartSetting>();
+
+    private String owner = "anonymous";
+
+    @NotNull
+    private Set<String> origin = new HashSet<>();
+
+    private Long created = System.currentTimeMillis();
+
+    private Long lastUpdated = System.currentTimeMillis();
+
+    @NotNull
+    private Set<String> users = new HashSet<>();
+
+    public SessionPage getPage() {
+        return page;
+    }
+
+    public void setPage(SessionPage page) {
+        this.page = page;
+    }
+
+    public List<ChartSetting> getChartSettings() {
+        return chartSettings;
+    }
+
+    public void setChartSettings(List<ChartSetting> chartSettings) {
+        this.chartSettings = chartSettings;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public Set<String> getOrigin() {
+        return origin;
+    }
+
+    public void setOrigin(Set<String> origin) {
+        this.origin = origin;
+    }
+
+    public Long getCreated() {
+        return created;
+    }
+
+    public void setCreated(Long created) {
+        this.created = created;
+    }
+
+    public Long getLastUpdated() {
+        return lastUpdated;
+    }
+
+    public void setLastUpdated(Long lastUpdated) {
+        this.lastUpdated = lastUpdated;
+    }
+
+    public Set<String> getUsers() {
+        return users;
+    }
+
+    public void setUsers(Set<String> users) {
+        this.users = users;
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/weblegacy/mixin/StudyPageSettingsMixin.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/mixin/StudyPageSettingsMixin.java
@@ -1,0 +1,16 @@
+package org.cbioportal.weblegacy.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class StudyPageSettingsMixin {
+
+    @JsonIgnore
+    private String created;
+    @JsonIgnore
+    private Long lastUpdated;
+    @JsonIgnore
+    private String owner;
+    @JsonIgnore
+    private String users;
+
+}

--- a/web/src/main/java/org/mskcc/cbio/portal/web/ProxySessionServiceController.java
+++ b/web/src/main/java/org/mskcc/cbio/portal/web/ProxySessionServiceController.java
@@ -18,10 +18,16 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.cbioportal.web.parameter.PageSession;
 import org.cbioportal.web.parameter.PagingConstants;
+import org.cbioportal.web.parameter.SessionType;
+import org.cbioportal.web.parameter.SettingsIdentifier;
+import org.cbioportal.web.parameter.StudyPageSettings;
 import org.cbioportal.web.parameter.VirtualStudy;
 import org.cbioportal.web.parameter.VirtualStudyData;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
@@ -41,6 +47,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -100,6 +107,15 @@ public class ProxySessionServiceController {
     
     private Boolean isSessionServiceEnabled() {
     	return !StringUtils.isEmpty(sessionServiceURL);
+    }
+    
+    private boolean isAuthorized() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return !(authentication == null || (authentication instanceof AnonymousAuthenticationToken));
+    }
+
+    private String userName() {
+        return ((UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUsername();
     }
 
     private HttpHeaders getHttpHeaders() {
@@ -200,45 +216,52 @@ public class ProxySessionServiceController {
 
     }
     
-	private ResponseEntity<HashMap> addSession(SessionType type, Optional<SessionOperation> operation, JSONObject body) {
-		try {
-			HttpEntity httpEntity = null;
-			if (type.equals(SessionType.virtual_study) || type.equals(SessionType.group)) {
-				ObjectMapper mapper = new ObjectMapper();
-				// JSON from file to Object
-				VirtualStudyData virtualStudyData = mapper.readValue(body.toString(), VirtualStudyData.class);
+    private ResponseEntity<HashMap> addSession(SessionType type, Optional<SessionOperation> operation, JSONObject body) {
+        try {
+            HttpEntity httpEntity = null;
+            ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+                    false).setSerializationInclusion(Include.NON_NULL);
+            if (type.equals(SessionType.virtual_study) || type.equals(SessionType.group)) {
+                // JSON from file to Object
+                VirtualStudyData virtualStudyData = mapper.readValue(body.toString(), VirtualStudyData.class);
 
-				Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+                if (isAuthorized()) {
+                    virtualStudyData.setOwner(userName());
+                    if ((operation.isPresent() && operation.get().equals(SessionOperation.save))
+                            || type.equals(SessionType.group)) {
+                        virtualStudyData.setUsers(Collections.singleton(userName()));
+                    }
+                }
+                
+                // use basic authentication for session service if set
+                httpEntity = new HttpEntity<VirtualStudyData>(virtualStudyData, getHttpHeaders());
+            } else if(type.equals(SessionType.settings)){
+                if (!(isAuthorized())) {
+                    return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
+                }
+                StudyPageSettings studyPageSettings = mapper.readValue(body.toString(), StudyPageSettings.class);
+                studyPageSettings.setOwner(userName());
+                studyPageSettings.setUsers(Collections.singleton(userName()));
+                httpEntity = new HttpEntity<StudyPageSettings>(studyPageSettings, getHttpHeaders());
 
-				if (authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
-					String userName = ((UserDetails) authentication.getPrincipal()).getUsername();
-					virtualStudyData.setOwner(userName);
-					if ((operation.isPresent() && operation.get().equals(SessionOperation.save))
-							|| type.equals(SessionType.group)) {
-						virtualStudyData.setUsers(Collections.singleton(userName));
-					}
-				}
-				
-				// use basic authentication for session service if set
-				httpEntity = new HttpEntity<VirtualStudyData>(virtualStudyData, getHttpHeaders());
-			} else {
-				httpEntity = new HttpEntity<JSONObject>(body, getHttpHeaders());
-			}
-			// returns {"id":"5799648eef86c0e807a2e965"}
-			// using HashMap because converter is MappingJackson2HttpMessageConverter
-			// (Jackson 2 is on classpath)
-			// was String when default converter StringHttpMessageConverter was used
-			RestTemplate restTemplate = new RestTemplate();
-			ResponseEntity<HashMap> resp =  restTemplate.exchange(sessionServiceURL + type, HttpMethod.POST,
-					httpEntity, HashMap.class);
-			
-			return new ResponseEntity<>(resp.getBody(), resp.getStatusCode());
+            }else {
+                httpEntity = new HttpEntity<JSONObject>(body, getHttpHeaders());
+            }
+            // returns {"id":"5799648eef86c0e807a2e965"}
+            // using HashMap because converter is MappingJackson2HttpMessageConverter
+            // (Jackson 2 is on classpath)
+            // was String when default converter StringHttpMessageConverter was used
+            RestTemplate restTemplate = new RestTemplate();
+            ResponseEntity<HashMap> resp =  restTemplate.exchange(sessionServiceURL + type, HttpMethod.POST,
+                    httpEntity, HashMap.class);
+            
+            return new ResponseEntity<>(resp.getBody(), resp.getStatusCode());
 
-		} catch (IOException e) {
-			LOG.error(e);
-			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-		}
-	}
+        } catch (IOException e) {
+            LOG.error(e);
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+    }
     
     
 	@RequestMapping(value = "/groups/fetch", method = RequestMethod.POST)
@@ -276,55 +299,172 @@ public class ProxySessionServiceController {
 		return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
 	}
 	
-	@RequestMapping(value = "/{type}/{id}", method = RequestMethod.POST)
-	public void updateSession(
-			@PathVariable SessionType type,
-			@PathVariable String id,
-            @RequestBody  JSONObject  body,
-			HttpServletResponse response) throws IOException {
+	
+	   @RequestMapping(value = "/{type}/{id}", method = RequestMethod.POST)
+	    public void updateSession(
+	            @PathVariable SessionType type,
+	            @PathVariable String id,
+	            @RequestBody  JSONObject  body,
+	            HttpServletResponse response) throws IOException {
 
-		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+	        // updates only allowed for type group and settings
+	        List<SessionType> validSessionTypes = Arrays.asList(SessionType.group, SessionType.settings);
 
-		// updates only allowed for type group for now
-		List<SessionType> validSessionTypes = Arrays.asList(SessionType.group);
+	        if (validSessionTypes.contains(type) && isAuthorized()) {
 
-		if (validSessionTypes.contains(type) && isSessionServiceEnabled() && !(authentication == null
-				|| (authentication instanceof AnonymousAuthenticationToken))) {
+	            ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+	                    false);
+	            String sessionString = mapper.writeValueAsString(getSession(type, id, response));
+	            
+	            if(type.equals(SessionType.group)) {
+	                VirtualStudy session = mapper.readValue(sessionString, VirtualStudy.class);
+	                VirtualStudyData virtualStudyData = session.getData();
+	                //only allow owner to update virtual study
+	                if (userName().equals(virtualStudyData.getOwner()) && session.getType().equals(type)) {
 
-			ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-					false);
-			String virtualStudyStr = mapper.writeValueAsString(getSession(type, id, response));
-			VirtualStudy virtualStudy = mapper.readValue(virtualStudyStr, VirtualStudy.class);
+	                    VirtualStudyData updatedVirtualStudyData = mapper.readValue(body.toString(), VirtualStudyData.class);
+	                    updatedVirtualStudyData.setCreated(virtualStudyData.getCreated());
+	                    updatedVirtualStudyData.setOwner(virtualStudyData.getOwner());
+	                    updatedVirtualStudyData.setUsers(virtualStudyData.getUsers());
 
-			String user = ((UserDetails) authentication.getPrincipal()).getUsername();
-			//only allow owner to update virtual study
-			if (user.equals(virtualStudy.getData().getOwner()) && virtualStudy.getType().equals(type.toString())) {
+	                    RestTemplate restTemplate = new RestTemplate();
+	                    HttpEntity<Object> httpEntity = new HttpEntity<Object>(updatedVirtualStudyData, getHttpHeaders());
+	                    
+	                    restTemplate.put(sessionServiceURL + type + "/" + id, httpEntity);
+	                    response.setStatus(HttpStatus.OK.value());
+	                } else {
+	                    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+	                }
+	            } else {
+	                PageSession session = mapper.readValue(sessionString, PageSession.class);
+	                StudyPageSettings studyPageSettings = session.getData();
+                    
+	                StudyPageSettings updatedPageSettings = mapper.readValue(body.toString(), StudyPageSettings.class);
+	                // only allow owner to update his session and see if the origin(studies) are same
+	                if (userName().equals(studyPageSettings.getOwner()) && session.getType().equals(type)
+	                        && sameOrigin(studyPageSettings.getOrigin(), updatedPageSettings.getOrigin())) {
 
-				VirtualStudyData updatedVirtualStudyData = mapper.readValue(body.toString(), VirtualStudyData.class);
-				updatedVirtualStudyData.setCreated(virtualStudy.getData().getCreated());
-				updatedVirtualStudyData.setOwner(virtualStudy.getData().getOwner());
-				updatedVirtualStudyData.setUsers(virtualStudy.getData().getUsers());
+	                    updatedPageSettings.setCreated(studyPageSettings.getCreated());
+	                    updatedPageSettings.setOwner(studyPageSettings.getOwner());
+	                    updatedPageSettings.setUsers(studyPageSettings.getUsers());
+	                    updatedPageSettings.setOrigin(studyPageSettings.getOrigin());
 
-				virtualStudy.setData(updatedVirtualStudyData);
-				RestTemplate restTemplate = new RestTemplate();
-				HttpEntity<Object> httpEntity = new HttpEntity<Object>(updatedVirtualStudyData, getHttpHeaders());
-				
-				restTemplate.put(sessionServiceURL + type + "/" + id, httpEntity);
-				response.setStatus(HttpStatus.OK.value());
-			} else {
-				response.setStatus(HttpStatus.UNAUTHORIZED.value());
-			}
-		} else {
-		    response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
-		}
-	}
-}
+	                    RestTemplate restTemplate = new RestTemplate();
+	                    HttpEntity<Object> httpEntity = new HttpEntity<Object>(updatedPageSettings, getHttpHeaders());
 
-enum SessionType {
-    main_session,
-    virtual_study,
-    group,
-    comparison_session;
+	                    restTemplate.put(sessionServiceURL + type + "/" + id, httpEntity);
+	                    response.setStatus(HttpStatus.OK.value());
+	                } else {
+	                    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+	                }
+	            }
+	            
+	        } else {
+	            response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
+	        }
+	    }
+	
+    @RequestMapping(value = "/settings", method = RequestMethod.POST)
+    public void updateUserPageSettings(@RequestBody StudyPageSettings settingsData, HttpServletResponse response) {
+
+        try {
+            ObjectMapper objectMapper = new ObjectMapper()
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                    .setSerializationInclusion(Include.NON_NULL);
+            if (isSessionServiceEnabled() && isAuthorized()) {
+                Map<String, Object> map = new HashMap<>();
+                map.put("data.users", userName());
+                map.put("data.page", settingsData.getPage());
+                map.put("data.origin", settingsData.getOrigin());
+
+                String query = objectMapper.writeValueAsString(map);
+
+                RestTemplate restTemplate = new RestTemplate();
+
+                HttpEntity<String> httpEntity = new HttpEntity<String>(query, getHttpHeaders());
+
+                ResponseEntity<List<PageSession>> responseEntity = restTemplate.exchange(
+                        sessionServiceURL + SessionType.settings + "/query/fetch", HttpMethod.POST, httpEntity,
+                        new ParameterizedTypeReference<List<PageSession>>() {
+                        });
+
+                List<PageSession> sessions = responseEntity.getBody();
+
+                // sort last updated in descending order
+                sessions.sort((PageSession s1, PageSession s2) -> {
+                    return ((StudyPageSettings) s1.getData()).getLastUpdated() > ((StudyPageSettings) s2.getData())
+                            .getLastUpdated() ? -1 : 1;
+                });
+                JSONParser parser = new JSONParser();
+                JSONObject jsonObject = (JSONObject) parser.parse(objectMapper.writeValueAsString(settingsData));
+
+                if (sessions.isEmpty()) {
+                    addSession(SessionType.settings, null, jsonObject);
+
+                } else {
+                    updateSession(SessionType.settings, sessions.get(0).getId(), jsonObject, response);
+                }
+                response.setStatus(HttpStatus.OK.value());
+            } else {
+                response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
+            }
+        } catch (IOException | ParseException e) {
+            LOG.error(e);
+            response.setStatus(HttpStatus.BAD_REQUEST.value());
+        }
+    }
+
+    @RequestMapping(value = "/settings/fetch", method = RequestMethod.POST)
+    public ResponseEntity<StudyPageSettings> getStudyPageUserSettings(
+            @RequestBody SettingsIdentifier settingsIdentifier, HttpServletResponse response) {
+
+        try {
+            if (isSessionServiceEnabled() && isAuthorized()) {
+
+                Map<String, Object> map = new HashMap<>();
+                map.put("data.users", userName());
+                map.put("data.page", settingsIdentifier.getPage());
+                map.put("data.origin", settingsIdentifier.getOrigin());
+
+                ObjectMapper mapper = new ObjectMapper();
+                String query = mapper.writeValueAsString(map);
+
+                RestTemplate restTemplate = new RestTemplate();
+
+                HttpEntity<String> httpEntity = new HttpEntity<String>(query, getHttpHeaders());
+
+                ResponseEntity<List<PageSession>> responseEntity = restTemplate.exchange(
+                        sessionServiceURL + SessionType.settings + "/query/fetch", HttpMethod.POST, httpEntity,
+                        new ParameterizedTypeReference<List<PageSession>>() {
+                        });
+
+                List<PageSession> sessions = responseEntity.getBody();
+
+                // sort last updated in descending order
+                sessions.sort((PageSession s1, PageSession s2) -> {
+                    return ((StudyPageSettings) s1.getData()).getLastUpdated() > ((StudyPageSettings) s2.getData())
+                            .getLastUpdated() ? -1 : 1;
+                });
+
+                return new ResponseEntity<>(sessions.isEmpty() ? null : (StudyPageSettings) sessions.get(0).getData(),
+                        HttpStatus.OK);
+            }
+            return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
+        } catch (IOException e) {
+            LOG.error(e);
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private boolean sameOrigin(Set<String> set1, Set<String> set2) {
+        if (set1 == null || set2 == null) {
+            return false;
+        }
+        if (set1.size() != set2.size()) {
+            return false;
+        }
+        return set1.containsAll(set2);
+    }
 }
 
 enum Operation {

--- a/web/src/main/java/org/mskcc/cbio/portal/web/config/CustomObjectMapper.java
+++ b/web/src/main/java/org/mskcc/cbio/portal/web/config/CustomObjectMapper.java
@@ -5,8 +5,11 @@ import java.util.Map;
 
 import org.cbioportal.model.DataAccessToken;
 import org.cbioportal.web.mixin.DataAccessTokenMixin;
+import org.cbioportal.web.parameter.PageSession;
+import org.cbioportal.web.parameter.StudyPageSettings;
 import org.cbioportal.web.parameter.VirtualStudy;
 import org.cbioportal.web.parameter.VirtualStudyData;
+import org.cbioportal.weblegacy.mixin.StudyPageSettingsMixin;
 import org.cbioportal.weblegacy.mixin.VirtualStudyDataMixin;
 import org.cbioportal.weblegacy.mixin.VirtualStudyMixin;
 
@@ -25,6 +28,8 @@ public class CustomObjectMapper extends ObjectMapper {
         mixinMap.put(VirtualStudy.class, VirtualStudyMixin.class);
         mixinMap.put(VirtualStudyData.class, VirtualStudyDataMixin.class);
         mixinMap.put(DataAccessToken.class, DataAccessTokenMixin.class);
+        mixinMap.put(PageSession.class, VirtualStudyMixin.class);
+        mixinMap.put(StudyPageSettings.class, StudyPageSettingsMixin.class);
         super.setMixIns(mixinMap);
     }
 }


### PR DESCRIPTION
# What? Why?
Backend changes for https://github.com/cBioPortal/cbioportal/issues/5892. Also includes refactoring existing code(doesn't change any of pre-existing models) to include types to some of the models.

model for each chart settings

```
{
    id: string,
    name?: string,
    chartType: PIE_CHART | BAR_CHART | SURVIVAL | TABLE | SCATTER | MUTATED_GENES_TABLE | CNA_GENES_TABLE | NONE,
    groups?: {
        studyId: string,
        sampleId: string,
        patientId: string
    }[]
    layout?: {
        x: number,
        y: number,
        w: number;
        h: number;
    }
}
```

Settings object stored in MongoDB
```
{
	"_id": string,
	"_class": string,
	"checksum": string,
	"source": string,
	"type": "settings" // this can be one of main_session|virtual_study|group|comparison_session|settings;
	"data": {
		"page": "study_view", //in future it will support more pages
		"owner": string,
		"origin": string[],
                "users": string[],
		"created": number,
		"lastUpdated": number,
		"chartSettings": {
			id: string,
			name ? : string,
			chartType: PIE_CHART | BAR_CHART | SURVIVAL | TABLE | SCATTER | MUTATED_GENES_TABLE | CNA_GENES_TABLE | NONE,
			groups ? : {
				studyId: string,
				sampleId: string,
				patientId: string
			} []
			layout ? : {
				x: number,
				y: number,
				w: number;
				h: number;
			}
		} []
	}
}
```

Example for the object stored in mongoDB
```
{
	"_id": ObjectId("abc"),
	"_class": "org.cbioportal.session_service.domain.Session",
	"checksum": "xyz",
	"data": {
		"page": "study_view",
		"chartSettings": [{
			"id": "DFS_SURVIVAL",
			"chartType": "SURVIVAL",
			"layout": {
				"x": 0,
				"y": 0,
				"w": 2,
				"h": 2
			},
			"patientAttribute": true
		}, {
			"id": "MUTATION_COUNT_CNA_FRACTION",
			"chartType": "SCATTER",
			"layout": {
				"x": 2,
				"y": 0,
				"w": 2,
				"h": 2
			},
			"patientAttribute": false
		}, {
			"id": "MUTATED_GENES_TABLE",
			"chartType": "MUTATED_GENES_TABLE",
			"patientAttribute": false
		}, {
			"id": "CNA_GENES_TABLE",
			"chartType": "CNA_GENES_TABLE",
			"patientAttribute": false
		}, {
			"id": "PATIENT_SEX",
			"chartType": "PIE_CHART",
			"layout": {
				"x": 6,
				"y": 0,
				"w": 1,
				"h": 1
			},
			"patientAttribute": true
		}, {
			"id": "PATIENT_ETHNICITY",
			"chartType": "TABLE",
			"layout": {
				"x": 5,
				"y": 1,
				"w": 2,
				"h": 1
			},
			"patientAttribute": true
		}, {
			"id": "PATIENT_AGE",
			"chartType": "BAR_CHART",
			"layout": {
				"x": 4,
				"y": 0,
				"w": 2,
				"h": 1
			},
			"patientAttribute": true
		}, {
			"id": "PATIENT_DAYS_TO_BIRTH",
			"chartType": "BAR_CHART",
			"layout": {
				"x": 0,
				"y": 2,
				"w": 2,
				"h": 1
			},
			"patientAttribute": true
		}, {
			"id": "CUSTOM_FILTERS_0",
			"name": "My Chart",
			"chartType": "PIE_CHART",
			"groups": [{
				"sampleIdentifiers": [{
					"sampleId": "TCGA-OR-A5J1-01",
					"studyId": "acc_tcga",
					"patientId": "TCGA-OR-A5J1"
				}, {
					"sampleId": "TCGA-OR-A5J3-01",
					"studyId": "acc_tcga",
					"patientId": "TCGA-OR-A5J3"
				}, {
					"sampleId": "TCGA-OR-A5J5-01",
					"studyId": "acc_tcga",
					"patientId": "TCGA-OR-A5J5"
				}],
				"name": "1"
			}, {
				"sampleIdentifiers": [{
					"sampleId": "TCGA-OR-A5J2-01",
					"studyId": "acc_tcga",
					"patientId": "TCGA-OR-A5J2"
				}, {
					"sampleId": "TCGA-OR-A5J4-01",
					"studyId": "acc_tcga",
					"patientId": "TCGA-OR-A5J4"
				}, {
					"sampleId": "TCGA-OR-A5J6-01",
					"studyId": "acc_tcga",
					"patientId": "TCGA-OR-A5J6"
				}],
				"name": "2"
			}, {
				"sampleIdentifiers": [{
					"sampleId": "TCGA-OR-A5J7-01",
					"studyId": "acc_tcga",
					"patientId": "TCGA-OR-A5J7"
				}],
				"name": "3"
			}],
			"layout": {
				"x": 4,
				"y": 1,
				"w": 1,
				"h": 1
			},
			"patientAttribute": false
		}],
		"owner": "abc@gmail.com",
		"origin": ["acc_tcga"],
		"created": NumberLong("1555943105415"),
		"lastUpdated": NumberLong("1555943376439"),
		"users": ["abc@gmail.com"]
	},
	"source": "localhost",
	"type": "settings"
}
```