### PR TITLE
Clinical data spark parquet persistence

### DIFF
--- a/model/src/main/java/org/cbioportal/model/ClinicalDataModel.java
+++ b/model/src/main/java/org/cbioportal/model/ClinicalDataModel.java
@@ -1,0 +1,50 @@
+package org.cbioportal.model;
+
+public class ClinicalDataModel {
+
+    private String sampleId;
+    private String patientId;
+    private String studyId;
+    private String attrId;
+    private String attrValue;
+
+    public String getSampleId() {
+        return sampleId;
+    }
+
+    public void setSampleId(String sampleId) {
+        this.sampleId = sampleId;
+    }
+
+    public String getPatientId() {
+        return patientId;
+    }
+
+    public void setPatientId(String patientId) {
+        this.patientId = patientId;
+    }
+    
+    public String getStudyId() {
+        return studyId;
+    }
+
+    public void setStudyId(String studyId) {
+        this.studyId = studyId;
+    }
+    
+    public String getAttrId() {
+        return attrId;
+    }
+
+    public void setAttrId(String attrId) {
+        this.attrId = attrId;
+    }
+
+    public String getAttrValue() {
+        return attrValue;
+    }
+
+    public void setAttrValue(String attrValue) {
+        this.attrValue = attrValue;
+    }
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/PersistenceConstants.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/PersistenceConstants.java
@@ -6,4 +6,5 @@ public class PersistenceConstants {
     public static final String SUMMARY_PROJECTION = "SUMMARY";
     public static final String ID_PROJECTION = "ID";
     public static final String SAMPLE_CLINICAL_DATA_TYPE = "SAMPLE";
+    public static final String PATIENT_CLINICAL_DATA_TYPE = "PATIENT";
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/ClinicalDataMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/ClinicalDataMyBatisRepository.java
@@ -9,6 +9,7 @@ import org.cbioportal.persistence.PatientRepository;
 import org.cbioportal.persistence.PersistenceConstants;
 import org.cbioportal.persistence.mybatis.util.OffsetCalculator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Repository
+@Qualifier("clinicalDataMyBatisRepository")
 public class ClinicalDataMyBatisRepository implements ClinicalDataRepository {
 
     @Autowired

--- a/persistence/persistence-spark/src/main/java/org/cbioportal/persistence/spark/ClinicalDataSparkRepository.java
+++ b/persistence/persistence-spark/src/main/java/org/cbioportal/persistence/spark/ClinicalDataSparkRepository.java
@@ -1,0 +1,289 @@
+package org.cbioportal.persistence.spark;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.expressions.UserDefinedFunction;
+import org.apache.spark.sql.types.DataTypes;
+import org.cbioportal.model.*;
+import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.persistence.ClinicalDataRepository;
+import org.cbioportal.persistence.PersistenceConstants;
+import org.cbioportal.persistence.spark.util.ParquetConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.apache.spark.sql.functions.*;
+
+
+@Component
+@Qualifier("clinicalDataSparkRepository")
+public class ClinicalDataSparkRepository implements ClinicalDataRepository {
+
+    @Autowired
+    private SparkSession spark;
+
+    @Value("${data.parquet.folder}")
+    private String PARQUET_DIR;
+
+    private static Log logger = LogFactory.getLog(ClinicalDataSparkRepository.class);
+    private static final String MUTATION_COUNT = "MUTATION_COUNT";
+    private static final String FRACTION_GENOME_ALTERED = "FRACTION_GENOME_ALTERED";
+
+    @Override
+    public List<ClinicalData> getAllClinicalDataOfSampleInStudy(String studyId, String sampleId, String attributeId, String projection, Integer pageSize, Integer pageNumber, String sortBy, String direction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseMeta getMetaSampleClinicalData(String studyId, String sampleId, String attributeId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ClinicalData> getAllClinicalDataOfPatientInStudy(String studyId, String patientId, String attributeId, String projection, Integer pageSize, Integer pageNumber, String sortBy, String direction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseMeta getMetaPatientClinicalData(String studyId, String patientId, String attributeId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ClinicalData> getAllClinicalDataInStudy(String studyId, String attributeId, String clinicalDataType, String projection, Integer pageSize, Integer pageNumber, String sortBy, String direction) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseMeta getMetaAllClinicalData(String studyId, String attributeId, String clinicalDataType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ClinicalData> fetchAllClinicalDataInStudy(String studyId, List<String> ids, List<String> attributeIds, String clinicalDataType, String projection) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseMeta fetchMetaClinicalDataInStudy(String studyId, List<String> ids, List<String> attributeIds, String clinicalDataType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ClinicalData> fetchClinicalData(List<String> studyIds, List<String> ids, List<String> attributeIds,
+                                                String clinicalDataType, String projection) {
+        List<Dataset<Row>> res = new ArrayList<>();
+        
+        Set<String> studyIdSet = new HashSet<>(studyIds);
+        String dataFile = ParquetConstants.CLINICAL_PATIENT;
+        if (PersistenceConstants.SAMPLE_CLINICAL_DATA_TYPE.equalsIgnoreCase(clinicalDataType)) {
+            dataFile = ParquetConstants.CLINICAL_SAMPLE;
+        }
+        Dataset<Row> clinicalData = loadStudyFiles(studyIdSet, dataFile);
+        
+        // join with clinical sample data to get sample id information.
+        if (PersistenceConstants.PATIENT_CLINICAL_DATA_TYPE.equalsIgnoreCase(clinicalDataType)) {
+            Dataset<Row> clinicalSampleData = loadStudyFiles(studyIdSet, ParquetConstants.CLINICAL_SAMPLE);
+            clinicalData = clinicalData.join(clinicalSampleData.drop("studyId"), "PATIENT_ID");
+        }
+        
+        // filter by sample id
+        if (!CollectionUtils.isEmpty(ids)) {
+            String[] caseArr = ids.stream().toArray(String[]::new);
+            if (PersistenceConstants.SAMPLE_CLINICAL_DATA_TYPE.equalsIgnoreCase(clinicalDataType)) {
+                clinicalData = clinicalData.filter(col("SAMPLE_ID").isin(caseArr));
+            } else {
+                clinicalData = clinicalData.filter(col("PATIENT_ID").isin(caseArr));
+            }
+        }
+
+        // if attributes is null return data from all columns
+        List<String> attributes = attributeIds;
+        if (CollectionUtils.isEmpty(attributeIds)) {
+            attributes = Arrays.asList(clinicalData.columns());
+        }
+        clinicalData.createOrReplaceTempView("clinicalData");
+
+        for (String attributeId : attributes) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("SELECT PATIENT_ID as patientId, SAMPLE_ID as sampleId, studyId");
+            if (!MUTATION_COUNT.equalsIgnoreCase(attributeId) && !FRACTION_GENOME_ALTERED.equalsIgnoreCase(attributeId)) {
+                sb.append(", " + attributeId + " AS attrValue");
+                sb.append(", '" + attributeId + "' AS attrId");
+            }
+            sb.append(" FROM clinicalData ");
+
+            String query = sb.toString();
+            Dataset<Row> sub = spark.sql(query);
+            
+            if (MUTATION_COUNT.equalsIgnoreCase(attributeId)) {
+                sub = sub.join(getMutationCount(studyIdSet), "sampleId");
+            }
+            if (FRACTION_GENOME_ALTERED.equalsIgnoreCase(attributeId)) {
+                sub = sub.join(getFractionGenomeAltered(studyIdSet), "sampleId");
+            }
+            res.add(sub);
+        }
+        
+        Dataset<Row> ds = res.get(0);
+        // union all datasets before calling collectAsList which move all  data into the application's driver process.
+        for (Dataset<Row> r : res.subList(1, res.size())) {
+            ds = ds.unionByName(r);
+        }
+
+        Dataset<ClinicalDataModel> clinicalDataModel = ds.as(Encoders.bean(ClinicalDataModel.class));
+        List<ClinicalDataModel> clinicalDataModels = clinicalDataModel.collectAsList();
+        return clinicalDataModels.stream()
+            .map(r -> mapToClinicalData(r)).collect(Collectors.toList());
+    }
+
+    @Override
+    public BaseMeta fetchMetaClinicalData(List<String> studyIds, List<String> ids, List<String> attributeIds, String clinicalDataType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ClinicalDataCount> fetchClinicalDataCounts(List<String> studyIds, List<String> ids,
+                                                           List<String> attributeIds, String clinicalDataType) {
+        List<Dataset<Row>> res = new ArrayList<>();
+
+        Set<String> studyIdSet = new HashSet<>(studyIds);
+        String dataFile = ParquetConstants.CLINICAL_PATIENT;
+        if (PersistenceConstants.SAMPLE_CLINICAL_DATA_TYPE.equalsIgnoreCase(clinicalDataType)) {
+            dataFile = ParquetConstants.CLINICAL_SAMPLE;
+        }
+        Dataset<Row> clinicalData = loadStudyFiles(studyIdSet, dataFile);
+
+        // join with clinical sample data to get sample id information.
+        if (PersistenceConstants.PATIENT_CLINICAL_DATA_TYPE.equalsIgnoreCase(clinicalDataType)) {
+            Dataset<Row> clinicalSampleData = loadStudyFiles(studyIdSet, ParquetConstants.CLINICAL_SAMPLE);
+            clinicalData = clinicalData.join(clinicalSampleData.drop("studyId"), "PATIENT_ID");
+        }
+
+        // filter by sample id
+        if (!CollectionUtils.isEmpty(ids)) {
+            String[] caseArr = ids.stream().toArray(String[]::new);
+            if (PersistenceConstants.SAMPLE_CLINICAL_DATA_TYPE.equalsIgnoreCase(clinicalDataType)) {
+                clinicalData = clinicalData.filter(col("SAMPLE_ID").isin(caseArr));
+            } else {
+                clinicalData = clinicalData.filter(col("PATIENT_ID").isin(caseArr));
+            }
+        }
+
+        // if attributes is null return data from all columns
+        List<String> attributes = attributeIds;
+        if (CollectionUtils.isEmpty(attributeIds)) {
+            attributes = Arrays.asList(clinicalData.columns());
+        }
+
+        clinicalData.createOrReplaceTempView("clinicalData");
+        for (String attributeId : attributes) {
+            StringBuilder sb = new StringBuilder();
+            if ("SAMPLE_COUNT".equalsIgnoreCase(attributeId)) {
+                sb.append("SELECT COUNT(*) AS count, countPatient AS value FROM ");
+                sb.append("(SELECT COUNT(*) AS countPatient FROM clinicalData GROUP BY PATIENT_ID) AS SUB ");
+                sb.append("GROUP BY countPatient");
+            } else {
+                sb.append("SELECT COUNT(*) AS count, ");
+                sb.append(attributeId + " AS value ");
+                sb.append("FROM clinicalData ");
+                sb.append(" GROUP BY ");
+                sb.append(attributeId);
+            }
+
+            String query = sb.toString();
+            Dataset<Row> sub = spark.sql(query);
+
+            sub = sub.withColumn("attributeId", lit(attributeId));
+            res.add(sub);
+        }
+        Dataset<Row> ds = res.get(0);
+        // union all datasets before calling collectAsList which move all  data into the application's driver process.
+        for (Dataset<Row> r : res.subList(1, res.size())) {
+            ds = ds.unionByName(r);
+        }
+        List<Row> dataCounts = ds.collectAsList();
+        return dataCounts.stream()
+            .map(r -> mapToClinicalDataCount(r)).collect(Collectors.toList());
+    }
+
+    private ClinicalDataCount mapToClinicalDataCount(Row row) {
+        ClinicalDataCount cdc = new ClinicalDataCount();
+        cdc.setCount((int) row.getLong(0));
+        cdc.setValue(String.valueOf(row.get(1)));
+        cdc.setAttributeId(String.valueOf(row.get(2)));
+
+        return cdc;
+    }
+
+    private ClinicalData mapToClinicalData(ClinicalDataModel cdm) {
+        ClinicalData cd = new ClinicalData();
+        cd.setSampleId(cdm.getSampleId());
+        cd.setPatientId(cdm.getPatientId());
+        cd.setStudyId(cdm.getStudyId());
+        cd.setAttrId(cdm.getAttrId());
+        cd.setAttrValue(cdm.getAttrValue());
+
+        return cd;
+    }
+
+    // Loads multiple tables with their schemas merged.
+    public Dataset<Row> loadStudyFiles(Set<String> studyIds, String file) {
+        List<String> studyIdArr = studyIds.stream()
+            .map(s -> PARQUET_DIR + ParquetConstants.STUDIES_DIR + s + "/" + file).collect(Collectors.toList());
+        Seq<String> fileSeq = JavaConverters.asScalaBuffer(studyIdArr).toSeq();
+
+        UserDefinedFunction getStudyId = udf((String fullPath) -> {
+                String[] paths = fullPath.split("/");
+                return paths[paths.length-3];
+            }, DataTypes.StringType);
+        
+        Dataset<Row> df = spark.read()
+            .option("mergeSchema", true)
+            .parquet(fileSeq)
+            .withColumn("studyId", getStudyId.apply(input_file_name()));
+        return df;
+    }
+
+    private Dataset<Row> getMutationCount(Set<String> studyIds) {
+        Dataset<Row> mutationDf = loadStudyFiles(studyIds, ParquetConstants.DATA_MUTATIONS);
+        
+        mutationDf = mutationDf.groupBy("Tumor_Sample_Barcode")
+            .agg(countDistinct("Chromosome", "Start_Position", "End_Position",
+                "Reference_Allele", "Tumor_Seq_Allele1").alias("attrValue"));
+        mutationDf = mutationDf.withColumn("attrValue", mutationDf.col("attrValue").cast("string"))
+                    .withColumn("attrId", lit(MUTATION_COUNT));
+        mutationDf = mutationDf.withColumnRenamed("Tumor_Sample_Barcode", "sampleId");
+        return mutationDf;
+    }
+
+    private Dataset<Row> getFractionGenomeAltered(Set<String> studyIds) {
+        Dataset<Row> copyNumberSeg = loadStudyFiles(studyIds, ParquetConstants.CNA_SEG);
+
+        Dataset<Row> copyNumberSegFiltered =copyNumberSeg
+            .filter(abs(col("`seg.mean`")).$greater$eq(0.2)).groupBy("ID")
+            .agg(sum(col("`loc.end`").minus(col("`loc.start`"))).alias("filteredSum"));
+
+        copyNumberSeg = copyNumberSeg.groupBy("ID")
+            .agg(sum(col("`loc.end`").minus(col("`loc.start`"))).alias("sumVal"));
+        copyNumberSeg = copyNumberSeg.join(copyNumberSegFiltered, "ID");
+        copyNumberSeg = copyNumberSeg.withColumn("attrValue",
+            copyNumberSeg.col("filteredSum")
+                .divide(copyNumberSeg.col("sumVal"))
+                .cast("string"))
+            .withColumn("attrId", lit(FRACTION_GENOME_ALTERED));
+        copyNumberSeg = copyNumberSeg.withColumnRenamed("ID", "sampleId");
+        copyNumberSeg = copyNumberSeg.drop("filteredSum", "sumVal");
+        return copyNumberSeg;
+    }
+}

--- a/persistence/persistence-spark/src/main/java/org/cbioportal/persistence/spark/SignificantlyMutatedGeneSparkRepository.java
+++ b/persistence/persistence-spark/src/main/java/org/cbioportal/persistence/spark/SignificantlyMutatedGeneSparkRepository.java
@@ -35,7 +35,7 @@ public class SignificantlyMutatedGeneSparkRepository implements SignificantlyMut
     public List<MutSig> getSignificantlyMutatedGenes(String studyId, String projection, Integer pageSize, Integer pageNumber, String sortBy, String direction) {
         Dataset<Row> mutationDf = spark.read()
             .option("mergeSchema", true)
-            .parquet(PARQUET_DIR + "/" + studyId + "/" + ParquetConstants.DATA_MUTATIONS);
+            .parquet(PARQUET_DIR + ParquetConstants.STUDIES_DIR + studyId + "/" + ParquetConstants.DATA_MUTATIONS);
         mutationDf.createOrReplaceTempView("mutation");
 
         StringBuilder sb = new StringBuilder("select first(Hugo_Symbol),");

--- a/persistence/persistence-spark/src/main/java/org/cbioportal/persistence/spark/util/ParquetConstants.java
+++ b/persistence/persistence-spark/src/main/java/org/cbioportal/persistence/spark/util/ParquetConstants.java
@@ -1,7 +1,11 @@
 package org.cbioportal.persistence.spark.util;
 
 public class ParquetConstants {
+    // Parquet folder names
+    public static final String STUDIES_DIR = "/studies/";
     // Parquet file names
-    public static final String DATA_MUTATIONS = "data_mutations*.txt.parquet";
-    
+    public static final String DATA_MUTATIONS = "mutations";
+    public static final String CLINICAL_SAMPLE = "clinical_sample";
+    public static final String CLINICAL_PATIENT = "clinical_patient";
+    public static final String CNA_SEG = "data_cna*.seg";
 }

--- a/persistence/persistence-spark/src/main/java/org/cbioportal/persistence/spark/util/ParquetWriter.java
+++ b/persistence/persistence-spark/src/main/java/org/cbioportal/persistence/spark/util/ParquetWriter.java
@@ -53,7 +53,8 @@ public class ParquetWriter {
             .option("header", "true")
             .option("comment","#")
             .load(inputFile);
-        df.write().parquet(outputFile);
+        df.write()
+            .mode("append").parquet(outputFile);
     }
     
     public static void main(String[] args) {

--- a/persistence/persistence-spark/src/test/java/org/cbioportal/persistence/spark/ClinicalDataSparkRepositoryTest.java
+++ b/persistence/persistence-spark/src/test/java/org/cbioportal/persistence/spark/ClinicalDataSparkRepositoryTest.java
@@ -1,0 +1,165 @@
+package org.cbioportal.persistence.spark;
+
+import org.apache.spark.sql.*;
+import org.cbioportal.model.*;
+import org.cbioportal.persistence.PersistenceConstants;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import scala.collection.Seq;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.spark.sql.functions.abs;
+import static org.apache.spark.sql.functions.col;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+@ContextConfiguration("/testSparkContext.xml")
+@TestPropertySource("/testPortal.properties")
+@Configurable
+public class ClinicalDataSparkRepositoryTest {
+
+    @Mock
+    private SparkSession spark;
+
+    @InjectMocks
+    private ClinicalDataSparkRepository clinicalDataSparkRepository;
+
+    private static final List<String> STUDY_IDS = Arrays.asList("msk_impact_2017");
+    private static final List<String> SAMPLE_ATTR_IDS = Arrays.asList("CANCER_TYPE",
+        "CANCER_TYPE_DETAILED", "SAMPLE_TYPE", "MATCHED_STATUS", "METASTATIC_SITE", "ONCOTREE_CODE",
+        "PRIMARY_SITE", "SAMPLE_CLASS", "SAMPLE_COLLECTION_SOURCE", "SPECIMEN_PRESERVATION_TYPE");
+    private static final List<String> PATIENT_ATTR_IDS = Arrays.asList("SAMPLE_COUNT", "SEX", "OS_STATUS", "VITAL_STATUS", "SMOKING_HISTORY");
+
+    private DataFrameReader dfr;
+    private Dataset<Row> ds;
+    private Dataset<ClinicalDataModel> dm;
+    private SQLContext sqlContext;
+    private RelationalGroupedDataset gds;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        dfr = mock(DataFrameReader.class);
+        ds = mock(Dataset.class);
+        dm = mock(Dataset.class);
+        sqlContext = mock(SQLContext.class);
+        gds = mock(RelationalGroupedDataset.class);
+
+        mockAssumptions();
+    }
+
+    private void mockAssumptions() {
+        when(spark.read()).thenReturn(dfr);
+        when(dfr.parquet(anyString())).thenReturn(ds);
+        when(spark.sql(anyString())).thenReturn(ds);
+        when(spark.sqlContext()).thenReturn(sqlContext);
+        when(dfr.option(anyString(), anyBoolean())).thenReturn(dfr);
+        when(dfr.parquet(any(Seq.class))).thenReturn(ds);
+
+        when(ds.withColumn(anyString(), any(Column.class))).thenReturn(ds);
+        when(ds.filter(abs(col("`seg.mean`")).$greater$eq(0.2))).thenReturn(ds);
+        when(ds.join(any(Dataset.class), anyString())).thenReturn(ds);
+        when(ds.groupBy(anyString())).thenReturn(gds);
+        when(gds.agg(any(Column.class))).thenReturn(ds);
+        when(ds.alias(anyString())).thenReturn(ds);
+        when(ds.unionByName(any(Dataset.class))).thenReturn(ds);
+        when(ds.withColumnRenamed(anyString(), anyString())).thenReturn(ds);
+        doNothing().when(ds).createOrReplaceTempView(anyString());
+        String[] cols = {"col"};
+        when(ds.columns()).thenReturn(cols);
+
+        when(ds.as(any(Encoder.class))).thenReturn(dm);
+        when(dm.collectAsList()).thenReturn(Arrays.asList(new ClinicalDataModel()));
+        when(ds.collectAsList()).thenReturn(Arrays.asList(RowFactory.create(1L, "value", "attrId")));
+    }
+
+    @Test
+    public void testFetchClinicalDataCountsSample() {
+
+        String[] sampleArr = {"CANCER_TYPE",
+            "CANCER_TYPE_DETAILED", "SAMPLE_TYPE", "MATCHED_STATUS", "METASTATIC_SITE", "ONCOTREE_CODE",
+            "PRIMARY_SITE", "SAMPLE_CLASS", "SAMPLE_COLLECTION_SOURCE", "SPECIMEN_PRESERVATION_TYPE"};
+        when(ds.filter(col("SAMPLE_ID").isin(sampleArr))).thenReturn(ds);
+
+        List<ClinicalDataCount> res = clinicalDataSparkRepository
+            .fetchClinicalDataCounts(STUDY_IDS, null, SAMPLE_ATTR_IDS, PersistenceConstants.SAMPLE_CLINICAL_DATA_TYPE);
+        Assert.assertNotNull(res);
+    }
+
+    @Test
+    public void testFetchClinicalDataCountsNull() {
+
+        List<ClinicalDataCount> res = clinicalDataSparkRepository
+            .fetchClinicalDataCounts(STUDY_IDS, null, null, PersistenceConstants.SAMPLE_CLINICAL_DATA_TYPE);
+        Assert.assertNotNull(res);
+    }
+
+    @Test
+    public void testFetchClinicalDataCountsPatient() {
+        String[] sampleArr = {"SAMPLE_COUNT", "SEX", "OS_STATUS", "VITAL_STATUS", "SMOKING_HISTORY"};
+        when(ds.filter(col("SAMPLE_ID").isin(sampleArr))).thenReturn(ds);
+        List<ClinicalDataCount> res = clinicalDataSparkRepository
+            .fetchClinicalDataCounts(STUDY_IDS, null, PATIENT_ATTR_IDS, "PATIENT");
+        Assert.assertNotNull(res);
+    }
+
+    @Test
+    public void testFetchClinicalData() {
+
+        List<ClinicalData> res = clinicalDataSparkRepository
+            .fetchClinicalData(STUDY_IDS, null, Arrays.asList("TUMOR_PURITY"),
+                PersistenceConstants.SAMPLE_CLINICAL_DATA_TYPE, "SUMMARY");
+
+        Assert.assertNotNull(res);
+    }
+
+    @Test
+    public void testClinicalDataStatusMonths() {
+        String[] samples = {"P-0000004","P-0000015"};
+        when(ds.filter(col("PATIENT_ID").isin(samples)))
+            .thenReturn(ds);
+
+        List<ClinicalData> res = clinicalDataSparkRepository
+            .fetchClinicalData(STUDY_IDS, Arrays.asList("P-0000004","P-0000015"), Arrays.asList("OS_STATUS", "OS_MONTHS"),
+                "PATIENT", "SUMMARY");
+
+        Assert.assertNotNull(res);
+    }
+
+    @Test
+    public void testClinicalDataSample() {
+        Column col = mock(Column.class);
+        when(ds.col(anyString())).thenReturn(col);
+        when(col.divide(any(Column.class))).thenReturn(col);
+
+        List<ClinicalData> res = clinicalDataSparkRepository
+            .fetchClinicalData(STUDY_IDS, null, Arrays.asList("MUTATION_COUNT","DNA_INPUT",
+                "FRACTION_GENOME_ALTERED","SAMPLE_COVERAGE"),
+                PersistenceConstants.SAMPLE_CLINICAL_DATA_TYPE, "SUMMARY");
+
+        Assert.assertNotNull(res);
+    }
+
+    @Test
+    public void testClinicalDataPatient() {
+
+        List<ClinicalData> res = clinicalDataSparkRepository
+            .fetchClinicalData(STUDY_IDS, null, Arrays.asList("OS_MONTHS"),
+                "PATIENT", "SUMMARY");
+
+        Assert.assertNotNull(res);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -523,6 +523,11 @@
           <artifactId>jackson-databind</artifactId>
           <version>2.9.7</version>
       </dependency>
+      <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+          <version>2.9.7</version>
+      </dependency>
     <!-- guava -->
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/service/src/main/java/org/cbioportal/service/impl/ClinicalDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ClinicalDataServiceImpl.java
@@ -15,6 +15,7 @@ import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -27,7 +28,11 @@ import java.util.stream.Collectors;
 public class ClinicalDataServiceImpl implements ClinicalDataService {
 
     @Autowired
+    @Qualifier("clinicalDataMyBatisRepository")
     private ClinicalDataRepository clinicalDataRepository;
+    @Autowired
+    @Qualifier("clinicalDataSparkRepository")
+    private ClinicalDataRepository clinicalDataSparkRepository;
     @Autowired
     private StudyService studyService;
     @Autowired
@@ -121,7 +126,7 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
     public List<ClinicalData> fetchClinicalData(List<String> studyIds, List<String> ids, List<String> attributeIds, 
                                                 String clinicalDataType, String projection) {
 
-        return clinicalDataRepository.fetchClinicalData(studyIds, ids, attributeIds, clinicalDataType, projection);
+        return clinicalDataSparkRepository.fetchClinicalData(studyIds, ids, attributeIds, clinicalDataType, projection);
     }
 
     @Override
@@ -138,7 +143,7 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
         if (attributeIds.isEmpty()) {
             return new ArrayList<>();
         }
-        List<ClinicalDataCount> clinicalDataCounts = clinicalDataRepository.fetchClinicalDataCounts(studyIds, sampleIds,
+        List<ClinicalDataCount> clinicalDataCounts = clinicalDataSparkRepository.fetchClinicalDataCounts(studyIds, sampleIds,
             attributeIds, clinicalDataType.name()).stream().filter(c -> !c.getValue().toUpperCase().equals("NA") && 
             !c.getValue().toUpperCase().equals("NAN") && !c.getValue().toUpperCase().equals("N/A")).collect(Collectors.toList());
 

--- a/service/src/test/java/org/cbioportal/service/impl/ClinicalDataServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ClinicalDataServiceImplTest.java
@@ -35,6 +35,8 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
     @Mock
     private ClinicalDataRepository clinicalDataRepository;
     @Mock
+    private ClinicalDataRepository clinicalDataSparkRepository;
+    @Mock
     private StudyService studyService;
     @Mock
     private PatientService patientService;
@@ -195,7 +197,7 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
         ClinicalData patientClinicalData = new ClinicalData();
         expectedPatientClinicalDataList.add(patientClinicalData);
 
-        Mockito.when(clinicalDataRepository.fetchClinicalData(studyIds, patientIds, 
+        Mockito.when(clinicalDataSparkRepository.fetchClinicalData(studyIds, patientIds, 
             Arrays.asList(CLINICAL_ATTRIBUTE_ID_1), CLINICAL_DATA_TYPE, PROJECTION))
             .thenReturn(expectedPatientClinicalDataList);
 
@@ -255,7 +257,7 @@ public class ClinicalDataServiceImplTest extends BaseServiceImplTest {
         clinicalDataCount5.setCount(3);
         clinicalDataCounts.add(clinicalDataCount5);
 
-        Mockito.when(clinicalDataRepository.fetchClinicalDataCounts(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID), 
+        Mockito.when(clinicalDataSparkRepository.fetchClinicalDataCounts(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID), 
             Arrays.asList(SAMPLE_ID1, SAMPLE_ID2, SAMPLE_ID3), Arrays.asList(CLINICAL_ATTRIBUTE_ID_1, 
             CLINICAL_ATTRIBUTE_ID_2, CLINICAL_ATTRIBUTE_ID_3), "PATIENT")).thenReturn(clinicalDataCounts);
 


### PR DESCRIPTION
Spark/parquet backend for clinical data apis in study view.

api/clinical-data-counts/fetch
api/clinical-data-bin-counts/fetch?dataBinMethod=STATIC
api/clinical-data-density-plot/fetch?xAxisAttributeId=FRACTION_GENOME_ALTERED&xAxisBinCount=50&xAxisStart=0&xAxisEnd=1&yAxisAttributeId=MUTATION_COUNT&yAxisBinCount=52&yAxisStart=0&clinicalDataType=SAMPLE

Reviewers:
@n1zea144 @kalletlak 