### PR TITLE
Created log for proxy and fix returned escaped json string issue

### DIFF
--- a/web/src/main/java/org/mskcc/cbio/portal/web/MatchMinerController.java
+++ b/web/src/main/java/org/mskcc/cbio/portal/web/MatchMinerController.java
@@ -1,7 +1,11 @@
 package org.mskcc.cbio.portal.web;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.http.converter.StringHttpMessageConverter;
@@ -20,6 +24,8 @@ import java.nio.charset.StandardCharsets;
 @RequestMapping("/proxy/matchminer")
 public class MatchMinerController {
 
+    private static final Log LOG = LogFactory.getLog( MatchMinerController.class);
+
     @Value("${matchminer.url:}")
     private String url;
 
@@ -27,25 +33,35 @@ public class MatchMinerController {
     private String token;
 
     @RequestMapping(value = "/**", produces = "application/json")
-    public String proxy(@RequestBody(required = false) JSONObject body, HttpMethod method, HttpServletRequest request)
-        throws URISyntaxException {
-        String path = request.getPathInfo().replace("/proxy/matchminer", "");
-        URI uri = new URI(this.url + path);
+    public ResponseEntity<Object> proxy(@RequestBody(required = false) JSONObject body, HttpMethod method, HttpServletRequest request) {
+        try {
+            String path = request.getPathInfo().replace("/proxy/matchminer", "");
+            URI uri = new URI(this.url + path);
 
-        HttpHeaders httpHeaders = new HttpHeaders();
-        String contentType = request.getHeader("Content-Type");
-        if (contentType != null) {
-            httpHeaders.setContentType(MediaType.valueOf(contentType));
-        }
-        if (this.token != "") {
-            String auth = this.token + ":";
-            byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(Charset.forName("US-ASCII")));
-            String authHeader = "Basic " + new String(encodedAuth);
-            httpHeaders.set("Authorization", authHeader);
-        }
+            HttpHeaders httpHeaders = new HttpHeaders();
+            String contentType = request.getHeader("Content-Type");
+            if (contentType != null) {
+                httpHeaders.setContentType(MediaType.valueOf(contentType));
+            }
+            if (this.token != "") {
+                String auth = this.token + ":";
+                byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(Charset.forName("US-ASCII")));
+                String authHeader = "Basic " + new String(encodedAuth);
+                httpHeaders.set("Authorization", authHeader);
+            }
 
-        RestTemplate restTemplate = new RestTemplate();
-        restTemplate.getMessageConverters().add(0, new StringHttpMessageConverter(StandardCharsets.UTF_8));
-        return restTemplate.exchange(uri, method, new HttpEntity<>(body, httpHeaders), String.class).getBody();
+            RestTemplate restTemplate = new RestTemplate();
+            restTemplate.getMessageConverters().add(0, new StringHttpMessageConverter(StandardCharsets.UTF_8));
+            ResponseEntity<String> responseEntity = restTemplate.exchange(uri, method, new HttpEntity<>(body, httpHeaders), String.class);
+            // The response might be a json object or a json array, so I return Object to cover both cases.
+            Object response = new JSONParser().parse(responseEntity.getBody());
+            return new ResponseEntity<>(response, responseEntity.getStatusCode());
+        } catch (URISyntaxException e) {
+            LOG.error(e);
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        } catch (ParseException e) {
+            LOG.error(e);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 }


### PR DESCRIPTION
# What? Why?
The returned json string is double quoted like `""[{\"key1\": \"v1\", \"key2\": \"v2\", .....}]""`, so I convert json string to object which can cover both JSONObject and JSONArray.
