### PR TITLE
Update docs to use dbcp + webapp-runner + session service w/o docker

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,7 +21,7 @@
     },
     "SPRING_OPTS": {
         "description":"set spring properties with e.g. -Dshow.civic=true (TODO: not all props work atm)",
-        "value":"-Dauthenticate=false -Dtomcat.catalina.scope=runtime -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test -Ddb.connection_string=jdbc:mysql://devdb.cbioportal.org:3306/ -Ddb.host=devdb.cbioportal.org -Dshow.civic=true -Ddbconnector=dbcp -Dsuppress_schema_version_mismatch_errors=true"
+        "value":"-Dauthenticate=false -Dtomcat.catalina.scope=runtime -Ddb.user=cbio_user -Ddb.password=cbio_pass -Ddb.portal_db_name=public_test -Ddb.connection_string=jdbc:mysql://devdb.cbioportal.org:3306/ -Ddb.host=devdb.cbioportal.org -Dshow.civic=true -Dsuppress_schema_version_mismatch_errors=true"
     }
   },
   "buildpacks": [

--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -9,7 +9,7 @@
      http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
      http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
 
-    <beans profile="jndi,dbcp">
+    <beans profile="dbcp,jndi">
         <bean id="propertyPlaceholderConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
             <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE" />
             <property name="searchSystemEnvironment" value="true" />

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -4012,10 +4012,10 @@ def interface(args=None):
     portal_mode_group = parser.add_mutually_exclusive_group()
     portal_mode_group.add_argument('-u', '--url_server',
                                    type=str,
-                                   default='http://localhost:8080/cbioportal',
+                                   default='http://localhost:8080',
                                    help='URL to cBioPortal server. You can '
                                         'set this if your URL is not '
-                                        'http://localhost:8080/cbioportal')
+                                        'http://localhost:8080')
     portal_mode_group.add_argument('-p', '--portal_info_dir',
                                    type=str,
                                    help='Path to a directory of cBioPortal '

--- a/core/src/main/scripts/importer/validateStudies.py
+++ b/core/src/main/scripts/importer/validateStudies.py
@@ -159,10 +159,10 @@ def interface(args=None):
     portal_mode_group = parser.add_mutually_exclusive_group()
     portal_mode_group.add_argument('-u', '--url_server',
                                    type=str,
-                                   default='http://localhost:8080/cbioportal',
+                                   default='http://localhost:8080',
                                    help='URL to cBioPortal server. You can '
                                         'set this if your URL is not '
-                                        'http://localhost:8080/cbioportal')
+                                        'http://localhost:8080')
     portal_mode_group.add_argument('-p', '--portal_info_dir',
                                    type=str,
                                    help='Path to a directory of cBioPortal '

--- a/core/src/test/scripts/test_data/study_es_1/report.html
+++ b/core/src/test/scripts/test_data/study_es_1/report.html
@@ -223,25 +223,25 @@
             <tr class="blue">
               <td></td>
               <td></td>
-              <td>Requesting genes from portal at &#39;http://localhost:8080/cbioportal&#39;</td>
+              <td>Requesting genes from portal at &#39;http://localhost:8080&#39;</td>
               <td></td>
             </tr>
             <tr class="blue">
               <td></td>
               <td></td>
-              <td>Requesting cancertypes from portal at &#39;http://localhost:8080/cbioportal&#39;</td>
+              <td>Requesting cancertypes from portal at &#39;http://localhost:8080&#39;</td>
               <td></td>
             </tr>
             <tr class="blue">
               <td></td>
               <td></td>
-              <td>Requesting clinicalattributes/patients from portal at &#39;http://localhost:8080/cbioportal&#39;</td>
+              <td>Requesting clinicalattributes/patients from portal at &#39;http://localhost:8080&#39;</td>
               <td></td>
             </tr>
             <tr class="blue">
               <td></td>
               <td></td>
-              <td>Requesting clinicalattributes/samples from portal at &#39;http://localhost:8080/cbioportal&#39;</td>
+              <td>Requesting clinicalattributes/samples from portal at &#39;http://localhost:8080&#39;</td>
               <td></td>
             </tr>
             <tr class="blue">

--- a/docs/Architecture-Overview.md
+++ b/docs/Architecture-Overview.md
@@ -1,0 +1,43 @@
+# Architecture Overview
+cBioPortal consists of the following components:
+
+- [backend](https://github.com/cBioPortal/cbioportal) written in Java.
+- MySQL database that the backend uses
+- [validator](https://github.com/cBioPortal/cbioportal/tree/master/core/src/main/scripts/importer)
+  which checks file formats before importing data into the database.
+- [frontend](https://github.com/cBioPortal/cbioportal-frontend)
+  built with React, Mobx and Bootstrap.
+- [session service](https://github.com/cBioPortal/session-service) for storing
+  user saved data such as virtual studies and groups
+- Mongo database which session service uses
+
+## Backend
+
+The [backend](https://github.com/cBioPortal/cbioportal) is written in Java and
+connects to a MySQL database to serve a REST API following the OpenAPI
+specification (https://www.cbioportal.org/api/). Note that the repo where this
+lives in (https://github.com/cBioPortal/cbioportal) also contains Java classes
+to import data as well as the validator.
+
+## Validator
+The
+[validator](https://github.com/cBioPortal/cbioportal/tree/master/core/src/main/scripts/importer)
+checks file formats before importing data into the database. There is a wrapper
+script `metaImport.py` that validates the data and subsequently calls the
+relevant Java classes to import the data.
+
+## Session Service
+
+The [session service](https://github.com/cBioPortal/session-service) is used
+for storing user saved data such as virtual studies and groups. See the
+[tutorials](https://www.cbioportal.org/tutorials) section to read more about
+these features. Session service is a Java app that serves a REST API backed by
+a Mongo database. The session service is served as a proxy through the
+cBioPortal backend REST API. The backend is therefore the only component that
+needs to be able to connect to it. The frontend does not connect to it
+directly. 
+
+## Frontend
+The frontend is a single page app built with React, Mobx and Bootstrap. The
+data gets pulled from the backend REST API. The frontend is by default included
+with the backend so no extra setup is required. 

--- a/docs/Authenticating-Users-via-LDAP.md
+++ b/docs/Authenticating-Users-via-LDAP.md
@@ -72,7 +72,6 @@ mvn -DskipTests clean install
 java \
     -Dauthorization=true \
     -Dauthenticate=ldap \
-    -Ddbconnector=dbcp \
     -jar \
     portal/target/dependency/webapp-runner.jar \
     --path /cbioportal \

--- a/docs/Authenticating-Users-via-LDAP.md
+++ b/docs/Authenticating-Users-via-LDAP.md
@@ -23,12 +23,8 @@ The cBioPortal code has no means of storing user name and passwords and no means
 
 ## Modifying configuration
 
-Make Tomcat pass the authentication method as a JVM argument
-by adding this line to `$CATALINA_HOME/bin/setenv.sh`:
-
-    CATALINA_OPTS='-Dauthenticate=ldap'
-
-In portal.properties, modify the section labeled `authentication`.  For example:
+In portal.properties, modify the section labeled `authentication`.  For
+example:
 
     ## configuration for the LDAP access
     ldap.user_search_base=DC=example,DC=com
@@ -73,7 +69,14 @@ Rebuild the WAR file and re-deploy:
 
 ```
 mvn -DskipTests clean install
-cp portal/target/cbioportal.war $CATALINA_HOME/webapps/
+java \
+    -Dauthorization=true \
+    -Dauthenticate=ldap \
+    -Ddbconnector=dbcp \
+    -jar \
+    portal/target/dependency/webapp-runner.jar \
+    --path /cbioportal \
+    portal/target/cbioportal.war
 ```
 
 Then, go to:  [http://localhost:8080/cbioportal/](http://localhost:8080/cbioportal/).
@@ -103,4 +106,3 @@ If you get stuck or get an obscure error message, you can try to turn on all DEB
     log4j.category.org.mskcc=DEBUG
 
 Then, rebuild the WAR, redeploy, and try to authenticate again.  
-

--- a/docs/Authenticating-Users-via-LDAP.md
+++ b/docs/Authenticating-Users-via-LDAP.md
@@ -78,7 +78,7 @@ java \
     portal/target/cbioportal.war
 ```
 
-Then, go to:  [http://localhost:8080/cbioportal/](http://localhost:8080/cbioportal/).
+Then, go to:  [http://localhost:8080/](http://localhost:8080/).
 
 If all goes well, the following should happen:
 

--- a/docs/Authenticating-Users-via-LDAP.md
+++ b/docs/Authenticating-Users-via-LDAP.md
@@ -65,18 +65,8 @@ skin.login.contact_html=If you think you have received this message in error, pl
 
 You are now ready to go.
 
-Rebuild the WAR file and re-deploy:
-
-```
-mvn -DskipTests clean install
-java \
-    -Dauthorization=true \
-    -Dauthenticate=ldap \
-    -jar \
-    portal/target/dependency/webapp-runner.jar \
-    --path /cbioportal \
-    portal/target/cbioportal.war
-```
+Rebuild the WAR file and follow the [Deployment with authentication
+steps](Deploying.md#required-login) using `authenticate=ldap`.
 
 Then, go to:  [http://localhost:8080/](http://localhost:8080/).
 

--- a/docs/Authenticating-Users-via-SAML.md
+++ b/docs/Authenticating-Users-via-SAML.md
@@ -121,11 +121,6 @@ both keystore and secure-key. This seems to be an extra restriction by Tomcat.
 
 ## Modifying configuration
 
-Make Tomcat pass the authentication method as a JVM argument
-by adding this line to `$CATALINA_HOME/bin/setenv.sh`:
-
-    CATALINA_OPTS='-Dauthenticate=saml'
-
 Within portal.properties, make sure that:
 
     app.name=cbioportal
@@ -216,7 +211,14 @@ Rebuild the WAR file and re-deploy:
 
 ```
 mvn -DskipTests clean install
-cp portal/target/cbioportal.war $CATALINA_HOME/webapps/
+java \
+    -Dauthorization=true \
+    -Dauthenticate=saml \
+    -Ddbconnector=dbcp \
+    -jar \
+    portal/target/dependency/webapp-runner.jar \
+    --path /cbioportal \
+    portal/target/cbioportal.war
 ```
 
 Then, go to:  [http://localhost:8080/cbioportal/](http://localhost:8080/cbioportal/).

--- a/docs/Authenticating-Users-via-SAML.md
+++ b/docs/Authenticating-Users-via-SAML.md
@@ -44,9 +44,9 @@ To get started:
 * Under the Configuration Tab for OneLogin SAML Test (IdP w/attr), paste the following fields (this is assuming you are testing everything via localhost).
 
     * Audience: cbioportal
-    * Recipient: http://localhost:8080/cbioportal/saml/SSO
+    * Recipient: http://localhost:8080/saml/SSO
     * ACS (Consumer) URL Validator*:  ^http:\/\/localhost\:8080\/cbioportal\/saml\/SSO$
-    * ACS (Consumer) URL*:  http://localhost:8080/cbioportal/saml/SSO
+    * ACS (Consumer) URL*:  http://localhost:8080/saml/SSO
 
 ![](images/previews/onelogin-config.png)
 
@@ -220,7 +220,7 @@ java \
     portal/target/cbioportal.war
 ```
 
-Then, go to:  [http://localhost:8080/cbioportal/](http://localhost:8080/cbioportal/).
+Then, go to:  [http://localhost:8080/](http://localhost:8080/).
 
 If all goes well, the following should happen:
 
@@ -256,5 +256,5 @@ By default, the portal will automatically generate a Service Provider (SP) Meta 
 
 You can access the Service Provider Meta Data File via a URL such as:
 
-[http://localhost:8080/cbioportal/saml/metadata](http://localhost:8080/cbioportal/saml/metadata)
+[http://localhost:8080/saml/metadata](http://localhost:8080/saml/metadata)
 

--- a/docs/Authenticating-Users-via-SAML.md
+++ b/docs/Authenticating-Users-via-SAML.md
@@ -207,18 +207,8 @@ skin.login.contact_html=If you think you have received this message in error, pl
 
 You are now ready to go.
 
-Rebuild the WAR file and re-deploy:
-
-```
-mvn -DskipTests clean install
-java \
-    -Dauthorization=true \
-    -Dauthenticate=saml \
-    -jar \
-    portal/target/dependency/webapp-runner.jar \
-    --path /cbioportal \
-    portal/target/cbioportal.war
-```
+Rebuild the WAR file and follow the [Deployment with authentication
+steps](Deploying.md#required-login) using `authenticate=saml`.
 
 Then, go to:  [http://localhost:8080/](http://localhost:8080/).
 

--- a/docs/Authenticating-Users-via-SAML.md
+++ b/docs/Authenticating-Users-via-SAML.md
@@ -214,7 +214,6 @@ mvn -DskipTests clean install
 java \
     -Dauthorization=true \
     -Dauthenticate=saml \
-    -Ddbconnector=dbcp \
     -jar \
     portal/target/dependency/webapp-runner.jar \
     --path /cbioportal \

--- a/docs/Authenticating-and-Authorizing-Users-via-keycloak.md
+++ b/docs/Authenticating-and-Authorizing-Users-via-keycloak.md
@@ -125,13 +125,6 @@ should now see the certificate and no private key.
     saml.logout.url=/
 ```
 
-3. Finally, make Tomcat pass the authentication method as a JVM argument
-   by adding this line to `$CATALINA_HOME/bin/setenv.sh`:
-
-```sh
-CATALINA_OPTS='-Dauthenticate=saml'
-```
-
 ## Obtain user identities
 
 ### Optional: create users in Keycloak
@@ -245,7 +238,14 @@ You are now ready to go. Rebuild the WAR file and re-deploy:
 
 ```
 mvn -DskipTests clean install
-cp portal/target/cbioportal.war $CATALINA_HOME/webapps/
+java \
+    -Dauthorization=true \
+    -Dauthenticate=saml \
+    -Ddbconnector=dbcp \
+    -jar \
+    portal/target/dependency/webapp-runner.jar \
+    --path /cbioportal \
+    portal/target/cbioportal.war
 ```
 
 Then, go to:  [http://localhost:8081/cbioportal/](http://localhost:8081/cbioportal/).

--- a/docs/Authenticating-and-Authorizing-Users-via-keycloak.md
+++ b/docs/Authenticating-and-Authorizing-Users-via-keycloak.md
@@ -234,19 +234,8 @@ the same as the one for assigning roles to individual users.
 
 ### Doing a Test Run
 
-You are now ready to go. Rebuild the WAR file and re-deploy:
-
-```
-mvn -DskipTests clean install
-java \
-    -Dauthorization=true \
-    -Dauthenticate=saml \
-    -Ddbconnector=dbcp \
-    -jar \
-    portal/target/dependency/webapp-runner.jar \
-    --path /cbioportal \
-    portal/target/cbioportal.war
-```
+Rebuild the WAR file and follow the [Deployment with authentication
+steps](Deploying.md#required-login) using `authenticate=saml`.
 
 Then, go to:  [http://localhost:8081/cbioportal/](http://localhost:8081/cbioportal/).
 

--- a/docs/Build-from-Source.md
+++ b/docs/Build-from-Source.md
@@ -17,7 +17,9 @@ run the following maven command:
 mvn -DskipTests clean install
 ```
 
-After this command completes, you will find a `cbioportal.war` file
-suitable for Apache Tomcat deployment in `portal/target/`.
+After this command completes, you will find a `cbioportal.war` file suitable
+for Apache Tomcat deployment in `portal/target/`. It is not neccessary to
+install Tomcat yourself, since a command line runnable version of Tomcat is
+provided as a dependency in `portal/target/dependency/webapp-runner.jar`.
 
 [Next Step: Importing the Seed Database](Import-the-Seed-Database.md)

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -1,17 +1,5 @@
 # Deploying the Web Application
 
-## Set Environment Variables
-
-The following environment variable is referenced in this document and is required for successful portal setup:
-
-* `CATALINA_HOME`: points to the home directory of your Apache Tomcat installation.
-
-To make it available to your bash shell, add the following to your `.bash_profile`:
-
-    export CATALINA_HOME=/path/to/tomcat
-
-Note:  If you are following the [recommended Ubuntu instructions](https://www.digitalocean.com/community/tutorials/how-to-install-apache-tomcat-8-on-ubuntu-14-04):  you should set ```export CATALINA_HOME=/opt/tomcat```
-
 ## Prepare the global configuration file
 
 The portal is configured using a global configuration file, `portal.properties`.
@@ -21,108 +9,55 @@ Use it as a template to create your own:
     cd src/main/resources
     cp portal.properties.EXAMPLE $HOME/cbioportal/portal.properties
 
-For more information about the `portal.properties` file,
-see the [reference](portal.properties-Reference.md) page.
+For more information about the `portal.properties` file, see the
+[reference](portal.properties-Reference.md) page.
 
-## Set environment variables for Tomcat
+Several scripts of cBioPortal use this `portal.properties` file to get info
+like db connection parameters. You can indicate the folder where this file is
+with an environment variable:
 
-The `PORTAL_HOME` environment variable needs to be available to
-the `cbioportal.war` file which runs within the Tomcat server,
-so that it can find the configuration file. To make it available to Tomcat,
-edit your Tomcat startup file (typically `$CATALINA_HOME/bin/setenv.sh`)
-and add a line like the following, pointing it to the folder containing
-`portal.properties`:
-
-    export PORTAL_HOME=/Users/johndoe/cbioportal
-
-In additon, add a line to make Tomcat pass `-Dauthenticate=false`
-as a JVM argument, or replace the word ‘false’ by the method to use:
-
-    CATALINA_OPTS='-Dauthenticate=false'
-
-## Add the MySQL JDBC Driver to Apache Tomcat
-
-A proper JDBC driver will also need to be accessible by Apache Tomcat.  If using MySQL, the [Connector/J](http://dev.mysql.com/downloads/connector/j/) driver jar file should be placed in `$CATALINA_HOME/lib`.
-
-More information on configuring Apache Tomcat connection pooling can be found [here](http://tomcat.apache.org/tomcat-7.0-doc/jndi-datasource-examples-howto.html).
-
-***We have reports that the Tomcat package that comes with (at least) Ubuntu 14.04 cannot handle the connection pool from resources.  If you are encountering this is, we suggest you [download the Tomcat archive from Apache and install from there](https://www.digitalocean.com/community/tutorials/how-to-install-apache-tomcat-8-on-ubuntu-14-04).***
-
-## Set up the Database Connection Pool
-
-Apache Tomcat provides the database database connection pool to the cBioPortal.  To setup a database connection pool managed by Tomcat, add the following line to `$CATALINA_HOME/conf/context.xml`, making sure that the properties match your system:
-
-``` xml
-<Context>
-    ...
-    <Resource name="jdbc/cbioportal" auth="Container"
-    type="javax.sql.DataSource"
-    maxActive="100" maxIdle="30" maxWait="10000"
-    username="cbio_user" password="somepassword"
-    driverClassName="com.mysql.jdbc.Driver"
-    connectionProperties="zeroDateTimeBehavior=convertToNull;"
-    testOnBorrow="true"
-    validationQuery="SELECT 1"
-    url="jdbc:mysql://localhost:3306/cbioportal"/>
-...
-</Context>
 ```
-## Deploy the cBioPortal WAR
-
-A tomcat server is usually started by running the following command:
-
-``` bash
-$CATALINA_HOME/bin/catalina.sh start
+export PORTAL_HOME=$HOME/cbioportal
 ```
 
-or, if you are following the [recommended Ubuntu instructions](https://www.digitalocean.com/community/tutorials/how-to-install-apache-tomcat-8-on-ubuntu-14-04)
+if your properties file is at `PORTAL_HOME/portal.properties`
 
-	sudo initctl restart tomcat
+## Run the app
 
-After the tomcat server has been started, to deploy the WAR file, run the following command:
-
-``` bash
-sudo cp portal/target/cbioportal-*-SNAPSHOT.war $CATALINA_HOME/webapps/cbioportal.war
+```
+java \
+    -Dauthorization=false \
+    -Dauthenticate=false \
+    -Ddbconnector=dbcp \
+    -jar \
+    portal/target/dependency/webapp-runner.jar \
+    --path /cbioportal \
+    portal/target/cbioportal.war
 ```
 
-After doing this, you can look in the tomcat log file (`$CATALINA_HOME/logs/catalina.out`) to see if the portal has been proper deployed.  You should see something like:
+As you can see the configuration defined in `portal.properties` can also be
+passed as command line arguments. The priority of property loading is as
+follows:
 
-    INFO: Deployment of web application archive /Users/ecerami/libraries/apache-tomcat-7.0.59/webapps/cbioportal.war has finished in 13,009 ms
+1. `-D` command line parameters overrides all
+2. `${PORTAL_HOME}/portal.properties`
+3. `portal.properties` supplied at compile time
+4. Defaults defined in code
+
+Note that some scripts require a `${PORTAL_HOME}/portal.properties` file, so
+usually it is best to define the properties there.
+
 
 ## Verify the Web Application
 
 Lastly, open a browser and go to:  
-<http://localhost:8080/cbioportal/>
+<http://localhost:8080/cbioportal>
 
 ## Important
 
-- Each time you modify any java code, you must recompile and redeploy the WAR file.
-- Each time you modify any properties (see customization options), you must restart tomcat.
-- Each time you add new data, you must restart tomcat.
+- Each time you modify any java code, you must recompile and redeploy the app.
+- Each time you modify any properties (see customization options), you must restart the app
+- Each time you add new data, you must restart the app
 
-## Developer Tip
-
-If you are actively developing for cBioPortal, you may notice OutOfMemory issues after you re-deploy your WAR file a few times.  Best option for dealing with this is increase your PermGen space settings.
-
-To do so, create a file:  `$CATALINA_HOME/setenv.sh`, and add the following line:
-
-``` bash
-export CATALINA_OPTS="$CATALINA_OPTS -XX:MaxPermSize=256m"
-```
-
-## Gotcha:  Broken MySQL Pipe after long periods of inactivity
-
-By default, MySQL will automatically close database connections after 8 hours of inactivity.  If no one accesses your instance of cBioPortal for 8 hours, users may be unable to access your data, and your log files may show "Broken Pipe" errors.  As described [here](http://juststuffreally.blogspot.com/2007/10/broken-pipes-with-tomcat-and-dbcp.html), and [here](http://stackoverflow.com/questions/20848219/tomcat-mysql-java-servlet-application-getting-500-error-after-some-hours-of-inac), the recommended solution is to add:
-
-    testOnBorrow="true"
-    validationQuery="SELECT 1"
-
-to the JNDI configuration.
-
-According to the stack overflow answer:
-
-> The first, `testOnBorrow` tells the datasource to validate the connection before handing it back to the application. The second, `validationQuery` is the SQL which is used to validate the connection. Note the SQL of SELECT 1 is a valid value for MySQL databases.
-
-The default JNDI settings above therefore include `testOnBorrow` and `validationQuery`, and you should therefore not see any broken pipe errors.  Should you see these errors, despite the settings, best to consult [here](http://juststuffreally.blogspot.com/2007/10/broken-pipes-with-tomcat-and-dbcp.html), and [here](http://stackoverflow.com/questions/20848219/tomcat-mysql-java-servlet-application-getting-500-error-after-some-hours-of-inac).
 
 [Next Step: Loading a Sample Study](Load-Sample-Cancer-Study.md)

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -26,11 +26,8 @@ if your properties file is at `PORTAL_HOME/portal.properties`
 
 ```
 java \
-    -Dauthorization=false \
-    -Dauthenticate=false \
     -jar \
     portal/target/dependency/webapp-runner.jar \
-    --path /cbioportal \
     portal/target/cbioportal.war
 ```
 
@@ -50,7 +47,7 @@ usually it is best to define the properties there.
 ## Verify the Web Application
 
 Lastly, open a browser and go to:  
-<http://localhost:8080/cbioportal>
+<http://localhost:8080>
 
 ## Important
 

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -28,7 +28,6 @@ if your properties file is at `PORTAL_HOME/portal.properties`
 java \
     -Dauthorization=false \
     -Dauthenticate=false \
-    -Ddbconnector=dbcp \
     -jar \
     portal/target/dependency/webapp-runner.jar \
     --path /cbioportal \

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -23,15 +23,69 @@ export PORTAL_HOME=$HOME/cbioportal
 if your properties file is at `PORTAL_HOME/portal.properties`
 
 ## Run the app
+There are three main ways to run the portal: without authentication, with
+optional login and with required login.
+
+### Without authentication
+In this mode users are able to use the portal, but they won't be able to save
+their own virtual studies and groups. See the [optional login
+section](#optional-login) to enable this.
+ 
+```bash
+java \
+    -jar \
+    -Dauthenticate=noauthsessionservice \
+    portal/target/dependency/webapp-runner.jar \
+    portal/target/cbioportal.war
+```
+
+### Optional login
+
+In this mode users can see all the data in the portal, but to save their own
+groups and virtual studies they are required to log in. This will allow them to
+store user data in the session service. See the
+[tutorials](https://www.cbioportal.org/tutorials) section to read more about
+these features.
+
+```bash
+java \
+    -jar \
+    -Dauthenticate=social_auth
+    portal/target/dependency/webapp-runner.jar \
+    portal/target/cbioportal.war
+```
+
+Only google is supported as optional login currently. One needs to set the
+Google related configuration in the `portal.properties` file:
 
 ```
+googleplus.consumer.key=
+googleplus.consumer.secret=
+```
+
+See [Google's Sign in
+Documentation](https://developers.google.com/identity/sign-in/web/sign-in#before_you_begin)
+to obtain these values.
+
+
+### Required login
+
+```bash
 java \
+    -Dauthenticate=CHOOSE_DESIRED_AUTHENTICATION_METHOD \
     -jar \
     portal/target/dependency/webapp-runner.jar \
     portal/target/cbioportal.war
 ```
 
-As you can see the configuration defined in `portal.properties` can also be
+Change `CHOOSE_DESIRED_AUTHENTICATION_METHOD` to one of `googleplus`,
+`social_auth`, `saml`, `openid`, `ad`, `ldap`. The various methods of
+authentication are described in the [Authorization and
+Authentication](https://docs.cbioportal.org/#2-2-authorization-and-authentication)
+section.
+
+### Property configuration
+The configuration defined in `portal.properties` can also be
 passed as command line arguments. The priority of property loading is as
 follows:
 
@@ -40,9 +94,12 @@ follows:
 3. `portal.properties` supplied at compile time
 4. Defaults defined in code
 
-Note that some scripts require a `${PORTAL_HOME}/portal.properties` file, so
-usually it is best to define the properties there.
+Note that the `authenticate` property is currently required to be set as a
+command line argument, it won't work when set in `portal.properties` (See issue
+[#6109](https://github.com/cBioPortal/cbioportal/issues/6109)).
 
+Some scripts require a `${PORTAL_HOME}/portal.properties` file, so it is best
+to define the properties there.
 
 ## Verify the Web Application
 

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -22,7 +22,20 @@ export PORTAL_HOME=$HOME/cbioportal
 
 if your properties file is at `PORTAL_HOME/portal.properties`
 
-## Run the app
+## Run cBioPortal Session Service
+The cBioPortal app requires [session service](Architecture-Overview.md). For
+instructions on how to run this without Docker see
+https://github.com/cBioPortal/session-service#run-without-docker. Once this is
+working, update the properties file:
+
+```bash
+# session-service url: http://[host]:[port]/[session_service_app]/api/sessions/[portal_instance]/
+# example session-service url: http://localhost:8080/session_service/api/sessions/public_portal/
+# see: https://github.com/cBioPortal/session-service
+session.service.url=
+```
+
+## Run the cbioportal backend
 To run the app we use `webapp-runner`. It's a command line version of Tomcat
 provided by [Heroku](https://github.com/jsimone/webapp-runner). All parameters
 can be seen with:
@@ -35,7 +48,8 @@ This runs the app in the foreground. If a port is already in use it will raise
 an error mentioning that. To change the port use the `--port` flag.
 
 There are three main ways to run the portal: without authentication, with
-optional login and with required login.
+optional login and with required login. All of them require the cBioPortal
+session service to be running.
 
 ### Without authentication
 In this mode users are able to use the portal, but they won't be able to save

--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -23,6 +23,17 @@ export PORTAL_HOME=$HOME/cbioportal
 if your properties file is at `PORTAL_HOME/portal.properties`
 
 ## Run the app
+To run the app we use `webapp-runner`. It's a command line version of Tomcat
+provided by [Heroku](https://github.com/jsimone/webapp-runner). All parameters
+can be seen with:
+
+```
+java -jar portal/target/dependency/webapp-runner.jar --help
+```
+
+This runs the app in the foreground. If a port is already in use it will raise
+an error mentioning that. To change the port use the `--port` flag.
+
 There are three main ways to run the portal: without authentication, with
 optional login and with required login.
 
@@ -66,7 +77,6 @@ googleplus.consumer.secret=
 See [Google's Sign in
 Documentation](https://developers.google.com/identity/sign-in/web/sign-in#before_you_begin)
 to obtain these values.
-
 
 ### Required login
 

--- a/docs/Hardware-Requirements.md
+++ b/docs/Hardware-Requirements.md
@@ -8,10 +8,10 @@ space. The site is visited by several thousands of users a day. For on-premise
 installation recommendations one can look at the AWS instance type specs:
 
 > 
-| Platform  | instance type | (v)CPUs  | RAM(GB) |  Storage (GB)|
-| ------------- | ------------- | ------------- | ------------- |
-| aws  | r5.xlarge | 4 | 32  | 50  |
-| on-premise  | - | 4  | 32  |  50 |
+| Platform | instance type | (v)CPUs | RAM(GB) | Storage (GB) |
+| ------------- | ------------- | ------------- | ------------- | ------------- |
+| aws | r5.xlarge | 4 | 32 | 50 |
+| on-premise | - | 4 | 32 | 50 |
 
 
 The hardware requirements are much lower when one has only a few users a day.

--- a/docs/Hardware-Requirements.md
+++ b/docs/Hardware-Requirements.md
@@ -1,0 +1,20 @@
+# Hardware Requirements
+
+Hardware requirements will vary depending on the volume of users you anticipate
+will access your cBioPortal instance and the amount of data loaded in the
+portal. We run [cbioportal.org](https://www.cbioportal.org) on an AWS r5.xlarge
+instance with 32 GB and 4 vCPUs. The public database consumes ~50 GB of disk
+space. The site is visited by several thousands of users a day. For on-premise
+installation recommendations one can look at the AWS instance type specs:
+
+> 
+| Platform  | instance type | (v)CPUs  | RAM(GB) |  Storage (GB)|
+| ------------- | ------------- | ------------- | ------------- |
+| aws  | r5.xlarge | 4 | 32  | 50  |
+| on-premise  | - | 4  | 32  |  50 |
+
+
+The hardware requirements are much lower when one has only a few users a day.
+Minimally, 2GB of RAM is needed to run a cBioPortal instance. If you do not
+plan to import public studies, depending on the size of your private data, 10GB
+of disk space may be sufficient.

--- a/docs/Load-Sample-Cancer-Study.md
+++ b/docs/Load-Sample-Cancer-Study.md
@@ -78,6 +78,6 @@ Done.
 Total time:  7742 ms
 ```
 
-After loading the study data, please restart Tomcat.
+After loading the study data, please restart the app.
 
 [Steps Complete: Return Home](README.md)

--- a/docs/Pre-Build-Steps.md
+++ b/docs/Pre-Build-Steps.md
@@ -2,7 +2,7 @@
 
 ## Get the Latest Code
 
-Make sure that you have cloned the last code, and make sure you are on the ```master``` branch:
+Make sure that you have cloned the last code, and make sure you are on the `master` branch:
 ```
 	git clone https://github.com/cBioPortal/cbioportal.git
 	git checkout master
@@ -53,26 +53,6 @@ You must create a `cbioportal` database and a `cgds_test` database within MySQL,
 
     mysql>  flush privileges;
     Query OK, 0 rows affected (0.00 sec)
-```
-
-## Create a Maven Settings File
-
-In order to access your database, you must create a Maven settings.xml file, and populate it with your database username and password.
-
-The file must be located under:  `~/.m2`, and named:  `settings.xml`.
-
-A sample file is shown below:
-
-```xml
-    <settings>
-      <servers>
-        <server>
-          <id>settingsKey</id>
-          <username>cbio_user</username>
-          <password>somepassword</password>
-        </server>
-      </servers>
-    </settings>
 ```
 
 [Next Step: Building From Source](Build-from-Source.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,19 @@ We also maintain an active [list of RFCs (Requests for Comments)](RFC-List.md) w
 
 ## 2. cBioPortal Deployment
 ### 2.1 Deployment
-* [Hardware and Software Requirements](System-Requirements.md)
+
+* [Architecture overview](Architecture-Overview.md)
+* [Hardware Requirements](Hardware-Requirements.md)
+
+#### 2.1.1 Docker
+* [Pre-Build Steps](Pre-Build-Steps.md)
+* [Building from Source](Build-from-Source.md)
+* [Importing the Seed Database](Import-the-Seed-Database.md)
+* [Deploying the Web Application](Deploying.md)
+* [Loading a Sample Study](Load-Sample-Cancer-Study.md)
+
+#### 2.1.2 Without Docker
+* [Software Requirements](Software-Requirements.md)
 * [Pre-Build Steps](Pre-Build-Steps.md)
 * [Building from Source](Build-from-Source.md)
 * [Importing the Seed Database](Import-the-Seed-Database.md)
@@ -31,7 +43,7 @@ We also maintain an active [list of RFCs (Requests for Comments)](RFC-List.md) w
 * [Customizing your cBioPortal Instance via portal.properties](Customizing-your-instance-of-cBioPortal.md)
 * [More portal.properties Settings](portal.properties-Reference.md)
 
-### 2.4 Docker
+### 2.4 Docker Deployment
 * [Docker Prerequisites](Docker-Prerequisites.md)
 * [Deploy using Docker](Deploy-Using-Docker.md)
 * [Uninstall Docker cBioPortal](Uninstall-Docker-cBioPortal.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,17 +12,17 @@ We also maintain an active [list of RFCs (Requests for Comments)](RFC-List.md) w
 * [List of RFCs](RFC-List.md)
 
 ## 2. cBioPortal Deployment
+
 ### 2.1 Deployment
 
 * [Architecture overview](Architecture-Overview.md)
 * [Hardware Requirements](Hardware-Requirements.md)
 
 #### 2.1.1 Docker
-* [Pre-Build Steps](Pre-Build-Steps.md)
-* [Building from Source](Build-from-Source.md)
-* [Importing the Seed Database](Import-the-Seed-Database.md)
-* [Deploying the Web Application](Deploying.md)
-* [Loading a Sample Study](Load-Sample-Cancer-Study.md)
+* [Docker Prerequisites](Docker-Prerequisites.md)
+* [Deploy using Docker](Deploy-Using-Docker.md)
+* [Uninstall Docker cBioPortal](Uninstall-Docker-cBioPortal.md)
+* [Import a Study Using Docker](Import-Study-Using-Docker.md)
 
 #### 2.1.2 Without Docker
 * [Software Requirements](Software-Requirements.md)
@@ -42,12 +42,6 @@ We also maintain an active [list of RFCs (Requests for Comments)](RFC-List.md) w
 ### 2.3 Customization 
 * [Customizing your cBioPortal Instance via portal.properties](Customizing-your-instance-of-cBioPortal.md)
 * [More portal.properties Settings](portal.properties-Reference.md)
-
-### 2.4 Docker Deployment
-* [Docker Prerequisites](Docker-Prerequisites.md)
-* [Deploy using Docker](Deploy-Using-Docker.md)
-* [Uninstall Docker cBioPortal](Uninstall-Docker-cBioPortal.md)
-* [Import a Study Using Docker](Import-Study-Using-Docker.md)
 
 ## 3. cBioPortal Maintenance
 * [Updating your cBioPortal Database Scheme](Updating-your-cBioPortal-installation.md)

--- a/docs/Software-Requirements.md
+++ b/docs/Software-Requirements.md
@@ -1,18 +1,6 @@
-# Hardware and Software Requirements
+# Software Requirements
 
 This page describes various system software required to run the cBioPortal.
-Note that one can also run cBioPortal using [Docker](Docker-Prerequisites.md),
-which is considerably easier.
-
-## Hardware
-
-Hardware requirements will vary depending on the volume of users you anticipate
-will access your cBioPortal instance.  As a guideline, we run
-[cbioportal.org](https://www.cbioportal.org) on an AWS r5.xlarge instance with
-32 GB and 4 vCPUs. Minimally, 2GB of RAM is needed to run a cBioPortal
-instance. The public database consumes ~50 GB of disk space. If you do not plan
-to import public studies, depending on the size of your private data, 10GB of
-disk space may be sufficient.
 
 ## MySQL
 
@@ -20,6 +8,10 @@ The cBioPortal software should run properly on MySQL version 5.x.x; to avoid a k
 The software can be found and downloaded from the [MySQL website](http://www.mysql.com/).
 
 On Ubuntu:  ```sudo apt-get install mysql-server```
+
+## MongoDB
+
+The session service uses MongoDB 3.6.6
 
 ## Java
 

--- a/docs/System-Requirements.md
+++ b/docs/System-Requirements.md
@@ -1,10 +1,18 @@
 # Hardware and Software Requirements
 
 This page describes various system software required to run the cBioPortal.
+Note that one can also run cBioPortal using [Docker](Docker-Prerequisites.md),
+which is considerably easier.
 
 ## Hardware
 
-Hardware requirements will vary depending on the volume of users you anticipate will access your cBioPortal instance.  As a guideline, we run [cbioportal.org](https://www.cbioportal.org) on an Intel Xeon 2.60GHz/8-core processor with 192GB of RAM. Minimally, 2GB of RAM is needed to run a cBioPortal instance. The public database consumes ~50 GB of disk space. If you do not plan to import public studies, depending on the size of your private data, 10GB of disk space may be sufficient.
+Hardware requirements will vary depending on the volume of users you anticipate
+will access your cBioPortal instance.  As a guideline, we run
+[cbioportal.org](https://www.cbioportal.org) on an AWS r5.xlarge instance with
+32 GB and 4 vCPUs. Minimally, 2GB of RAM is needed to run a cBioPortal
+instance. The public database consumes ~50 GB of disk space. If you do not plan
+to import public studies, depending on the size of your private data, 10GB of
+disk space may be sufficient.
 
 ## MySQL
 
@@ -18,12 +26,6 @@ On Ubuntu:  ```sudo apt-get install mysql-server```
 As of this writing, the cBioPortal can be compiled and run from Java 8.0 and above.  The software can be found and download from the [Oracle](http://www.oracle.com/us/technologies/java/overview/index.html) website.
 
 On Ubuntu:  ```sudo apt-get install default-jdk```
-
-## Apache Tomcat
-
-As of this writing, the cBioPortal runs properly on Apache Tomcat version 8 and above.  The software can be found and downloaded from the [Apache Tomcat website](http://tomcat.apache.org).
-
-On Ubuntu:  [See Recommended Installation Instructions](https://www.digitalocean.com/community/tutorials/how-to-install-apache-tomcat-8-on-ubuntu-14-04)
 
 ## Apache Maven
 

--- a/docs/Using-the-dataset-validator.md
+++ b/docs/Using-the-dataset-validator.md
@@ -31,7 +31,7 @@ optional arguments:
                         path to directory.
   -u URL_SERVER, --url_server URL_SERVER
                         URL to cBioPortal server. You can set this if your URL
-                        is not http://localhost:8080/cbioportal
+                        is not http://localhost:8080
   -p PORTAL_INFO_DIR, --portal_info_dir PORTAL_INFO_DIR
                         Path to a directory of cBioPortal info files to be
                         used instead of contacting a server
@@ -72,15 +72,15 @@ when the validator encounters these validation checks it will report them as an 
 ### Example 1: test study_es_0
 As an example, you can try the validator with one of the test studies found in  `<cbioportal_source_folder>/core/src/test/scripts/test_data`. Example, assuming port 8080 and using -v option to also see the progress:
 ```bash
-./validateData.py -s ../../../test/scripts/test_data/study_es_0/ -u http://localhost:8080/cbioportal -v
+./validateData.py -s ../../../test/scripts/test_data/study_es_0/ -u http://localhost:8080 -v
 ```
 Results in:
 ```console
-DEBUG: -: Requesting cancertypes from portal at 'http://localhost:8080/cbioportal'
-DEBUG: -: Requesting clinicalattributes/patients from portal at 'http://localhost:8080/cbioportal'
-DEBUG: -: Requesting clinicalattributes/samples from portal at 'http://localhost:8080/cbioportal'
-DEBUG: -: Requesting genes from portal at 'http://localhost:8080/cbioportal'
-DEBUG: -: Requesting genesaliases from portal at 'http://localhost:8080/cbioportal'
+DEBUG: -: Requesting cancertypes from portal at 'http://localhost:8080'
+DEBUG: -: Requesting clinicalattributes/patients from portal at 'http://localhost:8080'
+DEBUG: -: Requesting clinicalattributes/samples from portal at 'http://localhost:8080'
+DEBUG: -: Requesting genes from portal at 'http://localhost:8080'
+DEBUG: -: Requesting genesaliases from portal at 'http://localhost:8080'
 
 DEBUG: meta_CNA.txt: Starting validation of meta file
 INFO: meta_CNA.txt: Validation of meta file complete
@@ -174,15 +174,15 @@ When using the `-html` option, a report will be generated, which looks like this
 ### Example 2: test study_es_1
 More test studies for trying the validator (`study_es_1` and `study_es_3`) are available in  `<cbioportal_source_folder>/core/src/test/scripts/test_data`. Example, assuming port 8080 and using -v option:
 ```bash
-./validateData.py -s ../../../test/scripts/test_data/study_es_1/ -u http://localhost:8080/cbioportal -v
+./validateData.py -s ../../../test/scripts/test_data/study_es_1/ -u http://localhost:8080 -v
 ```
 Results in:
 ```console
-DEBUG: -: Requesting cancertypes from portal at 'http://localhost:8080/cbioportal'
-DEBUG: -: Requesting clinicalattributes/patients from portal at 'http://localhost:8080/cbioportal'
-DEBUG: -: Requesting clinicalattributes/samples from portal at 'http://localhost:8080/cbioportal'
-DEBUG: -: Requesting genes from portal at 'http://localhost:8080/cbioportal'
-DEBUG: -: Requesting genesaliases from portal at 'http://localhost:8080/cbioportal'
+DEBUG: -: Requesting cancertypes from portal at 'http://localhost:8080'
+DEBUG: -: Requesting clinicalattributes/patients from portal at 'http://localhost:8080'
+DEBUG: -: Requesting clinicalattributes/samples from portal at 'http://localhost:8080'
+DEBUG: -: Requesting genes from portal at 'http://localhost:8080'
+DEBUG: -: Requesting genesaliases from portal at 'http://localhost:8080'
 
 DEBUG: meta_samples.txt: Starting validation of meta file
 WARNING: meta_samples.txt: Unrecognized field in meta file; values encountered: ['show_profile_in_analysis_tab', 'profile_name', 'profile_description']
@@ -439,7 +439,7 @@ If your `portal.properties` does not have the default (human) settings, you shou
 
 As an example, the command for the "Example 1" listed above incorporating the `-P` parameter is given:
 ```
-./validateData.py -s ../../../test/scripts/test_data/study_es_0/ -P ../../../../../src/main/resources/portal.properties -u http://localhost:8080/cbioportal -v
+./validateData.py -s ../../../test/scripts/test_data/study_es_0/ -P ../../../../../src/main/resources/portal.properties -u http://localhost:8080 -v
 ```
 
 ## Running the validator for multiple studies
@@ -467,7 +467,7 @@ optional arguments:
                         Path to folder for output HTML reports
   -u URL_SERVER, --url_server URL_SERVER
                         URL to cBioPortal server. You can set this if your URL
-                        is not http://localhost:8080/cbioportal
+                        is not http://localhost:8080
   -p PORTAL_INFO_DIR, --portal_info_dir PORTAL_INFO_DIR
                         Path to a directory of cBioPortal info files to be
                         used instead of contacting a server

--- a/docs/Using-the-metaImport-script.md
+++ b/docs/Using-the-metaImport-script.md
@@ -69,7 +69,7 @@ and then run (this simple command only works if your cBioPortal is running at ht
 #### Advanced Example
 This example imports the study to the localhost, creates an html report and shows status messages.
 ```
-./metaImport.py -s ../../../test/scripts/test_data/study_es_0/ -u http://localhost:8080/cbioportal -html myReport.html -v
+./metaImport.py -s ../../../test/scripts/test_data/study_es_0/ -u http://localhost:8080 -html myReport.html -v
 ```
 
 By adding `-o`, warnings will be overridden and import will start after validation.

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -180,17 +180,8 @@ googleplus.consumer.secret=2jCfg4SPWdGfXF44WC588dK
 ```
 (note: these are just examples, you need to get your own) You will also need to go to "Google+ API" and click Enable button. In case of problems make sure to enable DEBUG logging for org.springframework.social and org.springframework.security.web.authentication.
 
-To activate password authentication, pass the `-Dauthenticate=googleplus`  to
-the command to run the portal:
-```sh
-java \
-    -Dauthorization=true \
-    -Dauthenticate=googleplus \
-    -jar \
-    portal/target/dependency/webapp-runner.jar \
-    --path /cbioportal \
-    portal/target/cbioportal.war
-```
+To activate password authentication follow the [Deployment with authentication
+steps](Deploying.md#required-login) and set `authenticate=googleplus`.
 
 In addition, set this property in `portal.properties`:
 ```

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -180,12 +180,17 @@ googleplus.consumer.secret=2jCfg4SPWdGfXF44WC588dK
 ```
 (note: these are just examples, you need to get your own) You will also need to go to "Google+ API" and click Enable button. In case of problems make sure to enable DEBUG logging for org.springframework.social and org.springframework.security.web.authentication.
 
-To activate password authentication,
-pass the `-Dauthenticate=googleplus` argument to the web server JVM.
-This can be done by adding the following line to the Tomcat config file
-`$CATALINA_HOME/bin/setenv.sh`:
+To activate password authentication, pass the `-Dauthenticate=googleplus`  to
+the command to run the portal:
 ```sh
-CATALINA_OPTS='-Dauthenticate=googleplus'
+java \
+    -Dauthorization=false \
+    -Dauthenticate=googleplus \
+    -Ddbconnector=dbcp \
+    -jar \
+    portal/target/dependency/webapp-runner.jar \
+    --path /cbioportal \
+    portal/target/cbioportal.war
 ```
 
 In addition, set this property in `portal.properties`:

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -186,7 +186,6 @@ the command to run the portal:
 java \
     -Dauthorization=false \
     -Dauthenticate=googleplus \
-    -Ddbconnector=dbcp \
     -jar \
     portal/target/dependency/webapp-runner.jar \
     --path /cbioportal \

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -184,7 +184,7 @@ To activate password authentication, pass the `-Dauthenticate=googleplus`  to
 the command to run the portal:
 ```sh
 java \
-    -Dauthorization=false \
+    -Dauthorization=true \
     -Dauthenticate=googleplus \
     -jar \
     portal/target/dependency/webapp-runner.jar \

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -23,11 +23,11 @@
     <!-- dbcp profile is defined here to prevent exceptions during war deployment -->
     <context-param>
         <param-name>spring.profiles.active</param-name>
-        <param-value>${dbconnector:dbcp},${authenticate:false}</param-value>
+        <param-value>${dbconnector:dbcp},${authenticate}</param-value>
     </context-param>
     <context-param>
         <param-name>spring.liveBeansView.mbeanDomain</param-name>
-        <param-value>${dbconnector:dbcp},${authenticate:false}</param-value>
+        <param-value>${dbconnector:dbcp},${authenticate}</param-value>
     </context-param>
 
     <context-param>

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -23,11 +23,11 @@
     <!-- dbcp profile is defined here to prevent exceptions during war deployment -->
     <context-param>
         <param-name>spring.profiles.active</param-name>
-        <param-value>${dbconnector:dbcp},${authenticate}</param-value>
+        <param-value>${dbconnector:dbcp},${authenticate:false}</param-value>
     </context-param>
     <context-param>
         <param-name>spring.liveBeansView.mbeanDomain</param-name>
-        <param-value>${dbconnector:dbcp},${authenticate}</param-value>
+        <param-value>${dbconnector:dbcp},${authenticate:false}</param-value>
     </context-param>
 
     <context-param>

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -20,14 +20,14 @@
     <display-name>Cancer Genomics Portal</display-name>
 
     <!-- context configuration -->
-    <!-- jndi profile is defined here to prevent exceptions during war deployment -->
+    <!-- dbcp profile is defined here to prevent exceptions during war deployment -->
     <context-param>
         <param-name>spring.profiles.active</param-name>
-        <param-value>${dbconnector:jndi},${authenticate}</param-value>
+        <param-value>${dbconnector:dbcp},${authenticate}</param-value>
     </context-param>
     <context-param>
         <param-name>spring.liveBeansView.mbeanDomain</param-name>
-        <param-value>${dbconnector:jndi},${authenticate}</param-value>
+        <param-value>${dbconnector:dbcp},${authenticate}</param-value>
     </context-param>
 
     <context-param>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -8,7 +8,10 @@ db.host=localhost
 db.portal_db_name=cbioportal
 db.driver=com.mysql.jdbc.Driver
 db.connection_string=jdbc:mysql://localhost/
-db.tomcat_resource_name=jdbc/cbioportal
+# set tomcat_resource_name when using dbconnector=jndi instead of the defaault
+# dbconnector=dbcp
+# db.tomcat_resource_name=jdbc/cbioportal
+
 # this should normally be set to false. In some cases you could set this to true (e.g. for testing a feature of a newer release that is not related to the schema change in expected db version above):
 db.suppress_schema_version_mismatch_errors=false
 db.use_ssl=false

--- a/test/end-to-end/docker-compose.yml
+++ b/test/end-to-end/docker-compose.yml
@@ -4,7 +4,7 @@ cbioportal:
     - "8080:8080"
   volumes:
     - $PWD/../../:/cbioportal
-  command: java -Ddbconnector=dbcp -Dauthenticate=false -jar portal/target/dependency/webapp-runner.jar --enable-compression portal/target/cbioportal.war
+  command: java -Dauthenticate=false -jar portal/target/dependency/webapp-runner.jar --enable-compression portal/target/cbioportal.war
   environment:
     PORTAL_HOME: /cbioportal/test/end-to-end/runtime-config
   working_dir: /cbioportal


### PR DESCRIPTION
Use dbcp + webapp-runner as default to deploy cBioPortal. Mention how to deploy session service w/o docker since it's a requirement for 3.0.0 and document the use of `-D` parameters.

Fix https://github.com/cBioPortal/cbioportal/issues/4832

I think using webapp-runner makes deploying the backend much easier compared to the Tomcat setup. No messing with Tomcat config files. I find `dbcp` a lot more clear than `jndi` as well. Only need to set database parameters in `portal.properties`. This is the exact same setup we are using on AWS (https://github.com/knowledgesystems/knowledgesystems-k8s-deployment/blob/master/cbioportal/cbioportal_spring_boot.yaml#L117). It makes sense for the default to be as similar to our own production environment as possible.