### PR TITLE
Proposed fix for issue 6305

### DIFF
--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -88,6 +88,9 @@
                     <property name="cacheEnabled" value="${mybatis.cache.enabled:true}" />
                 </bean>
             </property>
+            <!-- mapper locations is set here to support interdependency between mappers without -->
+            <!-- having to autowire repositories into java classes that do not make direct use of them -->
+            <property name="mapperLocations" value="classpath*:org/cbioportal/persistence/mybatis/**/*.xml" />
         </bean>
     </beans>
   

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/CacheMapUtil.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/CacheMapUtil.java
@@ -45,14 +45,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class CacheMapUtil {
 
-    // can't find another way to pull in the required mapper dependency at runtime for initCacheMemory
-    @Autowired
-    private PatientRepository patientRepository;
-
-    // can't find another way to pull in the required mapper dependency at runtime for initCacheMemory
-    @Autowired
-    private CancerTypeRepository cancerTypeRepository;
-
     @Autowired
     private StudyRepository studyRepository;
 


### PR DESCRIPTION
This fix was motivated by [issue 6305](https://github.com/cBioPortal/cbioportal/issues/6305).  The underlying issue that this PR fixes is interdependencies between MyBatis mappers independent of the autowiring of repositories in the middleware.  The fix instructs MyBatis to scan for mappers independent of repository bean scanning.