### PR TITLE
Convert Gene panel ID validation from error to warning

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -2809,7 +2809,7 @@ class GenePanelMatrixValidator(Validator):
         # Check whether gene panel stable ids are in the database
         for gene_panel_id in data:
             if gene_panel_id not in self.portal.gene_panel_list and gene_panel_id != 'NA':
-                self.logger.error('Gene panel ID is not in database. Please import this gene panel before loading '
+                self.logger.warning('Gene panel ID is not in database. Please import this gene panel before loading '
                                   'study data.',
                                   extra={'line_number': self.line_number,
                                          'cause': gene_panel_id})


### PR DESCRIPTION
# What? Why?
ISSUE: when adding a new gene panel to datahub the validation fails because the panel is not present in database/json files. It first requires the study to be imported to database from a different source(hg) or the panel to be added to JSON file and then create a PR to pass validation. 

FIX MADE: Changed the validation of Gene panel ID from error to warning.

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
