### PR TITLE
add unit tests for cache statistics controller

### DIFF
--- a/service/src/main/java/org/cbioportal/service/exception/CacheNotFoundException.java
+++ b/service/src/main/java/org/cbioportal/service/exception/CacheNotFoundException.java
@@ -2,8 +2,19 @@ package org.cbioportal.service.exception;
 
 public class CacheNotFoundException extends Exception {
 
+    private String cacheName;
+
     public CacheNotFoundException(String cacheName) {
         super("No cache found with name " + cacheName);
+        this.cacheName = cacheName;
+    }
+
+    public String getCacheName() {
+        return cacheName;
+    }
+
+    public void setCacheName(String cacheName) {
+        this.cacheName = cacheName;
     }
 
 }

--- a/web/src/main/java/org/cbioportal/web/error/GlobalExceptionHandler.java
+++ b/web/src/main/java/org/cbioportal/web/error/GlobalExceptionHandler.java
@@ -23,77 +23,66 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UnsupportedOperationException.class)
     public ResponseEntity<ErrorResponse> handleUnsupportedOperation() {
-
         return new ResponseEntity<>(new ErrorResponse("Requested API is not implemented yet"),
                 HttpStatus.NOT_IMPLEMENTED);
     }
 
     @ExceptionHandler(StudyNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleStudyNotFound(StudyNotFoundException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Study not found: " + ex.getStudyId()),
                 HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(PatientNotFoundException.class)
     public ResponseEntity<ErrorResponse> handlePatientNotFound(PatientNotFoundException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Patient not found in study " + ex.getStudyId() + ": " +
             ex.getPatientId()), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(CancerTypeNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleCancerTypeNotFound(CancerTypeNotFoundException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Cancer type not found: " + ex.getCancerTypeId()),
                 HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(MolecularProfileNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleMolecularProfileNotFound(MolecularProfileNotFoundException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Molecular profile not found: " + ex.getMolecularProfileId()),
                 HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(SampleNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleSampleNotFound(SampleNotFoundException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Sample not found in study " + ex.getStudyId() + ": " +
                 ex.getSampleId()), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(GeneNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleGeneNotFound(GeneNotFoundException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Gene not found: " + ex.getGeneId()),
                 HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(GenesetNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleGenesetNotFound(GenesetNotFoundException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Gene set not found: " + ex.getGenesetId()),
                 HttpStatus.NOT_FOUND);
     }
     
     @ExceptionHandler(SampleListNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleSampleListNotFound(SampleListNotFoundException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Sample list not found: " + ex.getSampleListId()),
             HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(ClinicalAttributeNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleClinicalAttributeNotFound(ClinicalAttributeNotFoundException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Clinical attribute not found in study " + ex.getStudyId() + 
             ": " + ex.getClinicalAttributeId()), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(GenePanelNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleGenePanelNotFound(GenePanelNotFoundException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Gene panel not found: " + ex.getGenePanelId()),
             HttpStatus.NOT_FOUND);
     }
@@ -101,28 +90,24 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ErrorResponse> handleMissingServletRequestParameter(
             MissingServletRequestParameterException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Request parameter is missing: " + ex.getParameterName()),
                 HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(TypeMismatchException.class)
     public ResponseEntity<ErrorResponse> handleTypeMismatch(TypeMismatchException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Request parameter type mismatch: " + ex.getMostSpecificCause()),
                 HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("There is an error in the JSON format of the request payload"),
                 HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException ex) {
-
         ConstraintViolation constraintViolation = ex.getConstraintViolations().iterator().next();
         Iterator<Path.Node> iterator = constraintViolation.getPropertyPath().iterator();
         String parameterName = null;
@@ -134,7 +119,6 @@ public class GlobalExceptionHandler {
                 break;
             }
         }
-
         return new ResponseEntity<>(new ErrorResponse(parameterName + " " + constraintViolation.getMessage()),
             HttpStatus.BAD_REQUEST);
     }
@@ -149,7 +133,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException ex) {
-
         return new ResponseEntity<>(new ErrorResponse("Access to the specified resource has been forbidden"),
             HttpStatus.FORBIDDEN);
     }
@@ -177,4 +160,11 @@ public class GlobalExceptionHandler {
         ErrorResponse response = new ErrorResponse("Specified token cannot be found");
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
+
+    @ExceptionHandler(CacheNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleCacheNotFoundException(CacheNotFoundException ex) {
+        return new ResponseEntity<>(new ErrorResponse("No cache found with name " + ex.getCacheName()),
+            HttpStatus.NOT_FOUND);
+    }
+
 }

--- a/web/src/test/java/org/cbioportal/web/CacheStatsControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CacheStatsControllerTest.java
@@ -1,0 +1,103 @@
+package org.cbioportal.web;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.cbioportal.service.CacheStatisticsService;
+import org.cbioportal.service.exception.CacheNotFoundException;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration("/applicationContext-web-test.xml")
+@Configuration
+public class CacheStatsControllerTest {
+
+    public static final String REPOSITORY_CACHE_ALIAS = "RepositoryCache";
+    public static final String INVALID_CACHE_ALIAS = "invalidcachealias";
+    @Autowired
+    private WebApplicationContext wac;
+    
+    private MockMvc mockMvc;
+
+    @Autowired
+    public CacheStatisticsService cacheStatisticsService;
+    
+    @Before
+    public void setUp() throws Exception {
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+    }
+    
+    @Bean
+    public static CacheStatisticsService cacheStatisticsService() throws CacheNotFoundException {
+        CacheStatisticsService cacheStatisticsServiceMock = Mockito.mock(CacheStatisticsService.class);
+        Mockito.when(cacheStatisticsServiceMock.getKeyCountsPerClass(Mockito.anyString())).thenAnswer(new Answer<List<String>>() {
+            public List<String> answer(InvocationOnMock invocation) throws CacheNotFoundException {
+                Object[] args = invocation.getArguments();
+                String cacheAlias = (String)args[0];
+                if (REPOSITORY_CACHE_ALIAS.equals(cacheAlias)) {
+                    return new ArrayList<String>();
+                } 
+                throw new CacheNotFoundException(cacheAlias);
+            }
+        });
+        Mockito.when(cacheStatisticsServiceMock.getKeysInCache(Mockito.anyString())).thenAnswer(new Answer<List<String>>() {
+            public List<String> answer(InvocationOnMock invocation) throws CacheNotFoundException {
+                Object[] args = invocation.getArguments();
+                String cacheAlias = (String)args[0];
+                if (REPOSITORY_CACHE_ALIAS.equals(cacheAlias)) {
+                    return new ArrayList<String>();
+                } 
+                throw new CacheNotFoundException(cacheAlias);
+            }
+        });
+        return cacheStatisticsServiceMock;
+    }
+
+    @Test
+    public void testGetKeysInCache() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/" + REPOSITORY_CACHE_ALIAS + "/keysInCache")
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    public void testGetKeysInInvalidCache() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/" + INVALID_CACHE_ALIAS + "/keysInCache")
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
+    public void testGetKeyCountsPerClass() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/" + REPOSITORY_CACHE_ALIAS + "/keyCountsPerClass")
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    public void testGetKeyCountsPerClassInvalidCache() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/" + INVALID_CACHE_ALIAS + "/keyCountsPerClass")
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+}

--- a/web/src/test/java/org/cbioportal/web/SampleListControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/SampleListControllerTest.java
@@ -4,7 +4,6 @@ import org.cbioportal.model.CancerStudy;
 import org.cbioportal.model.SampleList;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.service.SampleListService;
-import org.cbioportal.service.CacheStatisticsService;
 import org.cbioportal.service.exception.SampleListNotFoundException;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
 import org.hamcrest.Matchers;
@@ -71,11 +70,6 @@ public class SampleListControllerTest {
     @Bean
     public SampleListService sampleListService() {
         return Mockito.mock(SampleListService.class);
-    }
-
-    @Bean
-    public CacheStatisticsService cacheStatisticsService() {
-        return Mockito.mock(CacheStatisticsService .class);
     }
 
     @Before


### PR DESCRIPTION
- mock CacheStatisticsService to throw CacheNotFoundException when requests for unknown cache alias are made
- store requested cache name in CacheNotFoundException
- test keysInCache endpoint and keyCountsPerClass endpoints with valid and invalid cache aliases
adjust GlobalExceptionHandler to return a 404 NotFound status for requests on an invalid cache alias