### PR TITLE
raise logger level to error for unknown gene panels

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -3184,7 +3184,7 @@ class GenePanelMatrixValidator(Validator):
         if self.portal.gene_panel_list is not None:
             for gene_panel_id in data:
                 if gene_panel_id not in self.portal.gene_panel_list and gene_panel_id != 'NA':
-                    self.logger.warning('Gene panel ID is not in database. Please import this gene panel before loading '
+                    self.logger.error('Gene panel ID is not in database. Please import this gene panel before loading '
                                     'study data.',
                                     extra={'line_number': self.line_number,
                                             'cause': gene_panel_id})


### PR DESCRIPTION
Gene panel IDs are checked with the API whether they are already present. If not, a `warning` was raised and later on the importer crashes if this warning is overridden.

<b>Changes:</b>
- Raise logger `warning` to `error` in validator.