### PR TITLE
New portal.properties entry for genes filter default setting in Patient View

### DIFF
--- a/docs/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/Customizing-your-instance-of-cBioPortal.md
@@ -217,6 +217,12 @@ Below you can find the complete list of all the available skin properties.
             <td>3</td>
             <td>integer</td>
         </tr>
+		<tr>
+            <td>skin.patientview.filter_genes_profiled_all_samples</td>
+            <td>sets default setting for the genes filter in patient view to only show mutations for genes that were profiled for mutations or CNA's in all samples of that patient. If unset, patient view will show mutations/CNA's for genes that were profiled in any sample.</td>
+            <td>false</td>
+            <td>true / false</td>
+        </tr>
    </tbody>
 </table>
 

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -142,6 +142,12 @@ Add a custom logo in the right side of the menu. Place here the full name of the
 skin.right_logo=
 ```
 
+## Control default setting for filtering of genes in mutation and CNA tables of patient view
+Different samples of a patient may have been analyzed with different gene panels. In patient view mutations and discrete CNA's can be filtered based on whether the gene of respective mutations/CNA's was profiled in all samples of the patient (mutations profiled in `all samples`), or not (mutations profiled in `any sample`). Setting this field to `true` will make patient view select the `all samples` filter at startup. When set to false or left blank the patient view will default to the `any samples` filter setting.
+```
+skin.patientview.filter_genes_profiled_all_samples=
+```
+
 # Segment File URL
 
 This is a root URL to where segment files can be found.  This is used when you want to provide segment file viewing via external tools such as [IGV](http://www.broadinstitute.org/igv/).

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -89,6 +89,7 @@
             "skin.show_tutorials_tab",
             "skin.show_web_api_tab",
             "skin.show_tweet_button",
+            "skin.patientview.filter_genes_profiled_all_samples",
             "quick_search.enabled",
             "default_cross_cancer_study_session_id",
             "default_cross_cancer_study_list",

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -75,6 +75,9 @@ skin.right_nav.show_whats_new=true
 # settings controlling what to show in the right navigation bar
 skin.study_view.link_text=To build your own case set, try out our enhanced Study View.
 
+# setting controlling the default setting for filtering genes in patient view
+skin.patientview.filter_genes_profiled_all_samples=true
+
 ## enable and set this property to specify a study group to be used to identify public studies for which no specific authorization entries are needed in the `authorities` table
 # always_show_study_group=
 


### PR DESCRIPTION
As part of RFC45, the cbioportal backend implements a new setting

`skin.patientview.filter_genes_profiled_all_samples=`

 in _portal.properties_. This configuration option controls the default setting for gene filtering in patient view (implemented in cbioportal-frontend PR's related to RFC45). The default here is a to show mutations and CNA's that are profiled (and therefore 'known') in `any sample` of a patient. Setting `skin.patientview.filter_genes_profiled_all_samples` to `true` will transmit a new default setting, filtering of mutation and CNA tables for genes profiled in all samples of the patient, to the frontend via the `config_service.jsp` end point.
