### PR TITLE
Doc fixes

### DIFF
--- a/docs/Import-the-Seed-Database.md
+++ b/docs/Import-the-Seed-Database.md
@@ -30,19 +30,8 @@ After download, the files can be unzipped by entering the following command:
 
     **Important:** Replace `seed-cbioportal_RefGenome_vX.Y.Z.sql` with the downloaded version of the seed database, such as `seed-cbioportal_hg19_v2.3.1.sql` or `seed-cbioportal_mm10_v2.3.1.sql`.
 
-3. (Human only) Import the Protein Data Bank (PDB) part of the seed database. This will enable the visualization of PDB structures in the mutation tab. Loading this file takes more time than loading the previous files, and is optional for users that do not require PDB structures.
-
-    ```
-    mysql --user=cbio_user --password=somepassword cbioportal < seed-cbioportal_hg19_vX.Y.Z_only-pdb.sql
-    ```
-    **Important:** Replace `seed-cbioportal_hg19_vX.Y.Z_only-pdb.sql` with the downloaded version of the PDB database, such as `seed-cbioportal_hg19_v2.3.1_only-pdb.sql`.
-
 **Important:** Please be aware of the version of the seed database. In the [README on datahub](https://github.com/cbioportal/datahub/blob/master/seedDB/README.md), we stated which version of cBioPortal is compatible with the current seed database.
 
 If the database is older than what cBioPortal is expecting, the system will ask you (during startup or data loading) to migrate the database to a newer version. The migration process is described [here](Updating-your-cBioPortal-installation.md#running-the-migration-script).
-
-## Drug-target Data
-
-Due to data provider specific restrictions on data re-distribution, the database setup, as outlined above, will lack some of the drug-gene relationships from specific data-resources. If you would like to obtain the complete the data sets from these resources, we encourage you to take advantage of [PiHelper](http://bitbucket.org/armish/pihelper) for aggregating drug-target associations and use the corresponding data importer `importPiHelperData.sh` which is distributed as part of cBioPortal.
 
 [Next Step: Deploying the Web Application](Deploying.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,29 +7,35 @@
 * [List of RFCs](RFC-List.md)
 
 ## 2. cBioPortal Deployment
+
 ### 2.1 Deployment
-* [Hardware and Software Requirements](System-Requirements.md)
+
+* [Architecture overview](Architecture-Overview.md)
+* [Hardware Requirements](Hardware-Requirements.md)
+
+#### 2.1.1 Docker
+* [Deploy with Docker](docker/README.md)
+* [Example Commands](docker/example_commands.md)
+* [Authenticating and Authorizing Users using Keycloak in Docker](docker/using-keycloak.md)
+
+#### 2.1.2 Without Docker
+* [Software Requirements](Software-Requirements.md)
 * [Pre-Build Steps](Pre-Build-Steps.md)
 * [Building from Source](Build-from-Source.md)
 * [Importing the Seed Database](Import-the-Seed-Database.md)
-* [Loading a Sample Study](Load-Sample-Cancer-Study.md)  
 * [Deploying the Web Application](Deploying.md)
+* [Loading a Sample Study](Load-Sample-Cancer-Study.md)
 
 ### 2.2 Authorization and Authentication
 * [User Authorization](User-Authorization.md)
 * [Authenticating Users via SAML](Authenticating-Users-via-SAML.md)
 * [Authenticating Users via LDAP](Authenticating-Users-via-LDAP.md)
 * [Authenticating and Authorizing Users via Keycloak](Authenticating-and-Authorizing-Users-via-keycloak.md)
+* [Authenticating Users via Tokens](Authenticating-Users-via-Tokens.md)
 
 ### 2.3 Customization 
 * [Customizing your cBioPortal Instance via portal.properties](Customizing-your-instance-of-cBioPortal.md)
 * [More portal.properties Settings](portal.properties-Reference.md)
-
-### 2.4 Docker
-* [Docker Prerequisites](Docker-Prerequisites.md)
-* [Deploy using Docker](Deploy-Using-Docker.md)
-* [Uninstall Docker cBioPortal](Uninstall-Docker-cBioPortal.md)
-* [Import a Study Using Docker](Import-Study-Using-Docker.md)
 
 ## 3. cBioPortal Maintenance
 * [Updating your cBioPortal Database Scheme](Updating-your-cBioPortal-installation.md)
@@ -42,6 +48,9 @@
    * [API and API Client](The-API-and-API-Client-[Beta].md)
 * [Providing cBioPortal Parameters](providing-cBioPortal-parameters.md)
 * [Manual test cases](manual-test-cases.md)
+* [Build cBioPortal with a different frontend version](Build-Different-Frontend.md)
+* [Release-Procedure](Release-Procedure.md)
+* [Deployment-Procedure](Deployment-Procedure.md)
 
 ## 5. Data Loading
 ### 5.1 Data Loading


### PR DESCRIPTION
Fixes related to https://github.com/cBioPortal/cbioportal/issues/6280:

- Remove PDB (this is now in Genome Nexus)
- Remove drug targeting import (this is no longer displayed)

Other fixes:

- Fix SUMMARY such that gitbook shows correct breakdown of sections