### PR TITLE
Modify copy_number_seg.SEG_ID col to BIGINT(20)

### DIFF
--- a/db-scripts/src/main/resources/cgds.sql
+++ b/db-scripts/src/main/resources/cgds.sql
@@ -694,7 +694,7 @@ CREATE TABLE `sample_cna_event` (
 
 -- --------------------------------------------------------
 CREATE TABLE `copy_number_seg` (
-  `SEG_ID` int(255) NOT NULL auto_increment,
+  `SEG_ID` bigint(20) NOT NULL auto_increment,
   `CANCER_STUDY_ID` int(11) NOT NULL,
   `SAMPLE_ID` int(11) NOT NULL,
   `CHR` varchar(5) NOT NULL,
@@ -819,4 +819,4 @@ CREATE TABLE `info` (
   `GENESET_VERSION` varchar(24)
 );
 -- THIS MUST BE KEPT IN SYNC WITH db.version PROPERTY IN pom.xml
-INSERT INTO info VALUES ('2.9.0', NULL);
+INSERT INTO info VALUES ('2.9.1', NULL);

--- a/db-scripts/src/main/resources/migration.sql
+++ b/db-scripts/src/main/resources/migration.sql
@@ -605,3 +605,8 @@ CREATE TABLE `data_access_tokens` (
     FOREIGN KEY (`USERNAME`) REFERENCES `users` (`EMAIL`) ON DELETE CASCADE
 );
 UPDATE `info` SET `DB_SCHEMA_VERSION`="2.9.0";
+
+##version: 2.9.1
+ALTER TABLE `copy_number_seg` MODIFY COLUMN `SEG_ID` BIGINT(20);
+
+UPDATE `info` SET `DB_SCHEMA_VERSION`="2.9.1";

--- a/model/src/main/java/org/cbioportal/model/CopyNumberSeg.java
+++ b/model/src/main/java/org/cbioportal/model/CopyNumberSeg.java
@@ -5,7 +5,7 @@ import javax.validation.constraints.NotNull;
 
 public class CopyNumberSeg extends UniqueKeyBase {
 
-    private Integer segId;
+    private Long segId;
     private Integer cancerStudyId;
     @NotNull
     private String cancerStudyIdentifier;
@@ -25,11 +25,11 @@ public class CopyNumberSeg extends UniqueKeyBase {
     @NotNull
     private BigDecimal segmentMean;
 
-    public Integer getSegId() {
+    public Long getSegId() {
         return segId;
     }
 
-    public void setSegId(Integer segId) {
+    public void setSegId(Long segId) {
         this.segId = segId;
     }
 

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/CopyNumberSegmentMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/CopyNumberSegmentMyBatisRepositoryTest.java
@@ -40,7 +40,7 @@ public class CopyNumberSegmentMyBatisRepositoryTest {
         
         Assert.assertEquals(2, result0.size());
         CopyNumberSeg copyNumberSeg = result0.get(0);
-        Assert.assertEquals((Integer) 50236594, copyNumberSeg.getSegId());
+        Assert.assertEquals(new Long(50236594), copyNumberSeg.getSegId());
         Assert.assertEquals((Integer) 1, copyNumberSeg.getCancerStudyId());
         Assert.assertEquals("study_tcga_pub", copyNumberSeg.getCancerStudyIdentifier());
         Assert.assertEquals((Integer) 1, copyNumberSeg.getSampleId());
@@ -111,7 +111,7 @@ public class CopyNumberSegmentMyBatisRepositoryTest {
 
         Assert.assertEquals(2, result.size());
         CopyNumberSeg copyNumberSeg = result.get(0);
-        Assert.assertEquals((Integer) 50236594, copyNumberSeg.getSegId());
+        Assert.assertEquals(new Long(50236594), copyNumberSeg.getSegId());
         Assert.assertEquals((Integer) 1, copyNumberSeg.getCancerStudyId());
         Assert.assertEquals("study_tcga_pub", copyNumberSeg.getCancerStudyIdentifier());
         Assert.assertEquals((Integer) 1, copyNumberSeg.getSampleId());
@@ -230,7 +230,7 @@ public class CopyNumberSegmentMyBatisRepositoryTest {
 
         Assert.assertEquals(1, result0.size());
         CopyNumberSeg copyNumberSeg = result0.get(0);
-        Assert.assertEquals((Integer) 50236593, copyNumberSeg.getSegId());
+        Assert.assertEquals(new Long(50236593), copyNumberSeg.getSegId());
         Assert.assertEquals((Integer) 1, copyNumberSeg.getCancerStudyId());
         Assert.assertEquals("study_tcga_pub", copyNumberSeg.getCancerStudyIdentifier());
         Assert.assertEquals((Integer) 2, copyNumberSeg.getSampleId());

--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
     <tomcat.session.timeout>720</tomcat.session.timeout>
 
     <!-- THIS SHOULD BE KEPT IN SYNC TO VERSION IN CGDS.SQL -->
-    <db.version>2.9.0</db.version>
+    <db.version>2.9.1</db.version>
   </properties>
 
   <modules>

--- a/web/src/test/java/org/cbioportal/web/CopyNumberSegmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CopyNumberSegmentControllerTest.java
@@ -38,7 +38,7 @@ public class CopyNumberSegmentControllerTest {
     private static final String TEST_SAMPLE_STABLE_ID_1 = "test_sample_stable_id_1";
     private static final int TEST_CANCER_STUDY_ID_1 = 1;
     private static final String TEST_CANCER_STUDY_IDENTIFIER_1 = "test_study_1";
-    private static final Integer TEST_SEG_ID_1 = 1;
+    private static final Long TEST_SEG_ID_1 = 1L;
     private static final String TEST_CHR_1 = "test_chr_1";
     private static final Integer TEST_START_1 = 15;
     private static final Integer TEST_END_1 = 20;
@@ -48,7 +48,7 @@ public class CopyNumberSegmentControllerTest {
     private static final String TEST_SAMPLE_STABLE_ID_2 = "test_sample_stable_id_2";
     private static final int TEST_CANCER_STUDY_ID_2 = 2;
     private static final String TEST_CANCER_STUDY_IDENTIFIER_2 = "test_study_2";
-    private static final Integer TEST_SEG_ID_2 = 2;
+    private static final Long TEST_SEG_ID_2 = 2L;
     private static final String TEST_CHR_2 = "test_chr_2";
     private static final Integer TEST_START_2 = 25;
     private static final Integer TEST_END_2 = 34;


### PR DESCRIPTION
Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>

# What? Why?
Fixes out of range value for column `copy_number_seg.SEG_ID` exception during import. 

Changes proposed in this pull request:
- alter `copy_number_seg.SEG_ID` type to `BIGINT(20)` in database

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.