### PR TITLE
Fix migration script: cytoband string split - mm10

### DIFF
--- a/db-scripts/src/main/resources/migration.sql
+++ b/db-scripts/src/main/resources/migration.sql
@@ -422,7 +422,13 @@ INSERT INTO reference_genome_gene (ENTREZ_GENE_ID, CYTOBAND, EXONIC_LENGTH, CHR,
 	ENTREZ_GENE_ID,
 	CYTOBAND,
 	LENGTH,
-    SUBSTRING_INDEX(SUBSTRING_INDEX(SUBSTRING_INDEX(gene.CYTOBAND,IF(LOCATE('p', gene.CYTOBAND), 'p', 'q'), 1),'q',1),'cen',1),
+  SUBSTRING_INDEX(
+    SUBSTRING_INDEX(
+      SUBSTRING_INDEX(
+        SUBSTRING_INDEX(gene.CYTOBAND, 'p', 1),
+      'q', 1),
+    'cen', 1),
+  ' ', 1),
 	1
 FROM `gene`);
 


### PR DESCRIPTION
# What? Why?
We found a bug in migration.sql when migrating from seed DB 2.4.0 into a mouse seed DB.
(https://github.com/cBioPortal/datahub/blob/master/seedDB_mouse/README.md)

The chromosome characters are derived by parsing the cytoband string. However, in the mouse seed DB these cytoband strings are (unlike human genome cytobands, e.g. '17p39') split by a space; e.g. '6 F3'.

Changes proposed in this pull request:
In the file db-scripts/src/main/resources/migration.sql, we adapted the statements migrating from seed DB 2.4.0 to 2.4.1, when filling the table `reference_genome_gene` there is a series of `SUBSTRING_INDEX` statements meant to split the chromosome character from the cytoband. I adapted the code such that it is also able to split on whitespace.
