### PR TITLE
Refactor CoExpressionService to work with iterator over MolecularAlteration objects.

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
@@ -14,6 +14,9 @@ public interface MolecularDataRepository {
     List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
                                                               String projection);
 
+    Iterable<GeneMolecularAlteration> getGeneMolecularAlterationsIterable(String molecularProfileId, List<Integer> entrezGeneIds,
+                                                                          String projection);
+
     List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
                                                                                          List<Integer> entrezGeneIds,
                                                                                          String projection);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
@@ -4,13 +4,14 @@ import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GenesetMolecularAlteration;
 
 import java.util.List;
+import org.apache.ibatis.cursor.Cursor;
 
 public interface MolecularDataMapper {
 
     List<String> getCommaSeparatedSampleIdsOfMolecularProfiles(List<String> molecularProfileIds);
 
-    List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
-                                                              String projection);
+    Cursor<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
+                                                                String projection);
 
     List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
                                                                                          List<Integer> entrezGeneIds,

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepositoryTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -43,6 +44,7 @@ public class MolecularDataMyBatisRepositoryTest {
     }
 
     @Test
+    @Transactional(readOnly=true)
     public void getGeneMolecularAlterations() throws Exception {
 
         List<Integer> entrezGeneIds = new ArrayList<>();

--- a/service/src/main/java/org/cbioportal/service/MolecularDataService.java
+++ b/service/src/main/java/org/cbioportal/service/MolecularDataService.java
@@ -23,8 +23,8 @@ public interface MolecularDataService {
     BaseMeta fetchMetaMolecularData(String molecularProfileId, List<String> sampleIds, List<Integer> entrezGeneIds) 
         throws MolecularProfileNotFoundException;
 
-    List<GeneMolecularAlteration> getMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds, 
-        String projection) throws MolecularProfileNotFoundException;
+   Iterable<GeneMolecularAlteration> getMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds, 
+                                                              String projection) throws MolecularProfileNotFoundException;
     
     Integer getNumberOfSamplesInMolecularProfile(String molecularProfileId);
 

--- a/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java
@@ -6,6 +6,8 @@ import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.stat.correlation.SpearmansCorrelation;
 import org.cbioportal.model.Gene;
 import org.cbioportal.model.MolecularAlteration;
+import org.cbioportal.model.GeneMolecularAlteration;
+import org.cbioportal.model.GenesetMolecularAlteration;
 import org.cbioportal.model.Geneset;
 import org.cbioportal.model.MolecularData;
 import org.cbioportal.model.MolecularProfile;
@@ -26,6 +28,7 @@ import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.exception.SampleListNotFoundException;
 import org.cbioportal.service.CoExpressionService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -61,19 +64,8 @@ public class CoExpressionServiceImpl implements CoExpressionService {
     private SampleService sampleService;
 
     @Override
-    public List<CoExpression> getCoExpressions(String molecularProfileId, String sampleListId, String geneticEntityId,
-            CoExpression.GeneticEntityType geneticEntityType, Double threshold)
-            throws MolecularProfileNotFoundException, GenesetNotFoundException, GeneNotFoundException {
-
-        List<String> sampleIds = sampleListRepository.getAllSampleIdsInSampleList(sampleListId);
-        if (sampleIds.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        return fetchCoExpressions(molecularProfileId, sampleIds, geneticEntityId, geneticEntityType, threshold);
-    }
-
-    @Override
+    // transaction needs to be setup here in order to return Iterable from molecularDataService in fetchCoExpressions
+    @Transactional(readOnly=true)
     public List<CoExpression> getCoExpressions(String geneticEntityId, CoExpression.GeneticEntityType geneticEntityType,
             String sampleListId, String molecularProfileIdA, String molecularProfileIdB, Double threshold)
             throws MolecularProfileNotFoundException, SampleListNotFoundException, GenesetNotFoundException,
@@ -118,30 +110,48 @@ public class CoExpressionServiceImpl implements CoExpressionService {
     }
 
     @Override
+    public List<CoExpression> getCoExpressions(String molecularProfileId, String sampleListId, String geneticEntityId,
+                                               CoExpression.GeneticEntityType geneticEntityType, Double threshold)
+        throws MolecularProfileNotFoundException, GenesetNotFoundException, GeneNotFoundException {
+
+        List<String> sampleIds = sampleListRepository.getAllSampleIdsInSampleList(sampleListId);
+        if (sampleIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return fetchCoExpressions(molecularProfileId, sampleIds, geneticEntityId, geneticEntityType, threshold);
+    }
+
+    @Override
     public List<CoExpression> fetchCoExpressions(String molecularProfileId, List<String> sampleIds, 
                                                  String queryGeneticEntityId, CoExpression.GeneticEntityType geneticEntityType, 
                                                  Double threshold)
         throws MolecularProfileNotFoundException, GenesetNotFoundException, GeneNotFoundException {
-        
-        List<? extends MolecularAlteration> molecularAlterations = null;
+
+        // For the purpose of the CoExpression computation, we separate the MolecularAlteration
+        // (genetic_alteration table record) for the query gene/geneset from the MolecularAlteration(s)
+        // for the remaining genes/geneset in the profile.
+        MolecularAlteration queryMolecularDataList = null;
+        Iterable<? extends MolecularAlteration> maItr = null;
         if (geneticEntityType.equals(GeneticEntityType.GENE)) {
-            molecularAlterations = molecularDataService.getMolecularAlterations(
-                molecularProfileId, null, "SUMMARY");
+            List<Integer> queryGeneticEntityIds = Arrays.asList(Integer.valueOf(queryGeneticEntityId));
+            maItr = molecularDataService.getMolecularAlterations(molecularProfileId, queryGeneticEntityIds, "SUMMARY");
         } else if (geneticEntityType.equals(GeneticEntityType.GENESET)) {
-            molecularAlterations = genesetDataService.getGenesetAlterations(
-                molecularProfileId, null);
+            List<String> queryGeneticEntityIds = Arrays.asList(queryGeneticEntityId);
+            maItr = genesetDataService.getGenesetAlterations(molecularProfileId, queryGeneticEntityIds);
         }
-
-        Map<String, MolecularAlteration> molecularDataMap = molecularAlterations.stream()
-                .collect(Collectors.toMap(MolecularAlteration::getStableId, Function.identity()));
-        MolecularAlteration queryMolecularDataList = molecularDataMap.remove(queryGeneticEntityId);
-        
-        List<CoExpression> coExpressionList = new ArrayList<>();
-
+        for (MolecularAlteration ma : maItr) {
+            queryMolecularDataList = ma;
+        }
         if (queryMolecularDataList == null) {
-            return coExpressionList;
+            return Collections.emptyList();
         }
 
+        // These next few lines are used to build a map of internal sample ids to
+        // indices into the genetic_alteration.VALUES column. Recall this column
+        // of the genetic_alteration table is a comma separated list of scalar values.
+        // Each value in this list is associated with a sample at the same position found in
+        // the genetic_profile_samples.ORDERED_SAMPLE_LIST column.
         String commaSeparatedSampleIdsOfMolecularProfile = molecularDataRepository
             .getCommaSeparatedSampleIdsOfMolecularProfile(molecularProfileId);
         List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfile.split(","))
@@ -151,6 +161,9 @@ public class CoExpressionServiceImpl implements CoExpressionService {
             internalSampleIdToIndexMap.put(internalSampleIds.get(lc), lc);
         }
 
+        // These next few lines build a list of Sample from the sampleIds method parameter (the user query).
+        // A map is then built of internal sample ids to indices into the Sample list (although the map is
+        // only used to quickly identify if a sample in the molecular profile is part of the user query - see below).
         MolecularProfile molecularProfile = molecularProfileService.getMolecularProfile(molecularProfileId);
         List<String> studyIds = new ArrayList<>();
         sampleIds.forEach(s -> studyIds.add(molecularProfile.getCancerStudyIdentifier()));
@@ -160,29 +173,52 @@ public class CoExpressionServiceImpl implements CoExpressionService {
             selectedSampleIdsMap.put(samples.get(lc).getInternalId(), lc);
         }
 
+        // These next few lines build a list of indices into the genetic_alteration.VALUES
+        // column by iterating over all the samples in the molecular profile (method parameter)
+        // and selecting only samples that are included in the user query.
         Set<Integer> includedIndexes = new HashSet<>();
         for (Integer internalSampleId : internalSampleIds) {
             if (selectedSampleIdsMap.containsKey(internalSampleId)) {
                 includedIndexes.add(internalSampleIdToIndexMap.get(internalSampleId));
             }
         }
-        
+
         Boolean isMolecularProfileBOfGenesetType = molecularProfile.getMolecularAlterationType()
-                .equals(MolecularProfile.MolecularAlterationType.GENESET_SCORE);
+            .equals(MolecularProfile.MolecularAlterationType.GENESET_SCORE);
+
+
+        // These next few lines filter out genetic_alteration values from the query gene/geneset
+        // genetic_alteration.VALUES column by considering only the indices of the samples in the user query.
         List<String> queryValues = Arrays.asList(queryMolecularDataList.getSplitValues());
         List<String> includedQueryValues = includedIndexes.stream().map(index -> queryValues.get(index))
-                .collect(Collectors.toList());
+            .collect(Collectors.toList());
 
-        Map<String,List<String>> values = new HashMap<String,List<String>>();
-        for (String entityId : molecularDataMap.keySet()) {
-            List<String> internalValues = new ArrayList<>(
-                    Arrays.asList(molecularDataMap.get(entityId).getSplitValues()));
-            List<String> includedInternalValues = includedIndexes.stream().map(index -> internalValues.get(index))
-                    .collect(Collectors.toList());
-            values.put(entityId, includedInternalValues);
+        // Get an iterator to all the MolecularAlteration (genetic_alteration table records) in the profile
+        if (geneticEntityType.equals(GeneticEntityType.GENE)) {
+            maItr = molecularDataService.getMolecularAlterations(molecularProfileId, null, "SUMMARY");
+        } else if (geneticEntityType.equals(GeneticEntityType.GENESET)) {
+            maItr = genesetDataService.getGenesetAlterations(molecularProfileId, null);
         }
-        coExpressionList = computeCoExpressions(values, includedQueryValues, isMolecularProfileBOfGenesetType, threshold);  
-        return coExpressionList;
+
+        // For each MolecularAlteration in the profile, compute a CoExpression to return.
+        // If the MolecularAlteration is for the query gene/geneset, skip it.  Otherwise,
+        // filter out genetic_alteration values from genetic_alteration.VALUES
+        // by considering oly the indices of the samples in the user query.
+        List<CoExpression> toReturn = new ArrayList<>();
+        for (MolecularAlteration ma : maItr) {
+            String entityId = ma.getStableId();
+            if (entityId.equals(queryGeneticEntityId)) {
+                continue;
+            }
+            List<String> internalValues = new ArrayList<>(Arrays.asList(ma.getSplitValues()));
+            List<String> values = includedIndexes.stream().map(index -> internalValues.get(index)).collect(Collectors.toList());
+            CoExpression ce = computeCoExpressions(entityId, values, includedQueryValues, isMolecularProfileBOfGenesetType, threshold);
+            if (ce != null) {
+                toReturn.add(ce);
+            }
+        }
+
+        return toReturn;
     }
 
     @Override
@@ -222,100 +258,92 @@ public class CoExpressionServiceImpl implements CoExpressionService {
 
     private List<CoExpression> computeCoExpressionsFromMolecularData(List<? extends MolecularData> molecularDataListB,
             Boolean isMolecularProfileBOfGenesetType, List<? extends MolecularData> molecularDataListA,
-            String queryGeneticEntityId, Double threshold) throws GenesetNotFoundException, GeneNotFoundException 
-                                                     {
-        
+            String queryGeneticEntityId, Double threshold) throws GenesetNotFoundException, GeneNotFoundException {
+
         Map<String , List<MolecularData>> molecularDataMapA = molecularDataListA.stream()
             .collect(Collectors.groupingBy(MolecularData::getStableId));
         Map<String , List<MolecularData>> molecularDataMapB = molecularDataListB.stream()
             .collect(Collectors.groupingBy(MolecularData::getStableId));
-        
-        List<CoExpression> coExpressionList = new ArrayList<>();
-        
+
         if (!molecularDataMapA.keySet().contains(queryGeneticEntityId)) {
-            return coExpressionList;
+            return Collections.emptyList();
         }
 
         List<? extends MolecularData> finalMolecularDataListA = (List<? extends MolecularData>)molecularDataMapA.remove(queryGeneticEntityId);
         if (molecularDataMapB.get(queryGeneticEntityId) != null) {
             List<? extends MolecularData> finalMolecularDataListB = (List<? extends MolecularData>)molecularDataMapB.remove(queryGeneticEntityId);
             if (finalMolecularDataListB == null) {
-                return coExpressionList;
+                return Collections.emptyList();
             }
         }
 
-        Map<String,List<String>> values = new HashMap<String,List<String>>();
+        List<CoExpression> coExpressionList = new ArrayList<>();
+        List<String> valuesB = finalMolecularDataListA.stream().map(g -> g.getValue()).collect(Collectors.toList());
         for (String entityId : molecularDataMapB.keySet()) {
             List<String> internalValues = molecularDataMapB.get(entityId).stream().map(g -> g.getValue())
                 .collect(Collectors.toList());
-            values.put(entityId, internalValues);
+            CoExpression co = computeCoExpressions(entityId, internalValues, valuesB, isMolecularProfileBOfGenesetType, threshold);
+            if (co != null) {
+                coExpressionList.add(co);
+            }
         }
-        List<String> valuesB = finalMolecularDataListA.stream().map(g -> g.getValue()).collect(Collectors.toList());
-        coExpressionList = computeCoExpressions(values, valuesB, isMolecularProfileBOfGenesetType, threshold);
 
         return coExpressionList;
 
     }
 
-    private List<CoExpression> computeCoExpressions(Map<String, List<String>> valuesA, List<String> valuesB, 
+    private CoExpression computeCoExpressions(String entityId, List<String> valuesA, List<String> valuesB, 
             Boolean isMolecularProfileBOfGenesetType, Double threshold) throws GenesetNotFoundException, GeneNotFoundException {
-        
-        
-        List<CoExpression> coExpressionList = new ArrayList<>();
-        for (String entityId : valuesA.keySet()) {
-            List<String> values = valuesA.get(entityId);
-            List<String> valuesBCopy = new ArrayList<>(valuesB);
 
-            List<Integer> valuesToRemove = new ArrayList<>();
-            for (int i = 0; i < valuesBCopy.size(); i++) {
-                if (!NumberUtils.isNumber(valuesBCopy.get(i)) || !NumberUtils.isNumber(values.get(i))) {
-                    valuesToRemove.add(i);
-                }
+        List<String> valuesACopy = new ArrayList<>(valuesA);
+        List<String> valuesBCopy = new ArrayList<>(valuesB);
+
+        List<Integer> valuesToRemove = new ArrayList<>();
+        for (int i = 0; i < valuesBCopy.size(); i++) {
+            if (!NumberUtils.isNumber(valuesBCopy.get(i)) || !NumberUtils.isNumber(valuesACopy.get(i))) {
+                valuesToRemove.add(i);
             }
-
-            for (int i = 0; i < valuesToRemove.size(); i++) {
-                int valueToRemove = valuesToRemove.get(i) - i;
-                valuesBCopy.remove(valueToRemove);
-                values.remove(valueToRemove);
-            }
-            
-            CoExpression coExpression = new CoExpression();
-            coExpression.setGeneticEntityId(entityId);
-            if (isMolecularProfileBOfGenesetType) {
-                Geneset geneset = genesetService.getGeneset(entityId);
-                coExpression.setCytoband("-");
-                coExpression.setGeneticEntityName(geneset.getName());
-            } else {
-                Gene gene = geneService.getGene(entityId);
-                coExpression.setCytoband(gene.getCytoband());
-                coExpression.setGeneticEntityName(gene.getHugoGeneSymbol());
-            }
-            
-
-            double[] valuesBNumber = valuesBCopy.stream().mapToDouble(Double::parseDouble).toArray();
-            double[] valuesNumber = values.stream().mapToDouble(Double::parseDouble).toArray();
-
-            if (valuesNumber.length <= 2) {
-                continue;
-            }
-            
-            double[][] arrays = new double[2][valuesNumber.length];
-            arrays[0] = valuesBNumber;
-            arrays[1] = valuesNumber;
-            SpearmansCorrelation spearmansCorrelation = new SpearmansCorrelation((new Array2DRowRealMatrix(arrays, false)).transpose());
-
-            double spearmansValue = spearmansCorrelation.correlation(valuesBNumber, valuesNumber);
-            if (Double.isNaN(spearmansValue) || Math.abs(spearmansValue) < threshold) {
-                continue;
-            }
-            coExpression.setSpearmansCorrelation(BigDecimal.valueOf(spearmansValue));
-
-            RealMatrix resultMatrix = spearmansCorrelation.getRankCorrelation().getCorrelationPValues();
-            coExpression.setpValue(BigDecimal.valueOf(resultMatrix.getEntry(0, 1)));
-            
-            coExpressionList.add(coExpression);
         }
-        
-        return coExpressionList;
+
+        for (int i = 0; i < valuesToRemove.size(); i++) {
+            int valueToRemove = valuesToRemove.get(i) - i;
+            valuesBCopy.remove(valueToRemove);
+            valuesACopy.remove(valueToRemove);
+        }
+
+        CoExpression coExpression = new CoExpression();
+        coExpression.setGeneticEntityId(entityId);
+        if (isMolecularProfileBOfGenesetType) {
+            Geneset geneset = genesetService.getGeneset(entityId);
+            coExpression.setCytoband("-");
+            coExpression.setGeneticEntityName(geneset.getName());
+        } else {
+            Gene gene = geneService.getGene(entityId);
+            coExpression.setCytoband(gene.getCytoband());
+            coExpression.setGeneticEntityName(gene.getHugoGeneSymbol());
+        }
+
+        double[] valuesBNumber = valuesBCopy.stream().mapToDouble(Double::parseDouble).toArray();
+        double[] valuesANumber = valuesACopy.stream().mapToDouble(Double::parseDouble).toArray();
+
+        if (valuesANumber.length <= 2) {
+            return null;
+        }
+
+        double[][] arrays = new double[2][valuesANumber.length];
+        arrays[0] = valuesBNumber;
+        arrays[1] = valuesANumber;
+        SpearmansCorrelation spearmansCorrelation = new SpearmansCorrelation((new Array2DRowRealMatrix(arrays, false)).transpose());
+
+        double spearmansValue = spearmansCorrelation.correlation(valuesBNumber, valuesANumber);
+        if (Double.isNaN(spearmansValue) || Math.abs(spearmansValue) < threshold) {
+            return null;
+        }
+        coExpression.setSpearmansCorrelation(BigDecimal.valueOf(spearmansValue));
+
+        RealMatrix resultMatrix = spearmansCorrelation.getRankCorrelation().getCorrelationPValues();
+        coExpression.setpValue(BigDecimal.valueOf(resultMatrix.getEntry(0, 1)));
+
+        return coExpression;
     }
 }

--- a/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
@@ -16,12 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -122,12 +117,12 @@ public class MolecularDataServiceImpl implements MolecularDataService {
     }
 
     @Override
-    public List<GeneMolecularAlteration> getMolecularAlterations(String molecularProfileId, 
-                                                                 List<Integer> entrezGeneIds, String projection)
+    public Iterable<GeneMolecularAlteration> getMolecularAlterations(String molecularProfileId, 
+                                                                     List<Integer> entrezGeneIds, String projection)
         throws MolecularProfileNotFoundException {
 
         validateMolecularProfile(molecularProfileId);
-        return molecularDataRepository.getGeneMolecularAlterations(molecularProfileId, entrezGeneIds, projection);
+        return molecularDataRepository.getGeneMolecularAlterationsIterable(molecularProfileId, entrezGeneIds, projection);
     }
 
     @Override


### PR DESCRIPTION
In an effort to reduce memory consumption when the Co-expression tab is selected, this PR introduces the use of a MyBatis cursor to iterate over Molecular Alterations rather than fetch them all in a single database call.

The PR needs to be profiled in beta to determine the gain in memory optimization against the loss in runtime performance (it may be determined that a cursor should only be used when the cohort exceeds a certain sample size).  Also, its unclear what impact a large volume of concurrent Co-expression requests can have on the database connection pool when cursors are in use.

The PR limits the exposure of the MyBatis cursor to the persistence layer and returns an Iterable to the service layer.  The PR refactors code as needed, makes minor attempts to cleanup the existing code to avoid breaking functionality, but does add comments where time was spent understanding the codebase.

Some JProfiler screenshots comparing runtime performance /memory usage of this PR against the current master branch will be provided, but as previously mentioned, profiling in the beta environment should still be performed before this PR is merged.