### PR TITLE
Fix endpoint of molecularProfiles with structural variants

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportStructuralVariantData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportStructuralVariantData.java
@@ -115,6 +115,7 @@ public class ImportStructuralVariantData {
         // Genetic profile is read in first
         GeneticProfile geneticProfile = DaoGeneticProfile.getGeneticProfileById(geneticProfileId);
         String line = new String();
+        ArrayList <Integer> orderedSampleList = new ArrayList<Integer>();
         while ((line = buf.readLine()) != null) {
             ProgressMonitor.incrementCurValue();
             ConsoleUtil.showProgress();
@@ -217,10 +218,13 @@ public class ImportStructuralVariantData {
                             }
                         }
                         sampleSet.add(sample.getStableId());
+                        orderedSampleList.add(sample.getInternalId());
                     }
                 }
             }
         }
+        DaoGeneticProfileSamples.addGeneticProfileSamples(geneticProfileId, orderedSampleList);
+
         buf.close();
         MySQLbulkLoader.flushAll();
     }


### PR DESCRIPTION
# What? Why?
Following the merge of #4057 we found a bug: the structural variant profile does not add the ORDERED_SAMPLE_LIST in the genetic_profile_samples table, making the endpoint `/molecular-profiles/{molecularProfileId}/molecular-data/fetch` to fail when asking for a structural variant profile. This small fix solves the issue.

This is a critical bug: without the structural variants frontend PR merged, the current Plots tab in rc is broken. 