### PR TITLE
Fix refid in GenesetMapper xml

### DIFF
--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenesetMapper.xml
@@ -59,7 +59,7 @@
 
     <select id="getGenesByGenesetId" resultType="org.cbioportal.model.Gene">
         SELECT
-        <include refid="org.cbioportal.persistence.mybatis.GeneMapper.select">
+        <include refid="select">
             <property name="prefix" value=""/>
         </include>
         FROM gene


### PR DESCRIPTION
# What? Why?
Docker containers started with the new docker solution crash. The reason is a malformed refid in the GenesetMapper.xml 

# Fix
The reference has been fixed in this PR allowing the new docker containers to start.