### PR TITLE
Remove duplicate attributes while calculating scores

### DIFF
--- a/model/src/main/java/org/cbioportal/model/ClinicalAttribute.java
+++ b/model/src/main/java/org/cbioportal/model/ClinicalAttribute.java
@@ -81,4 +81,36 @@ public class ClinicalAttribute implements Serializable {
     public void setCancerStudyIdentifier(String cancerStudyIdentifier) {
         this.cancerStudyIdentifier = cancerStudyIdentifier;
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((attrId == null) ? 0 : attrId.hashCode());
+        result = prime * result + ((patientAttribute == null) ? 0 : patientAttribute.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ClinicalAttribute other = (ClinicalAttribute) obj;
+        if (attrId == null) {
+            if (other.attrId != null)
+                return false;
+        } else if (!attrId.equals(other.attrId))
+            return false;
+        if (patientAttribute == null) {
+            if (other.patientAttribute != null)
+                return false;
+        } else if (!patientAttribute.equals(other.patientAttribute))
+            return false;
+        return true;
+    }
+    
 }

--- a/web/src/main/java/org/cbioportal/web/ClinicalDataEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalDataEnrichmentController.java
@@ -99,7 +99,10 @@ public class ClinicalDataEnrichmentController {
 
             List<ClinicalAttribute> clinicalAttributes = clinicalAttributeService
                     .fetchClinicalAttributes(new ArrayList<String>(studyIds), "SUMMARY");
-
+            
+            //remove all duplicate attributes
+            clinicalAttributes = clinicalAttributes.stream().distinct().collect(Collectors.toList());
+            
             clinicalEnrichments.addAll(
                     clinicalDataEnrichmentUtil.createEnrichmentsForCategoricalData(clinicalAttributes, groupedSamples));
 


### PR DESCRIPTION
# What? Why?
`clinical-data-enrichments` api throws error when there are duplicate clinical attributes(this happens when there are multiple studies in the query). This pr fixes it by taking distinct attributes.