### PR TITLE
Ao master with hrrs fix

### DIFF
--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -256,9 +256,7 @@ matchminer.url=
 matchminer.token=
 
 # enable/disable hrrs logging
-# hrrs can be used for debugging - when enabled incoming web requests
-# will be logged into the specified directory
+# filter which logs incoming web requests to specified logging directory
 # logs must be decrypted for more in-depth information
-# see: https://github.com/vy/hrrs/blob/master/README.md
-#hrrs.logging.filepath=
-#hrrs.enable.logging=false
+hrrs.logging.filepath=
+hrrs.enable.logging=

--- a/web/src/main/java/org/cbioportal/web/util/ResettableHttpServletRequestFilter.java
+++ b/web/src/main/java/org/cbioportal/web/util/ResettableHttpServletRequestFilter.java
@@ -3,8 +3,11 @@ package org.cbioportal.web.util;
 import java.io.IOException;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
 
 
 /**
@@ -21,9 +24,10 @@ public class ResettableHttpServletRequestFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest aRequest, ServletResponse aResponse, FilterChain aChain) throws IOException, ServletException {
-        ResettableHttpServletRequestWrapper wrappedRequest = new ResettableHttpServletRequestWrapper((HttpServletRequest) aRequest);
-        aRequest = wrappedRequest;
-        aChain.doFilter(aRequest, aResponse);
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper((HttpServletRequest) aRequest);
+        ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper((HttpServletResponse) aResponse);
+        aChain.doFilter(wrappedRequest, wrappedResponse);
+        wrappedResponse.copyBodyToResponse();
     }
 
     @Override


### PR DESCRIPTION
# What? Why?
Early consumption of http requests were being triggered by the HRRS filter. 

Changes proposed in this pull request:
Changed which request wrapper was being used to one by spring which caches the content and copies the body back into the request for reusability.
