### PR TITLE
Support multi-study mutation and cna patient enrichments

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/DiscreteCopyNumberRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/DiscreteCopyNumberRepository.java
@@ -44,7 +44,7 @@ public interface DiscreteCopyNumberRepository {
                                                                           List<Integer> entrezGeneIds, 
                                                                           List<Integer> alterations);
 
-    List<CopyNumberCountByGene> getPatientCountByGeneAndAlterationAndPatientIds(String molecularProfileId,
+    List<CopyNumberCountByGene> getPatientCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                                 List<String> patientIds,
                                                                                 List<Integer> entrezGeneIds,
                                                                                 List<Integer> alterations);

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
@@ -42,7 +42,7 @@ public interface MutationRepository {
                                                                         List<String> sampleIds,
                                                                         List<Integer> entrezGeneIds);
 
-    List<MutationCountByGene> getPatientCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
+    List<MutationCountByGene> getPatientCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                          List<String> patientIds,
                                                                          List<Integer> entrezGeneIds);
 

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.java
@@ -38,7 +38,7 @@ public interface DiscreteCopyNumberMapper {
                                                                           List<Integer> entrezGeneIds, 
                                                                           List<Integer> alterations);
 
-    List<CopyNumberCountByGene> getPatientCountByGeneAndAlterationAndPatientIds(String molecularProfileId,
+    List<CopyNumberCountByGene> getPatientCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                                 List<String> patientIds,
                                                                                 List<Integer> entrezGeneIds,
                                                                                 List<Integer> alterations);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMyBatisRepository.java
@@ -87,12 +87,12 @@ public class DiscreteCopyNumberMyBatisRepository implements DiscreteCopyNumberRe
 	}
 
     @Override
-    public List<CopyNumberCountByGene> getPatientCountByGeneAndAlterationAndPatientIds(String molecularProfileId, 
+    public List<CopyNumberCountByGene> getPatientCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                                        List<String> patientIds, 
                                                                                        List<Integer> entrezGeneIds, 
                                                                                        List<Integer> alterations) {
         
-        return discreteCopyNumberMapper.getPatientCountByGeneAndAlterationAndPatientIds(molecularProfileId, patientIds, 
+        return discreteCopyNumberMapper.getPatientCountInMultipleMolecularProfiles(molecularProfileIds, patientIds, 
             entrezGeneIds, alterations);
     }
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
@@ -41,7 +41,7 @@ public interface MutationMapper {
                                                                         List<Integer> entrezGeneIds,
                                                                         Boolean snpOnly);
 
-    List<MutationCountByGene> getPatientCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
+    List<MutationCountByGene> getPatientCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                          List<String> patientIds,
                                                                          List<Integer> entrezGeneIds,
                                                                          Boolean snpOnly);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
@@ -90,11 +90,11 @@ public class MutationMyBatisRepository implements MutationRepository {
 	}
 
     @Override
-    public List<MutationCountByGene> getPatientCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
+    public List<MutationCountByGene> getPatientCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                                 List<String> patientIds,
                                                                                 List<Integer> entrezGeneIds) {
 
-        return mutationMapper.getPatientCountByEntrezGeneIdsAndSampleIds(molecularProfileId, patientIds, entrezGeneIds,
+        return mutationMapper.getPatientCountInMultipleMolecularProfiles(molecularProfileIds, patientIds, entrezGeneIds,
             null);
     }
 

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.xml
@@ -241,7 +241,7 @@
         GROUP BY cna_event.ENTREZ_GENE_ID, cna_event.ALTERATION, reference_genome_gene.CYTOBAND
     </select>
 
-    <select id="getPatientCountByGeneAndAlterationAndPatientIds" resultType="org.cbioportal.model.CopyNumberCountByGene">
+    <select id="getPatientCountInMultipleMolecularProfiles" resultType="org.cbioportal.model.CopyNumberCountByGene">
         SELECT
         cna_event.ENTREZ_GENE_ID AS entrezGeneId,
         gene.HUGO_GENE_SYMBOL AS hugoGeneSymbol,
@@ -253,7 +253,32 @@
         INNER JOIN sample ON sample_cna_event.SAMPLE_ID = sample.INTERNAL_ID
         INNER JOIN patient ON sample.PATIENT_ID = patient.INTERNAL_ID
         INNER JOIN gene ON cna_event.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
-        WHERE genetic_profile.STABLE_ID = #{molecularProfileId}
+        WHERE
+        <if test="patientIds != null and !patientIds.isEmpty()">
+            <if test="@java.util.Arrays@stream(molecularProfileIds.toArray()).distinct().count() == 1">
+                genetic_profile.STABLE_ID = #{molecularProfileIds[0]}
+                AND patient.STABLE_ID IN
+                <foreach item="item" collection="patientIds" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+            </if>
+            <if test="@java.util.Arrays@stream(molecularProfileIds.toArray()).distinct().count() > 1">
+                (patient.STABLE_ID, genetic_profile.STABLE_ID) IN
+                <foreach index="i" collection="patientIds" open="(" separator="," close=")">
+                    (#{patientIds[${i}]}, #{molecularProfileIds[${i}]})
+                </foreach>
+                AND genetic_profile.STABLE_ID IN
+                <foreach item="item" collection="molecularProfileIds" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+            </if>
+        </if>
+        <if test="patientIds == null">
+		    genetic_profile.STABLE_ID IN
+			<foreach item="item" collection="molecularProfileIds" open="(" separator="," close=")">
+			    #{item}
+			</foreach>
+		</if>
         <if test="entrezGeneIds != null and alterations != null">
             AND (cna_event.ENTREZ_GENE_ID, cna_event.ALTERATION) IN
             <foreach index="i" collection="entrezGeneIds" open="(" separator="," close=")">
@@ -270,12 +295,6 @@
             AND cna_event.ALTERATION IN
             <foreach item="alteration" collection="alterations" open="(" separator="," close=")">
                 #{alteration}
-            </foreach>
-        </if>
-        <if test="patientIds != null and !patientIds.isEmpty()">
-            AND patient.STABLE_ID IN
-            <foreach item="item" collection="patientIds" open="(" separator="," close=")">
-                #{item}
             </foreach>
         </if>
         GROUP BY cna_event.ENTREZ_GENE_ID, cna_event.ALTERATION

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
@@ -269,7 +269,7 @@
         GROUP BY mutation.ENTREZ_GENE_ID
     </select>
 
-    <select id="getPatientCountByEntrezGeneIdsAndSampleIds" resultType="org.cbioportal.model.MutationCountByGene">
+    <select id="getPatientCountInMultipleMolecularProfiles" resultType="org.cbioportal.model.MutationCountByGene">
         SELECT
         mutation.ENTREZ_GENE_ID AS entrezGeneId,
         gene.HUGO_GENE_SYMBOL AS hugoGeneSymbol,
@@ -281,13 +281,31 @@
         INNER JOIN patient ON sample.PATIENT_ID = patient.INTERNAL_ID
         INNER JOIN gene ON mutation.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
         WHERE
-        genetic_profile.STABLE_ID = #{molecularProfileId}
         <if test="patientIds != null and !patientIds.isEmpty()">
-            AND patient.STABLE_ID IN
-            <foreach item="item" collection="patientIds" open="(" separator="," close=")">
-                #{item}
-            </foreach>
+            <if test="@java.util.Arrays@stream(molecularProfileIds.toArray()).distinct().count() == 1">
+                genetic_profile.STABLE_ID = #{molecularProfileIds[0]}
+                AND patient.STABLE_ID IN
+                <foreach item="item" collection="patientIds" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+            </if>
+            <if test="@java.util.Arrays@stream(molecularProfileIds.toArray()).distinct().count() > 1">
+                (patient.STABLE_ID, genetic_profile.STABLE_ID) IN
+                <foreach index="i" collection="patientIds" open="(" separator="," close=")">
+                      (#{patientIds[${i}]}, #{molecularProfileIds[${i}]})
+                </foreach>
+                AND genetic_profile.STABLE_ID IN
+                <foreach item="item" collection="molecularProfileIds" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+            </if>
         </if>
+		<if test="patientIds == null">
+		    genetic_profile.STABLE_ID IN
+			<foreach item="item" collection="molecularProfileIds" open="(" separator="," close=")">
+			    #{item}
+			</foreach>
+		</if>
         <if test="entrezGeneIds != null and !entrezGeneIds.isEmpty()">
             AND mutation.ENTREZ_GENE_ID IN
             <foreach item="item" collection="entrezGeneIds" open="(" separator="," close=")">

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMyBatisRepositoryTest.java
@@ -170,7 +170,7 @@ public class DiscreteCopyNumberMyBatisRepositoryTest {
     public void getPatientCountByGeneAndAlterationAndPatientIds() throws Exception {
 
         List<CopyNumberCountByGene> result  = discreteCopyNumberMyBatisRepository
-            .getPatientCountByGeneAndAlterationAndPatientIds("study_tcga_pub_gistic", null, 
+            .getPatientCountInMultipleMolecularProfiles(Arrays.asList("study_tcga_pub_gistic"), null, 
                 Arrays.asList(207, 208), Arrays.asList(-2, 2));
         
         Assert.assertEquals(2, result.size());

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -301,8 +302,8 @@ public class MutationMyBatisRepositoryTest {
         List<Integer> entrezGeneIds = new ArrayList<>();
         entrezGeneIds.add(208);
         
-        List<MutationCountByGene> result = mutationMyBatisRepository.getPatientCountByEntrezGeneIdsAndSampleIds(
-            "acc_tcga_mutations", null, entrezGeneIds);
+        List<MutationCountByGene> result = mutationMyBatisRepository.getPatientCountInMultipleMolecularProfiles(
+            Arrays.asList("acc_tcga_mutations"), null, entrezGeneIds);
         
         Assert.assertEquals(1, result.size());
         Assert.assertEquals((Integer) 1, result.get(0).getNumberOfAlteredCases());

--- a/service/src/main/java/org/cbioportal/service/DiscreteCopyNumberService.java
+++ b/service/src/main/java/org/cbioportal/service/DiscreteCopyNumberService.java
@@ -51,7 +51,7 @@ public interface DiscreteCopyNumberService {
         List<Integer> alterations,
         boolean includeFrequency);
 
-    List<CopyNumberCountByGene> getPatientCountByGeneAndAlterationAndPatientIds(String molecularProfileId,
+    List<CopyNumberCountByGene> getPatientCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                                 List<String> patientIds,
                                                                                 List<Integer> entrezGeneIds,
                                                                                 List<Integer> alterations);

--- a/service/src/main/java/org/cbioportal/service/MutationService.java
+++ b/service/src/main/java/org/cbioportal/service/MutationService.java
@@ -48,10 +48,9 @@ public interface MutationService {
                                                                         List<Integer> entrezGeneIds,
                                                                         boolean includeFrequency);
 
-    List<MutationCountByGene> getPatientCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
+    List<MutationCountByGene> getPatientCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                         List<String> patientIds,
-                                                                        List<Integer> entrezGeneIds)
-        throws MolecularProfileNotFoundException;
+                                                                        List<Integer> entrezGeneIds);
 
     List<MutationCountByPosition> fetchMutationCountsByPosition(List<Integer> entrezGeneIds, 
                                                                 List<Integer> proteinPosStarts, 

--- a/service/src/main/java/org/cbioportal/service/impl/CopyNumberEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CopyNumberEnrichmentServiceImpl.java
@@ -1,14 +1,12 @@
 package org.cbioportal.service.impl;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.cbioportal.model.AlterationCountByGene;
 import org.cbioportal.model.AlterationEnrichment;
-import org.cbioportal.model.CopyNumberCountByGene;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.service.CopyNumberEnrichmentService;
 import org.cbioportal.service.DiscreteCopyNumberService;
@@ -31,62 +29,37 @@ public class CopyNumberEnrichmentServiceImpl implements CopyNumberEnrichmentServ
             List<Integer> alterationTypes,
             String enrichmentType) throws MolecularProfileNotFoundException {
 
-        Map<String, List<? extends AlterationCountByGene>> copyNumberCountByGeneAndGroup = new HashMap<>();
-
-        if (enrichmentType.equals("SAMPLE")) {
-            copyNumberCountByGeneAndGroup = molecularProfileCaseSets
-                    .entrySet()
-                    .stream()
-                    .collect(Collectors.toMap(
-                            entry -> entry.getKey(),
-                            entry -> { //set value of each group to list of CopyNumberCountByGene
-                                List<String> molecularProfileIds = new ArrayList<>();
-                                List<String> sampleIds = new ArrayList<>();
-        
-                                entry.getValue().forEach(molecularProfileCase -> {
-                                    molecularProfileIds.add(molecularProfileCase.getMolecularProfileId());
-                                    sampleIds.add(molecularProfileCase.getCaseId());
-                                });
+        Map<String, List<? extends AlterationCountByGene>> copyNumberCountByGeneAndGroup =
+                molecularProfileCaseSets
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey(),
+                        entry -> { //set value of each group to list of CopyNumberCountByGene
+                            
+                            List<String> molecularProfileIds = new ArrayList<>();
+                            List<String> sampleIds = new ArrayList<>();
+    
+                            entry.getValue().forEach(molecularProfileCase -> {
+                                molecularProfileIds.add(molecularProfileCase.getMolecularProfileId());
+                                sampleIds.add(molecularProfileCase.getCaseId());
+                            });
+                            
+                            if (enrichmentType.equals("SAMPLE")) {
                                 return discreteCopyNumberService
-                                        .getSampleCountInMultipleMolecularProfiles(
-                                                molecularProfileIds,
+                                        .getSampleCountInMultipleMolecularProfiles(molecularProfileIds,
                                                 sampleIds,
                                                 null,
                                                 alterationTypes,
                                                 false);
-                            }));
-        } else {
-            copyNumberCountByGeneAndGroup = molecularProfileCaseSets.entrySet().stream()
-                    .collect(Collectors.toMap(
-                            entry -> entry.getKey(),
-                            entry -> { //set value of each group to list of CopyNumberCountByGene
-                                Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseIdentifiersMap = entry
-                                        .getValue().stream()
-                                        .collect(Collectors.groupingBy(MolecularProfileCaseIdentifier::getMolecularProfileId));
-        
-                                return molecularProfileCaseIdentifiersMap
-                                        .entrySet()
-                                        .stream()
-                                        .flatMap(molecularProfileCaseIdentifiers -> {
-                                            
-                                            String molecularProfileId = molecularProfileCaseIdentifiers.getKey();
-                                            
-                                            List<String> caseIds = molecularProfileCaseIdentifiers
-                                                    .getValue()
-                                                    .stream()
-                                                    .map(MolecularProfileCaseIdentifier::getCaseId)
-                                                    .collect(Collectors.toList());
-                                            return discreteCopyNumberService
-                                                    .getPatientCountByGeneAndAlterationAndPatientIds(
-                                                            molecularProfileId,
-                                                            caseIds,
-                                                            null,
-                                                            alterationTypes)
-                                                    .stream();
-                                        })
-                                        .collect(Collectors.toList());
-                            }));
-        }
+                            } else {
+                                return discreteCopyNumberService
+                                        .getPatientCountInMultipleMolecularProfiles(molecularProfileIds,
+                                                sampleIds,
+                                                null,
+                                                alterationTypes);
+                            }
+                        }));
 
         return alterationEnrichmentUtil
                 .createAlterationEnrichments(

--- a/service/src/main/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImpl.java
@@ -164,12 +164,12 @@ public class DiscreteCopyNumberServiceImpl implements DiscreteCopyNumberService 
 	}
 
     @Override
-    public List<CopyNumberCountByGene> getPatientCountByGeneAndAlterationAndPatientIds(String molecularProfileId, 
+    public List<CopyNumberCountByGene> getPatientCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                                        List<String> patientIds, 
                                                                                        List<Integer> entrezGeneIds, 
                                                                                        List<Integer> alterations) {
 
-        return discreteCopyNumberRepository.getPatientCountByGeneAndAlterationAndPatientIds(molecularProfileId, 
+        return discreteCopyNumberRepository.getPatientCountInMultipleMolecularProfiles(molecularProfileIds, 
             patientIds, entrezGeneIds, alterations);
     }
 

--- a/service/src/main/java/org/cbioportal/service/impl/MutationEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationEnrichmentServiceImpl.java
@@ -1,7 +1,6 @@
 package org.cbioportal.service.impl;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -9,7 +8,6 @@ import java.util.stream.Collectors;
 import org.cbioportal.model.AlterationCountByGene;
 import org.cbioportal.model.AlterationEnrichment;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
-import org.cbioportal.model.MutationCountByGene;
 import org.cbioportal.service.MutationEnrichmentService;
 import org.cbioportal.service.MutationService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
@@ -31,51 +29,34 @@ public class MutationEnrichmentServiceImpl implements MutationEnrichmentService 
             String enrichmentType)
             throws MolecularProfileNotFoundException {
 
-        Map<String, List<? extends AlterationCountByGene>> mutationCountsbyEntrezGeneIdAndGroup = new HashMap<>();
-
-        if (enrichmentType.equals("SAMPLE")) {
-            mutationCountsbyEntrezGeneIdAndGroup = molecularProfileCaseSets.entrySet().stream()
-                    .collect(Collectors.toMap(
-                            entry -> entry.getKey(),
-                            entry -> { //set value of each group to list of MutationCountByGene
-                                List<String> molecularProfileIds = new ArrayList<>();
-                                List<String> sampleIds = new ArrayList<>();
-        
-                                entry.getValue().forEach(molecularProfileCase -> {
-                                    molecularProfileIds.add(molecularProfileCase.getMolecularProfileId());
-                                    sampleIds.add(molecularProfileCase.getCaseId());
-                                });
-                                List<MutationCountByGene> mutationCounts = mutationService
-                                        .getSampleCountInMultipleMolecularProfiles(molecularProfileIds, sampleIds, null, false);
-        
-                                return mutationCounts;
-                            }));
-        } else {
-            mutationCountsbyEntrezGeneIdAndGroup = molecularProfileCaseSets.entrySet().stream()
-                    .collect(Collectors.toMap(
-                            entry -> entry.getKey(),
-                            entry -> { //set value of each group to list of MutationCountByGene
-                                Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseIdentifiersMap = entry
-                                        .getValue().stream()
-                                        .collect(Collectors.groupingBy(MolecularProfileCaseIdentifier::getMolecularProfileId));
-        
-                                List<MutationCountByGene> mutationCounts = molecularProfileCaseIdentifiersMap.entrySet()
-                                        .stream().flatMap(molecularProfileCaseIdentifiers -> {
-                                            String molecularProfileId = molecularProfileCaseIdentifiers.getKey();
-                                            List<String> caseIds = molecularProfileCaseIdentifiers.getValue().stream()
-                                                    .map(MolecularProfileCaseIdentifier::getCaseId)
-                                                    .collect(Collectors.toList());
-                                            try {
-                                                return mutationService.getPatientCountByEntrezGeneIdsAndSampleIds(
-                                                        molecularProfileId, caseIds, null).stream();
-                                            } catch (MolecularProfileNotFoundException e) {
-                                                throw new RuntimeException(e);
-                                            }
-                                        }).collect(Collectors.toList());
-        
-                                return mutationCounts;
-                            }));
-        }
+        Map<String, List<? extends AlterationCountByGene>> mutationCountsbyEntrezGeneIdAndGroup =
+                molecularProfileCaseSets
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey(),
+                        entry -> { //set value of each group to list of MutationCountByGene
+                            List<String> molecularProfileIds = new ArrayList<>();
+                            List<String> sampleIds = new ArrayList<>();
+    
+                            entry.getValue().forEach(molecularProfileCase -> {
+                                molecularProfileIds.add(molecularProfileCase.getMolecularProfileId());
+                                sampleIds.add(molecularProfileCase.getCaseId());
+                            });
+    
+                            if (enrichmentType.equals("SAMPLE")) {
+                                return mutationService
+                                        .getSampleCountInMultipleMolecularProfiles(molecularProfileIds,
+                                                sampleIds,
+                                                null,
+                                                false);
+                            } else {
+                                return mutationService
+                                        .getPatientCountInMultipleMolecularProfiles(molecularProfileIds,
+                                                sampleIds,
+                                                null);
+                            }
+                        }));
 
         return alterationEnrichmentUtil.createAlterationEnrichments(mutationCountsbyEntrezGeneIdAndGroup,
                 molecularProfileCaseSets, enrichmentType);

--- a/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
@@ -135,14 +135,12 @@ public class MutationServiceImpl implements MutationService {
 	}
 
     @Override
-    public List<MutationCountByGene> getPatientCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
+    public List<MutationCountByGene> getPatientCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                                 List<String> patientIds,
-                                                                                List<Integer> entrezGeneIds)
-        throws MolecularProfileNotFoundException {
+                                                                                List<Integer> entrezGeneIds) {
 
-        validateMolecularProfile(molecularProfileId);
 
-        return mutationRepository.getPatientCountByEntrezGeneIdsAndSampleIds(molecularProfileId, patientIds, 
+        return mutationRepository.getPatientCountInMultipleMolecularProfiles(molecularProfileIds, patientIds, 
             entrezGeneIds);
     }
 

--- a/service/src/test/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImplTest.java
@@ -249,17 +249,17 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
     }
 
     @Test
-    public void getPatientCountByGeneAndAlterationAndPatientIds() throws Exception {
+    public void getPatientCountInMultipleMolecularProfiles() throws Exception {
         
         List<CopyNumberCountByGene> expectedCopyNumberSampleCountByGeneList = new ArrayList<>();
         expectedCopyNumberSampleCountByGeneList.add(new CopyNumberCountByGene());
 
-        Mockito.when(discreteCopyNumberRepository.getPatientCountByGeneAndAlterationAndPatientIds(MOLECULAR_PROFILE_ID, 
+        Mockito.when(discreteCopyNumberRepository.getPatientCountInMultipleMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID), 
             null, Arrays.asList(ENTREZ_GENE_ID_1), Arrays.asList(-2)))
             .thenReturn(expectedCopyNumberSampleCountByGeneList);
         
         List<CopyNumberCountByGene> result = discreteCopyNumberService
-            .getPatientCountByGeneAndAlterationAndPatientIds(MOLECULAR_PROFILE_ID, null, Arrays.asList(ENTREZ_GENE_ID_1), 
+            .getPatientCountInMultipleMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID), null, Arrays.asList(ENTREZ_GENE_ID_1), 
                 Arrays.asList(-2));
         
         Assert.assertEquals(expectedCopyNumberSampleCountByGeneList, result);

--- a/service/src/test/java/org/cbioportal/service/impl/MutationServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MutationServiceImplTest.java
@@ -214,7 +214,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
     }
 
     @Test
-    public void getPatientCountByEntrezGeneIds() throws Exception {
+    public void getPatientCountInMultipleMolecularProfiles() throws Exception {
 
         MolecularProfile molecularProfile = new MolecularProfile();
         molecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.MUTATION_EXTENDED);
@@ -224,22 +224,13 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         MutationCountByGene mutationPatientCountByGene = new MutationCountByGene();
         expectedMutationPatientCountByGeneList.add(mutationPatientCountByGene);
         
-        Mockito.when(mutationRepository.getPatientCountByEntrezGeneIdsAndSampleIds(MOLECULAR_PROFILE_ID, null,
+        Mockito.when(mutationRepository.getPatientCountInMultipleMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID), null,
             Arrays.asList(ENTREZ_GENE_ID_1))).thenReturn(expectedMutationPatientCountByGeneList);
         
-        List<MutationCountByGene> result = mutationService.getPatientCountByEntrezGeneIdsAndSampleIds(
-            MOLECULAR_PROFILE_ID, null, Arrays.asList(ENTREZ_GENE_ID_1));
+        List<MutationCountByGene> result = mutationService.getPatientCountInMultipleMolecularProfiles(
+                Arrays.asList(MOLECULAR_PROFILE_ID), null, Arrays.asList(ENTREZ_GENE_ID_1));
         
         Assert.assertEquals(expectedMutationPatientCountByGeneList, result);
-    }
-
-    @Test(expected = MolecularProfileNotFoundException.class)
-    public void getPatientCountByEntrezGeneIdsMolecularProfileNotFound() throws Exception {
-        
-        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenThrow(
-            new MolecularProfileNotFoundException(MOLECULAR_PROFILE_ID));
-        mutationService.getPatientCountByEntrezGeneIdsAndSampleIds(MOLECULAR_PROFILE_ID, null,
-            Arrays.asList(ENTREZ_GENE_ID_1));
     }
 
     @Test


### PR DESCRIPTION
Fix error while querying for mutation and cna enrichments with `PATIENT` enrichment type

**Changes made**
Renamed and updated `getPatientCountByGeneAndAlterationAndPatientIds`( to `getPatientCountInMultipleMolecularProfiles`) to support multi-study
Mainly update logic in
`DiscreteCopyNumberMapper.xml`
`MutationMapper.xml`