### PR TITLE
make dev clear button blue

### DIFF
--- a/portal/src/main/webapp/js/src/load-frontend.js
+++ b/portal/src/main/webapp/js/src/load-frontend.js
@@ -15,7 +15,7 @@ function showFrontendPopup(url) {
         newDiv.innerHTML = '<div style="">' +
             '<div class="alert alert-warning">' +
             '<button type="button" class="close" data-dismiss="alert">&times;</button>' +
-            'cbioportal-frontend dev mode, using ' + url + '&nbsp;<a onclick="javascript:clearDevState();window.location.reload()">clear</a>' +
+            'cbioportal-frontend dev mode, using ' + url + '&nbsp;<a href="" onclick="javascript:clearDevState();window.location.reload()">clear</a>' +
             '</div>' +
             '</div>';
         newDiv.onclick=function(){


### PR DESCRIPTION
when pointing to a non-existent frontend, the clear button is not blue, so it's not obvious one can click on it