### PR TITLE
Add portal.properties setting to disable all ehcaching

### DIFF
--- a/business/src/main/resources/applicationContext-business.xml
+++ b/business/src/main/resources/applicationContext-business.xml
@@ -85,7 +85,8 @@
             <property name="objectFactory" ref="customObjectFactory" />
             <property name="configuration">
                 <bean class="org.apache.ibatis.session.Configuration">
-                    <property name="cacheEnabled" value="${mybatis.cache.enabled:true}" />
+                    <!-- second level caching is provided via Ehcache -->
+                    <property name="cacheEnabled" value="false" />
                 </bean>
             </property>
             <!-- mapper locations is set here to support interdependency between mappers without -->

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/CNSegmentMapper.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/CNSegmentMapper.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.mskcc.cbio.portal.persistence.CNSegmentMapper">
-    <cache/>
 
     <select id="getCNSegmentData" resultType="org.mskcc.cbio.portal.model.CNSegmentData">
         select s.stable_id as sample, cns.chr as chr, cns.start as start, cns.end as end, cns.num_probes as numProbes, cns.segment_mean as value 

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/CosmicCountMapperLegacy.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/CosmicCountMapperLegacy.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.mskcc.cbio.portal.persistence.CosmicCountMapperLegacy">
-    <cache/>
 
     <select id="getCOSMICCountsByKeywords" resultType="org.mskcc.cbio.portal.model.CosmicCount">
         select

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/GeneAliasMapper.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/GeneAliasMapper.xml
@@ -3,8 +3,6 @@
 
 <mapper namespace="org.mskcc.cbio.portal.persistence.GeneAliasMapper">
     
-<cache/>
-
 <select id="getGenesAliasesByEntrez" resultType="DBGeneAlias" parameterType="list">
     select
         GENE_ALIAS as gene_alias,

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/GeneMapperLegacy.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/GeneMapperLegacy.xml
@@ -3,8 +3,6 @@
 
 <mapper namespace="org.mskcc.cbio.portal.persistence.GeneMapperLegacy">
     
-<cache/>
-
 <select id="getGenesByHugo" resultType="DBGene" parameterType="list">
     select
         HUGO_GENE_SYMBOL as hugo_gene_symbol,

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/GenePanelMapperLegacy.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/GenePanelMapperLegacy.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.mskcc.cbio.portal.persistence.GenePanelMapperLegacy">
-    <cache/>
 
    <resultMap id="genePanelResultMap" type="org.mskcc.cbio.portal.model.GenePanel">
         <result property="internalId" column="internalId"/>       

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/MutationMapperLegacy.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/MutationMapperLegacy.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.mskcc.cbio.portal.persistence.MutationMapperLegacy">
-    <cache/>
 
     <select id="getMutationsDetailed" resultType="org.mskcc.cbio.portal.model.Mutation">
         select

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/MutationalSignatureMapper.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/MutationalSignatureMapper.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.mskcc.cbio.portal.persistence.MutationalSignatureMapper">
-    <cache/>
 
     <select id="getSNPCountsBySampleId" resultType="org.mskcc.cbio.portal.model.SNPCount">
         select

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/StructuralVariantMapper.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/StructuralVariantMapper.xml
@@ -32,7 +32,6 @@
 -->
 
 <mapper namespace="org.mskcc.cbio.portal.persistence.StructuralVariantMapper">
-    <cache/>
 
     <select id="getStructuralVariant" resultType="org.mskcc.cbio.portal.model.StructuralVariant">
         select

--- a/business/src/main/resources/org/mskcc/cbio/portal/persistence/StudyMapperLegacy.xml
+++ b/business/src/main/resources/org/mskcc/cbio/portal/persistence/StudyMapperLegacy.xml
@@ -3,8 +3,6 @@
 
 <mapper namespace="org.mskcc.cbio.portal.persistence.StudyMapperLegacy">
     
-<cache/>
-
 <select id="getStudies" resultType="DBStudy">
     select
         CANCER_STUDY_IDENTIFIER as id,

--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -1,5 +1,5 @@
 # Backend Caching 
-cBioPortal provides the option of caching information on the backend as a means for improving performance. Without caching, each query including repeated queries, will query the database, process the returned data, and construct a response. This may lead to performance issues as the entire process is rather costly, especially for queries on larger studies. With caching turned on, the query response will be stored during the initial query. If the same query is made, the response will be taken directly from cache instead of having to be reconstructed. 
+cBioPortal provides the option of caching information on the backend to improve performance. Without caching, every time a request is received by the backend, a query is sent to the database system for information, and the returned data is processed to construct a response. This may lead to performance issues as the entire process can be rather costly, especially for queries on larger studies. With caching turned on, query responses can be taken directly from the cache if they have already been constructed. They would only be constructed for the initial query.
 
 ## Cache Configuration
 The portal is configured to use Ehcache for backend caching; caching configuration is
@@ -7,15 +7,14 @@ specified inside an xml file under `persistence/persistence-api/src/main/resourc
 three different configurations available - `disk-only`, `heap-only`, and `mixed`. The configuration files 
 specify which caches to create. Additional specifications such as cache size and location are set inside `portal.properties` (more information [here](portal.properties-Reference.md#ehcache-settings)).
  
- 
  ## Creating additional caches
-The default configuration initializes two separate caches. However, a user may wish to introduce new caches with different policies (e.g expiration policy) for different datatypes. To create additional caches (e.g creating a cache specifically for clinical data), a new cache must be added to the ehcache.xml configuration file. The `@Cacheable` annotation must also be added to function declarations to indicate which functions are to be cached. 
+The default configuration initializes two separate caches. However, you may wish to introduce new caches with different policies (e.g expiration policy) for different datatypes. To create additional caches (e.g creating a cache specifically for clinical data), a new cache must be added to the ehcache.xml_configuration file. The `@Cacheable` annotation must also be added (or adjusted) to function declarations to indicate which functions are to be cached. Those might look like this example:
 ``` 
-@Cacheable(ClinicalDataCache)
+@Cacheable(cacheNames = "ClinicalDataCache", condition = "@cacheEnabledConfig.getEnabled()")
 public String getDataFromClinicalDataRepository(String param) {}
 ```
-Additionally, new properties for setting cache sizes should be added to `portal.properties`. Alternatively, values may also be hardcoded directly into the ehcache.xml configuration file. 
+Additionally, new properties for setting cache sizes should be added to `portal.properties`. Alternatively, values may also be hardcoded directly into the ehcache.xml_configuration file. 
 
-For more information on constructing an ehcache.xml configuration file, refer to the documentation [here](https://www.ehcache.org/documentation/3.7/xml.html). 
+For more information on constructing an ehcache.xml_configuration file, refer to the documentation [here](https://www.ehcache.org/documentation/3.7/xml.html). 
 
 For more information on linking caches to functions, refer to the documentation [here](https://spring.io/guides/gs/caching/).

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -284,14 +284,14 @@ This gene set will add the following in the query box:
 # Ehcache Settings
 cBioPortal is supported on the backend with Ehcache. The configuration, size, and location of these caches are configurable from within portal.properties through the following properties.
 
-First, select a cache configuration using `ehcache.xml.configuration`. This specifies whether to use a disk-only, heap-only, or hybrid (disk + heap) cache. The default value is `ehcache-mixed.xml` which initializes a hybrid caching system.
+First, select a cache configuration using `ehcache.xml_configuration`. This specifies whether to use a disk-only, heap-only, or hybrid (disk + heap) cache. The default value is `ehcache-mixed.xml` which initializes a hybrid caching system.
 ```
-ehcache.xml.configuration=[ehcache-heap-only.xml OR ehcache-mixed.xml OR ehcache-disk-only.xml]
+ehcache.xml_configuration=[ehcache-heap-only.xml OR ehcache-mixed.xml OR ehcache-disk-only.xml]
 ```
 
-If the cache is configured to use disk resources, users must make a directory available and set it with the `ehcache.persistence.path` property. Ehcache will create seperate directories under the provided path for each cache defined in the ehcache.xml configuration file. 
+If the cache is configured to use disk resources, users must make a directory available and set it with the `ehcache.persistence_path` property. Ehcache will create seperate directories under the provided path for each cache defined in the ehcache.xml_configuration file. 
 ```
-ehcache.persistence.path=[location on the disk filesystem where Ehcache can write the cache to /tmp/]
+ehcache.persistence_path=[location on the disk filesystem where Ehcache can write the cache to /tmp/]
 ```
 
 Cache size must be set for both heap and disk; Ehcache requires disk size to be greater than heap size. Default values are provided. The general repository cache is specified to use 1021MB for heap and 4GB for disk. The static repository cache is specified to use 30MB for heap and 32MB for disk. For installations with increased traffic or data, cache sizes can be increased to further improve performance. 
@@ -307,10 +307,16 @@ ehcache.static_repository_cache_one.max_bytes_local_disk=
 ehcache.static_repository_cache_one.max_bytes_local_disk_units[size unit e.g MB, GB, entries]
 ```
 
-Additional properties can be specified for cache statistics monitoring. To log metrics regarding memory usage, set `ehcache.enable.statistics` to true. Logged metrics and additional information such as cache size and cached keys are available through an optional endpoint. The optional endpoint is turned off by default but can be turned on by setting `cache.statistics.endpoint.enabled` to true. 
+To configure a system where no caching occurs, use ehache-heap-only.xml with minimal heap sizes (0 is not supported, so set max_bytes_heap=1 and max_bytes_heap_units=B for all caches) and set
 ```
-ehcache.enable.statistics=true[true or false]
-cache.statistics.endpoint.enabled=false[true or false]
+ehcache.cache_enabled=false
+```
+This will prevent any response from being stored in the cache.
+
+Additional properties can be specified for cache statistics monitoring. To log metrics regarding memory usage, set `ehcache.statistics_enabled` to true. Logged metrics and additional information such as cache size and cached keys are available through an optional endpoint. The optional endpoint is turned off by default but can be turned on by setting `cache.statistics_endpoint_enabled` to true. 
+```
+ehcache.statistics_enabled=true[true or false]
+cache.statistics_endpoint_enabled=false[true or false]
 ```
 The cache statistics endpoint is hidden on the api page; users must directly access the URL to view the response. The cache statistics endpoint can be accessed in the following ways.
 

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CacheEnabledConfig.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CacheEnabledConfig.java
@@ -1,0 +1,25 @@
+package org.cbioportal.persistence;
+
+import org.springframework.beans.factory.annotation.Value;
+
+public class CacheEnabledConfig {
+
+    private boolean enabled;
+
+    public CacheEnabledConfig(String cacheEnabled) {
+        this.enabled = Boolean.parseBoolean(cacheEnabled);
+    }
+
+    public String getEnabled() {
+        if (enabled) {
+            return "true";
+        } else {
+            return "false";
+        }
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CancerTypeRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CancerTypeRepository.java
@@ -9,12 +9,12 @@ import java.util.List;
 
 public interface CancerTypeRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<TypeOfCancer> getAllCancerTypes(String projection, Integer pageSize, Integer pageNumber, String sortBy,
                                          String direction);
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaCancerTypes();
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     TypeOfCancer getCancerType(String cancerTypeId);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/ClinicalAttributeRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/ClinicalAttributeRepository.java
@@ -10,32 +10,32 @@ import java.util.List;
 
 public interface ClinicalAttributeRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalAttribute> getAllClinicalAttributes(String projection, Integer pageSize, Integer pageNumber,
                                                      String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaClinicalAttributes();
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     ClinicalAttribute getClinicalAttribute(String studyId, String clinicalAttributeId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalAttribute> getAllClinicalAttributesInStudy(String studyId, String projection, Integer pageSize,
                                                             Integer pageNumber, String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaClinicalAttributesInStudy(String studyId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalAttribute> fetchClinicalAttributes(List<String> studyIds, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta fetchMetaClinicalAttributes(List<String> studyIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalAttributeCount> getClinicalAttributeCountsBySampleIds(List<String> studyIds, List<String> sampleIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalAttributeCount> getClinicalAttributeCountsBySampleListId(String sampleListId);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/ClinicalDataRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/ClinicalDataRepository.java
@@ -10,48 +10,48 @@ import java.util.List;
 
 public interface ClinicalDataRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalData> getAllClinicalDataOfSampleInStudy(String studyId, String sampleId, String attributeId,
                                                          String projection, Integer pageSize, Integer pageNumber,
                                                          String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaSampleClinicalData(String studyId, String sampleId, String attributeId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalData> getAllClinicalDataOfPatientInStudy(String studyId, String patientId, String attributeId,
                                                           String projection, Integer pageSize,
                                                           Integer pageNumber, String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaPatientClinicalData(String studyId, String patientId, String attributeId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalData> getAllClinicalDataInStudy(String studyId, String attributeId,
                                                  String clinicalDataType, String projection,
                                                  Integer pageSize, Integer pageNumber, String sortBy,
                                                  String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaAllClinicalData(String studyId, String attributeId, String clinicalDataType);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalData> fetchAllClinicalDataInStudy(String studyId, List<String> ids, List<String> attributeIds, 
                                                    String clinicalDataType, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta fetchMetaClinicalDataInStudy(String studyId, List<String> ids, List<String> attributeIds, 
                                           String clinicalDataType);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalData> fetchClinicalData(List<String> studyIds, List<String> ids, List<String> attributeIds,
                                          String clinicalDataType, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta fetchMetaClinicalData(List<String> studyIds, List<String> ids, List<String> attributeIds,
                                    String clinicalDataType);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalDataCount> fetchClinicalDataCounts(List<String> studyIds, List<String> sampleIds, List<String> attributeIds, 
         String clinicalDataType);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/ClinicalEventRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/ClinicalEventRepository.java
@@ -10,20 +10,20 @@ import java.util.List;
 
 public interface ClinicalEventRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalEvent> getAllClinicalEventsOfPatientInStudy(String studyId, String patientId, String projection,
                                                              Integer pageSize, Integer pageNumber, String sortBy,
                                                              String direction);
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaPatientClinicalEvents(String studyId, String patientId);
     
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalEventData> getDataOfClinicalEvents(List<Integer> clinicalEventIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<ClinicalEvent> getAllClinicalEventsInStudy(String studyId, String projection, Integer pageSize,
                                                     Integer pageNumber, String sortBy, String direction);
     
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaClinicalEvents(String studyId);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CopyNumberSegmentRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CopyNumberSegmentRepository.java
@@ -9,23 +9,23 @@ import java.util.List;
 
 public interface CopyNumberSegmentRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<CopyNumberSeg> getCopyNumberSegmentsInSampleInStudy(String studyId, String sampleId, String chromosome, String projection,
                                                              Integer pageSize, Integer pageNumber, String sortBy,
                                                              String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaCopyNumberSegmentsInSampleInStudy(String studyId, String sampleId, String chromosome);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Integer> fetchSamplesWithCopyNumberSegments(List<String> studyIds, List<String> sampleIds, String chromosome);
 	    
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<CopyNumberSeg> fetchCopyNumberSegments(List<String> studyIds, List<String> sampleIds, String chromosome, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta fetchMetaCopyNumberSegments(List<String> studyIds, List<String> sampleIds, String chromosome);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<CopyNumberSeg> getCopyNumberSegmentsBySampleListId(String studyId, String sampleListId, String chromosome, String projection);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CosmicCountRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CosmicCountRepository.java
@@ -5,7 +5,7 @@ import org.cbioportal.model.CosmicMutation;
 import org.springframework.cache.annotation.Cacheable;
 
 public interface CosmicCountRepository {
-    
-    @Cacheable("GeneralRepositoryCache")
+
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
 	List<CosmicMutation> fetchCosmicCountsByKeywords(List<String> keywords);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/DiscreteCopyNumberRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/DiscreteCopyNumberRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface DiscreteCopyNumberRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMolecularProfileBySampleListId(String molecularProfileId,
                                                                                         String sampleListId,
                                                                                         List<Integer> entrezGeneIds,
@@ -18,42 +18,42 @@ public interface DiscreteCopyNumberRepository {
                                                                                         String projection);
 
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaDiscreteCopyNumbersInMolecularProfileBySampleListId(String molecularProfileId, String sampleListId,
                                                                         List<Integer> entrezGeneIds,
                                                                         List<Integer> alterationTypes);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<DiscreteCopyNumberData> fetchDiscreteCopyNumbersInMolecularProfile(String molecularProfileId,
                                                                             List<String> sampleIds,
                                                                             List<Integer> entrezGeneIds,
                                                                             List<Integer> alterationTypes,
                                                                             String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMultipleMolecularProfiles(List<String> molecularProfileIds, 
                                                                                    List<String> sampleIds,
                                                                                    List<Integer> entrezGeneIds,
                                                                                    List<Integer> alterationTypes, 
                                                                                    String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta fetchMetaDiscreteCopyNumbersInMolecularProfile(String molecularProfileId, List<String> sampleIds,
                                                             List<Integer> entrezGeneIds, List<Integer> alterationTypes);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<CopyNumberCountByGene> getSampleCountByGeneAndAlterationAndSampleIds(String molecularProfileId,
                                                                               List<String> sampleIds,
                                                                               List<Integer> entrezGeneIds,
                                                                               List<Integer> alterations);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<CopyNumberCountByGene> getSampleCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                           List<String> sampleIds, 
                                                                           List<Integer> entrezGeneIds, 
                                                                           List<Integer> alterations);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<CopyNumberCountByGene> getPatientCountByGeneAndAlterationAndPatientIds(String molecularProfileId,
                                                                                 List<String> patientIds,
                                                                                 List<Integer> entrezGeneIds,

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenePanelRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenePanelRepository.java
@@ -11,29 +11,29 @@ import java.util.List;
 
 public interface GenePanelRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GenePanel> getAllGenePanels(String projection, Integer pageSize, Integer pageNumber, String sortBy,
                                      String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaGenePanels();
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     GenePanel getGenePanel(String genePanelId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GenePanel> fetchGenePanels(List<String> genePanelIds, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GenePanelData> getGenePanelData(String molecularProfileId, String sampleListId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GenePanelData> fetchGenePanelData(String molecularProfileId, List<String> sampleIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<String> molecularProfileIds, 
         List<String> sampleIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GenePanelToGene> getGenesOfPanels(List<String> genePanelIds);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GeneRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GeneRepository.java
@@ -41,37 +41,37 @@ import java.util.List;
 
 public interface GeneRepository {
 
-    @Cacheable("StaticRepositoryCacheOne")
+    @Cacheable(cacheNames = "StaticRepositoryCacheOne", condition = "@cacheEnabledConfig.getEnabled()")
     List<Gene> getAllGenes(String keyword, String alias, String projection, Integer pageSize, Integer pageNumber, String sortBy, 
                            String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaGenes(String keyword, String alias);
 
-    @Cacheable("StaticRepositoryCacheOne")
+    @Cacheable(cacheNames = "StaticRepositoryCacheOne", condition = "@cacheEnabledConfig.getEnabled()")
     Gene getGeneByEntrezGeneId(Integer entrezGeneId);
 
-    @Cacheable("StaticRepositoryCacheOne")
+    @Cacheable(cacheNames = "StaticRepositoryCacheOne", condition = "@cacheEnabledConfig.getEnabled()")
     Gene getGeneByHugoGeneSymbol(String hugoGeneSymbol);
 
-    @Cacheable("StaticRepositoryCacheOne")
+    @Cacheable(cacheNames = "StaticRepositoryCacheOne", condition = "@cacheEnabledConfig.getEnabled()")
     List<String> getAliasesOfGeneByEntrezGeneId(Integer entrezGeneId);
 
-    @Cacheable("StaticRepositoryCacheOne")
+    @Cacheable(cacheNames = "StaticRepositoryCacheOne", condition = "@cacheEnabledConfig.getEnabled()")
     List<String> getAliasesOfGeneByHugoGeneSymbol(String hugoGeneSymbol);
 
     // not cached because this is called only a single time, during @PostConstruct method of GeneServiceImpl
     List<GeneAlias> getAllAliases();
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Gene> fetchGenesByEntrezGeneIds(List<Integer> entrezGeneIds, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Gene> fetchGenesByHugoGeneSymbols(List<String> hugoGeneSymbols, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta fetchMetaGenesByEntrezGeneIds(List<Integer> entrezGeneIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta fetchMetaGenesByHugoGeneSymbols(List<String> hugoGeneSymbols);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenesetHierarchyRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenesetHierarchyRepository.java
@@ -9,12 +9,12 @@ import org.springframework.cache.annotation.Cacheable;
 
 public interface GenesetHierarchyRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
 	List<GenesetHierarchyInfo> getGenesetHierarchyParents(List<String> genesetIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
 	List<Geneset> getGenesetHierarchyGenesets(Integer nodeId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
 	List<GenesetHierarchyInfo> getGenesetHierarchySuperNodes(List<String> genesetIds);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenesetRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenesetRepository.java
@@ -10,18 +10,18 @@ import org.springframework.cache.annotation.Cacheable;
 
 public interface GenesetRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Geneset> getAllGenesets(String projection, Integer pageSize, Integer pageNumber);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaGenesets();
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     Geneset getGeneset(String genesetId);
     
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Geneset> fetchGenesets(List<String> genesetIds);
     
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Gene> getGenesByGenesetId(String genesetId);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
@@ -9,26 +9,26 @@ import org.springframework.cache.annotation.Cacheable;
 
 public interface MolecularDataRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     String getCommaSeparatedSampleIdsOfMolecularProfile(String molecularProfileId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<String> getCommaSeparatedSampleIdsOfMolecularProfiles(List<String> molecularProfileIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
                                                               String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     Iterable<GeneMolecularAlteration> getGeneMolecularAlterationsIterable(String molecularProfileId, List<Integer> entrezGeneIds,
                                                                           String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                                          List<Integer> entrezGeneIds,
                                                                                          String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GenesetMolecularAlteration> getGenesetMolecularAlterations(String molecularProfileId, List<String> genesetIds,
                                                                     String projection);
 

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularProfileRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularProfileRepository.java
@@ -9,38 +9,38 @@ import java.util.List;
 
 public interface MolecularProfileRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<MolecularProfile> getAllMolecularProfiles(String projection, Integer pageSize, Integer pageNumber, 
                                                    String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaMolecularProfiles();
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     MolecularProfile getMolecularProfile(String molecularProfileId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<MolecularProfile> getMolecularProfiles(List<String> molecularProfileIds, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaMolecularProfiles(List<String> molecularProfileIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<MolecularProfile> getAllMolecularProfilesInStudy(String studyId, String projection, Integer pageSize,
                                                           Integer pageNumber, String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaMolecularProfilesInStudy(String studyId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<MolecularProfile> getMolecularProfilesInStudies(List<String> studyIds, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaMolecularProfilesInStudies(List<String> studyIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<MolecularProfile> getMolecularProfilesReferredBy(String referringMolecularProfileId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<MolecularProfile> getMolecularProfilesReferringTo(String referredMolecularProfileId);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
@@ -11,53 +11,53 @@ import java.util.List;
 
 public interface MutationRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Mutation> getMutationsInMolecularProfileBySampleListId(String molecularProfileId, String sampleListId,
                                                                 List<Integer> entrezGeneIds, Boolean snpOnly,
                                                                 String projection, Integer pageSize, Integer pageNumber,
                                                                 String sortBy, String direction);
 
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     MutationMeta getMetaMutationsInMolecularProfileBySampleListId(String molecularProfileId, String sampleListId,
                                                                   List<Integer> entrezGeneIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
                                                            List<Integer> entrezGeneIds, String projection,
                                                            Integer pageSize, Integer pageNumber,
                                                            String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
                                                              List<Integer> entrezGeneIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Mutation> fetchMutationsInMolecularProfile(String molecularProfileId, List<String> sampleIds,
                                                     List<Integer> entrezGeneIds, Boolean snpOnly, String projection,
                                                     Integer pageSize, Integer pageNumber, String sortBy,
                                                     String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     MutationMeta fetchMetaMutationsInMolecularProfile(String molecularProfileId, List<String> sampleIds,
                                                       List<Integer> entrezGeneIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<MutationCountByGene> getSampleCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
                                                                         List<String> sampleIds,
                                                                         List<Integer> entrezGeneIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<MutationCountByGene> getSampleCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                         List<String> sampleIds,
                                                                         List<Integer> entrezGeneIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<MutationCountByGene> getPatientCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
                                                                          List<String> patientIds,
                                                                          List<Integer> entrezGeneIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     MutationCountByPosition getMutationCountByPosition(Integer entrezGeneId, Integer proteinPosStart, 
                                                        Integer proteinPosEnd);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/PatientRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/PatientRepository.java
@@ -9,29 +9,29 @@ import java.util.List;
 
 public interface PatientRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Patient> getAllPatients(String keyword, String projection, Integer pageSize, Integer pageNumber, String sortBy,
         String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaPatients(String keyword);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Patient> getAllPatientsInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber, 
                                         String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaPatientsInStudy(String studyId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     Patient getPatientInStudy(String studyId, String patientId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Patient> fetchPatients(List<String> studyIds, List<String> patientIds, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta fetchMetaPatients(List<String> studyIds, List<String> patientIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Patient> getPatientsOfSamples(List<String> studyIds, List<String> sampleIds);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SampleListRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SampleListRepository.java
@@ -10,29 +10,29 @@ import java.util.List;
 
 public interface SampleListRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<SampleList> getAllSampleLists(String projection, Integer pageSize, Integer pageNumber, String sortBy,
                                        String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaSampleLists();
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     SampleList getSampleList(String sampleListId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<SampleList> getSampleLists(List<String> sampleListIds, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<SampleList> getAllSampleListsInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber,
                                               String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaSampleListsInStudy(String studyId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<String> getAllSampleIdsInSampleList(String sampleListId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<SampleListToSampleId> getSampleListSampleIds(List<Integer> sampleListIds);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SampleRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SampleRepository.java
@@ -9,45 +9,45 @@ import java.util.List;
 
 public interface SampleRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Sample> getAllSamplesInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber,
                                       String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaSamplesInStudy(String studyId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Sample> getAllSamplesInStudies(List<String> studyIds, String projection, Integer pageSize, Integer pageNumber,
                                       String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     Sample getSampleInStudy(String studyId, String sampleId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Sample> getAllSamplesOfPatientInStudy(String studyId, String patientId, String projection, Integer pageSize,
                                                Integer pageNumber, String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaSamplesOfPatientInStudy(String studyId, String patientId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Sample> getAllSamplesOfPatientsInStudy(String studyId, List<String> patientIds, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Sample> getSamplesOfPatientsInMultipleStudies(List<String> studyIds, List<String> patientIds, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Sample> fetchSamples(List<String> studyIds, List<String> sampleIds, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Sample> fetchSamples(List<String> sampleListIds, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta fetchMetaSamples(List<String> studyIds, List<String> sampleIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta fetchMetaSamples(List<String> sampleListIds);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Sample> getSamplesByInternalIds(List<Integer> internalIds);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SignificantCopyNumberRegionRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SignificantCopyNumberRegionRepository.java
@@ -9,14 +9,14 @@ import org.springframework.cache.annotation.Cacheable;
 import java.util.List;
 
 public interface SignificantCopyNumberRegionRepository {
-    
-    @Cacheable("GeneralRepositoryCache")
+   
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Gistic> getSignificantCopyNumberRegions(String studyId, String projection, Integer pageSize, 
                                                  Integer pageNumber, String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaSignificantCopyNumberRegions(String studyId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GisticToGene> getGenesOfRegions(List<Long> gisticRoiIds);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SignificantlyMutatedGeneRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SignificantlyMutatedGeneRepository.java
@@ -9,10 +9,10 @@ import java.util.List;
 
 public interface SignificantlyMutatedGeneRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<MutSig> getSignificantlyMutatedGenes(String studyId, String projection, Integer pageSize, Integer pageNumber,
                                               String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaSignificantlyMutatedGenes(String studyId);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/StudyRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/StudyRepository.java
@@ -10,25 +10,25 @@ import java.util.List;
 
 public interface StudyRepository {
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<CancerStudy> getAllStudies(String keyword, String projection, Integer pageSize, Integer pageNumber,
                                     String sortBy, String direction);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta getMetaStudies(String keyword);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     CancerStudy getStudy(String studyId, String projection);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<CancerStudy> fetchStudies(List<String> studyIds, String projection);
     
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta fetchMetaStudies(List<String> studyIds);
     
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     CancerStudyTags getTags(String studyId);
 
-    @Cacheable("GeneralRepositoryCache")
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<CancerStudyTags> getTagsForMultipleStudies(List<String> studyIds);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/VariantCountRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/VariantCountRepository.java
@@ -7,8 +7,8 @@ import org.springframework.cache.annotation.Cacheable;
 import java.util.List;
 
 public interface VariantCountRepository {
-    
-    @Cacheable("GeneralRepositoryCache")
+
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<VariantCount> fetchVariantCounts(String molecularProfileId, List<Integer> entrezGeneIds, 
                                           List<String> keywords);
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java
@@ -38,7 +38,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 public class CustomEhCachingProvider extends EhcacheCachingProvider {
 
-    @Value("${ehcache.xml.configuration}")
+    @Value("${ehcache.xml_configuration}")
     private String xmlConfiguration;
 
     @Override

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomKeyGenerator.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomKeyGenerator.java
@@ -33,16 +33,24 @@
 package org.cbioportal.persistence.util;
 
 import java.lang.reflect.Method;
+import org.cbioportal.persistence.CacheEnabledConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.util.StringUtils;
 
 public class CustomKeyGenerator implements KeyGenerator {
 
+    @Autowired
+    private CacheEnabledConfig cacheEnabledConfig;
+
     private static final Logger LOG = LoggerFactory.getLogger(CustomKeyGenerator.class);
 
     public Object generate(Object target, Method method, Object... params) {
+        if (!cacheEnabledConfig.isEnabled()) {
+            return "";
+        }
         String key = target.getClass().getSimpleName() + "_"
             + method.getName() + "_"
             + StringUtils.arrayToDelimitedString(params, "_");

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/EhCacheStatistics.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/EhCacheStatistics.java
@@ -37,7 +37,6 @@ import org.ehcache.config.ResourceType;
 import org.ehcache.impl.internal.statistics.DefaultStatisticsService;
 
 import org.springframework.stereotype.Component;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.Map;
 import javax.annotation.PostConstruct;
@@ -49,9 +48,6 @@ public class EhCacheStatistics {
 
     private static double BYTES_IN_MB = 1048576.0;
     private static double BYTES_IN_GB = 1073741824.0;
-
-    @Value("${ehcache.xml.configuration}")
-    private String xmlConfiguration;
 
     private javax.cache.CacheManager cacheManager;
     private DefaultStatisticsService statisticsService;

--- a/persistence/persistence-api/src/main/resources/applicationContext-ehcache.xml
+++ b/persistence/persistence-api/src/main/resources/applicationContext-ehcache.xml
@@ -11,6 +11,10 @@
 
     <cache:annotation-driven cache-manager="cacheManager" key-generator="customKeyGenerator"/>
 
+    <bean id="cacheEnabledConfig" class="org.cbioportal.persistence.CacheEnabledConfig">
+        <constructor-arg value="${ehcache.cache_enabled}"/>
+    </bean>
+
     <bean id="customEhCacheProvider" class="org.cbioportal.persistence.util.CustomEhCachingProvider"/>
 
     <bean id="getCacheManager" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">

--- a/persistence/persistence-api/src/main/resources/ehcache-disk-only.xml
+++ b/persistence/persistence-api/src/main/resources/ehcache-disk-only.xml
@@ -9,10 +9,10 @@
     http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
 
     <ehcache:service>
-      <jcache:defaults enable-management="true" enable-statistics="${ehcache.enable.statistics}"/>
+      <jcache:defaults enable-management="true" enable-statistics="${ehcache.statistics_enabled}"/>
     </ehcache:service>
 
-    <ehcache:persistence directory="${ehcache.persistence.path}"/>
+    <ehcache:persistence directory="${ehcache.persistence_path}"/>
 
     <ehcache:heap-store>
       <ehcache:max-object-graph-size>9223372036854775807</ehcache:max-object-graph-size><!-- using Long.MAX_VALUE -->

--- a/persistence/persistence-api/src/main/resources/ehcache-heap-only.xml
+++ b/persistence/persistence-api/src/main/resources/ehcache-heap-only.xml
@@ -9,7 +9,7 @@
     http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
 
     <ehcache:service>
-      <jcache:defaults enable-management="true" enable-statistics="${ehcache.enable.statistics}"/>
+      <jcache:defaults enable-management="true" enable-statistics="${ehcache.statistics_enabled}"/>
     </ehcache:service>
 
     <ehcache:heap-store>

--- a/persistence/persistence-api/src/main/resources/ehcache-mixed.xml
+++ b/persistence/persistence-api/src/main/resources/ehcache-mixed.xml
@@ -9,10 +9,10 @@
     http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
 
     <ehcache:service>
-      <jcache:defaults enable-management="true" enable-statistics="${ehcache.enable.statistics}"/>
+      <jcache:defaults enable-management="true" enable-statistics="${ehcache.statistics_enabled}"/>
     </ehcache:service>
 
-    <ehcache:persistence directory="${ehcache.persistence.path}"/>
+    <ehcache:persistence directory="${ehcache.persistence_path}"/>
 
     <ehcache:heap-store>
       <ehcache:max-object-graph-size>9223372036854775807</ehcache:max-object-graph-size><!-- using Long.MAX_VALUE -->

--- a/service/src/main/java/org/cbioportal/service/impl/CacheStatisticsServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CacheStatisticsServiceImpl.java
@@ -22,7 +22,7 @@ public class CacheStatisticsServiceImpl implements CacheStatisticsService {
     @Autowired
     public EhCacheStatistics ehCacheStatistics;
 
-    @Value("${cache.statistics.endpoint.enabled:false}")
+    @Value("${cache.statistics_endpoint_enabled:false}")
     public boolean cacheStatisticsEndpointEnabled;
     
     private void checkIfCacheStatisticsEndpointEnabled() {

--- a/service/src/main/java/org/cbioportal/service/impl/ClinicalAttributeServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ClinicalAttributeServiceImpl.java
@@ -33,7 +33,7 @@ public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
         
         List<ClinicalAttribute> clinicalAttributes = clinicalAttributeRepository.getAllClinicalAttributes(projection, pageSize, pageNumber, sortBy,
                                                                                                           direction);
-        // copy the list before returning so @PostFilter doesn't taint the list stored in the mybatis second-level cache
+        // copy the list before returning so @PostFilter doesn't taint the list stored in the persistence layer cache
         return (AUTHENTICATE.equals("false")) ? clinicalAttributes : new ArrayList<ClinicalAttribute>(clinicalAttributes);
     }
 

--- a/service/src/main/java/org/cbioportal/service/impl/MolecularProfileServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularProfileServiceImpl.java
@@ -33,7 +33,7 @@ public class MolecularProfileServiceImpl implements MolecularProfileService {
                                                           String sortBy, String direction) {
 
         List<MolecularProfile> molecularProfiles = molecularProfileRepository.getAllMolecularProfiles(projection, pageSize, pageNumber, sortBy, direction);
-        // copy the list before returning so @PostFilter doesn't taint the list stored in the mybatis second-level cache
+        // copy the list before returning so @PostFilter doesn't taint the list stored in the persistence layer cache
         return (AUTHENTICATE.equals("false")) ? molecularProfiles : new ArrayList<MolecularProfile>(molecularProfiles);
     }
 

--- a/service/src/main/java/org/cbioportal/service/impl/PatientServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/PatientServiceImpl.java
@@ -31,7 +31,7 @@ public class PatientServiceImpl implements PatientService {
             String sortBy, String direction) {
         
         List<Patient> patients = patientRepository.getAllPatients(keyword, projection, pageSize, pageNumber, sortBy, direction);
-        // copy the list before returning so @PostFilter doesn't taint the list stored in the mybatis second-level cache
+        // copy the list before returning so @PostFilter doesn't taint the list stored in the persistence layer cache
         return (AUTHENTICATE.equals("false")) ? patients : new ArrayList<Patient>(patients);
     }
 

--- a/service/src/main/java/org/cbioportal/service/impl/SampleListServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleListServiceImpl.java
@@ -35,7 +35,7 @@ public class SampleListServiceImpl implements SampleListService {
         
         List<SampleList> sampleListsFromRepo = sampleListRepository.getAllSampleLists(projection, pageSize, pageNumber, sortBy,
                                                                                       direction);
-        // copy the list before returning so @PostFilter doesn't taint the list stored in the mybatis second-level cache
+        // copy the list before returning so @PostFilter doesn't taint the list stored in the persistence layer cache
         List<SampleList> sampleLists = (AUTHENTICATE.equals("false")) ? sampleListsFromRepo : new ArrayList<SampleList>(sampleListsFromRepo);
         
         if(projection.equals("DETAILED")) {

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -230,13 +230,14 @@ oncoprint.hotspots.default=true
 
 # Custom gene sets
 # querypage.setsofgenes.location=file:/<path>
-#
-# Disable cache (for non authorized portals this can sometimes avoid running
-# out of memory with relatively little performance loss)
-# mybatis.cache.enabled=false
-ehcache.xml.configuration=/ehcache-mixed.xml
-ehcache.enable.statistics=true
-ehcache.persistence.path=
+
+# to disable use of Ehcache, set ehcache.cache.enabled to false, use ehcache.xml_configuration=/ehcache-heap-only.xml with ehcache.general_repository_cache.max_bytes_heap=1 with units=B
+ehcache.cache_enabled=true
+ehcache.xml_configuration=/ehcache-mixed.xml
+ehcache.persistence_path=/tmp
+ehcache.statistics_enabled=true
+# Enable cache statistics endpoint for Ehcache monitoring
+cache.statistics_endpoint_enabled=false
 
 # size allocation preferences for the general persistence cache
 ehcache.general_repository_cache.max_bytes_heap=1021
@@ -276,6 +277,3 @@ matchminer.token=
 # see: https://github.com/vy/hrrs/blob/master/README.md
 #hrrs.logging.filepath=
 #hrrs.enable.logging=false
-
-# Enable cache statistics endpoint for Ehcache monitoring
-cache.statistics.endpoint.enabled=false


### PR DESCRIPTION

# What? Why?
Ability to disable Ehcache caching requested

Changes proposed in this pull request:
- CacheDisableSetting bean added to hold setting
    - provide verbatim setting value, inverse, or boolean
- Add condition attribute to cacheable annotations, which will omit caching depending on the CacheDisableSetting
- Add check for disabled caching to CustomKeyGenerator (no key computed if caching is disabled)

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.
- [ ] If this is a bug fix, create a unit and/or e2e test, or explain why that cannnot be done.