### PR TITLE
Retrieve cBP version through API (fix https://github.com/cBioPortal/icebox/issues/55)

### DIFF
--- a/core/src/test/scripts/system_tests_validate_data.py
+++ b/core/src/test/scripts/system_tests_validate_data.py
@@ -32,10 +32,6 @@ class ValidateDataSystemTester(unittest.TestCase):
     '''
 
     def setUp(self):
-        def dummy_get_pom_path():
-            return "test_data/test.xml"
-        self.orig_get_pom_path = validateData.get_pom_path
-        validateData.get_pom_path = dummy_get_pom_path
         _resetClassVars()
 
         # Prepare global variables related to sample profiled for mutations and gene panels
@@ -46,7 +42,6 @@ class ValidateDataSystemTester(unittest.TestCase):
     def tearDown(self):
         """Close logging handlers after running validator and remove tmpdir."""
         # restore original function
-        validateData.get_pom_path = self.orig_get_pom_path
         validateData.mutation_sample_ids = None
         validateData.mutation_file_sample_ids = set()
         validateData.fusion_file_sample_ids = set()

--- a/core/src/test/scripts/test_data/study_es_0/result_report.html
+++ b/core/src/test/scripts/test_data/study_es_0/result_report.html
@@ -48,7 +48,7 @@
         <h1>cBioPortal validation report</h1>
         <p>Study directory:<br />test_data/study_es_0/</p>
         <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/blob/master/docs/File-Formats.md'>the documentation on file formats supported by cBioPortal</a></p>
-        <p>cBioPortal version 1.5.1-SYSTEM-TEST</p>
+        <p>cBioPortal version unknown -- offline instance</p>
       </div>
     </div>
 

--- a/core/src/test/scripts/test_data/study_es_1/result_report.html
+++ b/core/src/test/scripts/test_data/study_es_1/result_report.html
@@ -48,7 +48,7 @@
         <h1>cBioPortal validation report</h1>
         <p>Study directory:<br />/home/pnp300/git/cbioportal/core/src/test/scripts/test_data/study_es_1</p>
         <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/blob/master/docs/File-Formats.md'>the documentation on file formats supported by cBioPortal</a></p>
-        <p>cBioPortal version 1.19.0-SNAPSHOT</p>
+        <p>cBioPortal version -- offline instance</p>
       </div>
     </div>
 

--- a/core/src/test/scripts/test_data/study_es_3/result_report.html
+++ b/core/src/test/scripts/test_data/study_es_3/result_report.html
@@ -48,7 +48,7 @@
         <h1>cBioPortal validation report</h1>
         <p>Study directory:<br />/home/pnp300/git/cbioportal/core/src/test/scripts/test_data/study_es_3</p>
         <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/blob/master/docs/File-Formats.md'>the documentation on file formats supported by cBioPortal</a></p>
-        <p>cBioPortal version 1.19.0-SNAPSHOT</p>
+        <p>cBioPortal version unknown -- offline instance</p>
       </div>
     </div>
 

--- a/core/src/test/scripts/test_data/study_quotes/result_report.html
+++ b/core/src/test/scripts/test_data/study_quotes/result_report.html
@@ -48,7 +48,7 @@
         <h1>cBioPortal validation report</h1>
         <p>Study directory:<br />test_data/study_quotes/</p>
         <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/blob/master/docs/File-Formats.md'>the documentation on file formats supported by cBioPortal</a></p>
-        <p>cBioPortal version 1.5.1-SYSTEM-TEST</p>
+        <p>cBioPortal version unknown -- offline instance</p>
       </div>
     </div>
 

--- a/core/src/test/scripts/test_data/study_various_issues/result_report.html
+++ b/core/src/test/scripts/test_data/study_various_issues/result_report.html
@@ -48,7 +48,7 @@
         <h1>cBioPortal validation report</h1>
         <p>Study directory:<br />test_data/study_various_issues/</p>
         <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/blob/master/docs/File-Formats.md'>the documentation on file formats supported by cBioPortal</a></p>
-        <p>cBioPortal version 1.5.1-SYSTEM-TEST</p>
+        <p>cBioPortal version unknown -- offline instance</p>
       </div>
     </div>
 

--- a/core/src/test/scripts/test_data/study_wr_clin/result_report.html
+++ b/core/src/test/scripts/test_data/study_wr_clin/result_report.html
@@ -48,7 +48,7 @@
         <h1>cBioPortal validation report</h1>
         <p>Study directory:<br />test_data/study_wr_clin/</p>
         <p>For details, please see <a href='https://github.com/cbioportal/cbioportal/blob/master/docs/File-Formats.md'>the documentation on file formats supported by cBioPortal</a></p>
-        <p>cBioPortal version 1.5.1-SYSTEM-TEST</p>
+        <p>cBioPortal version unknown -- offline instance</p>
       </div>
     </div>
 

--- a/core/src/test/scripts/test_data/test.xml
+++ b/core/src/test/scripts/test_data/test.xml
@@ -6,6 +6,6 @@
   <artifactId>master</artifactId>
   <packaging>pom</packaging>
   <name>Portal Master</name>
-  <version>1.5.1-SYSTEM-TEST</version>
+  <version>unknown</version>
   <description>master maven module</description>
 </project>


### PR DESCRIPTION
Fix https://github.com/cBioPortal/icebox/issues/55

Validator now retrieves the cBioPortal version through the `/api/info` URI and displays it on the resulting HTML page.

When setting up a cBioPortal instance from a portal dump directory (`metaImport.py -p <dir>`), the validator will set the version to `unknown`, since there is no dump function implemented for the `info` API yet.

**EDIT:**
Turned out the version was already detemined in the logger prior to HTML generation. Now `cbio_version` was removed from the constructor of the Jinja2 HTML logger.

**EDIT:**
In case no version could be retrieved, the reason can be 1. A json format error 2. offline portal instance 3. Portal checks disabled.
The validator now considers these scenarios and displays them when no version could be retrieved.