### PR TITLE
Code for posting requests to google analytics

### DIFF
--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -23,7 +23,7 @@
     <!-- dbcp profile is defined here to prevent exceptions during war deployment -->
     <context-param>
         <param-name>spring.profiles.active</param-name>
-        <param-value>${dbconnector:dbcp},${authenticate}</param-value>
+        <param-value>${dbconnector:dbcp},${authenticate},${google.analytics.tracking:ga-api-tracking-disabled}</param-value>
     </context-param>
     <context-param>
         <param-name>spring.liveBeansView.mbeanDomain</param-name>

--- a/web/src/main/java/org/cbioportal/web/util/GoogleAnalyticsInterceptor.java
+++ b/web/src/main/java/org/cbioportal/web/util/GoogleAnalyticsInterceptor.java
@@ -1,0 +1,117 @@
+package org.cbioportal.web.util;
+
+import org.slf4j.*;
+
+import java.util.*;
+import javax.servlet.http.*;
+import javax.annotation.PostConstruct;
+import java.util.concurrent.CompletableFuture;
+
+import org.springframework.http.*;
+import org.springframework.web.client.*;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.LinkedMultiValueMap;
+
+@Component
+public class GoogleAnalyticsInterceptor extends HandlerInterceptorAdapter {
+
+    @Value("${google.analytics.tracking.code.api}")
+    private String trackingId;
+
+    @Value("${google.analytics.application.client.id}")
+    private String clientId;
+
+    private static HttpHeaders defaultHeaders;
+    private static LinkedMultiValueMap<String, String> globalURIVariables;
+    private static final Logger LOG = LoggerFactory.getLogger(GoogleAnalyticsInterceptor.class);
+    private static boolean missingGoogleAnalyticsCredentials;
+
+    @PostConstruct
+    private void initializeDefaultParams() {
+
+        if (trackingId == null || trackingId.isEmpty()) {
+            missingGoogleAnalyticsCredentials = true;
+        }
+        if (clientId == null || clientId.isEmpty()) {
+            missingGoogleAnalyticsCredentials = true;
+        }
+
+        if (missingGoogleAnalyticsCredentials) {
+            if (LOG.isInfoEnabled()) {
+                LOG.info("@PostContruct:");
+                LOG.info("Google Analytics tracking id: " + ((trackingId == null) ? "null" : trackingId));
+                LOG.info("Google Analytics client id: " + ((clientId == null) ? "null" : clientId));
+            }
+            return;
+        }
+
+        defaultHeaders = new HttpHeaders();
+        defaultHeaders.setAccept(Arrays.asList(MediaType.ALL));
+        defaultHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        defaultHeaders.set(HttpHeaders.USER_AGENT, "cBioPortal API Reporting/1.0 via org.cbioportal.web.util.GoogleAnalyticsInterceptor");
+
+        globalURIVariables = new LinkedMultiValueMap<String, String>();
+        globalURIVariables.add("v", "1");
+        globalURIVariables.add("dt", "request logged by GoogleAnalyticsInterceptor");
+        globalURIVariables.add("t", "pageview");
+        globalURIVariables.add("tid", trackingId);
+        globalURIVariables.add("cid", clientId);
+        globalURIVariables.add("dh", "cbioportal.org");
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+            throws Exception {
+
+        if (invalidAfterCompletionArgs(response)) {
+            return;
+        }
+
+        CompletableFuture.runAsync(() -> {
+                LinkedMultiValueMap<String, String> thisTasksURIVariables = new LinkedMultiValueMap<>();
+                thisTasksURIVariables.putAll(globalURIVariables);
+                thisTasksURIVariables.add("dp", request.getRequestURI());
+                HttpEntity<LinkedMultiValueMap<String, String>> requestEntity =
+                    new HttpEntity<LinkedMultiValueMap<String, String>>(thisTasksURIVariables, defaultHeaders);
+                try {
+                    RestTemplate restTemplate = new RestTemplate();
+                    ResponseEntity<String> responseEntity =
+                        restTemplate.exchange("https://www.google-analytics.com/collect", HttpMethod.POST, requestEntity, String.class);
+                    HttpStatus responseStatus = responseEntity.getStatusCode();
+                    if (responseStatus.is2xxSuccessful()) {
+                        if (LOG.isInfoEnabled()) {
+                            LOG.info("CompletableFuture.runAsync(): POST request successfully sent to Google Analytics: ");
+                            LOG.info(requestEntity.toString());
+                        }
+                    }
+                    else {
+                        if (LOG.isInfoEnabled()) {
+                            LOG.info("CompletableFuture.runAsync(): POST request to Google Analytics failed.  HTTP status code: "
+                                     + Integer.toString(responseStatus.value()));
+                        }
+                    }
+                }
+                catch(RestClientException e) {
+                    e.printStackTrace();
+                }
+        });
+    }
+
+    private boolean invalidAfterCompletionArgs(HttpServletResponse response) {
+        if (missingGoogleAnalyticsCredentials || response.getHeader("referer") != null) {
+            if (LOG.isInfoEnabled()) {
+                LOG.info("afterCompletion() cannot be completed:");
+                if (missingGoogleAnalyticsCredentials) {
+                    LOG.info("Invalid Google Analytics credentials (see @PostConstruct log entry)");
+                }
+                else {
+                    LOG.info("Response referer is not null");
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/web/src/main/resources/applicationContext-web.xml
+++ b/web/src/main/resources/applicationContext-web.xml
@@ -67,5 +67,10 @@
     <mvc:interceptors>
         <bean id="involvedCancerStudyInterceptor" class="org.cbioportal.web.util.InvolvedCancerStudyExtractorInterceptor"/>
     </mvc:interceptors>
+    <beans profile="ga-api-tracking-enabled">
+      <mvc:interceptors>
+        <bean id="googleAnalyticsInterceptor" class="org.cbioportal.web.util.GoogleAnalyticsInterceptor"/>
+      </mvc:interceptors>
+    </beans>
 
 </beans>


### PR DESCRIPTION
Interceptor posts request to cBioPortal website that occur outside of website to google analytics collect service.  Interceptor is enabled via following JVM argument:

-Dgoogle.analytics.tracking=ga-tracking-enabled

Requires the following properties set:

Tracking ID (Format UX-XXXX-X)
google.analytics.tracking.code.api=

Client id - it can be any valid UUID style format (e.g. XXXXXXXX-XXXXX-XXXX-XXXX-XXXXXXXXXXXXX)
google.analytics.application.client.id=

Updates to documentation to follow....