### PR TITLE
Update documentation: tomcat issue w jndi

### DIFF
--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -125,6 +125,15 @@ command line argument, it won't work when set in `portal.properties` (See issue
 Some scripts require a `${PORTAL_HOME}/portal.properties` file, so it is best
 to define the properties there.
 
+### Note for Tomcat Deployers
+Before we were using `webapp-runner`, our documentation recommended a system
+level installed Tomcat. In this case people might have been using
+`dbconnector=jndi` instead of the new default `dbconnector=dbcp`. There is a
+known issue where setting dbconnector in the properties file does not work
+([#6148](https://github.com/cBioPortal/cbioportal/issues/6148)). It needs to be
+set as a command line argument. For Tomcat this means
+`CATALINA_OPT="-Ddbconnector=jndi"`.
+
 ## Verify the Web Application
 
 Lastly, open a browser and go to:  

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -8,8 +8,12 @@ db.host=localhost
 db.portal_db_name=cbioportal
 db.driver=com.mysql.jdbc.Driver
 db.connection_string=jdbc:mysql://localhost/
-# set tomcat_resource_name when using dbconnector=jndi instead of the defaault
-# dbconnector=dbcp
+# set tomcat_resource_name when using dbconnector=jndi instead of the default
+# dbconnector=dbcp. Note that dbconnector needs to be set in CATLINA_OPTS when
+# using Tomcat (CATALINA_OPTS="-Ddbconnector=jndi"). It does not get picked up
+# from the properties file
+# (https://github.com/cBioPortal/cbioportal/issues/6148).
+#
 # db.tomcat_resource_name=jdbc/cbioportal
 
 # this should normally be set to false. In some cases you could set this to true (e.g. for testing a feature of a newer release that is not related to the schema change in expected db version above):


### PR DESCRIPTION
There is a known issue with dbconnector (https://github.com/cBioPortal/cbioportal/issues/6148). Since we switched to the new default of `jndi` it's good to mention how people
can get around it.