### PR TITLE
Adjustments to Ehcache settings

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GeneRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GeneRepository.java
@@ -41,7 +41,7 @@ import java.util.List;
 
 public interface GeneRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable("StaticRepositoryCacheOne")
     List<Gene> getAllGenes(String keyword, String alias, String projection, Integer pageSize, Integer pageNumber, String sortBy, 
                            String direction);
 
@@ -57,13 +57,13 @@ public interface GeneRepository {
     @Cacheable("StaticRepositoryCacheOne")
     Gene getGeneByHugoGeneSymbol(String hugoGeneSymbol);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable("StaticRepositoryCacheOne")
     List<String> getAliasesOfGeneByEntrezGeneId(Integer entrezGeneId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable("StaticRepositoryCacheOne")
     List<String> getAliasesOfGeneByHugoGeneSymbol(String hugoGeneSymbol);
 
-    @Cacheable("GeneralRepositoryCache")
+    // not cached because this is called only a single time, during @PostConstruct method of GeneServiceImpl
     List<GeneAlias> getAllAliases();
 
     @Cacheable("GeneralRepositoryCache")

--- a/persistence/persistence-api/src/main/resources/ehcache-disk-only.xml
+++ b/persistence/persistence-api/src/main/resources/ehcache-disk-only.xml
@@ -14,6 +14,11 @@
 
     <ehcache:persistence directory="${ehcache.persistence.path}"/>
 
+    <ehcache:heap-store>
+      <ehcache:max-object-graph-size>9223372036854775807</ehcache:max-object-graph-size><!-- using Long.MAX_VALUE -->
+      <ehcache:max-object-size>9223372036854775807</ehcache:max-object-size><!-- using Long.MAX_VALUE -->
+    </ehcache:heap-store>
+
     <ehcache:cache alias="GeneralRepositoryCache">
       <ehcache:expiry>
         <ehcache:none></ehcache:none>

--- a/persistence/persistence-api/src/main/resources/ehcache-heap-only.xml
+++ b/persistence/persistence-api/src/main/resources/ehcache-heap-only.xml
@@ -13,7 +13,8 @@
     </ehcache:service>
 
     <ehcache:heap-store>
-      <ehcache:max-object-graph-size>10000000</ehcache:max-object-graph-size>
+      <ehcache:max-object-graph-size>9223372036854775807</ehcache:max-object-graph-size><!-- using Long.MAX_VALUE -->
+      <ehcache:max-object-size>9223372036854775807</ehcache:max-object-size><!-- using Long.MAX_VALUE -->
     </ehcache:heap-store>
 
     <ehcache:cache alias="GeneralRepositoryCache">

--- a/persistence/persistence-api/src/main/resources/ehcache-mixed.xml
+++ b/persistence/persistence-api/src/main/resources/ehcache-mixed.xml
@@ -15,7 +15,8 @@
     <ehcache:persistence directory="${ehcache.persistence.path}"/>
 
     <ehcache:heap-store>
-      <ehcache:max-object-graph-size>10000000</ehcache:max-object-graph-size>
+      <ehcache:max-object-graph-size>9223372036854775807</ehcache:max-object-graph-size><!-- using Long.MAX_VALUE -->
+      <ehcache:max-object-size>9223372036854775807</ehcache:max-object-size><!-- using Long.MAX_VALUE -->
     </ehcache:heap-store>
 
     <ehcache:cache alias="GeneralRepositoryCache">

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -244,10 +244,10 @@ ehcache.general_repository_cache.max_bytes_heap_units=MB
 ehcache.general_repository_cache.max_bytes_local_disk=4
 ehcache.general_repository_cache.max_bytes_local_disk_units=GB
 # size allocation preferences for the first static persistence cache (genes)
-ehcache.static_repository_cache_one.max_bytes_heap=3
+ehcache.static_repository_cache_one.max_bytes_heap=30
 ehcache.static_repository_cache_one.max_bytes_heap_units=MB
-ehcache.static_repository_cache_one.max_bytes_local_disk=4
-ehcache.static_repository_cache_one.max_bytes_local_disk_units=GB
+ehcache.static_repository_cache_one.max_bytes_local_disk=32
+ehcache.static_repository_cache_one.max_bytes_local_disk_units=MB
 
 # Default cross cancer study query
 # query this session id when not specifying a study for


### PR DESCRIPTION
- add getAllGenes() and getAliasesOfGeneByEntrezGeneId() and getAliasesOfGeneByHugoGeneSymbol() to static cache
- stop caching a once-only persistence call getAllAliases()
- increase max-object-graph-size to Long.MAX_VALUE (from 10000000) and include in ehcache-disk-only settings
- increase heap resource for static cache to 30 MB (from 3 MB)
- decrease disk resource for static cache to 32 MB (from 4 GB)
