### PR TITLE
Remove unused reference to GENOME_BUILD

### DIFF
--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -24,7 +24,7 @@ MULTI_REFERENCE_GENOME_SUPPORT_MIGRATION_STEP = (2,11,0)
 class PortalProperties(object):
     """ Properties object class, just has fields for db conn """
 
-    def __init__(self, database_host, database_name, database_user, database_pw, genome_build):
+    def __init__(self, database_host, database_name, database_user, database_pw):
         # default port:
         self.database_port = 3306
         # if there is a port added to the host name, split and use this one:
@@ -96,8 +96,7 @@ def get_portal_properties(properties_filename):
     return PortalProperties(properties[DATABASE_HOST],
                             properties[DATABASE_NAME],
                             properties[DATABASE_USER],
-                            properties[DATABASE_PW],
-                            properties[GENOME_BUILD])
+                            properties[DATABASE_PW])
 
 def get_db_version(cursor):
     """ gets the version number of the database """


### PR DESCRIPTION
# What? Why?
correct error in recent #6589 merge

remove class constructor argument that is no longer used

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.
- [ ] If this is a bug fix, create a unit and/or e2e test, or explain why that cannnot be done.

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [GifGrabber](http://www.gifgrabber.com/).
