### PR TITLE
Fix for 6391 - removed unnecessary readonly transactional annotation on repos method.

### DIFF
--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
@@ -33,8 +33,6 @@ public class MolecularDataMyBatisRepository implements MolecularDataRepository {
     }
 
     @Override
-    // cursor processing requires a transaction 
-    @Transactional(readOnly=true, propagation=Propagation.NESTED)
     public List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, 
                                                                      List<Integer> entrezGeneIds, String projection) {
 


### PR DESCRIPTION
Not sure why I put it in the original PR, but further testing reveals this annotation is not required.

Fixes https://github.com/cbioportal/cbioportal/issues/6391