### PR TITLE
HRRS Properties Fix 

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/DebugHrrsFilter.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/DebugHrrsFilter.java
@@ -32,26 +32,67 @@
 
 package org.mskcc.cbio.portal.util;
 
-import java.io.*;
-import java.util.*;
-import org.apache.commons.logging.*;
-import org.cbioportal.model.*;
-import org.springframework.beans.factory.annotation.*;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.context.annotation.Bean;
-import org.springframework.stereotype.Component;
-import com.vlkan.hrrs.servlet.base64.Base64HrrsFilter;
+
+import com.vlkan.hrrs.api.HttpRequestRecordWriter;
+import com.vlkan.hrrs.api.HttpRequestRecordWriterTarget;
+import com.vlkan.hrrs.serializer.base64.Base64HttpRequestRecord;
+import com.vlkan.hrrs.serializer.base64.Base64HttpRequestRecordWriter;
+import com.vlkan.hrrs.serializer.base64.guava.GuavaBase64Encoder;
+import com.vlkan.hrrs.serializer.file.HttpRequestRecordWriterRotatingFileTarget;
+import com.vlkan.hrrs.servlet.HrrsFilter;
 import com.vlkan.rfos.RotationConfig;
 import com.vlkan.rfos.policy.DailyRotationPolicy;
+
+import java.io.*;
+import java.util.*;
 import javax.servlet.*;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.*;
+import org.cbioportal.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.stereotype.Component;
 
-public class DebugHrrsFilter extends Base64HrrsFilter {
+public class DebugHrrsFilter extends HrrsFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DebugHrrsFilter.class);
+
+    private static final String DEFAULT_HRRS_LOGGING_NAME = "/hrrs-logging.csv";
+    
+    private final HttpRequestRecordWriter<String> writer;
+    
+    private final HttpRequestRecordWriterTarget<String> writerTarget;
+
+    public DebugHrrsFilter() {
+        boolean enableHrrsLogging = Boolean.valueOf(GlobalProperties.getProperty("hrrs.enable.logging"));
+        // only initialize writers/writing target if logging is enabled in properties file
+        if (enableHrrsLogging) {
+            RotationConfig rotationConfig = createRotationConfig();
+            this.writerTarget = new HttpRequestRecordWriterRotatingFileTarget(rotationConfig, Base64HttpRequestRecord.CHARSET);
+            this.writer = new Base64HttpRequestRecordWriter(writerTarget, GuavaBase64Encoder.getInstance());
+            this.setEnabled(enableHrrsLogging);
+        } else {
+            this.writer = null;
+            this.writerTarget = null;
+        }
+    }
+
+    public HttpRequestRecordWriterTarget<String> getWriterTarget() {
+        return writerTarget;
+    }
+
+    @Override
+    protected HttpRequestRecordWriter<String> getWriter() {
+        return writer;
+    }
 
     private static RotationConfig createRotationConfig() {
-        String hrrsLoggingFilePath = GlobalProperties.getProperty("hrrs.logging.filepath");
+        // default to tmpdir if logging is enabled but no logging path is provided
+        String hrrsLoggingFilePath = (!StringUtils.isEmpty(GlobalProperties.getProperty("hrrs.logging.filepath")) ? GlobalProperties.getProperty("hrrs.logging.filepath") : System.getProperty("java.io.tmpdir") + DEFAULT_HRRS_LOGGING_NAME);
         String file = new File(hrrsLoggingFilePath).getAbsolutePath();
         String filePattern = new File(hrrsLoggingFilePath + "-%d{yyyyMMdd-HHmmss-SSS}.csv").getAbsolutePath();
         RotationConfig rotationConfig = RotationConfig
@@ -63,9 +104,12 @@ public class DebugHrrsFilter extends Base64HrrsFilter {
         return rotationConfig;
     }
  
-    public DebugHrrsFilter() {
-        super(createRotationConfig());
-        boolean enableHrrsLogging = Boolean.valueOf(GlobalProperties.getProperty("hrrs.enable.logging"));
-        this.setEnabled(enableHrrsLogging);
+    @Override
+    public void destroy() {
+        try {
+            writerTarget.close();
+        } catch (IOException error) {
+            LOGGER.error("failed closing writer", error);
+        }
     }
 }

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -256,7 +256,9 @@ matchminer.url=
 matchminer.token=
 
 # enable/disable hrrs logging
-# filter which logs incoming web requests to specified logging directory
+# hrrs can be used for debugging - when enabled incoming web requests
+# will be logged into the specified directory
 # logs must be decrypted for more in-depth information
-hrrs.logging.filepath=
-hrrs.enable.logging=
+# see: https://github.com/vy/hrrs/blob/master/README.md
+#hrrs.logging.filepath=
+#hrrs.enable.logging=false


### PR DESCRIPTION
# What? Why?
Fixes #6368 and #6377 - deployment was failing when hrrs properties were left blank.

Changes proposed in this pull request:
- `hrrs.enable.logging` defaults to `false`
- `hrrs.logging.filepath` defaults to `java.io.tmpdir/hrrs-logging.csv`

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
