### PR TITLE
enlarge CopyNumberSeg model to use Long segId

### DIFF
--- a/model/src/main/java/org/cbioportal/model/CopyNumberSeg.java
+++ b/model/src/main/java/org/cbioportal/model/CopyNumberSeg.java
@@ -5,7 +5,7 @@ import javax.validation.constraints.NotNull;
 
 public class CopyNumberSeg extends UniqueKeyBase {
 
-    private Integer segId;
+    private Long segId;
     private Integer cancerStudyId;
     @NotNull
     private String cancerStudyIdentifier;
@@ -25,11 +25,11 @@ public class CopyNumberSeg extends UniqueKeyBase {
     @NotNull
     private BigDecimal segmentMean;
 
-    public Integer getSegId() {
+    public Long getSegId() {
         return segId;
     }
 
-    public void setSegId(Integer segId) {
+    public void setSegId(Long segId) {
         this.segId = segId;
     }
 

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/CopyNumberSegmentMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/CopyNumberSegmentMyBatisRepositoryTest.java
@@ -40,7 +40,7 @@ public class CopyNumberSegmentMyBatisRepositoryTest {
         
         Assert.assertEquals(2, result0.size());
         CopyNumberSeg copyNumberSeg = result0.get(0);
-        Assert.assertEquals((Integer) 50236594, copyNumberSeg.getSegId());
+        Assert.assertEquals(new Long(50236594L), copyNumberSeg.getSegId());
         Assert.assertEquals((Integer) 1, copyNumberSeg.getCancerStudyId());
         Assert.assertEquals("study_tcga_pub", copyNumberSeg.getCancerStudyIdentifier());
         Assert.assertEquals((Integer) 1, copyNumberSeg.getSampleId());
@@ -111,7 +111,7 @@ public class CopyNumberSegmentMyBatisRepositoryTest {
 
         Assert.assertEquals(2, result.size());
         CopyNumberSeg copyNumberSeg = result.get(0);
-        Assert.assertEquals((Integer) 50236594, copyNumberSeg.getSegId());
+        Assert.assertEquals(new Long(50236594L), copyNumberSeg.getSegId());
         Assert.assertEquals((Integer) 1, copyNumberSeg.getCancerStudyId());
         Assert.assertEquals("study_tcga_pub", copyNumberSeg.getCancerStudyIdentifier());
         Assert.assertEquals((Integer) 1, copyNumberSeg.getSampleId());
@@ -230,7 +230,7 @@ public class CopyNumberSegmentMyBatisRepositoryTest {
 
         Assert.assertEquals(1, result0.size());
         CopyNumberSeg copyNumberSeg = result0.get(0);
-        Assert.assertEquals((Integer) 50236593, copyNumberSeg.getSegId());
+        Assert.assertEquals(new Long(50236593L), copyNumberSeg.getSegId());
         Assert.assertEquals((Integer) 1, copyNumberSeg.getCancerStudyId());
         Assert.assertEquals("study_tcga_pub", copyNumberSeg.getCancerStudyIdentifier());
         Assert.assertEquals((Integer) 2, copyNumberSeg.getSampleId());

--- a/web/src/main/java/org/cbioportal/web/mixin/CopyNumberSegMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/CopyNumberSegMixin.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class CopyNumberSegMixin {
 
     @JsonIgnore
-    private Integer segId;
+    private Long segId;
     @JsonIgnore
     private Integer cancerStudyId;
     @JsonProperty("studyId")

--- a/web/src/test/java/org/cbioportal/web/CopyNumberSegmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CopyNumberSegmentControllerTest.java
@@ -38,7 +38,7 @@ public class CopyNumberSegmentControllerTest {
     private static final String TEST_SAMPLE_STABLE_ID_1 = "test_sample_stable_id_1";
     private static final int TEST_CANCER_STUDY_ID_1 = 1;
     private static final String TEST_CANCER_STUDY_IDENTIFIER_1 = "test_study_1";
-    private static final Integer TEST_SEG_ID_1 = 1;
+    private static final Long TEST_SEG_ID_1 = 1L;
     private static final String TEST_CHR_1 = "test_chr_1";
     private static final Integer TEST_START_1 = 15;
     private static final Integer TEST_END_1 = 20;
@@ -48,7 +48,7 @@ public class CopyNumberSegmentControllerTest {
     private static final String TEST_SAMPLE_STABLE_ID_2 = "test_sample_stable_id_2";
     private static final int TEST_CANCER_STUDY_ID_2 = 2;
     private static final String TEST_CANCER_STUDY_IDENTIFIER_2 = "test_study_2";
-    private static final Integer TEST_SEG_ID_2 = 2;
+    private static final Long TEST_SEG_ID_2 = 2L;
     private static final String TEST_CHR_2 = "test_chr_2";
     private static final Integer TEST_START_2 = 25;
     private static final Integer TEST_END_2 = 34;


### PR DESCRIPTION
- in preparation for migration to db schema version 2.10.1

# What? Why?
Current production databases have autoincremented the seg_id field in copy_number_seg table beyond the maximum sized java Integer. This hotfix is in preparation for a db migration to expand that field from type int to type BigInt

Changes proposed in this pull request:
- Change model for CopyNumberSeg
- Adjust unit test methods

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
