### PR TITLE
Exclude fusions from StudyViewController call to get alteration counts by gene

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
@@ -40,7 +40,8 @@ public interface MutationRepository {
 
     List<MutationCountByGene> getSampleCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                         List<String> sampleIds,
-                                                                        List<Integer> entrezGeneIds);
+                                                                        List<Integer> entrezGeneIds,
+                                                                        Boolean excludeFusions);
 
     List<MutationCountByGene> getPatientCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
                                                                          List<String> patientIds,

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
@@ -21,10 +21,10 @@ public interface MutationRepository {
     List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
                                                            List<Integer> entrezGeneIds, String projection,
                                                            Integer pageSize, Integer pageNumber,
-                                                           String sortBy, String direction);
+                                                           String sortBy, String direction, Boolean excludeFusions);
 
     MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
-                                                             List<Integer> entrezGeneIds);
+                                                             List<Integer> entrezGeneIds, Boolean excludeFusions);
 
     List<Mutation> fetchMutationsInMolecularProfile(String molecularProfileId, List<String> sampleIds,
                                                     List<Integer> entrezGeneIds, Boolean snpOnly, String projection,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
@@ -39,7 +39,8 @@ public interface MutationMapper {
     List<MutationCountByGene> getSampleCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                         List<String> sampleIds,
                                                                         List<Integer> entrezGeneIds,
-                                                                        Boolean snpOnly);
+                                                                        Boolean snpOnly,
+                                                                        Boolean excludeFusions);
 
     List<MutationCountByGene> getPatientCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
                                                                          List<String> patientIds,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
@@ -19,10 +19,11 @@ public interface MutationMapper {
     List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
                                                            List<Integer> entrezGeneIds, Boolean snpOnly,
                                                            String projection, Integer limit, Integer offset,
-                                                           String sortBy, String direction);
+                                                           String sortBy, String direction, Boolean excludeFusions);
 
     MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
-                                                             List<Integer> entrezGeneIds, Boolean snpOnly);
+                                                             List<Integer> entrezGeneIds, Boolean snpOnly,
+                                                             Boolean excludeFusions);
 
     List<Mutation> getMutationsBySampleIds(String molecularProfileId, List<String> sampleIds, 
                                            List<Integer> entrezGeneIds, Boolean snpOnly, String projection, 

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
@@ -41,19 +41,21 @@ public class MutationMyBatisRepository implements MutationRepository {
     public List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
                                                                   List<String> sampleIds, List<Integer> entrezGeneIds, 
                                                                   String projection, Integer pageSize, 
-                                                                  Integer pageNumber, String sortBy, String direction) {
+                                                                  Integer pageNumber, String sortBy, String direction,
+                                                                  Boolean excludeFusions) {
 
         return mutationMapper.getMutationsInMultipleMolecularProfiles(molecularProfileIds, sampleIds, entrezGeneIds, 
-            null, projection, pageSize, offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction);
+            null, projection, pageSize, offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction, excludeFusions);
     }
 
     @Override
     public MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                     List<String> sampleIds, 
-                                                                    List<Integer> entrezGeneIds) {
+                                                                    List<Integer> entrezGeneIds,
+                                                                    Boolean excludeFusions) {
 
         return mutationMapper.getMetaMutationsInMultipleMolecularProfiles(molecularProfileIds, sampleIds, entrezGeneIds,
-            null);
+            null, excludeFusions);
     }
 
     @Override

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
@@ -84,9 +84,9 @@ public class MutationMyBatisRepository implements MutationRepository {
 
 	@Override
 	public List<MutationCountByGene> getSampleCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
-			List<String> sampleIds, List<Integer> entrezGeneIds) {
+			List<String> sampleIds, List<Integer> entrezGeneIds, Boolean excludeFusions) {
         
-        return mutationMapper.getSampleCountInMultipleMolecularProfiles(molecularProfileIds, sampleIds, entrezGeneIds, null);
+        return mutationMapper.getSampleCountInMultipleMolecularProfiles(molecularProfileIds, sampleIds, entrezGeneIds, null, excludeFusions);
 	}
 
     @Override

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
@@ -147,6 +147,9 @@
                 AND mutation_event.REFERENCE_ALLELE IN ('A','T','C','G')
                 AND mutation_event.TUMOR_SEQ_ALLELE IN ('A','T','C','G')
             </if>
+            <if test="excludeFusions != null and excludeFusions == true">
+                AND mutation_event.MUTATION_TYPE  <![CDATA[ <> ]]> 'Fusion'
+            </if>
         </where>
     </sql>
 
@@ -264,6 +267,9 @@
         INNER JOIN genetic_profile ON mutation.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
         INNER JOIN sample ON mutation.SAMPLE_ID = sample.INTERNAL_ID
         INNER JOIN gene ON mutation.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
+        <if test="excludeFusions != null and excludeFusions == true">
+            INNER JOIN mutation_event ON mutation_event.MUTATION_EVENT_ID = mutation.MUTATION_EVENT_ID
+        </if>
         <include refid="whereInMultipleMolecularProfiles"/>
         GROUP BY mutation.ENTREZ_GENE_ID
     </select>

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepositoryTest.java
@@ -219,7 +219,7 @@ public class MutationMyBatisRepositoryTest {
         sampleIds.add("TCGA-A1-A0SH-01");
         
         List<Mutation> result = mutationMyBatisRepository.getMutationsInMultipleMolecularProfiles(molecularProfileIds, 
-            sampleIds, null, "SUMMARY", null, null, null, null);
+            sampleIds, null, "SUMMARY", null, null, null, null, false);
         
         Assert.assertEquals(3, result.size());
         Mutation mutation1 = result.get(0);
@@ -245,7 +245,7 @@ public class MutationMyBatisRepositoryTest {
         sampleIds.add("TCGA-A1-A0SH-01");
         
         MutationMeta result = mutationMyBatisRepository.getMetaMutationsInMultipleMolecularProfiles(molecularProfileIds,
-            sampleIds, null);
+            sampleIds, null, false);
 
         Assert.assertEquals((Integer) 3, result.getTotalCount());
         Assert.assertEquals((Integer) 2, result.getSampleCount());

--- a/service/src/main/java/org/cbioportal/service/MutationService.java
+++ b/service/src/main/java/org/cbioportal/service/MutationService.java
@@ -46,7 +46,8 @@ public interface MutationService {
     List<MutationCountByGene> getSampleCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                         List<String> sampleIds,
                                                                         List<Integer> entrezGeneIds,
-                                                                        boolean includeFrequency);
+                                                                        boolean includeFrequency,
+                                                                        boolean excludeFusions);
 
     List<MutationCountByGene> getPatientCountByEntrezGeneIdsAndSampleIds(String molecularProfileId,
                                                                         List<String> patientIds,

--- a/service/src/main/java/org/cbioportal/service/MutationService.java
+++ b/service/src/main/java/org/cbioportal/service/MutationService.java
@@ -26,7 +26,7 @@ public interface MutationService {
                                                            String sortBy, String direction);
 
     MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
-                                                             List<Integer> entrezGeneIds);
+                                                             List<Integer> entrezGeneIds, Boolean excludeFusions);
 
     List<Mutation> fetchMutationsInMolecularProfile(String molecularProfileId, List<String> sampleIds,
                                                     List<Integer> entrezGeneIds, Boolean snpOnly, String projection,

--- a/service/src/main/java/org/cbioportal/service/impl/MutationEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationEnrichmentServiceImpl.java
@@ -46,7 +46,7 @@ public class MutationEnrichmentServiceImpl implements MutationEnrichmentService 
                                     sampleIds.add(molecularProfileCase.getCaseId());
                                 });
                                 List<MutationCountByGene> mutationCounts = mutationService
-                                        .getSampleCountInMultipleMolecularProfiles(molecularProfileIds, sampleIds, null, false);
+                                        .getSampleCountInMultipleMolecularProfiles(molecularProfileIds, sampleIds, null, false, false);
         
                                 return mutationCounts;
                             }));

--- a/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
@@ -121,14 +121,14 @@ public class MutationServiceImpl implements MutationService {
 
     @Override
 	public List<MutationCountByGene> getSampleCountInMultipleMolecularProfiles(List<String> molecularProfileIds,
-			List<String> sampleIds, List<Integer> entrezGeneIds, boolean includeFrequency) {
+			List<String> sampleIds, List<Integer> entrezGeneIds, boolean includeFrequency, boolean excludeFusions) {
         
         List<MutationCountByGene> result;
         if (molecularProfileIds.isEmpty()) {
             result = Collections.emptyList();
         } else {
             result = mutationRepository.getSampleCountInMultipleMolecularProfiles(
-                molecularProfileIds, sampleIds, entrezGeneIds);
+                molecularProfileIds, sampleIds, entrezGeneIds, excludeFusions);
             if (includeFrequency) {
                 profiledSamplesCounter.calculate(molecularProfileIds, sampleIds, result);
             }

--- a/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
@@ -64,7 +64,7 @@ public class MutationServiceImpl implements MutationService {
                                                                   Integer pageNumber, String sortBy, String direction) {
 
         List<Mutation> mutationList = mutationRepository.getMutationsInMultipleMolecularProfiles(molecularProfileIds,
-            sampleIds, entrezGeneIds, projection, pageSize, pageNumber, sortBy, direction);
+            sampleIds, entrezGeneIds, projection, pageSize, pageNumber, sortBy, direction, false);
 
         mutationList.forEach(mutation -> chromosomeCalculator.setChromosome(mutation.getGene()));
         return mutationList;
@@ -73,10 +73,11 @@ public class MutationServiceImpl implements MutationService {
     @Override
     public MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
                                                                     List<String> sampleIds, 
-                                                                    List<Integer> entrezGeneIds) {
+                                                                    List<Integer> entrezGeneIds,
+                                                                    Boolean excludeFusions) {
 
         return mutationRepository.getMetaMutationsInMultipleMolecularProfiles(molecularProfileIds, sampleIds,
-            entrezGeneIds);
+            entrezGeneIds, false);
     }
 
     @Override

--- a/service/src/test/java/org/cbioportal/service/impl/MutationEnrichmentServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MutationEnrichmentServiceImplTest.java
@@ -70,7 +70,7 @@ public class MutationEnrichmentServiceImplTest extends BaseServiceImplTest {
                     });
 
             Mockito.when(mutationService.getSampleCountInMultipleMolecularProfiles(new ArrayList<>(molecularProfileIds),
-                    new ArrayList<>(sampleIds), null, false)).thenReturn(mutationSampleCountByGeneList);
+                    new ArrayList<>(sampleIds), null, false, false)).thenReturn(mutationSampleCountByGeneList);
         }
 
         List<AlterationEnrichment> expectedAlterationEnrichments = new ArrayList<>();

--- a/service/src/test/java/org/cbioportal/service/impl/MutationServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MutationServiceImplTest.java
@@ -104,7 +104,7 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
 
         Mockito.when(mutationRepository.getMutationsInMultipleMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID), 
             Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, 
-            DIRECTION)).thenReturn(expectedMutationList);
+            DIRECTION, false)).thenReturn(expectedMutationList);
         Mockito.doAnswer(invocationOnMock -> {
             ((Gene) invocationOnMock.getArguments()[0]).setChromosome("19");
             return null;
@@ -123,9 +123,9 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
 
         MutationMeta expectedMutationMeta = new MutationMeta();
         Mockito.when(mutationRepository.getMetaMutationsInMultipleMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID),
-            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1))).thenReturn(expectedMutationMeta);
+            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), false)).thenReturn(expectedMutationMeta);
         MutationMeta result = mutationService.getMetaMutationsInMultipleMolecularProfiles(
-            Arrays.asList(MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1));
+            Arrays.asList(MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), false);
 
         Assert.assertEquals(expectedMutationMeta, result);
     }

--- a/web/src/main/java/org/cbioportal/web/MutationController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationController.java
@@ -181,14 +181,14 @@ public class MutationController {
             if (interceptedMutationMultipleStudyFilter.getMolecularProfileIds() != null) {
                 mutationMeta = mutationService.getMetaMutationsInMultipleMolecularProfiles(
                     interceptedMutationMultipleStudyFilter.getMolecularProfileIds(), null,
-                    interceptedMutationMultipleStudyFilter.getEntrezGeneIds());
+                    interceptedMutationMultipleStudyFilter.getEntrezGeneIds(), false);
             } else {
 
                 List<String> molecularProfileIds = new ArrayList<>();
                 List<String> sampleIds = new ArrayList<>();
                 extractMolecularProfileAndSampleIds(interceptedMutationMultipleStudyFilter, molecularProfileIds, sampleIds);
                 mutationMeta = mutationService.getMetaMutationsInMultipleMolecularProfiles(molecularProfileIds,
-                    sampleIds, interceptedMutationMultipleStudyFilter.getEntrezGeneIds());
+                    sampleIds, interceptedMutationMultipleStudyFilter.getEntrezGeneIds(), false);
             }
             responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, mutationMeta.getTotalCount().toString());
             responseHeaders.add(HeaderKeyConstants.SAMPLE_COUNT, mutationMeta.getSampleCount().toString());

--- a/web/src/main/java/org/cbioportal/web/StudyViewController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyViewController.java
@@ -205,7 +205,7 @@ public class StudyViewController {
             List<String> sampleIds = new ArrayList<>();
             studyViewFilterUtil.extractStudyAndSampleIds(filteredSampleIdentifiers, studyIds, sampleIds);
             result = mutationService.getSampleCountInMultipleMolecularProfiles(molecularProfileService
-                .getFirstMutationProfileIds(studyIds, sampleIds), sampleIds, null, true);
+                .getFirstMutationProfileIds(studyIds, sampleIds), sampleIds, null, true, true);
             result.sort((a, b) -> b.getNumberOfAlteredCases() - a.getNumberOfAlteredCases());
             List<String> distinctStudyIds = studyIds.stream().distinct().collect(Collectors.toList());
             if (distinctStudyIds.size() == 1 && !result.isEmpty()) {

--- a/web/src/test/java/org/cbioportal/web/StudyViewControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StudyViewControllerTest.java
@@ -265,7 +265,7 @@ public class StudyViewControllerTest {
         mutationCounts.add(mutationCount2);
 
         Mockito.when(mutationService.getSampleCountInMultipleMolecularProfiles(Mockito.anyListOf(String.class), 
-            Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyBoolean())).thenReturn(mutationCounts);
+            Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), Mockito.anyBoolean())).thenReturn(mutationCounts);
 
         StudyViewFilter studyViewFilter = new StudyViewFilter();
         studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));


### PR DESCRIPTION
# What? Why?
The calculated frequencies in the mutated genes table also counted fusion events. 

Changes proposed in this pull request:
This PR excludes fusion events from the calculated frequencies / alteration counts by gene on the study view page mutated genes table. It does not affect the CNA genes table on this page. 

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.
- [ ] If this is a bug fix, create a unit and/or e2e test, or explain why that cannot be done.

# screenshots

## mutated genes table with fusions
![mutated-genes-with-fusions](https://user-images.githubusercontent.com/15623749/63524233-a52a6380-c4c9-11e9-882c-03b6c0cddb63.png)

## mutated genes table without fusions
![mutated-genes-no-fusions](https://user-images.githubusercontent.com/15623749/63524250-ac517180-c4c9-11e9-8a7f-eded9d423bd8.png)


Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>