### PR TITLE
Add proper handling of access control for Treatments API

### DIFF
--- a/web/src/main/java/org/cbioportal/web/TreatmentDataController.java
+++ b/web/src/main/java/org/cbioportal/web/TreatmentDataController.java
@@ -65,7 +65,7 @@ public class TreatmentDataController {
 	@Autowired
     private TreatmentDataService treatmentDataService;
 
-    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfile', 'read')")    
+    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfileId', 'read')")
     @RequestMapping(value = "/genetic-profiles/{geneticProfileId}/treatment-genetic-data/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch treatment \"genetic data\" items (treatment response values) by profile Id, treatment Ids and sample Ids")


### PR DESCRIPTION
# What? Why?
Fixes #6623
API requests to /api/treatments are failing due to missing computation of involved cancer studies

Changes proposed in this pull request:
- handle TreatmentFilter in InvolvedCancerStudyExtractorInterceptor
- pass involved cancer studies to CancerStudyPermissionEvaluator

# Checks
- [ ] Runs on Heroku.
- [ ] Follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Follows the [Google Style Guide](https://github.com/google/styleguide).
- [ ] If this is a feature, the PR is to rc. If this is a bug fix, the PR is to master.
- [ ] If this is a bug fix, create a unit and/or e2e test, or explain why that cannnot be done.