### PR TITLE
change ObjectMapper in InvolvedCancerStudyExtractorInterceptor 

### DIFF
--- a/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
+++ b/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
@@ -64,8 +64,7 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
     @Autowired
     private UniqueKeyExtractor uniqueKeyExtractor;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     @Autowired
     private CacheMapUtil cacheMapUtil;

--- a/web/src/main/resources/applicationContext-web.xml
+++ b/web/src/main/resources/applicationContext-web.xml
@@ -67,6 +67,5 @@
     <mvc:interceptors>
         <bean id="involvedCancerStudyInterceptor" class="org.cbioportal.web.util.InvolvedCancerStudyExtractorInterceptor"/>
     </mvc:interceptors>
-    <bean class="com.fasterxml.jackson.databind.ObjectMapper"/>
 
 </beans>

--- a/web/src/test/java/org/cbioportal/web/ClinicalAttributeControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/ClinicalAttributeControllerTest.java
@@ -62,8 +62,7 @@ public class ClinicalAttributeControllerTest {
     @Autowired
     private ClinicalAttributeService clinicalAttributeService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/ClinicalDataControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/ClinicalDataControllerTest.java
@@ -48,8 +48,7 @@ public class ClinicalDataControllerTest {
     @Autowired
     private ClinicalDataService clinicalDataService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/CoExpressionControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CoExpressionControllerTest.java
@@ -50,8 +50,7 @@ public class CoExpressionControllerTest {
     @Autowired
     private CoExpressionService coExpressionService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/CopyNumberEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CopyNumberEnrichmentControllerTest.java
@@ -54,8 +54,7 @@ public class CopyNumberEnrichmentControllerTest {
     @Autowired
     private CopyNumberEnrichmentService copyNumberEnrichmentService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/CopyNumberSegmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CopyNumberSegmentControllerTest.java
@@ -62,8 +62,7 @@ public class CopyNumberSegmentControllerTest {
     @Autowired
     private CopyNumberSegmentService copyNumberSegmentService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/CosmicCountControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CosmicCountControllerTest.java
@@ -44,8 +44,7 @@ public class CosmicCountControllerTest {
     @Autowired
     private CosmicCountService cosmicCountService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/DiscreteCopyNumberControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/DiscreteCopyNumberControllerTest.java
@@ -67,8 +67,7 @@ public class DiscreteCopyNumberControllerTest {
     @Autowired
     private DiscreteCopyNumberService discreteCopyNumberService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/ExpressionEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/ExpressionEnrichmentControllerTest.java
@@ -56,8 +56,7 @@ public class ExpressionEnrichmentControllerTest {
     @Autowired
     private ExpressionEnrichmentService expressionEnrichmentService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/GeneControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GeneControllerTest.java
@@ -54,8 +54,7 @@ public class GeneControllerTest {
     @Autowired
     private GeneService geneService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/GenePanelControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GenePanelControllerTest.java
@@ -69,8 +69,7 @@ public class GenePanelControllerTest {
     @Autowired
     private GenePanelService genePanelService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/GenesetDataControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GenesetDataControllerTest.java
@@ -47,8 +47,7 @@ public class GenesetDataControllerTest {
     @Autowired
     private GenesetDataService genesetDataService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/MolecularDataControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MolecularDataControllerTest.java
@@ -54,8 +54,7 @@ public class MolecularDataControllerTest {
     @Autowired
     private MolecularDataService molecularDataService;
 
-    @Autowired 
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/MolecularProfileControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MolecularProfileControllerTest.java
@@ -67,8 +67,7 @@ public class MolecularProfileControllerTest {
     @Autowired
     private MolecularProfileService molecularProfileService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/MrnaPercentileControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MrnaPercentileControllerTest.java
@@ -46,8 +46,7 @@ public class MrnaPercentileControllerTest {
     @Autowired
     private MrnaPercentileService mrnaPercentileService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/MutationControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MutationControllerTest.java
@@ -126,8 +126,7 @@ public class MutationControllerTest {
     @Autowired
     private MutationService mutationService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/MutationEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MutationEnrichmentControllerTest.java
@@ -56,8 +56,7 @@ public class MutationEnrichmentControllerTest {
     @Autowired
     private MutationEnrichmentService mutationEnrichmentService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/MutationSpectrumControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MutationSpectrumControllerTest.java
@@ -54,8 +54,7 @@ public class MutationSpectrumControllerTest {
     @Autowired
     private MutationSpectrumService mutationSpectrumService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/PatientControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/PatientControllerTest.java
@@ -55,8 +55,7 @@ public class PatientControllerTest {
     @Autowired
     private PatientService patientService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/SampleControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/SampleControllerTest.java
@@ -51,8 +51,7 @@ public class SampleControllerTest {
     @Autowired
     private SampleService sampleService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/SampleListControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/SampleListControllerTest.java
@@ -63,8 +63,7 @@ public class SampleListControllerTest {
     @Autowired
     private SampleListService sampleListService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/StudyControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StudyControllerTest.java
@@ -77,8 +77,7 @@ public class StudyControllerTest {
     @Autowired
     private StudyService studyService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/StudyViewControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StudyViewControllerTest.java
@@ -90,8 +90,7 @@ public class StudyViewControllerTest {
     @Autowired
     private GenePanelService genePanelService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 

--- a/web/src/test/java/org/cbioportal/web/VariantCountControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/VariantCountControllerTest.java
@@ -49,8 +49,7 @@ public class VariantCountControllerTest {
     @Autowired
     private VariantCountService variantCountService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
 


### PR DESCRIPTION
Don't use Autowiring/Bean

Just instantiate an ObjectMapper to use resolves "bean not found of type" error message in tomcat catalina.out

This is an essential fix for v2.2.1 (mskcc tomcat won't work otherwise)