### PR TITLE
Converted stable_id validation from error to warning

### DIFF
--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -592,7 +592,7 @@ def validate_types_and_id(meta_dictionary, logger, filename):
                                genetic_alteration_type, data_type)
         # validate stable_id:
         elif stable_id not in alt_type_datatype_and_stable_id[(genetic_alteration_type, data_type)]:
-            logger.error("Invalid stable id for genetic_alteration_type '%s', "
+            logger.warning("Invalid stable id for genetic_alteration_type '%s', "
                          "data_type '%s'; expected one of [%s]",
                         genetic_alteration_type,
                         data_type,


### PR DESCRIPTION
ISSUE: Studies with new stable_ids/genetic_alteration types fails validation. Allowed_data_types file in the importer folder has a list a stable ids and genetic alteration types that the validator compares against. Adding new profile names and stable ids to the allowed_data_types file fails unit tests (https://github.com/cBioPortal/cbioportal/pull/6258) Validation status of all studies on Datahub master branch is been failing for a while because of this issue. Adding a quick fix here. 

FIX: Changed stable_id validation from error to warning to pass studies with new stable_ids.