### PR TITLE
Fix filtering alteration type while fetching CNA enrichments count

### DIFF
--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.xml
@@ -218,10 +218,22 @@
             AND sample.INTERNAL_ID = sample_cna_event.SAMPLE_ID 
             AND genetic_profile.GENETIC_PROFILE_ID = sample_cna_event.GENETIC_PROFILE_ID)
         </if>
-        <if test="entrezGeneIds != null">
+        <if test="entrezGeneIds != null and alterations != null">
             AND (cna_event.ENTREZ_GENE_ID, cna_event.ALTERATION) IN
             <foreach index="i" collection="entrezGeneIds" open="(" separator="," close=")">
                 (#{entrezGeneIds[${i}]}, #{alterations[${i}]})
+            </foreach>
+        </if>
+        <if test="entrezGeneIds != null and alterations == null">
+            AND cna_event.ENTREZ_GENE_ID IN
+            <foreach item="entrezGeneId" collection="entrezGeneIds" open="(" separator="," close=")">
+                #{entrezGeneId}
+            </foreach>
+        </if>
+        <if test="entrezGeneIds == null and alterations != null">
+            AND cna_event.ALTERATION IN
+            <foreach item="alteration" collection="alterations" open="(" separator="," close=")">
+                #{alteration}
             </foreach>
         </if>
         GROUP BY cna_event.ENTREZ_GENE_ID, cna_event.ALTERATION
@@ -241,11 +253,22 @@
         INNER JOIN patient ON sample.PATIENT_ID = patient.INTERNAL_ID
         INNER JOIN gene ON cna_event.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
         WHERE genetic_profile.STABLE_ID = #{molecularProfileId}
-        <if test="entrezGeneIds != null">
-            AND
-            (cna_event.ENTREZ_GENE_ID, cna_event.ALTERATION) IN
+        <if test="entrezGeneIds != null and alterations != null">
+            AND (cna_event.ENTREZ_GENE_ID, cna_event.ALTERATION) IN
             <foreach index="i" collection="entrezGeneIds" open="(" separator="," close=")">
                 (#{entrezGeneIds[${i}]}, #{alterations[${i}]})
+            </foreach>
+        </if>
+        <if test="entrezGeneIds != null and alterations == null">
+            AND cna_event.ENTREZ_GENE_ID IN
+            <foreach item="entrezGeneId" collection="entrezGeneIds" open="(" separator="," close=")">
+                #{entrezGeneId}
+            </foreach>
+        </if>
+        <if test="entrezGeneIds == null and alterations != null">
+            AND cna_event.ALTERATION IN
+            <foreach item="alteration" collection="alterations" open="(" separator="," close=")">
+                #{alteration}
             </foreach>
         </if>
         <if test="patientIds != null and !patientIds.isEmpty()">

--- a/service/src/main/java/org/cbioportal/service/impl/CopyNumberEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CopyNumberEnrichmentServiceImpl.java
@@ -47,21 +47,13 @@ public class CopyNumberEnrichmentServiceImpl implements CopyNumberEnrichmentServ
                                     molecularProfileIds.add(molecularProfileCase.getMolecularProfileId());
                                     sampleIds.add(molecularProfileCase.getCaseId());
                                 });
-                                List<CopyNumberCountByGene> copyNumberCountByGeneListFromRepo = discreteCopyNumberService
+                                return discreteCopyNumberService
                                         .getSampleCountInMultipleMolecularProfiles(
                                                 molecularProfileIds,
                                                 sampleIds,
                                                 null,
-                                                null,
+                                                alterationTypes,
                                                 false);
-        
-                                List<CopyNumberCountByGene> copyNumberCountByGeneList = new ArrayList<CopyNumberCountByGene>(
-                                        copyNumberCountByGeneListFromRepo);
-        
-                                // remove alteration not present in given alterationTypes
-                                copyNumberCountByGeneList.removeIf(m -> !alterationTypes.contains(m.getAlteration()));
-        
-                                return copyNumberCountByGeneList;
                             }));
         } else {
             copyNumberCountByGeneAndGroup = molecularProfileCaseSets.entrySet().stream()


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/4637#issuecomment-509765742

This is issue while fetching CNA enrichments with PATIENT type filter.
In the existing logic at https://github.com/cBioPortal/cbioportal/blob/6c3f73ebd1f380c3a385662911b8092ee290d674/service/src/main/java/org/cbioportal/service/impl/CopyNumberEnrichmentServiceImpl.java#L92
passing alteration types isn't getting added to database query.

There are couple of ways to fix it
1. Filter result based alteration types after fetching all the data(this is how is currently done while fetching CNA enrichments with SAMPLE type filter)
https://github.com/cBioPortal/cbioportal/blob/6c3f73ebd1f380c3a385662911b8092ee290d674/service/src/main/java/org/cbioportal/service/impl/CopyNumberEnrichmentServiceImpl.java#L62

2. Update the my-batis xml mapping to properly reflect alteration types filter

I chose option 2 as the data is filtered directly on the database
