### PR TITLE
Quick Search For Samples

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SampleRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SampleRepository.java
@@ -8,6 +8,11 @@ import org.springframework.cache.annotation.Cacheable;
 import java.util.List;
 
 public interface SampleRepository {
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    List<Sample> getAllSamples(String keyword, String projection, Integer pageSize,
+                               Integer pageNumber, String sort, String direction);
+
+    BaseMeta getMetaSamples(String keyword);
 
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Sample> getAllSamplesInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/SampleMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/SampleMapper.java
@@ -7,12 +7,12 @@ import java.util.List;
 
 public interface SampleMapper {
 
-    List<Sample> getSamples(List<String> studyIds, String patientId, List<String> sampleIds, String projection, 
-                            Integer limit, Integer offset, String sortBy, String direction);
+    List<Sample> getSamples(List<String> studyIds, String patientId, List<String> sampleIds, String keyword, 
+                            String projection, Integer limit, Integer offset, String sortBy, String direction);
 
     List<Sample> getSamplesBySampleListIds(List<String> sampleListIds, String projection);
 
-    BaseMeta getMetaSamples(List<String> studyIds, String patientId, List<String> sampleIds);
+    BaseMeta getMetaSamples(List<String> studyIds, String patientId, List<String> sampleIds, String keyword);
 
     BaseMeta getMetaSamplesBySampleListIds(List<String> sampleListIds);
 

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepository.java
@@ -20,23 +20,35 @@ public class SampleMyBatisRepository implements SampleRepository {
     private OffsetCalculator offsetCalculator;
 
     @Override
+    public List<Sample> getAllSamples(String keyword, String projection, Integer pageSize, Integer pageNumber, String sort, String direction) {
+        
+        return sampleMapper.getSamples(null, null, null, keyword, projection, pageSize,
+            offsetCalculator.calculate(pageSize, pageNumber), sort, direction);
+    }
+
+    @Override
+    public BaseMeta getMetaSamples(String keyword) {
+        return sampleMapper.getMetaSamples(null, null, null, keyword);
+    }
+
+    @Override
     public List<Sample> getAllSamplesInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber,
                                              String sortBy, String direction) {
 
-        return sampleMapper.getSamples(Arrays.asList(studyId), null, null, projection, pageSize,
+        return sampleMapper.getSamples(Arrays.asList(studyId), null, null, null, projection, pageSize,
                 offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction);
     }
 
     @Override
     public BaseMeta getMetaSamplesInStudy(String studyId) {
 
-        return sampleMapper.getMetaSamples(Arrays.asList(studyId), null, null);
+        return sampleMapper.getMetaSamples(Arrays.asList(studyId), null, null, null);
     }
 
     @Override
 	public List<Sample> getAllSamplesInStudies(List<String> studyIds, String projection, Integer pageSize,
 			Integer pageNumber, String sortBy, String direction) {
-        return sampleMapper.getSamples(studyIds, null, null, projection, pageSize, 
+        return sampleMapper.getSamples(studyIds, null, null, null, projection, pageSize, 
             offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction);
     }
     
@@ -51,14 +63,14 @@ public class SampleMyBatisRepository implements SampleRepository {
                                                       Integer pageSize, Integer pageNumber, String sortBy,
                                                       String direction) {
 
-        return sampleMapper.getSamples(Arrays.asList(studyId), patientId, null, projection, pageSize,
-                offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction);
+        return sampleMapper.getSamples(Arrays.asList(studyId), patientId, null, null, projection,
+            pageSize, offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction);
     }
 
     @Override
     public BaseMeta getMetaSamplesOfPatientInStudy(String studyId, String patientId) {
 
-        return sampleMapper.getMetaSamples(Arrays.asList(studyId), patientId, null);
+        return sampleMapper.getMetaSamples(Arrays.asList(studyId), patientId, null, null);
     }
 
     @Override
@@ -77,7 +89,8 @@ public class SampleMyBatisRepository implements SampleRepository {
     @Override
     public List<Sample> fetchSamples(List<String> studyIds, List<String> sampleIds, String projection) {
 
-        return sampleMapper.getSamples(studyIds, null, sampleIds, projection, 0, 0, null, null);
+        return sampleMapper.getSamples(studyIds, null, sampleIds, null,
+            projection, 0, 0, null, null);
     }
 
     @Override
@@ -89,7 +102,7 @@ public class SampleMyBatisRepository implements SampleRepository {
     @Override
     public BaseMeta fetchMetaSamples(List<String> studyIds, List<String> sampleIds) {
 
-        return sampleMapper.getMetaSamples(studyIds, null, sampleIds);
+        return sampleMapper.getMetaSamples(studyIds, null, sampleIds, null);
     }
 
     @Override

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/PatientMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/PatientMapper.xml
@@ -39,6 +39,8 @@
             <if test="keyword != null">
                 <foreach item="item" collection="keyword.split(' ')" open="(" separator=") AND (" close=")">
                     patient.STABLE_ID like CONCAT('%', #{item}, '%')
+                    OR
+                    sample.STABLE_ID like CONCAT('%', #{item}, '%')
                 </foreach>
             </if>
         </where>
@@ -50,6 +52,9 @@
             <property name="prefix" value=""/>
         </include>
         <include refid="from"/>
+        <if test="keyword != null">
+            INNER JOIN sample ON patient.INTERNAL_ID = sample.PATIENT_ID
+        </if>
         <include refid="where"/>
         <if test="sortBy != null and projection != 'ID' and keyword == null">
             ORDER BY ${sortBy} ${direction}
@@ -69,6 +74,9 @@
         SELECT
         COUNT(*) AS totalCount
         <include refid="from"/>
+        <if test="keyword != null">
+            INNER JOIN sample ON patient.INTERNAL_ID = sample.PATIENT_ID
+        </if>
         <include refid="where"/>
     </select>
 

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleMapper.xml
@@ -31,7 +31,7 @@
 
     <sql id="where">
         <where>
-            <if test="sampleIds == null">
+            <if test="sampleIds == null and studyIds != null">
                 cancer_study.CANCER_STUDY_IDENTIFIER IN
                 <foreach item="item" collection="studyIds" open="(" separator="," close=")">
                     #{item}
@@ -55,6 +55,11 @@
             <if test="patientId != null">
                 AND patient.STABLE_ID = #{patientId}
             </if>
+            <if test="keyword != null">
+                <foreach item="item" collection="keyword.split(' ')" open="(" separator=") AND (" close=")">
+                    sample.STABLE_ID like CONCAT('%', #{item}, '%')
+                </foreach>
+            </if>
         </where>
     </sql>
 
@@ -68,8 +73,11 @@
         <if test="sortBy != null and projection != 'ID'">
             ORDER BY ${sortBy} ${direction}
         </if>
-        <if test="projection == 'ID'">
+        <if test="projection == 'ID' and keyword == null">
             ORDER BY sample.STABLE_ID ASC
+        </if>
+        <if test="keyword != null">
+            ORDER BY CASE WHEN sample.STABLE_ID LIKE CONCAT(#{keyword}, '%') THEN 0 ELSE 1 END, sample.STABLE_ID
         </if>
         <if test="limit != null and limit != 0">
             LIMIT #{limit} OFFSET #{offset}

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/PatientMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/PatientMyBatisRepositoryTest.java
@@ -13,7 +13,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/testContextDatabase.xml")
@@ -33,6 +35,16 @@ public class PatientMyBatisRepositoryTest {
         Assert.assertEquals((Integer) 1, patient.getInternalId());
         Assert.assertEquals("TCGA-A1-A0SB", patient.getStableId());
         Assert.assertNull(patient.getCancerStudy());
+    }
+    
+    @Test
+    public void getAllPatientsByKeywordMatchingSample() {
+        // Sample TCGA-A1-A0SB-02 belongs to patient TCGA-A1-A0SB
+        List<Patient> result = patientMyBatisRepository.getAllPatients("TCGA-A1-A0SB-02", "ID", null, null, null, null);
+        List<String> actual = result.stream().map(Patient::getStableId).collect(Collectors.toList());
+        List<String> expected = Collections.singletonList("TCGA-A1-A0SB");
+        
+        Assert.assertEquals(expected, actual);
     }
 
     @Test

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepositoryTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/testContextDatabase.xml")
@@ -336,4 +337,21 @@ public class SampleMyBatisRepositoryTest {
         Assert.assertEquals("TCGA-A1-A0SB-01", result.get(0).getStableId());
         Assert.assertEquals("TCGA-A1-A0SD-01", result.get(1).getStableId());
      }
+     
+    @Test
+    public void getSamplesByKeyword() {
+         List<Sample> result = sampleMyBatisRepository.getAllSamples("TCGA-A1-A0SB", "SUMMARY", 10, 0, null, null);
+         List<String> actual = result.stream().map((Sample::getStableId)).collect(Collectors.toList());
+         List<String> expected = Arrays.asList("TCGA-A1-A0SB-01", "TCGA-A1-A0SB-01", "TCGA-A1-A0SB-02");
+
+         Assert.assertEquals(expected, actual);
+     }
+     
+    @Test
+    public void getMetaSamplesByKeyword() {
+        BaseMeta actual = sampleMyBatisRepository.getMetaSamples("TCGA-A1-A0SB");
+        Integer expected = 3;
+        
+        Assert.assertEquals(expected, actual.getTotalCount());
+    } 
 }

--- a/service/src/main/java/org/cbioportal/service/SampleService.java
+++ b/service/src/main/java/org/cbioportal/service/SampleService.java
@@ -40,4 +40,9 @@ public interface SampleService {
     BaseMeta fetchMetaSamples(List<String> sampleListIds);
 
     List<Sample> getSamplesByInternalIds(List<Integer> internalIds);
+
+    List<Sample> getAllSamples(String keyword, String projection, Integer pageSize,
+                               Integer pageNumber, String sort, String direction);
+
+    BaseMeta getMetaSamples(String keyword);
 }

--- a/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
@@ -13,14 +13,10 @@ import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -38,7 +34,20 @@ public class SampleServiceImpl implements SampleService {
     private SampleListRepository sampleListRepository;
     @Autowired
     private CopyNumberSegmentRepository copyNumberSegmentRepository;
+    
+    @Override
+    public List<Sample> getAllSamples(String keyword, String projection, Integer pageSize,
+                                      Integer pageNumber, String sort, String direction) {
+        List<Sample> samples = sampleRepository.getAllSamples(keyword, projection, pageSize, pageNumber, sort, direction);
+        processSamples(samples, projection);
+        return samples;
+    }
 
+    @Override
+    public BaseMeta getMetaSamples(String keyword) {
+        return sampleRepository.getMetaSamples(keyword);
+    }
+    
     @Override
     public List<Sample> getAllSamplesInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber,
                                              String sortBy, String direction) throws StudyNotFoundException {

--- a/service/src/test/java/org/cbioportal/service/impl/SampleServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/SampleServiceImplTest.java
@@ -21,6 +21,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SampleServiceImplTest extends BaseServiceImplTest {
@@ -38,6 +39,42 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
     private SampleListRepository sampleListRepository;
     @Mock
     private CopyNumberSegmentRepository copyNumberSegmentRepository;
+    
+    private Sample createSample(String id) {
+        Sample sample = new Sample();
+        sample.setStableId(id);
+        return sample;
+    }
+    
+    @Test
+    public void getAllSamples() {
+        List<Sample> samples = Arrays.asList(
+            createSample(SAMPLE_ID1), createSample(SAMPLE_ID2),
+            createSample(SAMPLE_ID3), createSample(SAMPLE_ID4)
+        );
+        Mockito
+            .when(sampleRepository.getAllSamples("sample_id", PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION))
+            .thenReturn(samples);
+
+        List<Sample> result = sampleService.getAllSamples("sample_id", PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+        List<String> actual = result.stream().map(Sample::getStableId).collect(Collectors.toList());
+        List<String> expected = Arrays.asList(SAMPLE_ID1, SAMPLE_ID2, SAMPLE_ID3, SAMPLE_ID4);
+        
+        Assert.assertEquals(expected, actual);
+    }
+    
+    @Test
+    public void getAllMetaSamples() {
+        BaseMeta baseMeta = new BaseMeta();
+        baseMeta.setTotalCount(4);
+        Mockito.when(sampleRepository.getMetaSamples("sample_id")).thenReturn(baseMeta);
+
+        BaseMeta result = sampleService.getMetaSamples("sample_id");
+        Integer actual = result.getTotalCount();
+        Integer expected = 4;
+
+        Assert.assertEquals(expected, actual);
+    }
 
     @Test
     public void getAllSamplesInStudy() throws Exception {

--- a/web/src/main/java/org/cbioportal/web/SampleController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleController.java
@@ -50,6 +50,44 @@ public class SampleController {
     private UniqueKeyExtractor uniqueKeyExtractor;
 
     @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @RequestMapping(value = "/samples", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Get all samples")
+    public ResponseEntity<List<Sample>> getAllSamples (
+        @ApiParam("Search keyword that applies to the study ID")
+        @RequestParam(required = false) String keyword,
+        
+        @ApiParam("Level of detail of the response")
+        @RequestParam(defaultValue = "SUMMARY") Projection projection,
+        
+        @ApiParam("Page size of the result list")
+        @Max(PagingConstants.MAX_PAGE_SIZE)
+        @Min(PagingConstants.MIN_PAGE_SIZE)
+        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
+        
+        @ApiParam("Page number of the result list")
+        @Min(PagingConstants.MIN_PAGE_NUMBER)
+        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber,
+        
+        @ApiParam("Name of the property that the result list is sorted by")
+        @RequestParam(required = false) SampleSortBy sortBy,
+        
+        @ApiParam("Direction of the sort")
+        @RequestParam(defaultValue = "ASC") Direction direction
+    ) {
+        String sort = sortBy == null ? null : sortBy.getOriginalValue();
+        
+        if (projection == Projection.META) {
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.add(HeaderKeyConstants.TOTAL_COUNT, sampleService.getMetaSamples(keyword).getTotalCount().toString());
+            return new ResponseEntity<>(httpHeaders, HttpStatus.OK);
+        }
+        return new ResponseEntity<>(
+            sampleService.getAllSamples(keyword, projection.name(), pageSize, pageNumber, sort, direction.name()),
+            HttpStatus.OK
+        );
+    }
+
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
     @RequestMapping(value = "/studies/{studyId}/samples", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all samples in a study")

--- a/web/src/test/java/org/cbioportal/web/SampleControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/SampleControllerTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -118,6 +119,39 @@ public class SampleControllerTest {
             .andExpect(MockMvcResultMatchers.status().isNotFound())
             .andExpect(MockMvcResultMatchers.jsonPath("$.message")
                 .value("Sample not found in study test_study_id: test_sample_id"));
+    }
+
+    @Test
+    public void getAllSamples() throws Exception {
+        List<Sample> samples = createExampleSamples();
+        
+        Mockito
+            .when(sampleService.getAllSamples(
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(),
+                Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()
+            )).thenReturn(samples);
+        
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/samples").accept(MediaType.APPLICATION_JSON))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].internalId").doesNotExist())
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].sampleId").value(TEST_STABLE_ID_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].patientId").value(TEST_PATIENT_STABLE_ID_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].patientStableId").doesNotExist())
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].sampleType")
+                .value(Sample.SampleType.PRIMARY_SOLID_TUMOR.getValue()))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].studyId").value(TEST_CANCER_STUDY_IDENTIFIER_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].patient").doesNotExist())
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].internalId").doesNotExist())
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].sampleId").value(TEST_STABLE_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].patientId").value(TEST_PATIENT_STABLE_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].patientStableId").doesNotExist())
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].sampleType")
+                .value(Sample.SampleType.PRIMARY_SOLID_TUMOR.getValue()))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].studyId").value(TEST_CANCER_STUDY_IDENTIFIER_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].patient").doesNotExist());
     }
 
     @Test


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Add Sample endpoint for keyword search
    - Added logic to Sample controller, service, and repository, as well as the XML
    - If the keyword parameter is present, samples are matched to it based on STABLE_ID
- Expand Patient keyword search
    - XML: added an internal join to the corresponding samples so that patients with
    matching samples show up in quicksearch

# Checks
- [ ] Runs on heroku
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)

# Any screenshots or GIFs?
![foo](https://user-images.githubusercontent.com/20069833/65913638-3da3e580-e39e-11e9-8ddc-4340cba6e904.gif)
