### PR TITLE
Reduce response size of gene panel data for ProfiledSamplesCounter (fixes issue #6461)

### DIFF
--- a/service/src/main/java/org/cbioportal/service/util/ProfiledSamplesCounter.java
+++ b/service/src/main/java/org/cbioportal/service/util/ProfiledSamplesCounter.java
@@ -56,7 +56,11 @@ public class ProfiledSamplesCounter {
                 List<GenePanel> matchingGenePanels = geneGenePanelMap.get(entrezGeneId);
                 for (GenePanel genePanel : matchingGenePanels) {
                     numberOfSamplesProfiled += genePanelDataMap.get(genePanel.getStableId()).size();
-                    allPanels.add(genePanel);
+                    GenePanel genePanelSummary = new GenePanel();
+                    genePanelSummary.setDescription(genePanel.getDescription());
+                    genePanelSummary.setInternalId(genePanel.getInternalId());
+                    genePanelSummary.setStableId(genePanel.getStableId());
+                    allPanels.add(genePanelSummary);
                 }
                 
                 numberOfSamplesProfiled += profiled.stream().filter(g -> g.getGenePanelId() == null).count();


### PR DESCRIPTION
# What? Why?
Fix #6461

Changes proposed in this pull request:

ProfiledSamplesCounter was returning detailed gene panel data for each altered gene in the response. Matching gene panels are returned for every altered gene on the study summary page which included every single gene in every matching gene panel found.

This is problematic for large studies with many altered genes, samples, and associated gene panels. The call for mutated genes resulted in very large data transfers (4GB for genie_private study) which ultimately crash the study summary page.

The ProfiledSamplesCounter response now excludes the list of genes linked to a gene panel and instead only includes the meta information (gene panel stable id and description). For the beta genie study (genie_private) this reduced the size of the response from 4GB to 2.4MB and the study summary page now renders as expected.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
Co-authored by: Manda Wilson <1458628+mandawilson@users.noreply.github.com>
Co-authored by: Robert Sheridan <7747489+sheridancbio@users.noreply.github.com>
 


# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.
- [ ] If this is a bug fix, create a unit and/or e2e test, or explain why that cannnot be done.
