### PR TITLE
Allow overlapping samples in clinical-data-enrichments api

### DIFF
--- a/web/src/main/java/org/cbioportal/web/parameter/GroupFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/GroupFilter.java
@@ -1,13 +1,9 @@
 package org.cbioportal.web.parameter;
 
 import java.io.Serializable;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.validation.Valid;
-import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
 
 public class GroupFilter implements Serializable {
@@ -15,17 +11,6 @@ public class GroupFilter implements Serializable {
     @Size(min = 2)
     @Valid
     private List<Group> groups;
-
-    @AssertTrue
-    private boolean isGroupsContainsDistinctSamples() {
-
-        List<SampleIdentifier> sampleIdentifiers = groups.stream().flatMap(x -> x.getSampleIdentifiers().stream())
-                .collect(Collectors.toList());
-
-        Set<SampleIdentifier> uniqSampleIdentifiers = new HashSet<>(sampleIdentifiers);
-
-        return uniqSampleIdentifiers.size() == sampleIdentifiers.size();
-    }
 
     public List<Group> getGroups() {
         return groups;

--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataEnrichmentUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataEnrichmentUtil.java
@@ -3,7 +3,6 @@ package org.cbioportal.web.util;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,8 +88,7 @@ public class ClinicalDataEnrichmentUtil {
 
         List<ClinicalDataEnrichment> clinicalEnrichments = new ArrayList<ClinicalDataEnrichment>();
 
-        // ClinicalDataCountItem for all STRING datatype attributes and for all sample
-        // groups
+        // ClinicalDataCountItem for all STRING datatype attributes and for all sample groups
         List<Map<String, ClinicalDataCountItem>> dataCountsByGroupAndByAttribute = groupedSamples.stream()
                 .map(groupSamples -> getClinicalDataCounts(attributes, groupSamples)).collect(Collectors.toList());
 

--- a/web/src/test/java/org/cbioportal/web/ClinicalDataEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/ClinicalDataEnrichmentControllerTest.java
@@ -199,15 +199,6 @@ public class ClinicalDataEnrichmentControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message")
                         .value("groups[1].sampleIdentifiers size must be between 1 and 10000000"));
 
-        group2.setSampleIdentifiers(
-                new ArrayList<SampleIdentifier>(Arrays.asList(sampleIdentifier1, sampleIdentifier2)));
-
-        mockMvc.perform(
-                MockMvcRequestBuilders.post("/clinical-data-enrichments/fetch").accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(groupFilter)))
-                .andExpect(MockMvcResultMatchers.status().isBadRequest()).andExpect(MockMvcResultMatchers
-                        .jsonPath("$.message").value("groupsContainsDistinctSamples must be true"));
-
         group2.setSampleIdentifiers(new ArrayList<SampleIdentifier>(
                 Arrays.asList(sampleIdentifier3, sampleIdentifier4, sampleIdentifier5)));
 


### PR DESCRIPTION
Instead of excluding overlapping samples, consider them as separate entities within a group while fetching data through `clinical-data-enrichments/fetch` api