### PR TITLE
Fix imports for Python scripts when __package__ is empty string

### DIFF
--- a/core/src/main/scripts/importer/cbioportalImporter.py
+++ b/core/src/main/scripts/importer/cbioportalImporter.py
@@ -14,7 +14,8 @@ import re
 from pathlib import Path
 
 # configure relative imports if running as a script; see PEP 366
-if __name__ == "__main__" and __package__ is None:
+# it might passed as empty string by certain tooling to mark a top level module
+if __name__ == "__main__" and (__package__ is None or __package__ == ''):
     # replace the script's location in the Python search path by the main
     # scripts/ folder, above it, so that the importer package folder is in
     # scope and *not* directly in sys.path; see PEP 395

--- a/core/src/main/scripts/importer/metaImport.py
+++ b/core/src/main/scripts/importer/metaImport.py
@@ -14,7 +14,8 @@ import logging
 from pathlib import Path
 
 # configure relative imports if running as a script; see PEP 366
-if __name__ == "__main__" and __package__ is None:
+# it might passed as empty string by certain tooling to mark a top level module
+if __name__ == "__main__" and (__package__ is None or __package__ == ''):
     # replace the script's location in the Python search path by the main
     # scripts/ folder, above it, so that the importer package folder is in
     # scope and *not* directly in sys.path; see PEP 395

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -48,7 +48,8 @@ import math
 from abc import ABCMeta, abstractmethod
 
 # configure relative imports if running as a script; see PEP 366
-if __name__ == "__main__" and __package__ is None:
+# it might passed as empty string by certain tooling to mark a top level module
+if __name__ == "__main__" and (__package__ is None or __package__ == ''):
     # replace the script's location in the Python search path by the main
     # scripts/ folder, above it, so that the importer package folder is in
     # scope and *not* directly in sys.path; see PEP 395


### PR DESCRIPTION
# What? Why?
According to PEP 366 \_\__package_\_\_ may be passed as empty string for top level modules:

>Note that setting __package__ to the empty string explicitly is permitted, and has the effect of disabling all relative imports from that module (since the import machinery will consider it to be a top level module in that case). 

Current data processing Python scripts do not take this into account and fail due to relative imports failing on VSCode.

# Fix
Python scripts correctly evaluate imports when \_\__package_\_\_ is empty string.
