### PR TITLE
Fix Application Shutdown when HRRS Disabled

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/DebugHrrsFilter.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/DebugHrrsFilter.java
@@ -107,7 +107,9 @@ public class DebugHrrsFilter extends HrrsFilter {
     @Override
     public void destroy() {
         try {
-            writerTarget.close();
+            if (writerTarget != null) {
+                writerTarget.close();
+            }
         } catch (IOException error) {
             LOGGER.error("failed closing writer", error);
         }


### PR DESCRIPTION
# What? Why?
Fix application shutdown (NPE when attempting to destroy HrrsFilter). NPE is due to writerTarget not being set when hrrs logging is disabled. `.close()` gets called on null object. 

Changes proposed in this pull request:
- Check if writerTarget was set and only close() if not null

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.
- [ ] If this is a bug fix, create a unit and/or e2e test, or explain why that cannnot be done.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
