### PR TITLE
Webapp-runner deployment on decompressed webapp directory (not .war file)

### DIFF
--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -17,6 +17,9 @@ WORKDIR /cbioportal
 RUN mvn -DskipTests clean install
 
 FROM openjdk:8-jre
+
+ENV PORTAL_WEB_HOME=/cbioportal-webapp
+
 RUN mkdir -p /cbioportal
 COPY --from=build /cbioportal/portal/target/cbioportal*.war /app.war
 COPY --from=build /cbioportal/portal/target/dependency/webapp-runner.jar /webapp-runner.jar
@@ -45,3 +48,6 @@ RUN find /cbioportal/core/src/main/scripts/ -type f -executable \! -name '*.pl' 
 
 # put config files in this folder if you want to override config
 ENV PORTAL_HOME=/cbioportal
+
+RUN mkdir -p $PORTAL_WEB_HOME
+RUN unzip /app.war -d  $PORTAL_WEB_HOME

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -23,6 +23,14 @@ WORKDIR /cbioportal
 RUN mvn -DskipTests clean install
 
 FROM shipilev/openjdk-shenandoah:8
+
+ENV PORTAL_WEB_HOME=/cbioportal-webapp
+
 COPY --from=build /cbioportal/portal/target/cbioportal*.war /app.war
 COPY --from=build /cbioportal/portal/target/dependency/webapp-runner.jar /webapp-runner.jar
-CMD /usr/bin/java ${JAVA_OPTS} -jar /webapp-runner.jar ${WEBAPP_OPTS} /app.war
+
+RUN apt-get update && apt-get install unzip
+RUN mkdir -p $PORTAL_WEB_HOME
+RUN unzip /app.war -d $PORTAL_WEB_HOME
+
+CMD ["/bin/sh", "-c", "/usr/bin/java ${JAVA_OPTS} -jar /webapp-runner.jar ${WEB_OPTS} ${PORTAL_WEB_HOME}"]

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -29,8 +29,7 @@ ENV PORTAL_WEB_HOME=/cbioportal-webapp
 COPY --from=build /cbioportal/portal/target/cbioportal*.war /app.war
 COPY --from=build /cbioportal/portal/target/dependency/webapp-runner.jar /webapp-runner.jar
 
-RUN apt-get update && apt-get install unzip
 RUN mkdir -p $PORTAL_WEB_HOME
-RUN unzip /app.war -d $PORTAL_WEB_HOME
+RUN cd $PORTAL_WEB_HOME && /root/jdk/bin/jar -xvf /app.war
 
 CMD ["/bin/sh", "-c", "/usr/bin/java ${JAVA_OPTS} -jar /webapp-runner.jar ${WEB_OPTS} ${PORTAL_WEB_HOME}"]

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -32,4 +32,4 @@ COPY --from=build /cbioportal/portal/target/dependency/webapp-runner.jar /webapp
 RUN mkdir -p $PORTAL_WEB_HOME
 RUN cd $PORTAL_WEB_HOME && /root/jdk/bin/jar -xvf /app.war
 
-CMD ["/bin/sh", "-c", "/usr/bin/java ${JAVA_OPTS} -jar /webapp-runner.jar ${WEB_OPTS} ${PORTAL_WEB_HOME}"]
+CMD ["/bin/sh", "-c", "/usr/bin/java ${JAVA_OPTS} -jar /webapp-runner.jar ${WEBAPP_OPTS} ${PORTAL_WEB_HOME}"]

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -145,7 +145,7 @@ docker run -d --restart=always \
     ' \
     -p 8081:8080 \
     cbioportal/cbioportal:3.0.1 \
-    /bin/sh -c 'java ${JAVA_OPTS} -jar webapp-runner.jar /app.war'
+    /bin/sh -c 'java ${JAVA_OPTS} -jar webapp-runner.jar /cbioportal-webapp'
 ```
 
 To read more about the various ways to use authentication and `webapp-runner`


### PR DESCRIPTION
# What? Why?
For customization of the portal and for implementation of authentication solutions (e.g. KeyCloak) in Docker container environment, custom files are mounted into the webapp file structure using volumen mounts. With the new docker solution the portal is deployed as a .war file served by webapp-runner. As described in [Issue #6359](https://github.com/cBioPortal/cbioportal/issues/6359) running from .war compressed webapp does not allow mounting of custom files with a volume mount in a Docker container. 

This PR will update the webapp-runner deployment to run from the `/cbioportal-webapp` directory in the docker image, instead of the compressed .war file. Changes involve:
- decompression of the .war in the Dockerfile's into `/cbioportal-webapp`.
- update of the `CMD` entry in `/docker/web/Dockerfile` to correctly handle `$JAVA_OPTS` and `$WEB_OPTS` env. vars
- update of `README.md` to reflect change in webapp-runner deployment mechanism.

# Note
- Although the .war-based mechanism still works I decided to no longer feature it in the documentation since this may lead to problems with volume mounts.  