### PR TITLE
fix bug in context loading for scripts module

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/SpringUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/SpringUtil.java
@@ -64,7 +64,7 @@ public class SpringUtil
     public static synchronized void initDataSource()
     {
         if (SpringUtil.context == null) {
-            context = new ClassPathXmlApplicationContext("classpath:applicationContext-business.xml");
+            context = new ClassPathXmlApplicationContext("classpath:applicationContext-ehcache.xml", "classpath:applicationContext-business.xml");
         }
     }
 


### PR DESCRIPTION
# What? Why?
Circle-ci tests were failing during database setup operations (in a call to ImportGenePanel).
This is due to some dependency on the persistence-api layer from the scripts module, requiring beans defined in applicationContext-ehcache.xml to be available.

Changes proposed in this pull request:
- added parse of applicationContext-ehcache.xml in SpringUtil class.
- SpringUtil must provide applicationContext-ehcache.xml beans for some import functionality (e.g. ImportGenePanel)

Co-authored-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
Co-authored-by: Manda Wilson <1458628+mandawilson@users.noreply.github.com>

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.
- [ ] If this is a bug fix, create a unit and/or e2e test, or explain why that cannnot be done.
