### PR TITLE
Fix for 6424

### DIFF
--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
@@ -10,8 +10,11 @@ public interface MolecularDataMapper {
 
     List<String> getCommaSeparatedSampleIdsOfMolecularProfiles(List<String> molecularProfileIds);
 
-    Cursor<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
+    List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
                                                                 String projection);
+
+    Cursor<GeneMolecularAlteration> getGeneMolecularAlterationsIter(String molecularProfileId, List<Integer> entrezGeneIds,
+                                                                    String projection);
 
     List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
                                                                                          List<Integer> entrezGeneIds,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
@@ -30,13 +30,7 @@ public class MolecularDataMyBatisRepository implements MolecularDataRepository {
     public List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, 
                                                                      List<Integer> entrezGeneIds, String projection) {
 
-        List<GeneMolecularAlteration> toReturn = new ArrayList();
-        Iterable<GeneMolecularAlteration> gmasItr =
-            molecularDataMapper.getGeneMolecularAlterations(molecularProfileId, entrezGeneIds, projection);
-        for (GeneMolecularAlteration gma : gmasItr) {
-            toReturn.add(gma);
-        }
-        return toReturn;
+        return molecularDataMapper.getGeneMolecularAlterations(molecularProfileId, entrezGeneIds, projection);
     }
 
     @Override
@@ -46,7 +40,7 @@ public class MolecularDataMyBatisRepository implements MolecularDataRepository {
     public Iterable<GeneMolecularAlteration> getGeneMolecularAlterationsIterable(String molecularProfileId, 
                                                                                  List<Integer> entrezGeneIds, String projection) {
 
-        return molecularDataMapper.getGeneMolecularAlterations(molecularProfileId, entrezGeneIds, projection);
+        return molecularDataMapper.getGeneMolecularAlterationsIter(molecularProfileId, entrezGeneIds, projection);
     }
 
     @Override

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
@@ -38,7 +38,38 @@
         ORDER BY REPLACE(genetic_profile.STABLE_ID, '_', ' '), genetic_profile.STABLE_ID ASC
     </select>
     
+    <!-- Any changes to this routine should be kept in sync with getGeneMolecularAlterationsIter below -->
     <select id="getGeneMolecularAlterations" resultType="org.cbioportal.model.GeneMolecularAlteration">
+        SELECT
+        gene.ENTREZ_GENE_ID AS entrezGeneId,
+        genetic_alteration.VALUES AS "values"
+        <if test="projection == 'DETAILED'">
+            ,
+            <include refid="org.cbioportal.persistence.mybatis.GeneMapper.select">
+                <property name="prefix" value="gene."/>
+            </include>
+        </if>
+        FROM genetic_alteration
+        INNER JOIN genetic_profile ON genetic_alteration.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
+        INNER JOIN gene ON genetic_alteration.GENETIC_ENTITY_ID = gene.GENETIC_ENTITY_ID
+        <where>
+            genetic_profile.STABLE_ID = #{molecularProfileId}
+            <if test="entrezGeneIds != null and !entrezGeneIds.isEmpty()">
+                AND gene.ENTREZ_GENE_ID IN
+                <foreach item="item" collection="entrezGeneIds" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+            </if>
+        </where>
+    </select>
+
+    <!-- This routine is a copy of getGeneMolecularAlterations above.  This copy is necessary because
+         it is backing a corresponding method in MolecularDataMapper.java which returns a Cursor as
+         opposed to a List. This method should be kept in sync with getGeneMolecularAlterations above.
+         (Attempts where made to share getGeneMolecularAlterations between methods in MolecularDataMapper.java
+         all of which have failed).
+    -->
+    <select id="getGeneMolecularAlterationsIter" resultType="org.cbioportal.model.GeneMolecularAlteration">
         SELECT
         gene.ENTREZ_GENE_ID AS entrezGeneId,
         genetic_alteration.VALUES AS "values"


### PR DESCRIPTION
This is a fix for [6424](https://github.com/cBioPortal/cbioportal/issues/6424).  This is related to the introduction of the Cursor type in the MolecularDataMapper.  The original PR tried to reuse code in the MolecularDataMapper.xml file.  When the PR was first submitted, all tests past because not all execution paths were covered.  These errors have since come to light.  This PR addresses these errors by separating the use of MolecularDataMapper.xml:getGeneMolecularAlterations into geteGeneMolecularAlterations and getGeneMolecularAlterationsIter, the latter of which is used by the Cursor Implementation.