### PR TITLE
Added missing stable ids to allowed_data_types file

### DIFF
--- a/core/src/main/scripts/importer/allowed_data_types.txt
+++ b/core/src/main/scripts/importer/allowed_data_types.txt
@@ -36,3 +36,9 @@ PROTEIN_LEVEL	CONTINUOUS	protein_quantification
 PROTEIN_LEVEL	Z-SCORE	protein_quantification_zscores
 GENESET_SCORE	GSVA-SCORE	gsva_scores
 GENESET_SCORE	P-VALUE	gsva_pvalues
+MRNA_EXPRESSION	CONTINUOUS	mrna_seq_fpkm_capture
+MRNA_EXPRESSION	CONTINUOUS	mrna_seq_fpkm_polya
+MRNA_EXPRESSION	Z-SCORE	mrna_seq_fpkm_capture_Zscores
+MRNA_EXPRESSION	Z-SCORE	mrna_seq_fpkm_polya_Zscores
+MRNA_EXPRESSION	CONTINUOUS	mrna_seq_cpm
+MRNA_EXPRESSION	Z-SCORE	mrna_seq_cpm_Zscores


### PR DESCRIPTION
# What? Why?
Allowed_data_types file has a list a stable ids and genetic alteration types that the validator compares against. Currently, the validation fails for studies that have any new stable ids.

Fix:
Adding the missing ids to the file.

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
