### PR TITLE
Update validator: remove portal_info_dir argument (path to JSON files)

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -4016,11 +4016,6 @@ def interface(args=None):
                                    help='URL to cBioPortal server. You can '
                                         'set this if your URL is not '
                                         'http://localhost:8080/cbioportal')
-    portal_mode_group.add_argument('-p', '--portal_info_dir',
-                                   type=str,
-                                   help='Path to a directory of cBioPortal '
-                                        'info files to be used instead of '
-                                        'contacting a server')
     portal_mode_group.add_argument('-n', '--no_portal_checks',
                                    action='store_true',
                                    help='Skip tests requiring information '
@@ -4323,9 +4318,6 @@ def main_validate(args):
                                          alias_entrez_map=None,
                                          gene_set_list=None,
                                          gene_panel_list=None)
-    elif args.portal_info_dir:
-        portal_instance = load_portal_info(args.portal_info_dir, logger,
-                                           offline=True)
     else:
         portal_instance = load_portal_info(server_url, logger)
 

--- a/core/src/main/scripts/importer/validateStudies.py
+++ b/core/src/main/scripts/importer/validateStudies.py
@@ -67,9 +67,7 @@ def main(args):
         print("\n=== Validating study %s" %study)
 
         # Check which portal info variable is given as input, and set correctly in the arguments for validateData
-        if args.portal_info_dir is not None:
-            validator_args = ['-v', '--study_directory', study, '-p', args.portal_info_dir]
-        elif args.no_portal_checks:
+        if args.no_portal_checks:
             validator_args = ['-v', '--study_directory', study, '-n']
         else:
             validator_args = ['-v', '--study_directory', study, '-u', args.url_server]
@@ -163,11 +161,6 @@ def interface(args=None):
                                    help='URL to cBioPortal server. You can '
                                         'set this if your URL is not '
                                         'http://localhost:8080/cbioportal')
-    portal_mode_group.add_argument('-p', '--portal_info_dir',
-                                   type=str,
-                                   help='Path to a directory of cBioPortal '
-                                        'info files to be used instead of '
-                                        'contacting a server')
     portal_mode_group.add_argument('-n', '--no_portal_checks',
                                    action='store_true',
                                    help='Skip tests requiring information '


### PR DESCRIPTION
# What? Why?
Switching to use cbioportal API url instead of using static JSON files for validation.

Changes proposed in this pull request:
- Remove the portal_info_dir argument

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
