### PR TITLE
Add preauth filtering of structural variants

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -19,7 +19,7 @@
       <url>https://jitpack.io</url>
     </repository>
   </repositories>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.mskcc.cbio</groupId>
@@ -81,9 +81,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-autoconfigure</artifactId>
-        <version>2.1.6.RELEASE</version>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <version>2.1.6.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
@@ -116,47 +116,47 @@
       <artifactId>aspectjweaver</artifactId>
       <version>1.8.12</version>
     </dependency>
-	<dependency>
-        <groupId>com.datumbox</groupId>
-        <artifactId>datumbox-framework-lib</artifactId>
-        <version>0.8.1</version>
+    <dependency>
+      <groupId>com.datumbox</groupId>
+      <artifactId>datumbox-framework-lib</artifactId>
+      <version>0.8.1</version>
     </dependency>
-	<dependency>
-		<groupId>com.github.cbioportal</groupId>
-        <artifactId>session-service</artifactId>
-        <version>master-SNAPSHOT</version>
-		<classifier>model</classifier>
-		<exclusions>
-			<exclusion>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter</artifactId>
-			</exclusion>
-			<exclusion>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-			</exclusion>
-			<exclusion>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-web</artifactId>
-			</exclusion>
-			<exclusion>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-security</artifactId>
-			</exclusion>
-			<exclusion>
-				<groupId>io.springfox</groupId>
-				<artifactId>springfox-swagger2</artifactId>
-			</exclusion>
-			<exclusion>
-				<groupId>io.springfox</groupId>
-				<artifactId>springfox-swagger-ui</artifactId>
-			</exclusion>
-			<exclusion>
-				<groupId>io.sentry</groupId>
-				<artifactId>sentry</artifactId>
-			</exclusion>
-		</exclusions>
-	</dependency>
+    <dependency>
+      <groupId>com.github.cbioportal</groupId>
+      <artifactId>session-service</artifactId>
+      <version>master-SNAPSHOT</version>
+      <classifier>model</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-web</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-security</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.springfox</groupId>
+          <artifactId>springfox-swagger2</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.springfox</groupId>
+          <artifactId>springfox-swagger-ui</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.sentry</groupId>
+          <artifactId>sentry</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
 </project>

--- a/web/src/main/java/org/cbioportal/logging/LoggingAspect.java
+++ b/web/src/main/java/org/cbioportal/logging/LoggingAspect.java
@@ -14,14 +14,14 @@ public class LoggingAspect {
 
     private static final Logger logger = LogManager.getLogger("LoggingAspect");
 
-    @Before("execution(* org.cbioportal.web..*(..)) || execution(* org.cbioportal.service.impl..*(..)) || " + 
+    @Before("execution(* org.cbioportal.web..*(..)) || execution(* org.cbioportal.service.impl..*(..)) || " +
     "execution(* org.cbioportal.persistence.mybatis..*(..))")
     public void logBefore(JoinPoint joinPoint) {
         logger.debug("Entered: " + joinPoint.getTarget().getClass().getName() + "." +
             joinPoint.getSignature().getName());
     }
 
-    @After("execution(* org.cbioportal.web..*(..)) || execution(* org.cbioportal.service.impl..*(..)) || " + 
+    @After("execution(* org.cbioportal.web..*(..)) || execution(* org.cbioportal.service.impl..*(..)) || " +
     "execution(* org.cbioportal.persistence.mybatis..*(..))")
     public void logAfter(JoinPoint joinPoint) {
         logger.debug("Exited: " + joinPoint.getTarget().getClass().getName() + "." +

--- a/web/src/main/java/org/cbioportal/url_shortener/URLShortenerController.java
+++ b/web/src/main/java/org/cbioportal/url_shortener/URLShortenerController.java
@@ -17,13 +17,13 @@ public class URLShortenerController {
 
     @Value("${bitly.access.token}")
     private String bitlyAccessToken;
-    
+
     private Bitly bitly ;
     private UrlValidator urlValidator = new UrlValidator();
-    
+
     @RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<URLShortenerResponse> urlShortener(@RequestParam String url) {
-        
+
         if (urlValidator.isValid(url)) {
             if (bitly == null) {
                 bitly = Bit.ly(bitlyAccessToken);

--- a/web/src/main/java/org/cbioportal/url_shortener/URLShortenerResponse.java
+++ b/web/src/main/java/org/cbioportal/url_shortener/URLShortenerResponse.java
@@ -1,7 +1,7 @@
 package org.cbioportal.url_shortener;
 
 public class URLShortenerResponse {
-    
+
     private String shortURL;
     private String error;
 

--- a/web/src/main/java/org/cbioportal/web/ClinicalAttributeController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalAttributeController.java
@@ -118,7 +118,7 @@ public class ClinicalAttributeController {
             @ApiParam(required = true, value = "Study ID e.g. acc_tcga")
             @PathVariable String studyId,
             @ApiParam(required = true, value= "Clinical Attribute ID e.g. CANCER_TYPE")
-            @PathVariable String clinicalAttributeId) 
+            @PathVariable String clinicalAttributeId)
         throws ClinicalAttributeNotFoundException, StudyNotFoundException {
 
         return new ResponseEntity<>(clinicalAttributeService.getClinicalAttribute(studyId, clinicalAttributeId),
@@ -126,7 +126,7 @@ public class ClinicalAttributeController {
     }
 
     @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', 'read')")
-    @RequestMapping(value = "/clinical-attributes/fetch", method = RequestMethod.POST, 
+    @RequestMapping(value = "/clinical-attributes/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical attributes")
     public ResponseEntity<List<ClinicalAttribute>> fetchClinicalAttributes(
@@ -142,7 +142,7 @@ public class ClinicalAttributeController {
                 studyIds).getTotalCount().toString());
             return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
         } else {
-            return new ResponseEntity<>(clinicalAttributeService.fetchClinicalAttributes(studyIds, projection.name()), 
+            return new ResponseEntity<>(clinicalAttributeService.fetchClinicalAttributes(studyIds, projection.name()),
                 HttpStatus.OK);
         }
     }

--- a/web/src/main/java/org/cbioportal/web/ClinicalDataEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalDataEnrichmentController.java
@@ -100,13 +100,13 @@ public class ClinicalDataEnrichmentController {
 
             List<ClinicalAttribute> clinicalAttributes = clinicalAttributeService
                     .fetchClinicalAttributes(new ArrayList<String>(studyIds), "SUMMARY");
-            
+
             // remove all duplicate attributes
             Map<String, ClinicalAttribute> clinicalAttributesByUniqId = clinicalAttributes.stream()
                     .collect(Collectors.toMap(c -> c.getAttrId() + c.getPatientAttribute(), c -> c, (e1, e2) -> e2));
 
             clinicalAttributes = new ArrayList<>(clinicalAttributesByUniqId.values());
- 
+
             clinicalEnrichments.addAll(
                     clinicalDataEnrichmentUtil.createEnrichmentsForCategoricalData(clinicalAttributes, groupedSamples));
 

--- a/web/src/main/java/org/cbioportal/web/ClinicalEventController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalEventController.java
@@ -60,7 +60,7 @@ public class ClinicalEventController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) ClinicalEventSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) throws PatientNotFoundException, 
+        @RequestParam(defaultValue = "ASC") Direction direction) throws PatientNotFoundException,
         StudyNotFoundException {
 
         if (projection == Projection.META) {
@@ -95,7 +95,7 @@ public class ClinicalEventController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) ClinicalEventSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) throws PatientNotFoundException, 
+        @RequestParam(defaultValue = "ASC") Direction direction) throws PatientNotFoundException,
         StudyNotFoundException {
 
         if (projection == Projection.META) {

--- a/web/src/main/java/org/cbioportal/web/CoExpressionController.java
+++ b/web/src/main/java/org/cbioportal/web/CoExpressionController.java
@@ -27,7 +27,7 @@ import java.util.List;
 @Validated
 @Api(tags = "Co-Expressions", description = " ")
 public class CoExpressionController {
-    
+
     @Autowired
     private CoExpressionService coExpressionService;
 

--- a/web/src/main/java/org/cbioportal/web/CopyNumberEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/CopyNumberEnrichmentController.java
@@ -58,7 +58,7 @@ public class CopyNumberEnrichmentController {
         @RequestParam(defaultValue = "SAMPLE") EnrichmentType enrichmentType,
         @ApiParam(required = true, value = "List of groups containing sample identifiers")
         @Valid @RequestBody(required = false) List<MolecularProfileCasesGroupFilter> groups) throws MolecularProfileNotFoundException {
-        
+
         Map<String, List<MolecularProfileCaseIdentifier>> groupCaseIdentifierSet = interceptedMolecularProfileCasesGroupFilters.stream()
                 .collect(Collectors.toMap(MolecularProfileCasesGroupFilter::getName,
                         MolecularProfileCasesGroupFilter::getMolecularProfileCaseIdentifiers));

--- a/web/src/main/java/org/cbioportal/web/CopyNumberSegmentController.java
+++ b/web/src/main/java/org/cbioportal/web/CopyNumberSegmentController.java
@@ -70,7 +70,7 @@ public class CopyNumberSegmentController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) CopyNumberSegmentSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) throws SampleNotFoundException, 
+        @RequestParam(defaultValue = "ASC") Direction direction) throws SampleNotFoundException,
         StudyNotFoundException {
 
         if (projection == Projection.META) {
@@ -118,7 +118,7 @@ public class CopyNumberSegmentController {
             return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
         } else {
             return new ResponseEntity<>(
-                copyNumberSegmentService.fetchCopyNumberSegments(studyIds, sampleIds, chromosome, projection.name()), 
+                copyNumberSegmentService.fetchCopyNumberSegments(studyIds, sampleIds, chromosome, projection.name()),
                 HttpStatus.OK);
         }
     }

--- a/web/src/main/java/org/cbioportal/web/CosmicCountController.java
+++ b/web/src/main/java/org/cbioportal/web/CosmicCountController.java
@@ -26,11 +26,11 @@ import java.util.List;
 public class CosmicCountController {
 
     private static final int COSMIC_COUNT_MAX_PAGE_SIZE = 50000;
-    
+
     @Autowired
     private CosmicCountService cosmicCountService;
-    
-    @RequestMapping(value = "/cosmic-counts/fetch", method = RequestMethod.POST, 
+
+    @RequestMapping(value = "/cosmic-counts/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get counts within the COSMIC database by keywords")
     public ResponseEntity<List<CosmicMutation>> fetchCosmicCounts(

--- a/web/src/main/java/org/cbioportal/web/DiscreteCopyNumberController.java
+++ b/web/src/main/java/org/cbioportal/web/DiscreteCopyNumberController.java
@@ -66,8 +66,8 @@ public class DiscreteCopyNumberController {
             return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
         } else {
             return new ResponseEntity<>(
-                discreteCopyNumberService.getDiscreteCopyNumbersInMolecularProfileBySampleListId(molecularProfileId, 
-                    sampleListId, null, discreteCopyNumberEventType.getAlterationTypes(), projection.name()), 
+                discreteCopyNumberService.getDiscreteCopyNumbersInMolecularProfileBySampleListId(molecularProfileId,
+                    sampleListId, null, discreteCopyNumberEventType.getAlterationTypes(), projection.name()),
                 HttpStatus.OK);
         }
     }
@@ -94,11 +94,11 @@ public class DiscreteCopyNumberController {
 
             if (discreteCopyNumberFilter.getSampleListId() != null) {
                 baseMeta = discreteCopyNumberService.getMetaDiscreteCopyNumbersInMolecularProfileBySampleListId(
-                    molecularProfileId, discreteCopyNumberFilter.getSampleListId(), 
+                    molecularProfileId, discreteCopyNumberFilter.getSampleListId(),
                     discreteCopyNumberFilter.getEntrezGeneIds(), discreteCopyNumberEventType.getAlterationTypes());
             } else {
-                baseMeta = discreteCopyNumberService.fetchMetaDiscreteCopyNumbersInMolecularProfile(molecularProfileId, 
-                    discreteCopyNumberFilter.getSampleIds(), discreteCopyNumberFilter.getEntrezGeneIds(), 
+                baseMeta = discreteCopyNumberService.fetchMetaDiscreteCopyNumbersInMolecularProfile(molecularProfileId,
+                    discreteCopyNumberFilter.getSampleIds(), discreteCopyNumberFilter.getEntrezGeneIds(),
                     discreteCopyNumberEventType.getAlterationTypes());
             }
             responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, baseMeta.getTotalCount().toString());
@@ -107,16 +107,16 @@ public class DiscreteCopyNumberController {
             List<DiscreteCopyNumberData> discreteCopyNumberDataList;
             if (discreteCopyNumberFilter.getSampleListId() != null) {
                 discreteCopyNumberDataList = discreteCopyNumberService
-                    .getDiscreteCopyNumbersInMolecularProfileBySampleListId(molecularProfileId, 
-                        discreteCopyNumberFilter.getSampleListId(), discreteCopyNumberFilter.getEntrezGeneIds(), 
+                    .getDiscreteCopyNumbersInMolecularProfileBySampleListId(molecularProfileId,
+                        discreteCopyNumberFilter.getSampleListId(), discreteCopyNumberFilter.getEntrezGeneIds(),
                         discreteCopyNumberEventType.getAlterationTypes(), projection.name());
             } else {
                 discreteCopyNumberDataList = discreteCopyNumberService.fetchDiscreteCopyNumbersInMolecularProfile(
-                    molecularProfileId, discreteCopyNumberFilter.getSampleIds(), 
-                    discreteCopyNumberFilter.getEntrezGeneIds(), discreteCopyNumberEventType.getAlterationTypes(), 
+                    molecularProfileId, discreteCopyNumberFilter.getSampleIds(),
+                    discreteCopyNumberFilter.getEntrezGeneIds(), discreteCopyNumberEventType.getAlterationTypes(),
                     projection.name());
             }
-            
+
             return new ResponseEntity<>(discreteCopyNumberDataList, HttpStatus.OK);
         }
     }

--- a/web/src/main/java/org/cbioportal/web/ExpressionEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/ExpressionEnrichmentController.java
@@ -53,22 +53,22 @@ public class ExpressionEnrichmentController {
         @Valid @RequestBody(required = false) List<MolecularProfileCasesGroupFilter> groups,
         @ApiIgnore // prevent reference to this attribute in the swagger-ui interface. this attribute is needed for the @PreAuthorize tag above.
         @Valid @RequestAttribute(required = false, value = "interceptedMolecularProfileCasesGroupFilters") List<MolecularProfileCasesGroupFilter> interceptedMolecularProfileCasesGroupFilters) throws MolecularProfileNotFoundException {
-        
+
         Map<String, List<MolecularProfileCaseIdentifier>> groupCaseIdentifierSet = interceptedMolecularProfileCasesGroupFilters.stream()
                 .collect(Collectors.toMap(MolecularProfileCasesGroupFilter::getName,
                         MolecularProfileCasesGroupFilter::getMolecularProfileCaseIdentifiers));
-        
+
         Set<String> molecularProfileIds = groupCaseIdentifierSet
                 .values()
                 .stream()
                 .flatMap(molecularProfileCaseSet -> molecularProfileCaseSet.stream()
                         .map(MolecularProfileCaseIdentifier::getMolecularProfileId))
                 .collect(Collectors.toSet());
-        
+
         if(molecularProfileIds.size()> 1) {
             throw new UnsupportedOperationException("Multi-study expression enrichments is not yet implemented");
         }
-        
+
 
         return new ResponseEntity<>(expressionEnrichmentService.getExpressionEnrichments(molecularProfileIds.iterator().next(), groupCaseIdentifierSet, enrichmentType.name()), HttpStatus.OK);
     }

--- a/web/src/main/java/org/cbioportal/web/GeneController.java
+++ b/web/src/main/java/org/cbioportal/web/GeneController.java
@@ -113,7 +113,7 @@ public class GeneController {
                 .getTotalCount().toString());
             return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
         } else {
-            return new ResponseEntity<>(geneService.fetchGenes(geneIds, geneIdType.name(), projection.name()), 
+            return new ResponseEntity<>(geneService.fetchGenes(geneIds, geneIdType.name(), projection.name()),
                 HttpStatus.OK);
         }
     }

--- a/web/src/main/java/org/cbioportal/web/GenePanelController.java
+++ b/web/src/main/java/org/cbioportal/web/GenePanelController.java
@@ -101,7 +101,7 @@ public class GenePanelController {
     }
 
     @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
-    @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/gene-panel-data/fetch", method = RequestMethod.POST, 
+    @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/gene-panel-data/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get gene panel data")
     public ResponseEntity<List<GenePanelData>> getGenePanelData(
@@ -124,7 +124,7 @@ public class GenePanelController {
 
 
     @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
-    @RequestMapping(value = "/gene-panel-data/fetch", method = RequestMethod.POST, 
+    @RequestMapping(value = "/gene-panel-data/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch gene panel data")
     public ResponseEntity<List<GenePanelData>> fetchGenePanelDataInMultipleMolecularProfiles(
@@ -135,7 +135,7 @@ public class GenePanelController {
         @ApiParam(required = true, value = "List of Molecular Profile ID and Sample ID pairs")
         @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
         @RequestBody(required = false) List<SampleMolecularIdentifier> sampleMolecularIdentifiers) {
-        
+
         List<String> molecularProfileIds = new ArrayList<>();
         List<String> sampleIds = new ArrayList<>();
 

--- a/web/src/main/java/org/cbioportal/web/GenesetController.java
+++ b/web/src/main/java/org/cbioportal/web/GenesetController.java
@@ -59,7 +59,7 @@ public class GenesetController {
             return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
         } else {
             return new ResponseEntity<>(
-            		genesetService.getAllGenesets(projection.name(), pageSize, pageNumber), HttpStatus.OK);
+                    genesetService.getAllGenesets(projection.name(), pageSize, pageNumber), HttpStatus.OK);
         }
     }
 
@@ -73,14 +73,14 @@ public class GenesetController {
     }
 
     @RequestMapping(value = "/genesets/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
-	        produces = MediaType.APPLICATION_JSON_VALUE)
-	    @ApiOperation("Fetch gene sets by ID")
-	    public ResponseEntity<List<Geneset>> fetchGenesets(
-	        @ApiParam(required = true, value = "List of Gene set IDs")
-	        @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
-	        @RequestBody List<String> genesetIds) {
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Fetch gene sets by ID")
+    public ResponseEntity<List<Geneset>> fetchGenesets(
+        @ApiParam(required = true, value = "List of Gene set IDs")
+        @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
+        @RequestBody List<String> genesetIds) {
 
-	        return new ResponseEntity<>(genesetService.fetchGenesets(genesetIds), HttpStatus.OK);
+        return new ResponseEntity<>(genesetService.fetchGenesets(genesetIds), HttpStatus.OK);
     }
 
 }

--- a/web/src/main/java/org/cbioportal/web/GenesetCorrelationController.java
+++ b/web/src/main/java/org/cbioportal/web/GenesetCorrelationController.java
@@ -65,33 +65,34 @@ public class GenesetCorrelationController {
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get the genes in a gene set that have expression correlated to the gene set scores (calculated using Spearman's correlation)")
     public ResponseEntity<List<GenesetCorrelation>> fetchCorrelatedGenes(
-    	@ApiParam(required = true, value = "Gene set ID, e.g. HINATA_NFKB_MATRIX.")
+        @ApiParam(required = true, value = "Gene set ID, e.g. HINATA_NFKB_MATRIX.")
         @PathVariable String genesetId,
         @ApiParam(required = true, value = "Genetic Profile ID e.g. gbm_tcga_gsva_scores")
-    	@RequestParam String geneticProfileId,
-    	@ApiParam("Correlation threshold (for absolute correlation value, Spearman correlation)")
+        @RequestParam String geneticProfileId,
+        @ApiParam("Correlation threshold (for absolute correlation value, Spearman correlation)")
         @Max(1)
         @Min(0)
         @RequestParam(defaultValue = "0.3") Double correlationThreshold,
         @ApiParam(required = false, value = "Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all")
-    	@RequestParam(required = false) String sampleListId,
+        @RequestParam(required = false) String sampleListId,
         @ApiParam(required = false, value = "Fill this one if you want to specify a subset of samples:"
-        		+ " sampleIds: custom list of samples or patients to query, e.g. [\"TCGA-A1-A0SD-01\", \"TCGA-A1-A0SE-01\"]")
+                + " sampleIds: custom list of samples or patients to query, e.g. [\"TCGA-A1-A0SD-01\", \"TCGA-A1-A0SE-01\"]")
         @RequestBody(required = false) List<String> sampleIds)
         throws MolecularProfileNotFoundException, SampleListNotFoundException, GenesetNotFoundException {
 
-    	if (sampleListId != null && sampleListId.trim().length() > 0) {
-    		return new ResponseEntity<>(
-	        		genesetCorrelationService.fetchCorrelatedGenes(genesetId, geneticProfileId, sampleListId, correlationThreshold.doubleValue())
-	        		, HttpStatus.OK);
-    	} else if (sampleIds != null && sampleIds.size() > 0){
-	        return new ResponseEntity<>(
-	        		genesetCorrelationService.fetchCorrelatedGenes(genesetId, geneticProfileId, sampleIds, correlationThreshold.doubleValue())
-	        		, HttpStatus.OK);
-    	} else {
-	        return new ResponseEntity<>(
-	        		genesetCorrelationService.fetchCorrelatedGenes(genesetId, geneticProfileId, correlationThreshold.doubleValue())
-	        		, HttpStatus.OK);
-    	}
+        if (sampleListId != null && sampleListId.trim().length() > 0) {
+            return new ResponseEntity<>(
+                    genesetCorrelationService.fetchCorrelatedGenes(genesetId, geneticProfileId, sampleListId, correlationThreshold.doubleValue()),
+                    HttpStatus.OK);
+        }
+        if (sampleIds != null && sampleIds.size() > 0) {
+            return new ResponseEntity<>(
+                    genesetCorrelationService.fetchCorrelatedGenes(genesetId, geneticProfileId, sampleIds, correlationThreshold.doubleValue()),
+                    HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(
+                    genesetCorrelationService.fetchCorrelatedGenes(genesetId, geneticProfileId, correlationThreshold.doubleValue()),
+                    HttpStatus.OK);
+        }
     }
 }

--- a/web/src/main/java/org/cbioportal/web/GenesetDataController.java
+++ b/web/src/main/java/org/cbioportal/web/GenesetDataController.java
@@ -31,10 +31,10 @@ import io.swagger.annotations.ApiParam;
 public class GenesetDataController {
 
 
-	@Autowired
+    @Autowired
     private GenesetDataService genesetDataService;
 
-    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfileId', 'read')")    
+    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfileId', 'read')")
     @RequestMapping(value = "/genetic-profiles/{geneticProfileId}/geneset-genetic-data/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch gene set \"genetic data\" items (gene set scores) by profile Id, gene set ids and sample ids")
@@ -42,21 +42,21 @@ public class GenesetDataController {
             @ApiParam(required = true, value = "Genetic profile ID, e.g. gbm_tcga_gsva_scores")
             @PathVariable String geneticProfileId,
             @ApiParam(required = true, value = "Search criteria to return the values for a given set of samples and gene set items. "
-            		+ "genesetIds: The list of identifiers for the gene sets of interest, e.g. HINATA_NFKB_MATRIX. "
-            		+ "Use one of these if you want to specify a subset of samples:"
-            		+ "(1) sampleListId: Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all " 
-            		+ "or (2) sampleIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01")
+                    + "genesetIds: The list of identifiers for the gene sets of interest, e.g. HINATA_NFKB_MATRIX. "
+                    + "Use one of these if you want to specify a subset of samples:"
+                    + "(1) sampleListId: Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all "
+                    + "or (2) sampleIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01")
             @RequestBody GenesetDataFilterCriteria genesetDataFilterCriteria) throws MolecularProfileNotFoundException, SampleListNotFoundException {
 
-    	if (genesetDataFilterCriteria.getSampleListId() != null && genesetDataFilterCriteria.getSampleListId().trim().length() > 0) {
-    		return new ResponseEntity<>(
-    				genesetDataService.fetchGenesetData(geneticProfileId, genesetDataFilterCriteria.getSampleListId(), 
-    						genesetDataFilterCriteria.getGenesetIds()), HttpStatus.OK);
-    	} else {
-    		return new ResponseEntity<>(
-    				genesetDataService.fetchGenesetData(geneticProfileId, genesetDataFilterCriteria.getSampleIds(), 
-    						genesetDataFilterCriteria.getGenesetIds()), HttpStatus.OK);
-    	}
+        if (genesetDataFilterCriteria.getSampleListId() != null && genesetDataFilterCriteria.getSampleListId().trim().length() > 0) {
+            return new ResponseEntity<>(
+                    genesetDataService.fetchGenesetData(geneticProfileId, genesetDataFilterCriteria.getSampleListId(),
+                            genesetDataFilterCriteria.getGenesetIds()), HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(
+                    genesetDataService.fetchGenesetData(geneticProfileId, genesetDataFilterCriteria.getSampleIds(),
+                            genesetDataFilterCriteria.getGenesetIds()), HttpStatus.OK);
+        }
     }
 
 }

--- a/web/src/main/java/org/cbioportal/web/GenesetHierarchyController.java
+++ b/web/src/main/java/org/cbioportal/web/GenesetHierarchyController.java
@@ -81,23 +81,23 @@ public class GenesetHierarchyController {
         @ApiParam(required = false, value = "Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all")
         @RequestParam(required = false) String sampleListId,
         @ApiParam(required = false, value = "Fill this one if you want to specify a subset of samples:"
-        		+ " sampleIds: custom list of samples or patients to query, e.g. [\"TCGA-A1-A0SD-01\", \"TCGA-A1-A0SE-01\"]")
+                + " sampleIds: custom list of samples or patients to query, e.g. [\"TCGA-A1-A0SD-01\", \"TCGA-A1-A0SE-01\"]")
         @RequestBody(required = false) List<String> sampleIds)
         throws MolecularProfileNotFoundException, SampleListNotFoundException {
 
-	        if (sampleListId != null && sampleListId.trim().length() > 0) {
-	    		return new ResponseEntity<>(
-	    				genesetHierarchyService.fetchGenesetHierarchyInfo(geneticProfileId, percentile, scoreThreshold, pvalueThreshold, sampleListId)
-		        		, HttpStatus.OK);
-	    	} else if (sampleIds != null && sampleIds.size() > 0){
-		        return new ResponseEntity<>(
-		        		genesetHierarchyService.fetchGenesetHierarchyInfo(geneticProfileId, percentile, scoreThreshold, pvalueThreshold, sampleIds)
-		        		, HttpStatus.OK);
-	    	} else {
-		        return new ResponseEntity<>(
-		        		genesetHierarchyService.fetchGenesetHierarchyInfo(geneticProfileId, percentile, scoreThreshold, pvalueThreshold)
-		        		, HttpStatus.OK);
-	    	}
-        
+        if (sampleListId != null && sampleListId.trim().length() > 0) {
+            return new ResponseEntity<>(
+                    genesetHierarchyService.fetchGenesetHierarchyInfo(geneticProfileId, percentile, scoreThreshold, pvalueThreshold, sampleListId),
+                    HttpStatus.OK);
+        } else if (sampleIds != null && sampleIds.size() > 0){
+            return new ResponseEntity<>(
+                    genesetHierarchyService.fetchGenesetHierarchyInfo(geneticProfileId, percentile, scoreThreshold, pvalueThreshold, sampleIds),
+                    HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(
+                    genesetHierarchyService.fetchGenesetHierarchyInfo(geneticProfileId, percentile, scoreThreshold, pvalueThreshold),
+                    HttpStatus.OK);
+        }
+
     }
 }

--- a/web/src/main/java/org/cbioportal/web/InfoController.java
+++ b/web/src/main/java/org/cbioportal/web/InfoController.java
@@ -21,7 +21,7 @@ public class InfoController {
 
     @Value("${portal.version}")
     private String portalVersion;
-    
+
     @Value("${db.version}")
     private String dbVersion;
 
@@ -58,7 +58,7 @@ public class InfoController {
     @RequestMapping(value = "/info", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get information about the running instance")
     public ResponseEntity<Info> getInfo() {
-        
+
         Info info = new Info();
         info.setPortalVersion(portalVersion);
         info.setDbVersion(dbVersion);

--- a/web/src/main/java/org/cbioportal/web/MrnaPercentileController.java
+++ b/web/src/main/java/org/cbioportal/web/MrnaPercentileController.java
@@ -34,8 +34,8 @@ public class MrnaPercentileController {
     private MrnaPercentileService mrnaPercentileService;
 
     @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
-    @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mrna-percentile/fetch", 
-        method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, 
+    @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mrna-percentile/fetch",
+        method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get mRNA expression percentiles for list of genes for a sample")
     public ResponseEntity<List<MrnaPercentile>> fetchMrnaPercentile(

--- a/web/src/main/java/org/cbioportal/web/MutationEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationEnrichmentController.java
@@ -15,21 +15,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import org.springframework.security.access.prepost.PreAuthorize;
-
 import javax.validation.Valid;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.springframework.web.bind.annotation.RequestAttribute;
 import springfox.documentation.annotations.ApiIgnore;
 
 @InternalApi

--- a/web/src/main/java/org/cbioportal/web/PatientController.java
+++ b/web/src/main/java/org/cbioportal/web/PatientController.java
@@ -161,7 +161,7 @@ public class PatientController {
     }
 
     private void extractStudyAndPatientIds(PatientFilter patientFilter, List<String> studyIds, List<String> patientIds) {
-        
+
         for (PatientIdentifier patientIdentifier : patientFilter.getPatientIdentifiers()) {
             studyIds.add(patientIdentifier.getStudyId());
             patientIds.add(patientIdentifier.getPatientId());

--- a/web/src/main/java/org/cbioportal/web/ReferenceGenomeGeneController.java
+++ b/web/src/main/java/org/cbioportal/web/ReferenceGenomeGeneController.java
@@ -30,7 +30,7 @@ public class ReferenceGenomeGeneController {
 
     private static final int GENE_MAX_PAGE_SIZE = 100000;
     private static final String GENE_DEFAULT_PAGE_SIZE = "100000";
-    
+
     @Autowired
     private ReferenceGenomeGeneService referenceGenomeGeneService;
 
@@ -39,7 +39,7 @@ public class ReferenceGenomeGeneController {
     public ResponseEntity<List<ReferenceGenomeGene>> getAllReferenceGenomeGenes(
         @ApiParam(required = true, value = "Name of Reference Genome hg19")
         @PathVariable String genomeName)  {
-        
+
         return new ResponseEntity<>(
                 referenceGenomeGeneService.fetchAllReferenceGenomeGenes(genomeName), HttpStatus.OK);
     }
@@ -51,10 +51,10 @@ public class ReferenceGenomeGeneController {
         @PathVariable String genomeName,
         @ApiParam(required = true, value = "Entrez Gene ID 207")
         @PathVariable Integer geneId) throws GeneNotFoundException {
-    
+
         return new ResponseEntity<>(referenceGenomeGeneService.getReferenceGenomeGene(geneId, genomeName), HttpStatus.OK);
     }
-    
+
     @RequestMapping(value = "/reference-genome-genes/{genomeName}/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch genes of reference genome of interest")
@@ -64,7 +64,7 @@ public class ReferenceGenomeGeneController {
         @ApiParam(required = true, value = "List of Entrez Gene IDs")
         @Size(min = 1, max = GENE_MAX_PAGE_SIZE)
         @RequestBody List<String> geneIds) {
-        
+
         if (isInteger(geneIds.get(0))) {
             List<Integer> newIds = geneIds.stream().map(s -> Integer.parseInt(s)).collect(Collectors.toList());
             return new ResponseEntity<>(referenceGenomeGeneService.fetchGenesByGenomeName(newIds, genomeName), HttpStatus.OK);
@@ -73,7 +73,7 @@ public class ReferenceGenomeGeneController {
                     geneIds, genomeName), HttpStatus.OK);
         }
     }
-    
+
     private boolean isInteger(String s) {
         try {
             Integer.parseInt(s);

--- a/web/src/main/java/org/cbioportal/web/SampleController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleController.java
@@ -116,7 +116,7 @@ public class SampleController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) SampleSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) throws PatientNotFoundException, 
+        @RequestParam(defaultValue = "ASC") Direction direction) throws PatientNotFoundException,
         StudyNotFoundException {
 
         if (projection == Projection.META) {
@@ -169,7 +169,7 @@ public class SampleController {
 
             if (interceptedSampleFilter.getSampleListIds() != null) {
                 samples = sampleService.fetchSamples(interceptedSampleFilter.getSampleListIds(), projection.name());
-            } else { 
+            } else {
                 if (interceptedSampleFilter.getSampleIdentifiers() != null) {
                     extractStudyAndSampleIds(interceptedSampleFilter, studyIds, sampleIds);
                 } else {
@@ -183,7 +183,7 @@ public class SampleController {
     }
 
     private void extractStudyAndSampleIds(SampleFilter sampleFilter, List<String> studyIds, List<String> sampleIds) {
-        
+
         for (SampleIdentifier sampleIdentifier : sampleFilter.getSampleIdentifiers()) {
             studyIds.add(sampleIdentifier.getStudyId());
             sampleIds.add(sampleIdentifier.getSampleId());

--- a/web/src/main/java/org/cbioportal/web/SampleListController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleListController.java
@@ -127,7 +127,7 @@ public class SampleListController {
     }
 
     @PreAuthorize("hasPermission(#sampleListIds, 'Collection<SampleListId>', 'read')")
-    @RequestMapping(value = "/sample-lists/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, 
+    @RequestMapping(value = "/sample-lists/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
     produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch sample lists by ID")
     public ResponseEntity<List<SampleList>> fetchSampleLists(

--- a/web/src/main/java/org/cbioportal/web/StructuralVariantController.java
+++ b/web/src/main/java/org/cbioportal/web/StructuralVariantController.java
@@ -53,14 +53,14 @@ import java.util.ArrayList;
 public class StructuralVariantController {
     @Autowired
     private StructuralVariantService structuralVariantService;
-    
-    @RequestMapping(value = "/structuralvariant/fetch", method = RequestMethod.POST, 
+
+    @RequestMapping(value = "/structuralvariant/fetch", method = RequestMethod.POST,
             consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch structural variants for entrezGeneIds and molecularProfileIds or sampleMolecularIdentifiers")
     public ResponseEntity<List<StructuralVariant>> fetchStructuralVariants(
             @ApiParam(required = true, value = "List of entrezGeneIds and molecularProfileIds or sampleMolecularIdentifiers")
             @Valid @RequestBody StructuralVariantFilter structuralVariantFilter) {
-        
+
         List<StructuralVariant> structuralVariantList;
 
         if (structuralVariantFilter.getSampleMolecularIdentifiers() != null) {
@@ -73,12 +73,12 @@ public class StructuralVariantController {
                 sampleIds.add(sampleMolecularIdentifier.getSampleId());
             }
             structuralVariantList = structuralVariantService.fetchStructuralVariants(molecularProfileIds, structuralVariantFilter.getEntrezGeneIds(), sampleIds);
-            
+
         } else {
             List<String> sampleIds = new ArrayList<>();
             structuralVariantList = structuralVariantService.fetchStructuralVariants(structuralVariantFilter.getMolecularProfileIds(), structuralVariantFilter.getEntrezGeneIds(), sampleIds);
         }
-        
+
         return new ResponseEntity<>(structuralVariantList, HttpStatus.OK);
 
     }

--- a/web/src/main/java/org/cbioportal/web/StructuralVariantController.java
+++ b/web/src/main/java/org/cbioportal/web/StructuralVariantController.java
@@ -36,15 +36,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestBody;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
-import java.util.List;
-import java.util.ArrayList;
+import java.util.*;
 
 @PublicApi
 @RestController
@@ -54,17 +56,21 @@ public class StructuralVariantController {
     @Autowired
     private StructuralVariantService structuralVariantService;
 
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
     @RequestMapping(value = "/structuralvariant/fetch", method = RequestMethod.POST,
             consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch structural variants for entrezGeneIds and molecularProfileIds or sampleMolecularIdentifiers")
     public ResponseEntity<List<StructuralVariant>> fetchStructuralVariants(
+            @ApiIgnore // prevent reference to this attribute in the swagger-ui interface
+            @RequestAttribute(required = false, value = "involvedCancerStudies") Collection<String> involvedCancerStudies,
+            @Valid @RequestAttribute(required = false, value = "interceptedStructuralVariantFilter") StructuralVariantFilter interceptedStructuralVariantFilter,
             @ApiParam(required = true, value = "List of entrezGeneIds and molecularProfileIds or sampleMolecularIdentifiers")
-            @Valid @RequestBody StructuralVariantFilter structuralVariantFilter) {
+            @Valid @RequestBody(required = false) StructuralVariantFilter structuralVariantFilter) {
 
         List<StructuralVariant> structuralVariantList;
 
-        if (structuralVariantFilter.getSampleMolecularIdentifiers() != null) {
-            List<SampleMolecularIdentifier> sampleMolecularIdentifiers = structuralVariantFilter.getSampleMolecularIdentifiers();
+        if (interceptedStructuralVariantFilter.getSampleMolecularIdentifiers() != null) {
+            List<SampleMolecularIdentifier> sampleMolecularIdentifiers = interceptedStructuralVariantFilter.getSampleMolecularIdentifiers();
             List<String> molecularProfileIds = new ArrayList<>();
             List<String> sampleIds = new ArrayList<>();
 
@@ -72,11 +78,11 @@ public class StructuralVariantController {
                 molecularProfileIds.add(sampleMolecularIdentifier.getMolecularProfileId());
                 sampleIds.add(sampleMolecularIdentifier.getSampleId());
             }
-            structuralVariantList = structuralVariantService.fetchStructuralVariants(molecularProfileIds, structuralVariantFilter.getEntrezGeneIds(), sampleIds);
+            structuralVariantList = structuralVariantService.fetchStructuralVariants(molecularProfileIds, interceptedStructuralVariantFilter.getEntrezGeneIds(), sampleIds);
 
         } else {
             List<String> sampleIds = new ArrayList<>();
-            structuralVariantList = structuralVariantService.fetchStructuralVariants(structuralVariantFilter.getMolecularProfileIds(), structuralVariantFilter.getEntrezGeneIds(), sampleIds);
+            structuralVariantList = structuralVariantService.fetchStructuralVariants(interceptedStructuralVariantFilter.getMolecularProfileIds(), interceptedStructuralVariantFilter.getEntrezGeneIds(), sampleIds);
         }
 
         return new ResponseEntity<>(structuralVariantList, HttpStatus.OK);

--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -93,7 +93,7 @@ public class StudyController {
     }
 
     @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', 'read')")
-    @RequestMapping(value = "/studies/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, 
+    @RequestMapping(value = "/studies/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
     produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch studies by IDs")
     public ResponseEntity<List<CancerStudy>> fetchStudies(
@@ -112,7 +112,7 @@ public class StudyController {
             return new ResponseEntity<>(
                 studyService.fetchStudies(studyIds, projection.name()), HttpStatus.OK);
         }
-    
+
     }
 
     @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
@@ -123,14 +123,14 @@ public class StudyController {
         @ApiParam(required = true, value = "Study ID e.g. acc_tcga")
         @PathVariable String studyId) throws JsonParseException, JsonMappingException,
         IOException {
-        
-    	Map<String,Object> map = new HashMap<String,Object>();
+
+        Map<String,Object> map = new HashMap<String,Object>();
         ObjectMapper mapper = new ObjectMapper();
         CancerStudyTags cancerStudyTags = studyService.getTags(studyId);
         if (cancerStudyTags != null) { //If tags is null an empty map is returned
-    		map = mapper.readValue(cancerStudyTags.getTags(), Map.class);
+            map = mapper.readValue(cancerStudyTags.getTags(), Map.class);
         }
-        
+
         return new ResponseEntity<>(map, HttpStatus.OK);
     }
 
@@ -141,9 +141,9 @@ public class StudyController {
     public ResponseEntity<List<CancerStudyTags>> getTagsForMultipleStudies(
         @ApiParam(required = true, value = "List of Study IDs")
         @RequestBody List<String> studyIds) {
-        
+
         List<CancerStudyTags> cancerStudyTags = studyService.getTagsForMultipleStudies(studyIds);
-        
+
         return new ResponseEntity<>(cancerStudyTags, HttpStatus.OK);
     }
 }

--- a/web/src/main/java/org/cbioportal/web/StudyViewController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyViewController.java
@@ -68,7 +68,7 @@ public class StudyViewController {
     private StudyViewFilterUtil studyViewFilterUtil;
 
     @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
-    @RequestMapping(value = "/clinical-data-counts/fetch", method = RequestMethod.POST, 
+    @RequestMapping(value = "/clinical-data-counts/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical data counts by study view filter")
     public ResponseEntity<List<ClinicalDataCountItem>> fetchClinicalDataCounts(
@@ -96,7 +96,7 @@ public class StudyViewController {
         List<ClinicalDataCountItem> resultForSampleAttributes = clinicalDataService.fetchClinicalDataCounts(
             studyIds, sampleIds, attributes.stream().filter(a -> a.getClinicalDataType().equals(ClinicalDataType.SAMPLE))
             .map(a -> a.getAttributeId()).collect(Collectors.toList()), ClinicalDataType.SAMPLE);
-        List<ClinicalDataCountItem> resultForPatientAttributes = clinicalDataService.fetchClinicalDataCounts(studyIds, sampleIds, 
+        List<ClinicalDataCountItem> resultForPatientAttributes = clinicalDataService.fetchClinicalDataCounts(studyIds, sampleIds,
         attributes.stream().filter(a -> a.getClinicalDataType().equals(ClinicalDataType.PATIENT))
             .map(a -> a.getAttributeId()).collect(Collectors.toList()), ClinicalDataType.PATIENT);
         combinedResult.addAll(resultForSampleAttributes);
@@ -120,27 +120,27 @@ public class StudyViewController {
 
         List<ClinicalDataBinFilter> attributes = interceptedClinicalDataBinCountFilter.getAttributes();
         StudyViewFilter studyViewFilter = interceptedClinicalDataBinCountFilter.getStudyViewFilter();
-        
+
         if (attributes.size() == 1) {
             studyViewFilterUtil.removeSelfFromFilter(attributes.get(0).getAttributeId(), studyViewFilter);
         }
-        
+
         List<DataBin> clinicalDataBins = null;
         List<String> filteredSampleIds = new ArrayList<>();
         List<String> filteredPatientIds = new ArrayList<>();
         List<ClinicalData> filteredClinicalData = fetchClinicalData(attributes, studyViewFilter, filteredSampleIds, filteredPatientIds);
-        Map<String, List<ClinicalData>> filteredClinicalDataByAttributeId = 
+        Map<String, List<ClinicalData>> filteredClinicalDataByAttributeId =
             filteredClinicalData.stream().collect(Collectors.groupingBy(ClinicalData::getAttrId));
-        
-        if (dataBinMethod == DataBinMethod.STATIC) 
+
+        if (dataBinMethod == DataBinMethod.STATIC)
         {
             StudyViewFilter filter = studyViewFilter == null ? null : new StudyViewFilter();
-            
+
             if (filter != null) {
                 filter.setStudyIds(studyViewFilter.getStudyIds());
                 filter.setSampleIdentifiers(studyViewFilter.getSampleIdentifiers());
             }
-            
+
             List<String> unfilteredSampleIds = new ArrayList<>();
             List<String> unfilteredPatientIds = new ArrayList<>();
             List<ClinicalData> unfilteredClinicalData = fetchClinicalData(attributes, filter, unfilteredSampleIds, unfilteredPatientIds);
@@ -152,9 +152,9 @@ public class StudyViewController {
                 for (ClinicalDataBinFilter attribute: attributes) {
                     List<String> filteredIds = attribute.getClinicalDataType() == ClinicalDataType.PATIENT ?
                         filteredPatientIds : filteredSampleIds;
-                    List<String> unfilteredIds = attribute.getClinicalDataType() == ClinicalDataType.PATIENT ? 
+                    List<String> unfilteredIds = attribute.getClinicalDataType() == ClinicalDataType.PATIENT ?
                         unfilteredPatientIds : unfilteredSampleIds;
-                    
+
                     List<DataBin> dataBins = dataBinner.calculateClinicalDataBins(
                         attribute,
                         filteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(), Collections.emptyList()),
@@ -172,7 +172,7 @@ public class StudyViewController {
                 for (ClinicalDataBinFilter attribute: attributes) {
                     List<String> filteredIds = attribute.getClinicalDataType() == ClinicalDataType.PATIENT ?
                         filteredPatientIds : filteredSampleIds;
-                    
+
                     List<DataBin> dataBins = dataBinner.calculateClinicalDataBins(
                         attribute,
                         filteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(), Collections.emptyList()),
@@ -182,12 +182,12 @@ public class StudyViewController {
                 }
             }
         }
-        
+
         return new ResponseEntity<>(clinicalDataBins, HttpStatus.OK);
     }
 
     @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
-    @RequestMapping(value = "/mutated-genes/fetch", method = RequestMethod.POST, 
+    @RequestMapping(value = "/mutated-genes/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch mutated genes by study view filter")
     public ResponseEntity<List<MutationCountByGene>> fetchMutatedGenes(
@@ -219,12 +219,12 @@ public class StudyViewController {
                 });
             }
         }
-        
+
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
-    
+
     @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
-    @RequestMapping(value = "/cna-genes/fetch", method = RequestMethod.POST, 
+    @RequestMapping(value = "/cna-genes/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch CNA genes by study view filter")
     public ResponseEntity<List<CopyNumberCountByGene>> fetchCNAGenes(
@@ -262,12 +262,12 @@ public class StudyViewController {
                 });
             }
         }
-        
+
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
     @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
-    @RequestMapping(value = "/filtered-samples/fetch", method = RequestMethod.POST, 
+    @RequestMapping(value = "/filtered-samples/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch sample IDs by study view filter")
     public ResponseEntity<List<Sample>> fetchFilteredSamples(
@@ -279,13 +279,13 @@ public class StudyViewController {
         @Valid @RequestAttribute(required = false, value = "interceptedStudyViewFilter") StudyViewFilter interceptedStudyViewFilter,
         @ApiParam(required = true, value = "Study view filter")
         @Valid @RequestBody(required = false) StudyViewFilter studyViewFilter) {
-        
+
         List<String> studyIds = new ArrayList<>();
         List<String> sampleIds = new ArrayList<>();
-        
+
         studyViewFilterUtil.extractStudyAndSampleIds(
             studyViewFilterApplier.apply(interceptedStudyViewFilter, negateFilters), studyIds, sampleIds);
-        
+
         List<Sample> result = new ArrayList<>();
         if (!sampleIds.isEmpty()) {
             result = sampleService.fetchSamples(studyIds, sampleIds, Projection.ID.name());
@@ -294,7 +294,7 @@ public class StudyViewController {
     }
 
     @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
-    @RequestMapping(value = "/sample-counts/fetch", method = RequestMethod.POST, 
+    @RequestMapping(value = "/sample-counts/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch sample counts by study view filter")
     public ResponseEntity<MolecularProfileSampleCount> fetchMolecularProfileSampleCounts(
@@ -304,7 +304,7 @@ public class StudyViewController {
         @RequestAttribute(required = false, value = "involvedCancerStudies") Collection<String> involvedCancerStudies,
         @ApiIgnore // prevent reference to this attribute in the swagger-ui interface. this attribute is needed for the @PreAuthorize tag above.
         @Valid @RequestAttribute(required = false, value = "interceptedStudyViewFilter") StudyViewFilter interceptedStudyViewFilter) {
-        
+
         List<String> studyIds = new ArrayList<>();
         List<String> sampleIds = new ArrayList<>();
         studyViewFilterUtil.extractStudyAndSampleIds(studyViewFilterApplier.apply(interceptedStudyViewFilter), studyIds, sampleIds);
@@ -322,7 +322,7 @@ public class StudyViewController {
                 molecularProfileSampleCount.setNumberOfMutationProfiledSamples(Math.toIntExact(genePanelService
                     .fetchGenePanelDataInMultipleMolecularProfiles(firstMutationProfileIds, mutationSampleIds).stream().filter(
                         g -> g.getProfiled()).count()));
-                molecularProfileSampleCount.setNumberOfMutationUnprofiledSamples(sampleCount - 
+                molecularProfileSampleCount.setNumberOfMutationUnprofiledSamples(sampleCount -
                     molecularProfileSampleCount.getNumberOfMutationProfiledSamples());
             }
             List<String> cnaSampleIds = new ArrayList<>(sampleIds);
@@ -331,7 +331,7 @@ public class StudyViewController {
                 molecularProfileSampleCount.setNumberOfCNAProfiledSamples(Math.toIntExact(genePanelService
                     .fetchGenePanelDataInMultipleMolecularProfiles(firstDiscreteCNAProfileIds, cnaSampleIds).stream().filter(
                         g -> g.getProfiled()).count()));
-                molecularProfileSampleCount.setNumberOfCNAUnprofiledSamples(sampleCount - 
+                molecularProfileSampleCount.setNumberOfCNAUnprofiledSamples(sampleCount -
                     molecularProfileSampleCount.getNumberOfCNAProfiledSamples());
             }
             molecularProfileSampleCount.setNumberOfCNSegmentSamples(Math.toIntExact(sampleService
@@ -342,7 +342,7 @@ public class StudyViewController {
     }
 
     @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
-    @RequestMapping(value = "/clinical-data-density-plot/fetch", method = RequestMethod.POST, 
+    @RequestMapping(value = "/clinical-data-density-plot/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical data density plot bins by study view filter")
     public ResponseEntity<List<DensityPlotBin>> fetchClinicalDataDensityPlot(
@@ -370,7 +370,7 @@ public class StudyViewController {
         @Valid @RequestAttribute(required = false, value = "interceptedStudyViewFilter") StudyViewFilter interceptedStudyViewFilter,
         @ApiParam(required = true, value = "Study view filter")
         @Valid @RequestBody(required = false) StudyViewFilter studyViewFilter) {
-        
+
         List<String> studyIds = new ArrayList<>();
         List<String> sampleIds = new ArrayList<>();
         studyViewFilterUtil.extractStudyAndSampleIds(studyViewFilterApplier.apply(interceptedStudyViewFilter), studyIds, sampleIds);
@@ -378,16 +378,16 @@ public class StudyViewController {
         if (sampleIds.isEmpty()) {
             return new ResponseEntity<>(result, HttpStatus.OK);
         }
-        
-        List<ClinicalData> clinicalDataList = clinicalDataService.fetchClinicalData(studyIds, sampleIds, 
+
+        List<ClinicalData> clinicalDataList = clinicalDataService.fetchClinicalData(studyIds, sampleIds,
             Arrays.asList(xAxisAttributeId, yAxisAttributeId), clinicalDataType.name(), Projection.SUMMARY.name());
 
         Map<String, Map<String, List<ClinicalData>>> clinicalDataMap;
         if (clinicalDataType == ClinicalDataType.SAMPLE) {
-            clinicalDataMap = clinicalDataList.stream().collect(Collectors.groupingBy(ClinicalData::getSampleId, 
+            clinicalDataMap = clinicalDataList.stream().collect(Collectors.groupingBy(ClinicalData::getSampleId,
                 Collectors.groupingBy(ClinicalData::getStudyId)));
         } else {
-            clinicalDataMap = clinicalDataList.stream().collect(Collectors.groupingBy(ClinicalData::getPatientId, 
+            clinicalDataMap = clinicalDataList.stream().collect(Collectors.groupingBy(ClinicalData::getPatientId,
                 Collectors.groupingBy(ClinicalData::getStudyId)));
         }
         List<ClinicalData> filteredClinicalDataList = new ArrayList<>();
@@ -468,12 +468,11 @@ public class StudyViewController {
 
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
-    
-    private List<ClinicalData> fetchClinicalData(List<String> attributeIds, 
-                                                 ClinicalDataType clinicalDataType, 
+
+    private List<ClinicalData> fetchClinicalData(List<String> attributeIds,
+                                                 ClinicalDataType clinicalDataType,
                                                  StudyViewFilter studyViewFilter,
-                                                 List<String> ids)
-    {
+                                                 List<String> ids) {
         List<SampleIdentifier> filteredSampleIdentifiers = studyViewFilterApplier.apply(studyViewFilter);
 
         if (filteredSampleIdentifiers.isEmpty()) {
@@ -482,7 +481,7 @@ public class StudyViewController {
 
         List<String> studyIds = new ArrayList<>();
         List<String> sampleIds = new ArrayList<>();
-        
+
         ids.clear();
 
         studyViewFilterUtil.extractStudyAndSampleIds(filteredSampleIdentifiers, studyIds, sampleIds);
@@ -494,33 +493,32 @@ public class StudyViewController {
             List<Patient> patients = patientService.getPatientsOfSamples(studyIds, sampleIds);
             ids.addAll(patients.stream().map(Patient::getStableId).collect(Collectors.toList()));
 
-            // we need to regenerate study ids for the patients	
+            // we need to regenerate study ids for the patients
             studyIds.clear();
             patients.forEach(p -> studyIds.add(p.getCancerStudyIdentifier()));
         }
-        
+
         return clinicalDataService.fetchClinicalData(
             studyIds, ids, attributeIds, clinicalDataType.name(), Projection.SUMMARY.name());
     }
-    
-    private List<ClinicalData> fetchClinicalData(List<ClinicalDataBinFilter> attributes, 
+
+    private List<ClinicalData> fetchClinicalData(List<ClinicalDataBinFilter> attributes,
                                                  StudyViewFilter studyViewFilter,
                                                  List<String> sampleIds,
-                                                 List<String> patientIds)
-    {
+                                                 List<String> patientIds) {
         List<String> filteredIds = new ArrayList<>();
-        
+
         List<String> sampleAttributes = attributes.stream()
             .filter(a -> a.getClinicalDataType().equals(ClinicalDataType.SAMPLE))
             .map(ClinicalDataBinFilter::getAttributeId)
             .collect(Collectors.toList());
         List<ClinicalData> filteredClinicalDataForSamples = null;
-        
+
         if (sampleAttributes.size() > 0) {
             filteredClinicalDataForSamples = fetchClinicalData(sampleAttributes, ClinicalDataType.SAMPLE, studyViewFilter, filteredIds);
             sampleIds.addAll(filteredIds);
         }
-        
+
         List<String> patientAttributes = attributes.stream()
             .filter(a -> a.getClinicalDataType().equals(ClinicalDataType.PATIENT))
             .map(ClinicalDataBinFilter::getAttributeId)
@@ -531,17 +529,17 @@ public class StudyViewController {
             filteredClinicalDataForPatients = fetchClinicalData(patientAttributes, ClinicalDataType.PATIENT, studyViewFilter, filteredIds);
             patientIds.addAll(filteredIds);
         }
-        
+
         List<ClinicalData> combinedResult = new ArrayList<>();
-        
+
         if (filteredClinicalDataForSamples != null) {
             combinedResult.addAll(filteredClinicalDataForSamples);
         }
-        
+
         if (filteredClinicalDataForPatients != null) {
             combinedResult.addAll(filteredClinicalDataForPatients);
         }
-        
+
         return combinedResult;
     }
 }

--- a/web/src/main/java/org/cbioportal/web/TreatmentDataController.java
+++ b/web/src/main/java/org/cbioportal/web/TreatmentDataController.java
@@ -29,6 +29,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 package org.cbioportal.web;
 
 import java.util.List;
@@ -61,8 +62,7 @@ import io.swagger.annotations.ApiParam;
 @Api(tags = "Treatment response values", description = " ")
 public class TreatmentDataController {
 
-
-	@Autowired
+    @Autowired
     private TreatmentDataService treatmentDataService;
 
     @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfileId', 'read')")
@@ -73,21 +73,20 @@ public class TreatmentDataController {
             @ApiParam(required = true, value = "Genetic profile ID, e.g. study_es_0_treatment_ic50")
             @PathVariable String geneticProfileId,
             @ApiParam(required = true, value = "Search parameters to return the values for a given set of samples and treatment items. "
-            		+ "treatmentIds: The list of identifiers (STABLE_ID) for the treatments of interest, e.g. 17-AAG. "
-            		+ "Use one of these if you want to specify a subset of samples:"
-            		+ "(1) sampleListId: Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all " 
-            		+ "or (2) sampleIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01")
+                    + "treatmentIds: The list of identifiers (STABLE_ID) for the treatments of interest, e.g. 17-AAG. "
+                    + "Use one of these if you want to specify a subset of samples:"
+                    + "(1) sampleListId: Identifier of pre-defined sample list with samples to query, e.g. brca_tcga_all "
+                    + "or (2) sampleIds: custom list of samples or patients to query, e.g. TCGA-BH-A1EO-01, TCGA-AR-A1AR-01")
             @RequestBody TreatmentDataFilterCriteria treatmentDataFilterCriteria) throws MolecularProfileNotFoundException, SampleListNotFoundException {
-
-				if (treatmentDataFilterCriteria.getSampleListId() != null && treatmentDataFilterCriteria.getSampleListId().trim().length() > 0) {
-					return new ResponseEntity<>(
-							treatmentDataService.fetchTreatmentData(geneticProfileId, treatmentDataFilterCriteria.getSampleListId(), 
-									treatmentDataFilterCriteria.getTreatmentIds()), HttpStatus.OK);
-				} else {
-					return new ResponseEntity<>(
-							treatmentDataService.fetchTreatmentData(geneticProfileId, treatmentDataFilterCriteria.getSampleIds(), 
-									treatmentDataFilterCriteria.getTreatmentIds()), HttpStatus.OK);
-				}
-			}
+        if (treatmentDataFilterCriteria.getSampleListId() != null && treatmentDataFilterCriteria.getSampleListId().trim().length() > 0) {
+            return new ResponseEntity<>(
+                    treatmentDataService.fetchTreatmentData(geneticProfileId, treatmentDataFilterCriteria.getSampleListId(),
+                    treatmentDataFilterCriteria.getTreatmentIds()), HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(
+                    treatmentDataService.fetchTreatmentData(geneticProfileId, treatmentDataFilterCriteria.getSampleIds(),
+                    treatmentDataFilterCriteria.getTreatmentIds()), HttpStatus.OK);
+        }
+    }
 
 }

--- a/web/src/main/java/org/cbioportal/web/VariantCountController.java
+++ b/web/src/main/java/org/cbioportal/web/VariantCountController.java
@@ -36,8 +36,8 @@ public class VariantCountController {
     private VariantCountService variantCountService;
 
     @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
-    @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/variant-counts/fetch", 
-        method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, 
+    @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/variant-counts/fetch",
+        method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get counts of specific variants within a mutation molecular profile")
     public ResponseEntity<List<VariantCount>> fetchVariantCounts(
@@ -48,15 +48,15 @@ public class VariantCountController {
         @RequestBody List<VariantCountIdentifier> variantCountIdentifiers) throws MolecularProfileNotFoundException {
 
         List<Integer> entrezGeneIds = new ArrayList<>();
-        List<String> keywords = new ArrayList<>(); 
-        
+        List<String> keywords = new ArrayList<>();
+
         for (VariantCountIdentifier variantCountIdentifier : variantCountIdentifiers) {
-         
+
             entrezGeneIds.add(variantCountIdentifier.getEntrezGeneId());
             keywords.add(variantCountIdentifier.getKeyword());
         }
 
-        return new ResponseEntity<>(variantCountService.fetchVariantCounts(molecularProfileId, entrezGeneIds, keywords), 
+        return new ResponseEntity<>(variantCountService.fetchVariantCounts(molecularProfileId, entrezGeneIds, keywords),
             HttpStatus.OK);
     }
 }

--- a/web/src/main/java/org/cbioportal/web/error/GlobalExceptionHandler.java
+++ b/web/src/main/java/org/cbioportal/web/error/GlobalExceptionHandler.java
@@ -68,7 +68,7 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(new ErrorResponse("Gene set not found: " + ex.getGenesetId()),
                 HttpStatus.NOT_FOUND);
     }
-    
+
     @ExceptionHandler(SampleListNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleSampleListNotFound(SampleListNotFoundException ex) {
         return new ResponseEntity<>(new ErrorResponse("Sample list not found: " + ex.getSampleListId()),
@@ -77,7 +77,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ClinicalAttributeNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleClinicalAttributeNotFound(ClinicalAttributeNotFoundException ex) {
-        return new ResponseEntity<>(new ErrorResponse("Clinical attribute not found in study " + ex.getStudyId() + 
+        return new ResponseEntity<>(new ErrorResponse("Clinical attribute not found in study " + ex.getStudyId() +
             ": " + ex.getClinicalAttributeId()), HttpStatus.NOT_FOUND);
     }
 
@@ -111,7 +111,7 @@ public class GlobalExceptionHandler {
         ConstraintViolation constraintViolation = ex.getConstraintViolations().iterator().next();
         Iterator<Path.Node> iterator = constraintViolation.getPropertyPath().iterator();
         String parameterName = null;
-        
+
         while (iterator.hasNext()) {
             Path.Node node = iterator.next();
             if (node.getKind() == ElementKind.PARAMETER) {
@@ -125,7 +125,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
-        
+
         FieldError fieldError = ex.getBindingResult().getFieldError();
         return new ResponseEntity<>(new ErrorResponse(fieldError.getField() + " " + fieldError.getDefaultMessage()),
             HttpStatus.BAD_REQUEST);

--- a/web/src/main/java/org/cbioportal/web/interceptor/UniqueKeyInterceptor.java
+++ b/web/src/main/java/org/cbioportal/web/interceptor/UniqueKeyInterceptor.java
@@ -80,10 +80,10 @@ public class UniqueKeyInterceptor extends AbstractMappingJacksonResponseBodyAdvi
                 } else if (object instanceof Sample) {
                     Sample sample = (Sample) object;
                     sample.setUniqueSampleKey(calculateBase64(sample.getStableId(), sample.getCancerStudyIdentifier()));
-                    sample.setUniquePatientKey(calculateBase64(sample.getPatientStableId(), 
+                    sample.setUniquePatientKey(calculateBase64(sample.getPatientStableId(),
                         sample.getCancerStudyIdentifier()));
                 } else if (object instanceof StructuralVariant) {
-                    
+
                     StructuralVariant structuralVariant = (StructuralVariant) object;
                     structuralVariant.setUniqueSampleKey(calculateBase64(structuralVariant.getSampleId(), structuralVariant.getStudyId()));
                     structuralVariant.setUniquePatientKey(calculateBase64(structuralVariant.getPatientId(), structuralVariant.getStudyId()));

--- a/web/src/main/java/org/cbioportal/web/mixin/ClinicalEventMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/ClinicalEventMixin.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ClinicalEventMixin {
-    
+
     @JsonIgnore
     private Integer clinicalEventId;
     @JsonProperty("startNumberOfDaysSinceDiagnosis")

--- a/web/src/main/java/org/cbioportal/web/mixin/GenePanelToGeneMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/GenePanelToGeneMixin.java
@@ -3,7 +3,7 @@ package org.cbioportal.web.mixin;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class GenePanelToGeneMixin {
-    
+
     @JsonIgnore
     private String genePanelId;
 }

--- a/web/src/main/java/org/cbioportal/web/mixin/GenesetMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/GenesetMixin.java
@@ -3,7 +3,7 @@ package org.cbioportal.web.mixin;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class GenesetMixin {
-	
-	@JsonIgnore
+
+    @JsonIgnore
     private Integer internalId;
 }

--- a/web/src/main/java/org/cbioportal/web/mixin/GisticMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/GisticMixin.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GisticMixin {
-    
+
     @JsonIgnore
     private Long gisticRoiId;
     @JsonProperty("studyId")

--- a/web/src/main/java/org/cbioportal/web/mixin/MolecularProfileMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/MolecularProfileMixin.java
@@ -16,5 +16,5 @@ public class MolecularProfileMixin {
     private String cancerStudyIdentifier;
     @JsonProperty("study")
     private CancerStudy cancerStudy;
-    
+
 }

--- a/web/src/main/java/org/cbioportal/web/mixin/MutationMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/MutationMixin.java
@@ -3,7 +3,7 @@ package org.cbioportal.web.mixin;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class MutationMixin {
-    
+
     @JsonProperty("variantAllele")
     private String tumorSeqAllele;
     @JsonProperty("refseqMrnaId")

--- a/web/src/main/java/org/cbioportal/web/mixin/TreatmentMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/TreatmentMixin.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TreatmentMixin {
-	
-	@JsonIgnore
+
+    @JsonIgnore
     private Integer id;
     @JsonProperty("treatmentId")
     private String stableId;

--- a/web/src/main/java/org/cbioportal/web/parameter/ChartType.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ChartType.java
@@ -5,6 +5,7 @@ package org.cbioportal.web.parameter;
  * https://github.com/cBioPortal/cbioportal-frontend/blob/34dd97eafc73551816b8dd8b1b837e21640dad0e/src/pages/studyView/StudyViewUtils.tsx#L38
  */
 public enum ChartType {
+
     PIE_CHART,
     BAR_CHART,
     SURVIVAL,

--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataBinCountFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataBinCountFilter.java
@@ -4,9 +4,10 @@ import java.io.Serializable;
 import java.util.List;
 
 public class ClinicalDataBinCountFilter implements Serializable {
+
     private List<ClinicalDataBinFilter> attributes;
     private StudyViewFilter studyViewFilter;
-    
+
     public List<ClinicalDataBinFilter> getAttributes() {
         return attributes;
     }

--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataBinFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataBinFilter.java
@@ -7,12 +7,10 @@ import java.util.List;
 import javax.validation.constraints.AssertTrue;
 
 public class ClinicalDataBinFilter extends ClinicalDataFilter implements Serializable {
+
     private Boolean disableLogScale = false;
-
     private List<BigDecimal> customBins;
-
     private BigDecimal start;
-    
     private BigDecimal end;
 
     public Boolean getDisableLogScale() {

--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataCountFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataCountFilter.java
@@ -9,18 +9,18 @@ public class ClinicalDataCountFilter implements Serializable {
     private StudyViewFilter studyViewFilter;
 
     public List<ClinicalDataFilter> getAttributes() {
-		return attributes;
-	}
-
-	public void setAttributes(List<ClinicalDataFilter> attributes) {
-		this.attributes = attributes;
+        return attributes;
     }
-    
-    public StudyViewFilter getStudyViewFilter() {
-		return studyViewFilter;
-	}
 
-	public void setStudyViewFilter(StudyViewFilter studyViewFilter) {
-		this.studyViewFilter = studyViewFilter;
-	}
+    public void setAttributes(List<ClinicalDataFilter> attributes) {
+        this.attributes = attributes;
+    }
+
+    public StudyViewFilter getStudyViewFilter() {
+        return studyViewFilter;
+    }
+
+    public void setStudyViewFilter(StudyViewFilter studyViewFilter) {
+        this.studyViewFilter = studyViewFilter;
+    }
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataEqualityFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataEqualityFilter.java
@@ -4,13 +4,14 @@ import java.io.Serializable;
 import java.util.List;
 
 public class ClinicalDataEqualityFilter extends ClinicalDataFilter  implements Serializable {
+
     private List<String> values;
 
-	public List<String> getValues() {
-		return values;
-	}
+    public List<String> getValues() {
+        return values;
+    }
 
-	public void setValues(List<String> values) {
-		this.values = values;
-	}
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataFilter.java
@@ -4,8 +4,8 @@ import java.io.Serializable;
 
 import org.cbioportal.model.ClinicalDataCountItem.ClinicalDataType;
 
-public class ClinicalDataFilter  implements Serializable
-{
+public class ClinicalDataFilter implements Serializable {
+
     private String attributeId;
     private ClinicalDataType clinicalDataType;
 

--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataIntervalFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataIntervalFilter.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.List;
 
 public class ClinicalDataIntervalFilter extends ClinicalDataFilter implements Serializable {
+
     private List<ClinicalDataIntervalFilterValue> values;
 
     public List<ClinicalDataIntervalFilterValue> getValues() {

--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataIntervalFilterValue.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataIntervalFilterValue.java
@@ -3,12 +3,12 @@ package org.cbioportal.web.parameter;
 import java.io.Serializable;
 import java.math.BigDecimal;
 
-public class ClinicalDataIntervalFilterValue implements Serializable
-{
+public class ClinicalDataIntervalFilterValue implements Serializable {
+
     private BigDecimal start;
     private BigDecimal end;
     private String value;
-    
+
     public BigDecimal getStart() {
         return start;
     }

--- a/web/src/main/java/org/cbioportal/web/parameter/CoExpressionFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/CoExpressionFilter.java
@@ -37,7 +37,7 @@ public class CoExpressionFilter {
     public void setSampleListId(String sampleListId) {
         this.sampleListId = sampleListId;
     }
-    
+
     public Integer getEntrezGeneId() {
         return entrezGeneId;
     }

--- a/web/src/main/java/org/cbioportal/web/parameter/CopyNumberCountIdentifier.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/CopyNumberCountIdentifier.java
@@ -1,7 +1,7 @@
 package org.cbioportal.web.parameter;
 
 public class CopyNumberCountIdentifier {
-    
+
     private Integer entrezGeneId;
     private Integer alteration;
 

--- a/web/src/main/java/org/cbioportal/web/parameter/CopyNumberGeneFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/CopyNumberGeneFilter.java
@@ -7,11 +7,11 @@ public class CopyNumberGeneFilter implements Serializable {
 
     private List<CopyNumberGeneFilterElement> alterations;
 
-	public List<CopyNumberGeneFilterElement> getAlterations() {
-		return alterations;
-	}
+    public List<CopyNumberGeneFilterElement> getAlterations() {
+        return alterations;
+    }
 
-	public void setAlterations(List<CopyNumberGeneFilterElement> alterations) {
-		this.alterations = alterations;
-	}
+    public void setAlterations(List<CopyNumberGeneFilterElement> alterations) {
+        this.alterations = alterations;
+    }
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/CopyNumberGeneFilterElement.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/CopyNumberGeneFilterElement.java
@@ -13,18 +13,18 @@ public class CopyNumberGeneFilterElement {
     }
 
     public Integer getEntrezGeneId() {
-		return entrezGeneId;
-	}
+        return entrezGeneId;
+    }
 
-	public void setEntrezGeneId(Integer entrezGeneId) {
-		this.entrezGeneId = entrezGeneId;
-	}
+    public void setEntrezGeneId(Integer entrezGeneId) {
+        this.entrezGeneId = entrezGeneId;
+    }
 
-	public Integer getAlteration() {
-		return alteration;
-	}
+    public Integer getAlteration() {
+        return alteration;
+    }
 
-	public void setAlteration(Integer alteration) {
-		this.alteration = alteration;
-	}
+    public void setAlteration(Integer alteration) {
+        this.alteration = alteration;
+    }
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/DataBinMethod.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/DataBinMethod.java
@@ -1,7 +1,7 @@
 package org.cbioportal.web.parameter;
 
-public enum DataBinMethod
-{
+public enum DataBinMethod {
+
     STATIC,
     DYNAMIC
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/DiscreteCopyNumberEventType.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/DiscreteCopyNumberEventType.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public enum DiscreteCopyNumberEventType {
-    
+
     HOMDEL_AND_AMP(-2, 2),
     HOMDEL(-2),
     AMP(2),
@@ -12,11 +12,10 @@ public enum DiscreteCopyNumberEventType {
     HETLOSS(-1),
     DIPLOID(0),
     ALL(-2, -1, 0, 1, 2);
-    
+
     private List<Integer> alterationTypes;
 
     DiscreteCopyNumberEventType(Integer... alterationTypes) {
-        
         this.alterationTypes = Arrays.asList(alterationTypes);
     }
 

--- a/web/src/main/java/org/cbioportal/web/parameter/DiscreteCopyNumberFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/DiscreteCopyNumberFilter.java
@@ -7,7 +7,6 @@ import java.util.List;
 public class DiscreteCopyNumberFilter {
 
     private static final int DISCRETE_COPY_NUMBER_MAX_PAGE_SIZE = 50000;
-    
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> sampleIds;
     private String sampleListId;

--- a/web/src/main/java/org/cbioportal/web/parameter/EnrichmentFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/EnrichmentFilter.java
@@ -5,7 +5,7 @@ import javax.validation.constraints.Size;
 import java.util.List;
 
 public class EnrichmentFilter {
-    
+
     @NotNull
     @Size(min = 1)
     private List<String> alteredIds;

--- a/web/src/main/java/org/cbioportal/web/parameter/GeneIdType.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/GeneIdType.java
@@ -1,7 +1,7 @@
 package org.cbioportal.web.parameter;
 
 public enum GeneIdType {
-    
+
     ENTREZ_GENE_ID,
     HUGO_GENE_SYMBOL
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/GenePanelDataFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/GenePanelDataFilter.java
@@ -5,7 +5,6 @@ import javax.validation.constraints.Size;
 import java.util.List;
 
 public class GenePanelDataFilter {
-
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> sampleIds;
     private String sampleListId;

--- a/web/src/main/java/org/cbioportal/web/parameter/GenesetDataFilterCriteria.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/GenesetDataFilterCriteria.java
@@ -5,41 +5,40 @@ import java.util.List;
 /**
  * Wrapper class for specifying filter criteria for GeneticData items
  * in the GeneticDataController services.
- *  
+ *
  * @author pieter
  *
  */
 public class GenesetDataFilterCriteria {
-	//The list of identifiers for the gene sets of interest. 
+
+    //The list of identifiers for the gene sets of interest.
     private List<String> genesetIds;
-
-    //Identifier of pre-defined sample list with samples to query. E.g. brca_tcga_all 
+    //Identifier of pre-defined sample list with samples to query. E.g. brca_tcga_all
     private String sampleListId;
-
     //Full list of samples or patients to query, E.g. list with TCGA-AR-A1AR-01, TCGA-BH-A1EO-01...
     private List<String> sampleIds;
 
-	public List<String> getGenesetIds() {
-		return genesetIds;
-	}
+    public List<String> getGenesetIds() {
+        return genesetIds;
+    }
 
-	public void setGenesetIds(List<String> genesetIds) {
-		this.genesetIds = genesetIds;
-	}
+    public void setGenesetIds(List<String> genesetIds) {
+        this.genesetIds = genesetIds;
+    }
 
-	public String getSampleListId() {
-		return sampleListId;
-	}
+    public String getSampleListId() {
+        return sampleListId;
+    }
 
-	public void setSampleListId(String sampleListId) {
-		this.sampleListId = sampleListId;
-	}
+    public void setSampleListId(String sampleListId) {
+        this.sampleListId = sampleListId;
+    }
 
-	public List<String> getSampleIds() {
-		return sampleIds;
-	}
+    public List<String> getSampleIds() {
+        return sampleIds;
+    }
 
-	public void setSampleIds(List<String> sampleIds) {
-		this.sampleIds = sampleIds;
-	}
+    public void setSampleIds(List<String> sampleIds) {
+        this.sampleIds = sampleIds;
+    }
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/Group.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/Group.java
@@ -9,7 +9,6 @@ public class Group implements Serializable {
 
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<SampleIdentifier> sampleIdentifiers;
-
     private String name;
 
     public List<SampleIdentifier> getSampleIdentifiers() {

--- a/web/src/main/java/org/cbioportal/web/parameter/MolecularProfileCasesGroupFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/MolecularProfileCasesGroupFilter.java
@@ -10,7 +10,6 @@ public class MolecularProfileCasesGroupFilter {
 
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<MolecularProfileCaseIdentifier> MolecularProfileCaseIdentifiers;
-
     private String name;
 
     public String getName() {

--- a/web/src/main/java/org/cbioportal/web/parameter/MolecularProfileFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/MolecularProfileFilter.java
@@ -6,12 +6,12 @@ import java.util.List;
 import java.io.Serializable;
 
 public class MolecularProfileFilter implements Serializable {
-    
+
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> studyIds;
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> molecularProfileIds;
-    
+
     @AssertTrue
     private boolean isEitherStudyIdsOrMolecularProfileIdsPresent() {
         return studyIds != null ^ molecularProfileIds != null;

--- a/web/src/main/java/org/cbioportal/web/parameter/MutationFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/MutationFilter.java
@@ -7,13 +7,13 @@ import javax.validation.constraints.Size;
 import java.util.List;
 
 public class MutationFilter {
-    
+
     @Size(min = 1, max = MutationController.MUTATION_MAX_PAGE_SIZE)
     private List<String> sampleIds;
     private String sampleListId;
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<Integer> entrezGeneIds;
-    
+
     @AssertTrue
     private boolean isEitherSampleListIdOrSampleIdsPresent() {
         return sampleListId != null ^ sampleIds != null;

--- a/web/src/main/java/org/cbioportal/web/parameter/MutationGeneFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/MutationGeneFilter.java
@@ -7,11 +7,11 @@ public class MutationGeneFilter implements Serializable {
 
     private List<Integer> entrezGeneIds;
 
-	public List<Integer> getEntrezGeneIds() {
-		return entrezGeneIds;
-	}
+    public List<Integer> getEntrezGeneIds() {
+        return entrezGeneIds;
+    }
 
-	public void setEntrezGeneIds(List<Integer> entrezGeneIds) {
-		this.entrezGeneIds = entrezGeneIds;
-	}
+    public void setEntrezGeneIds(List<Integer> entrezGeneIds) {
+        this.entrezGeneIds = entrezGeneIds;
+    }
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/MutationMultipleStudyFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/MutationMultipleStudyFilter.java
@@ -6,7 +6,7 @@ import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
 import java.util.List;
 import java.io.Serializable;
-    
+
 public class MutationMultipleStudyFilter implements Serializable {
 
     @Size(min = 1, max = MutationController.MUTATION_MAX_PAGE_SIZE)

--- a/web/src/main/java/org/cbioportal/web/parameter/PageSettings.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/PageSettings.java
@@ -11,9 +11,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PageSettings extends Session {
-    
-    private final Log LOG = LogFactory.getLog(PageSettings.class);
 
+    private final Log LOG = LogFactory.getLog(PageSettings.class);
     private PageSettingsData data;
 
     @Override
@@ -25,7 +24,7 @@ public class PageSettings extends Session {
             LOG.error(e);
         }
     }
-    
+
     @Override
     public PageSettingsData getData() {
         return data;

--- a/web/src/main/java/org/cbioportal/web/parameter/PageSettingsData.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/PageSettingsData.java
@@ -19,14 +19,10 @@ public abstract class PageSettingsData implements Serializable {
 
     @NotNull
     private SessionPage page;
-
     private String owner = "anonymous";
-
     @NotNull
     private Set<String> origin;
-
     private Long created = System.currentTimeMillis();
-
     private Long lastUpdated = System.currentTimeMillis();
 
     public SessionPage getPage() {

--- a/web/src/main/java/org/cbioportal/web/parameter/PageSettingsIdentifier.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/PageSettingsIdentifier.java
@@ -10,7 +10,6 @@ public class PageSettingsIdentifier implements Serializable {
 
     @NotNull
     private SessionPage page;
-
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     List<String> origin;
 

--- a/web/src/main/java/org/cbioportal/web/parameter/PatientFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/PatientFilter.java
@@ -6,12 +6,12 @@ import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
 
 public class PatientFilter implements Serializable {
-    
+
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<PatientIdentifier> patientIdentifiers;
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> uniquePatientKeys;
-    
+
     @AssertTrue
     private boolean isEitherPatientIdentifiersOrUniquePatientKeysPresent() {
         return patientIdentifiers != null ^ uniquePatientKeys != null;

--- a/web/src/main/java/org/cbioportal/web/parameter/SampleFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/SampleFilter.java
@@ -8,14 +8,14 @@ import java.util.List;
 import java.io.Serializable;
 
 public class SampleFilter implements Serializable {
-    
+
     @Size(min = 1, max = SampleController.SAMPLE_MAX_PAGE_SIZE)
     private List<SampleIdentifier> sampleIdentifiers;
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> sampleListIds;
     @Size(min = 1, max = SampleController.SAMPLE_MAX_PAGE_SIZE)
     private List<String> uniqueSampleKeys;
-    
+
     @AssertTrue
     private boolean isOnlyOneTypeOfFilterPresent() {
         return sampleIdentifiers != null ^ sampleListIds != null ^ uniqueSampleKeys != null;

--- a/web/src/main/java/org/cbioportal/web/parameter/SampleMolecularIdentifier.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/SampleMolecularIdentifier.java
@@ -3,7 +3,7 @@ package org.cbioportal.web.parameter;
 import java.io.Serializable;
 
 public class SampleMolecularIdentifier implements Serializable {
-    
+
     private String sampleId;
     private String molecularProfileId;
 

--- a/web/src/main/java/org/cbioportal/web/parameter/SessionPage.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/SessionPage.java
@@ -1,5 +1,6 @@
 package org.cbioportal.web.parameter;
 
 public enum SessionPage {
+
     study_view;
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/StructuralVariantFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/StructuralVariantFilter.java
@@ -34,7 +34,7 @@ public class StructuralVariantFilter {
     private List<Integer> entrezGeneIds;
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<SampleMolecularIdentifier> sampleMolecularIdentifiers;
-    
+
     @AssertTrue
     private boolean isEitherMolecularProfileIdsOrSampleMolecularIdentifiersPresent() {
         return molecularProfileIds != null ^ sampleMolecularIdentifiers != null;

--- a/web/src/main/java/org/cbioportal/web/parameter/StructuralVariantFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/StructuralVariantFilter.java
@@ -25,9 +25,10 @@ package org.cbioportal.web.parameter;
 
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
+import java.io.Serializable;
 import java.util.List;
 
-public class StructuralVariantFilter {
+public class StructuralVariantFilter implements Serializable {
 
     @Size(min=1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> molecularProfileIds;

--- a/web/src/main/java/org/cbioportal/web/parameter/StudyPageSettings.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/StudyPageSettings.java
@@ -190,13 +190,9 @@ public class StudyPageSettings extends PageSettingsData implements Serializable 
     }
 
     private List<ChartSetting> chartSettings = new ArrayList<ChartSetting>();
-
     private String owner = "anonymous";
-
     private Set<String> origin = new HashSet<>();
-
     private Long created = System.currentTimeMillis();
-
     private Long lastUpdated = System.currentTimeMillis();
 
     public String getOwner() {

--- a/web/src/main/java/org/cbioportal/web/parameter/StudyViewFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/StudyViewFilter.java
@@ -13,24 +13,24 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 @JsonInclude(Include.NON_NULL)
 public class StudyViewFilter implements Serializable {
 
-	@Size(min = 1)
-	private List<SampleIdentifier> sampleIdentifiers;
-	@Size(min = 1)
-	private List<String> studyIds;
+    @Size(min = 1)
+    private List<SampleIdentifier> sampleIdentifiers;
+    @Size(min = 1)
+    private List<String> studyIds;
     private List<ClinicalDataEqualityFilter> clinicalDataEqualityFilters;
     private List<ClinicalDataIntervalFilter> clinicalDataIntervalFilters;
-	private List<MutationGeneFilter> mutatedGenes;
-	private List<CopyNumberGeneFilter> cnaGenes;
-	private Boolean withMutationData;
-	private Boolean withCNAData;
-	private RectangleBounds mutationCountVsCNASelection;
+    private List<MutationGeneFilter> mutatedGenes;
+    private List<CopyNumberGeneFilter> cnaGenes;
+    private Boolean withMutationData;
+    private Boolean withCNAData;
+    private RectangleBounds mutationCountVsCNASelection;
 
-	@AssertTrue
+    @AssertTrue
     private boolean isEitherSampleIdentifiersOrStudyIdsPresent() {
         return sampleIdentifiers != null ^ studyIds != null;
     }
 
-	@AssertTrue
+    @AssertTrue
     private boolean isEitherValueOrRangePresentInClinicalDataIntervalFilters() {
         long invalidCount = 0;
 
@@ -44,30 +44,30 @@ public class StudyViewFilter implements Serializable {
 
         return invalidCount == 0;
     }
-	
-	public List<SampleIdentifier> getSampleIdentifiers() {
-		return sampleIdentifiers;
-	}
 
-	public void setSampleIdentifiers(List<SampleIdentifier> sampleIdentifiers) {
-		this.sampleIdentifiers = sampleIdentifiers;
-	}
+    public List<SampleIdentifier> getSampleIdentifiers() {
+        return sampleIdentifiers;
+    }
 
-	public List<String> getStudyIds() {
-		return studyIds;
-	}
+    public void setSampleIdentifiers(List<SampleIdentifier> sampleIdentifiers) {
+        this.sampleIdentifiers = sampleIdentifiers;
+    }
 
-	public void setStudyIds(List<String> studyIds) {
-		this.studyIds = studyIds;
-	}
+    public List<String> getStudyIds() {
+        return studyIds;
+    }
 
-	public List<ClinicalDataEqualityFilter> getClinicalDataEqualityFilters() {
-		return clinicalDataEqualityFilters;
-	}
+    public void setStudyIds(List<String> studyIds) {
+        this.studyIds = studyIds;
+    }
 
-	public void setClinicalDataEqualityFilters(List<ClinicalDataEqualityFilter> clinicalDataEqualityFilters) {
-		this.clinicalDataEqualityFilters = clinicalDataEqualityFilters;
-	}
+    public List<ClinicalDataEqualityFilter> getClinicalDataEqualityFilters() {
+        return clinicalDataEqualityFilters;
+    }
+
+    public void setClinicalDataEqualityFilters(List<ClinicalDataEqualityFilter> clinicalDataEqualityFilters) {
+        this.clinicalDataEqualityFilters = clinicalDataEqualityFilters;
+    }
 
     public List<ClinicalDataIntervalFilter> getClinicalDataIntervalFilters() {
         return clinicalDataIntervalFilters;
@@ -78,42 +78,42 @@ public class StudyViewFilter implements Serializable {
     }
 
     public List<MutationGeneFilter> getMutatedGenes() {
-		return mutatedGenes;
-	}
+        return mutatedGenes;
+    }
 
-	public void setMutatedGenes(List<MutationGeneFilter> mutatedGenes) {
-		this.mutatedGenes = mutatedGenes;
-	}
+    public void setMutatedGenes(List<MutationGeneFilter> mutatedGenes) {
+        this.mutatedGenes = mutatedGenes;
+    }
 
-	public List<CopyNumberGeneFilter> getCnaGenes() {
-		return cnaGenes;
-	}
+    public List<CopyNumberGeneFilter> getCnaGenes() {
+        return cnaGenes;
+    }
 
-	public void setCnaGenes(List<CopyNumberGeneFilter> cnaGenes) {
-		this.cnaGenes = cnaGenes;
-	}
+    public void setCnaGenes(List<CopyNumberGeneFilter> cnaGenes) {
+        this.cnaGenes = cnaGenes;
+    }
 
-	public Boolean getWithMutationData() {
-		return withMutationData;
-	}
+    public Boolean getWithMutationData() {
+        return withMutationData;
+    }
 
-	public void setWithMutationData(Boolean withMutationData) {
-		this.withMutationData = withMutationData;
-	}
+    public void setWithMutationData(Boolean withMutationData) {
+        this.withMutationData = withMutationData;
+    }
 
-	public Boolean getWithCNAData() {
-		return withCNAData;
-	}
+    public Boolean getWithCNAData() {
+        return withCNAData;
+    }
 
-	public void setWithCNAData(Boolean withCNAData) {
-		this.withCNAData = withCNAData;
-	}
+    public void setWithCNAData(Boolean withCNAData) {
+        this.withCNAData = withCNAData;
+    }
 
-	public RectangleBounds getMutationCountVsCNASelection() {
-		return mutationCountVsCNASelection;
-	}
+    public RectangleBounds getMutationCountVsCNASelection() {
+        return mutationCountVsCNASelection;
+    }
 
-	public void setMutationCountVsCNASelection(RectangleBounds mutationCountVsCNASelection) {
-		this.mutationCountVsCNASelection = mutationCountVsCNASelection;
-	}
+    public void setMutationCountVsCNASelection(RectangleBounds mutationCountVsCNASelection) {
+        this.mutationCountVsCNASelection = mutationCountVsCNASelection;
+    }
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/TreatmentDataFilterCriteria.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/TreatmentDataFilterCriteria.java
@@ -5,42 +5,40 @@ import java.util.List;
 /**
  * Wrapper class for specifying filter criteria for GeneticData items
  * in the GeneticDataController services.
- *  
+ *
  * @author Pim van Nierop, pim@thehyve.nl
  *
  */
 public class TreatmentDataFilterCriteria {
 
-	//The list of identifiers for the treatments of interest. 
+    //The list of identifiers for the treatments of interest.
     private List<String> treatmentIds;
-
-    //Identifier of pre-defined sample list with samples to query. E.g. brca_tcga_all 
+    //Identifier of pre-defined sample list with samples to query. E.g. brca_tcga_all
     private String sampleListId;
-
     //Full list of samples or patients to query, E.g. list with TCGA-AR-A1AR-01, TCGA-BH-A1EO-01...
     private List<String> sampleIds;
 
-	public List<String> getTreatmentIds() {
-		return treatmentIds;
-	}
+    public List<String> getTreatmentIds() {
+        return treatmentIds;
+    }
 
-	public void setTreatmentIds(List<String> treatmentIds) {
-		this.treatmentIds = treatmentIds;
-	}
+    public void setTreatmentIds(List<String> treatmentIds) {
+        this.treatmentIds = treatmentIds;
+    }
 
-	public String getSampleListId() {
-		return sampleListId;
-	}
+    public String getSampleListId() {
+        return sampleListId;
+    }
 
-	public void setSampleListId(String sampleListId) {
-		this.sampleListId = sampleListId;
-	}
+    public void setSampleListId(String sampleListId) {
+        this.sampleListId = sampleListId;
+    }
 
-	public List<String> getSampleIds() {
-		return sampleIds;
-	}
+    public List<String> getSampleIds() {
+        return sampleIds;
+    }
 
-	public void setSampleIds(List<String> sampleIds) {
-		this.sampleIds = sampleIds;
-	}
+    public void setSampleIds(List<String> sampleIds) {
+        this.sampleIds = sampleIds;
+    }
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/TreatmentFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/TreatmentFilter.java
@@ -6,12 +6,12 @@ import java.util.List;
 import java.io.Serializable;
 
 public class TreatmentFilter implements Serializable {
-    
+
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> studyIds;
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> treatmentIds;
-    
+
     @AssertTrue
     private boolean isEitherStudyIdsOrTreatmentIdsPresent() {
         return studyIds != null ^ treatmentIds != null;

--- a/web/src/main/java/org/cbioportal/web/parameter/VariantCountIdentifier.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/VariantCountIdentifier.java
@@ -1,7 +1,7 @@
 package org.cbioportal.web.parameter;
 
 public class VariantCountIdentifier {
-    
+
     private Integer entrezGeneId;
     private String keyword;
 

--- a/web/src/main/java/org/cbioportal/web/parameter/VirtualStudy.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/VirtualStudy.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class VirtualStudy extends Session {
 
     private final Log LOG = LogFactory.getLog(VirtualStudy.class);
-
     private VirtualStudyData data;
 
     @Override

--- a/web/src/main/java/org/cbioportal/web/parameter/VirtualStudyData.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/VirtualStudyData.java
@@ -9,25 +9,16 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VirtualStudyData implements Serializable {
-    
-	private String name;
 
-	private String description;
-
-	private Set<VirtualStudySamples> studies;
-
-	private StudyViewFilter studyViewFilter;
-
-	private Float version = 1.0f;
-	
-	private String owner = "anonymous";
-
+    private String name;
+    private String description;
+    private Set<VirtualStudySamples> studies;
+    private StudyViewFilter studyViewFilter;
+    private Float version = 1.0f;
+    private String owner = "anonymous";
     private Set<String> origin = new HashSet<>();
-
     private Long created = System.currentTimeMillis();
-    
     private Long lastUpdated = System.currentTimeMillis();
-    
     private Set<String> users = new HashSet<>();
 
     public String getOwner() {
@@ -65,53 +56,52 @@ public class VirtualStudyData implements Serializable {
     public void setUsers(Set<String> users) {
         this.users = users;
     }
-    
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public String getDescription() {
-		return description;
-	}
+    public String getDescription() {
+        return description;
+    }
 
-	public void setDescription(String description) {
-		this.description = description;
-	}
+    public void setDescription(String description) {
+        this.description = description;
+    }
 
-	public Set<VirtualStudySamples> getStudies() {
-		return studies;
-	}
+    public Set<VirtualStudySamples> getStudies() {
+        return studies;
+    }
 
-	public void setStudies(Set<VirtualStudySamples> studies) {
-		this.studies = studies;
-	}
+    public void setStudies(Set<VirtualStudySamples> studies) {
+        this.studies = studies;
+    }
 
-	public Set<String> getOrigin() {
-		if (this.origin == null || this.origin.size() == 0) {
-			return studies.stream().map(map -> map.getId()).collect(Collectors.toSet());
-		}
-		return this.origin;
-	}
+    public Set<String> getOrigin() {
+        if (this.origin == null || this.origin.size() == 0) {
+            return studies.stream().map(map -> map.getId()).collect(Collectors.toSet());
+        }
+        return this.origin;
+    }
 
-	public Float getVersion() {
-		return version;
-	}
+    public Float getVersion() {
+        return version;
+    }
 
-	public void setVersion(Float version) {
-		this.version = version;
-	}
+    public void setVersion(Float version) {
+        this.version = version;
+    }
 
-	public StudyViewFilter getStudyViewFilter() {
-		return studyViewFilter;
-	}
+    public StudyViewFilter getStudyViewFilter() {
+        return studyViewFilter;
+    }
 
-	public void setStudyViewFilter(StudyViewFilter studyViewFilter) {
-		this.studyViewFilter = studyViewFilter;
-	}
-	
+    public void setStudyViewFilter(StudyViewFilter studyViewFilter) {
+        this.studyViewFilter = studyViewFilter;
+    }
+
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/VirtualStudySamples.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/VirtualStudySamples.java
@@ -3,23 +3,24 @@ package org.cbioportal.web.parameter;
 import java.util.Set;
 
 public class VirtualStudySamples {
-	private String id;
-	private Set<String> samples;
 
-	public String getId() {
-		return id;
-	}
+    private String id;
+    private Set<String> samples;
 
-	public void setId(String id) {
-		this.id = id;
-	}
+    public String getId() {
+        return id;
+    }
 
-	public Set<String> getSamples() {
-		return samples;
-	}
+    public void setId(String id) {
+        this.id = id;
+    }
 
-	public void setSamples(Set<String> samples) {
-		this.samples = samples;
-	}
+    public Set<String> getSamples() {
+        return samples;
+    }
+
+    public void setSamples(Set<String> samples) {
+        this.samples = samples;
+    }
 
 }

--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataEnrichmentUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataEnrichmentUtil.java
@@ -66,7 +66,7 @@ public class ClinicalDataEnrichmentUtil {
                     }
                 }
             }
-            
+
             Double totalCount = transposeDataCollection
                     .values()
                     .stream()
@@ -154,7 +154,7 @@ public class ClinicalDataEnrichmentUtil {
 
     /**
      * get data for all NUMBER datatype attributes for given samples
-     * 
+     *
      * @param attributes
      * @param samples
      * @return
@@ -212,7 +212,7 @@ public class ClinicalDataEnrichmentUtil {
 
     /**
      * get data category counts for all STRING datatype attributes for given samples
-     * 
+     *
      * @param attributes
      * @param samples
      * @return

--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataEqualityFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataEqualityFilterApplier.java
@@ -13,24 +13,21 @@ import java.util.List;
 import java.util.Optional;
 
 @Component
-public class ClinicalDataEqualityFilterApplier extends ClinicalDataFilterApplier<ClinicalDataEqualityFilter>
-{
+public class ClinicalDataEqualityFilterApplier extends ClinicalDataFilterApplier<ClinicalDataEqualityFilter> {
     @Autowired
-    public ClinicalDataEqualityFilterApplier(PatientService patientService, 
-                                             ClinicalDataService clinicalDataService, 
+    public ClinicalDataEqualityFilterApplier(PatientService patientService,
+                                             ClinicalDataService clinicalDataService,
                                              SampleService sampleService,
-                                             StudyViewFilterUtil studyViewFilterUtil) 
-    {
+                                             StudyViewFilterUtil studyViewFilterUtil) {
         super(patientService, clinicalDataService, sampleService, studyViewFilterUtil);
     }
-    
+
     @Override
     public Integer apply(List<ClinicalDataEqualityFilter> attributes,
                          MultiKeyMap clinicalDataMap,
                          String entityId,
                          String studyId,
-                         Boolean negateFilters)
-    {
+                         Boolean negateFilters) {
         Integer count = 0;
 
         for (ClinicalDataEqualityFilter s : attributes) {

--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataFilterApplier.java
@@ -16,18 +16,16 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public abstract class ClinicalDataFilterApplier<T extends ClinicalDataFilter>
-{
+public abstract class ClinicalDataFilterApplier<T extends ClinicalDataFilter> {
     private PatientService patientService;
     private ClinicalDataService clinicalDataService;
     private SampleService sampleService;
     protected StudyViewFilterUtil studyViewFilterUtil;
 
-    public ClinicalDataFilterApplier(PatientService patientService, 
-                                     ClinicalDataService clinicalDataService, 
+    public ClinicalDataFilterApplier(PatientService patientService,
+                                     ClinicalDataService clinicalDataService,
                                      SampleService sampleService,
-                                     StudyViewFilterUtil studyViewFilterUtil) 
-    {
+                                     StudyViewFilterUtil studyViewFilterUtil) {
         this.patientService = patientService;
         this.clinicalDataService = clinicalDataService;
         this.sampleService = sampleService;
@@ -116,7 +114,7 @@ public abstract class ClinicalDataFilterApplier<T extends ClinicalDataFilter>
 
         return sampleIdentifiers;
     }
-    
+
     // Must be overridden by child classes
     protected abstract Integer apply(List<T> attributes, MultiKeyMap clinicalDataMap, String entityId, String studyId, Boolean negateFilters);
 }

--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataIntervalFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataIntervalFilterApplier.java
@@ -18,14 +18,12 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
-public class ClinicalDataIntervalFilterApplier extends ClinicalDataFilterApplier<ClinicalDataIntervalFilter>
-{
+public class ClinicalDataIntervalFilterApplier extends ClinicalDataFilterApplier<ClinicalDataIntervalFilter> {
     @Autowired
-    public ClinicalDataIntervalFilterApplier(PatientService patientService, 
-                                             ClinicalDataService clinicalDataService, 
+    public ClinicalDataIntervalFilterApplier(PatientService patientService,
+                                             ClinicalDataService clinicalDataService,
                                              SampleService sampleService,
-                                             StudyViewFilterUtil studyViewFilterUtil) 
-    {
+                                             StudyViewFilterUtil studyViewFilterUtil) {
         super(patientService, clinicalDataService, sampleService, studyViewFilterUtil);
     }
 
@@ -34,8 +32,7 @@ public class ClinicalDataIntervalFilterApplier extends ClinicalDataFilterApplier
                          MultiKeyMap clinicalDataMap,
                          String entityId,
                          String studyId,
-                         Boolean negateFilters)
-    {
+                         Boolean negateFilters) {
         int count = 0;
 
         for (ClinicalDataIntervalFilter filter : attributes) {
@@ -43,7 +40,7 @@ public class ClinicalDataIntervalFilterApplier extends ClinicalDataFilterApplier
             if (entityClinicalData != null) {
                 Optional<ClinicalData> clinicalData = entityClinicalData.stream().filter(c -> c.getAttrId()
                     .equals(filter.getAttributeId())).findFirst();
-                if (clinicalData.isPresent()) 
+                if (clinicalData.isPresent())
                 {
                     String attrValue = clinicalData.get().getAttrValue();
                     Range<BigDecimal> rangeValue = calculateRangeValueForAttr(attrValue);
@@ -64,7 +61,7 @@ public class ClinicalDataIntervalFilterApplier extends ClinicalDataFilterApplier
                         if (negateFilters ^ ranges.stream().anyMatch(r -> r.encloses(rangeValue))) {
                             count++;
                         }
-                    } 
+                    }
                     else if (negateFilters ^ specialValues.contains(attrValue.toUpperCase())) {
                         count++;
                     }
@@ -79,25 +76,24 @@ public class ClinicalDataIntervalFilterApplier extends ClinicalDataFilterApplier
         return count;
     }
 
-    private Range<BigDecimal> calculateRangeValueForAttr(String attrValue)
-    {
+    private Range<BigDecimal> calculateRangeValueForAttr(String attrValue) {
         if (attrValue == null) {
             return null;
         }
-        
+
         BigDecimal min = null;
         BigDecimal max = null;
-        
+
         String value = attrValue.trim();
-        
+
         String lte = "<=";
         String lt = "<";
         String gte = ">=";
         String gt = ">";
-        
+
         boolean startInclusive = true;
         boolean endInclusive = true;
-        
+
         try {
             if (value.startsWith(lte)) {
                 max = new BigDecimal(value.substring(lte.length()));
@@ -120,31 +116,29 @@ public class ClinicalDataIntervalFilterApplier extends ClinicalDataFilterApplier
             // invalid range -- TODO: also support ranges like 20-30?
             return null;
         }
-        
+
         return studyViewFilterUtil.calcRange(min, startInclusive, max, endInclusive);
     }
 
-    private Range<BigDecimal> calculateRangeValueForFilter(ClinicalDataIntervalFilterValue filterValue) 
-    {
+    private Range<BigDecimal> calculateRangeValueForFilter(ClinicalDataIntervalFilterValue filterValue) {
         BigDecimal start = filterValue.getStart();
         BigDecimal end = filterValue.getEnd();
 
         // default: (start, end]
         boolean startInclusive = false;
         boolean endInclusive = true;
-        
+
         // special case: end == start (both inclusive)
         if (end != null && end.equals(start)) {
             startInclusive = true;
         }
-        
+
         // TODO also add startInclusive and endInclusive as a filterValue parameter?
-        
+
         return studyViewFilterUtil.calcRange(start, startInclusive, end, endInclusive);
     }
 
-    private Boolean containsNA(ClinicalDataIntervalFilter filter)
-    {
+    private Boolean containsNA(ClinicalDataIntervalFilter filter) {
         return filter.getValues().stream().anyMatch(
             r -> r.getValue() != null && r.getValue().toUpperCase().equals("NA"));
     }

--- a/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
+++ b/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
@@ -11,8 +11,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
-public class DataBinHelper
-{
+public class DataBinHelper {
     private StudyViewFilterUtil studyViewFilterUtil;
 
     @Autowired
@@ -20,8 +19,7 @@ public class DataBinHelper
         this.studyViewFilterUtil = studyViewFilterUtil;
     }
 
-    public DataBin calcUpperOutlierBin(String attributeId, List<BigDecimal> gteValues, List<BigDecimal> gtValues)
-    {
+    public DataBin calcUpperOutlierBin(String attributeId, List<BigDecimal> gteValues, List<BigDecimal> gtValues) {
         BigDecimal gteMin = gteValues.size() > 0 ? Collections.min(gteValues) : null;
         BigDecimal gtMin = gtValues.size() > 0 ? Collections.min(gtValues) : null;
         BigDecimal min;
@@ -31,12 +29,10 @@ public class DataBinHelper
             // no special outlier
             min = null;
             value = ">";
-        }
-        else if (gtMin == null || (gteMin != null && gteMin.compareTo(gtMin) == -1)) {
+        } else if (gtMin == null || (gteMin != null && gteMin.compareTo(gtMin) == -1)) {
             min = gteMin;
             value = ">=";
-        }
-        else {
+        } else {
             min = gtMin;
             value = ">";
         }
@@ -51,8 +47,7 @@ public class DataBinHelper
         return dataBin;
     }
 
-    public DataBin calcLowerOutlierBin(String attributeId, List<BigDecimal> lteValues, List<BigDecimal> ltValues)
-    {
+    public DataBin calcLowerOutlierBin(String attributeId, List<BigDecimal> lteValues, List<BigDecimal> ltValues) {
         BigDecimal lteMax = lteValues.size() > 0 ? Collections.max(lteValues) : null;
         BigDecimal ltMax = ltValues.size() > 0 ? Collections.max(ltValues) : null;
         BigDecimal max;
@@ -61,12 +56,10 @@ public class DataBinHelper
         if (ltMax == null && lteMax == null) {
             max = null;
             specialValue = "<=";
-        }
-        else if (lteMax == null || (ltMax != null && lteMax.compareTo(ltMax) == -1)) {
+        } else if (lteMax == null || (ltMax != null && lteMax.compareTo(ltMax) == -1)) {
             max = ltMax;
             specialValue = "<";
-        }
-        else {
+        } else {
             max = lteMax;
             specialValue = "<=";
         }
@@ -80,15 +73,14 @@ public class DataBinHelper
 
         return dataBin;
     }
-    
-    public Range<BigDecimal> calcBoxRange(List<BigDecimal> sortedValues)
-    {
+
+    public Range<BigDecimal> calcBoxRange(List<BigDecimal> sortedValues) {
         if (sortedValues == null || sortedValues.size() == 0) {
             return null;
         }
 
-        // Find a generous IQR. This is generous because if (values.length / 4) 
-        // is not an int, then really you should average the two elements on either 
+        // Find a generous IQR. This is generous because if (values.length / 4)
+        // is not an int, then really you should average the two elements on either
         // side to find q1 and q3.
         Range<BigDecimal> interquartileRange = calcInterquartileRange(sortedValues);
 
@@ -98,7 +90,7 @@ public class DataBinHelper
         BigDecimal iqrOneAndHalf = iqr.multiply(new BigDecimal("1.5"));
         BigDecimal q1LowerBoundry = q1.subtract(iqrOneAndHalf);
         BigDecimal q3upperBoundry = q3.add(iqrOneAndHalf);
-        
+
 
         // Then find min and max values
         BigDecimal maxValue;
@@ -109,40 +101,35 @@ public class DataBinHelper
             // we simply set min and max to the same value
             minValue = sortedValues.get(0);
             maxValue = minValue;
-        }
-        else if (q3.compareTo(new BigDecimal("0.001")) != -1 && q3.compareTo(new BigDecimal("1")) == -1) {
+        } else if (q3.compareTo(new BigDecimal("0.001")) != -1 && q3.compareTo(new BigDecimal("1")) == -1) {
             //maxValue = Number((q3 + iqr * 1.5).toFixed(3));
             //minValue = Number((q1 - iqr * 1.5).toFixed(3));
             maxValue = q3upperBoundry.setScale(3, BigDecimal.ROUND_HALF_UP);
             minValue = q1LowerBoundry.setScale(3, BigDecimal.ROUND_HALF_UP);
-        } 
-        else if (q3.compareTo(BigDecimal.valueOf(0.001)) == -1) {
+        } else if (q3.compareTo(BigDecimal.valueOf(0.001)) == -1) {
             // get IQR for very small number(<0.001)
             maxValue = q3upperBoundry;
             minValue = q1LowerBoundry;
-        } 
-        else {
+        } else {
             maxValue = q3upperBoundry.setScale(1, RoundingMode.CEILING);
             minValue = q1LowerBoundry.setScale(1, RoundingMode.FLOOR);
         }
-        
+
         if (minValue.compareTo(sortedValues.get(0)) == -1) {
             minValue = sortedValues.get(0);
         }
-        
+
         if (maxValue.compareTo(sortedValues.get(sortedValues.size() - 1)) == 1) {
             maxValue = sortedValues.get(sortedValues.size() - 1);
         }
 
         return Range.closed(minValue, maxValue);
     }
-    
-    public Range<BigDecimal> calcInterquartileRange(List<BigDecimal> sortedValues)
-    {
+
+    public Range<BigDecimal> calcInterquartileRange(List<BigDecimal> sortedValues) {
         Range<BigDecimal> iqr = null;
-        
-        if (sortedValues.size() > 0)
-        {
+
+        if (sortedValues.size() > 0) {
             BigDecimal q1 = calcQ1(sortedValues);
             BigDecimal q3 = calcQ3(sortedValues);
             BigDecimal max = sortedValues.get(sortedValues.size() - 1);
@@ -159,36 +146,32 @@ public class DataBinHelper
                 iqr = Range.closedOpen(q1, q3);
             }
         }
-        
+
         return iqr;
     }
-    
-    public BigDecimal calcQ1(List<BigDecimal> sortedValues)
-    {
-        return sortedValues.size() > 0 ? 
+
+    public BigDecimal calcQ1(List<BigDecimal> sortedValues) {
+        return sortedValues.size() > 0 ?
             sortedValues.get((int) Math.floor(sortedValues.size() / 4.0)) : null;
     }
 
-    public BigDecimal calcQ3(List<BigDecimal> sortedValues)
-    {
-        return sortedValues.size() > 0 ? 
+    public BigDecimal calcQ3(List<BigDecimal> sortedValues) {
+        return sortedValues.size() > 0 ?
             sortedValues.get((int) Math.floor(sortedValues.size() * (3.0 / 4.0))) : null;
     }
-    
-    public List<BigDecimal> filterIntervals(List<BigDecimal> intervals, BigDecimal lowerOutlier, BigDecimal upperOutlier)
-    {
+
+    public List<BigDecimal> filterIntervals(List<BigDecimal> intervals, BigDecimal lowerOutlier, BigDecimal upperOutlier) {
         // remove values that fall outside the lower and upper outlier limits
         return intervals.stream()
             .filter(d -> (lowerOutlier == null || d.compareTo(lowerOutlier) == 1 ) && (upperOutlier == null || d.compareTo(upperOutlier) == -1))
             .collect(Collectors.toList());
     }
-    
+
     public List<DataBin> initDataBins(String attributeId,
                                       List<BigDecimal> values,
                                       List<BigDecimal> intervals,
                                       BigDecimal lowerOutlier,
-                                      BigDecimal upperOutlier)
-    {
+                                      BigDecimal upperOutlier) {
         return initDataBins(attributeId,
             values,
             filterIntervals(intervals, lowerOutlier, upperOutlier));
@@ -196,17 +179,15 @@ public class DataBinHelper
 
     public List<DataBin> initDataBins(String attributeId,
                                       List<BigDecimal> values,
-                                      List<BigDecimal> intervals)
-    {
+                                      List<BigDecimal> intervals) {
         List<DataBin> dataBins = initDataBins(attributeId, intervals);
 
         calcCounts(dataBins, values);
 
         return dataBins;
     }
-    
-    public List<DataBin> initDataBins(String attributeId, List<BigDecimal> intervalValues)
-    {
+
+    public List<DataBin> initDataBins(String attributeId, List<BigDecimal> intervalValues) {
         List<DataBin> dataBins = new ArrayList<>();
 
         for (int i = 0; i < intervalValues.size() - 1; i++) {
@@ -223,72 +204,65 @@ public class DataBinHelper
         return dataBins;
     }
 
-    public List<DataBin> trim(List<DataBin> dataBins)
-    {
+    public List<DataBin> trim(List<DataBin> dataBins) {
         List<DataBin> toRemove = new ArrayList<>();
-        
+
         // find out leading empty bins
-        for (DataBin dataBin : dataBins)
-        {
+        for (DataBin dataBin : dataBins) {
             if (dataBin.getCount() == null || dataBin.getCount() <= 0) {
                 toRemove.add(dataBin);
-            }
-            else {
+            } else {
                 break;
             }
         }
-        
+
         // find out trailing empty bins
         ListIterator<DataBin> iterator = dataBins.listIterator(dataBins.size());
-        
+
         while (iterator.hasPrevious()) {
             DataBin dataBin = iterator.previous();
 
             if (dataBin.getCount() == null || dataBin.getCount() <= 0) {
                 toRemove.add(dataBin);
-            }
-            else {
+            } else {
                 break;
             }
         }
-        
+
         List<DataBin> trimmed = new ArrayList<>(dataBins);
         trimmed.removeAll(toRemove);
-        
+
         return trimmed;
     }
-    
-    public void calcCounts(List<DataBin> dataBins, List<BigDecimal> values)
-    {
+
+    public void calcCounts(List<DataBin> dataBins, List<BigDecimal> values) {
         Map<Range<BigDecimal>, DataBin> rangeMap = dataBins.stream().collect(Collectors.toMap(this::calcRange, b -> b));
-        
+
         // TODO complexity here is O(n x m), find a better way to do this
         for (Range<BigDecimal> range : rangeMap.keySet()) {
             for (BigDecimal value: values) {
                 // check if the value falls within the data bin range
                 if (range != null && range.contains(value)) {
-                    DataBin dataBin = rangeMap.get(range); 
+                    DataBin dataBin = rangeMap.get(range);
                     dataBin.setCount(dataBin.getCount() + 1);
                 }
             }
         }
     }
-    
-    public Range<BigDecimal> calcRange(DataBin dataBin)
-    {
+
+    public Range<BigDecimal> calcRange(DataBin dataBin) {
         boolean startInclusive = ">=".equals(dataBin.getSpecialValue());
         boolean endInclusive = !"<".equals(dataBin.getSpecialValue());
-        
+
         // special condition (start == end)
         if (dataBin.getStart() != null && dataBin.getEnd() != null && dataBin.getStart().compareTo(dataBin.getEnd())==0) {
             startInclusive = endInclusive = true;
         }
-        
+
         return studyViewFilterUtil.calcRange(dataBin.getStart(), startInclusive, dataBin.getEnd(), endInclusive);
     }
 
-    public Range<BigDecimal> calcRange(String operator, BigDecimal value)
-    {
+    public Range<BigDecimal> calcRange(String operator, BigDecimal value) {
         boolean startInclusive = ">=".equals(operator);
         BigDecimal start = operator.contains(">") ? value : null;
         boolean endInclusive = !"<".equals(operator);
@@ -297,55 +271,47 @@ public class DataBinHelper
         return studyViewFilterUtil.calcRange(start, startInclusive, end, endInclusive);
     }
 
-    public boolean isNA(String value)
-    {
-        return value.toUpperCase().equals("NA") || 
-            value.toUpperCase().equals("NAN") || 
+    public boolean isNA(String value) {
+        return value.toUpperCase().equals("NA") ||
+            value.toUpperCase().equals("NAN") ||
             value.toUpperCase().equals("N/A");
     }
-    
-    public boolean isSmallData(List<BigDecimal> sortedValues)
-    {
+
+    public boolean isSmallData(List<BigDecimal> sortedValues) {
         BigDecimal median = sortedValues.get((int) Math.ceil((sortedValues.size() * (1.0 / 2.0))));
-        
+
         return median.compareTo(new BigDecimal("0.001")) == -1&& median.compareTo(new BigDecimal("-0.001")) == 1 && median.compareTo(new BigDecimal("0")) != 0;
     }
 
-    public String extractOperator(String value)
-    {
+    public String extractOperator(String value) {
         int length = 0;
 
         if (value.trim().startsWith(">=") || value.trim().startsWith("<=")) {
             length = 2;
-        }
-        else if (value.trim().startsWith(">") || value.trim().startsWith("<")) {
+        } else if (value.trim().startsWith(">") || value.trim().startsWith("<")) {
             length = 1;
         }
 
         return value.trim().substring(0, length);
     }
-    
-    public Integer calcExponent(BigDecimal value)
-    {
+
+    public Integer calcExponent(BigDecimal value) {
         return value.precision() - value.scale() - 1;
     }
 
-    public String stripOperator(String value) 
-    {
+    public String stripOperator(String value) {
         int length = 0;
 
         if (value.trim().startsWith(">=") || value.trim().startsWith("<=")) {
             length = 2;
-        }
-        else if (value.trim().startsWith(">") || value.trim().startsWith("<")) {
+        } else if (value.trim().startsWith(">") || value.trim().startsWith("<")) {
             length = 1;
         }
 
         return value.trim().substring(length);
     }
 
-    public boolean isAgeAttribute(String attributeId)
-    {
+    public boolean isAgeAttribute(String attributeId) {
         return attributeId != null && attributeId.matches("(^AGE$)|(^AGE_.*)|(.*_AGE_.*)|(.*_AGE&)");
     }
 }

--- a/web/src/main/java/org/cbioportal/web/util/DiscreteDataBinner.java
+++ b/web/src/main/java/org/cbioportal/web/util/DiscreteDataBinner.java
@@ -10,8 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
-public class DiscreteDataBinner
-{
+public class DiscreteDataBinner {
     private DataBinHelper dataBinHelper;
 
     @Autowired
@@ -21,18 +20,16 @@ public class DiscreteDataBinner
 
     public List<DataBin> calculateDataBins(String attributeId,
                                            List<BigDecimal> values,
-                                           Set<BigDecimal> uniqueValues)
-    {
+                                           Set<BigDecimal> uniqueValues) {
         List<DataBin> dataBins = initDataBins(attributeId, uniqueValues);
 
         dataBinHelper.calcCounts(dataBins, values);
 
         return dataBins;
     }
-    
+
     public List<DataBin> initDataBins(String attributeId,
-                                      Set<BigDecimal> uniqueValues)
-    {
+                                      Set<BigDecimal> uniqueValues) {
         return uniqueValues.stream()
             .map(d -> {
                 DataBin dataBin = new DataBin();

--- a/web/src/main/java/org/cbioportal/web/util/LinearDataBinner.java
+++ b/web/src/main/java/org/cbioportal/web/util/LinearDataBinner.java
@@ -13,8 +13,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
-public class LinearDataBinner 
-{
+public class LinearDataBinner {
     public static final Double[] POSSIBLE_INTERVALS = {
         0.001, 0.002, 0.0025, 0.005, 0.01,
         0.02, 0.025, 0.05, 0.1,
@@ -26,9 +25,9 @@ public class LinearDataBinner
     };
 
     public static final Integer DEFAULT_INTERVAL_COUNT = 20;
-    
+
     private DataBinHelper dataBinHelper;
-    
+
     @Autowired
     public LinearDataBinner(DataBinHelper dataBinHelper) {
         this.dataBinHelper = dataBinHelper;
@@ -44,15 +43,15 @@ public class LinearDataBinner
 
         List<DataBin> dataBins = initDataBins(attributeId, min, max, lowerOutlier, upperOutlier);
 
-        // special case for "AGE" attributes	
+        // special case for "AGE" attributes
         if (dataBinHelper.isAgeAttribute(attributeId) &&
             min.doubleValue() < 18 &&
             boxRange.upperEndpoint().subtract(boxRange.lowerEndpoint()).divide(BigDecimal.valueOf(2)).compareTo(BigDecimal.valueOf(18)) == 1 &&
             dataBins.get(0).getEnd().compareTo(BigDecimal.valueOf(18)) == 1) {
-            // force first bin to start from 18	
+            // force first bin to start from 18
             dataBins.get(0).setStart(BigDecimal.valueOf(18));
         }
-        
+
         dataBinHelper.calcCounts(dataBins, values);
 
         return dataBins;
@@ -83,11 +82,10 @@ public class LinearDataBinner
                                       BigDecimal min,
                                       BigDecimal max,
                                       BigDecimal lowerOutlier,
-                                      BigDecimal upperOutlier)
-    {
+                                      BigDecimal upperOutlier) {
         List<DataBin> dataBins = new ArrayList<>();
 
-        BigDecimal interval = calcBinInterval(Arrays.asList(POSSIBLE_INTERVALS).stream().map(val -> BigDecimal.valueOf(val)).collect(Collectors.toList()), 
+        BigDecimal interval = calcBinInterval(Arrays.asList(POSSIBLE_INTERVALS).stream().map(val -> BigDecimal.valueOf(val)).collect(Collectors.toList()),
             max.subtract(min),
             DEFAULT_INTERVAL_COUNT);
 
@@ -118,12 +116,10 @@ public class LinearDataBinner
         return dataBins;
     }
 
-    public BigDecimal calcBinInterval(List<BigDecimal> possibleIntervals, BigDecimal totalRange, Integer maxIntervalCount)
-    {
+    public BigDecimal calcBinInterval(List<BigDecimal> possibleIntervals, BigDecimal totalRange, Integer maxIntervalCount) {
         BigDecimal interval = new BigDecimal("-1.0");
 
-        for (int i = 0; i < possibleIntervals.size(); i++)
-        {
+        for (int i = 0; i < possibleIntervals.size(); i++) {
             interval = possibleIntervals.get(i);
             BigDecimal count = totalRange.divide(interval);
 

--- a/web/src/main/java/org/cbioportal/web/util/LogScaleDataBinner.java
+++ b/web/src/main/java/org/cbioportal/web/util/LogScaleDataBinner.java
@@ -11,8 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
-public class LogScaleDataBinner 
-{
+public class LogScaleDataBinner {
     private DataBinHelper dataBinHelper;
 
     @Autowired
@@ -24,49 +23,44 @@ public class LogScaleDataBinner
                                            Range<BigDecimal> boxRange,
                                            List<BigDecimal> values,
                                            BigDecimal lowerOutlier,
-                                           BigDecimal upperOutlier)
-    {
+                                           BigDecimal upperOutlier) {
         List<BigDecimal> intervals = new ArrayList<>();
         BigDecimal start = new BigDecimal("0");
-        
+
         if (boxRange.lowerEndpoint().compareTo(new BigDecimal("0")) != 0) {
             double absLogValue = Math.log10(boxRange.lowerEndpoint().abs().doubleValue());
             start = BigDecimal.valueOf(boxRange.lowerEndpoint().compareTo(new BigDecimal("0")) == -1 ? -Math.ceil(absLogValue) : Math.floor(absLogValue));
         }
-        
+
         if (lowerOutlier != null) {
             intervals.add(lowerOutlier);
         }
-        
-        for (BigDecimal exponent = start; ; exponent=exponent.add(new BigDecimal("0.5")))
-        {
+
+        for (BigDecimal exponent = start; ; exponent=exponent.add(new BigDecimal("0.5"))) {
             BigDecimal value = calcIntervalValue(exponent);
-            
-            if ((lowerOutlier == null || value.compareTo(lowerOutlier) == 1) && 
+
+            if ((lowerOutlier == null || value.compareTo(lowerOutlier) == 1) &&
                 (upperOutlier == null || value.compareTo(upperOutlier) != 1)) {
                 intervals.add(value);
             }
 
-            if (value.compareTo(boxRange.upperEndpoint()) == 1)
-            {
+            if (value.compareTo(boxRange.upperEndpoint()) == 1) {
                 value = calcIntervalValue(exponent.add(new BigDecimal("0.5")));
-                
+
                 if (upperOutlier == null || value.compareTo(upperOutlier) != 1) {
                     intervals.add(value);
-                }
-                else {
+                } else {
                     intervals.add(upperOutlier);
                 }
-                
+
                 break;
             }
         }
-        
+
         return dataBinHelper.initDataBins(attributeId, values, intervals);
     }
-    
-    public BigDecimal calcIntervalValue(BigDecimal exponent)
-    {
+
+    public BigDecimal calcIntervalValue(BigDecimal exponent) {
         return BigDecimal.valueOf(exponent.signum() * Math.floor(Math.pow(10, exponent.abs().doubleValue())));
     }
 }

--- a/web/src/main/java/org/cbioportal/web/util/ScientificSmallDataBinner.java
+++ b/web/src/main/java/org/cbioportal/web/util/ScientificSmallDataBinner.java
@@ -11,8 +11,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
-public class ScientificSmallDataBinner
-{
+public class ScientificSmallDataBinner {
     private DataBinHelper dataBinHelper;
 
     @Autowired
@@ -24,8 +23,7 @@ public class ScientificSmallDataBinner
                                            List<BigDecimal> sortedNumericalValues,
                                            List<BigDecimal> valuesWithoutOutliers,
                                            BigDecimal lowerOutlier,
-                                           BigDecimal upperOutlier)
-    {
+                                           BigDecimal upperOutlier) {
         List<BigDecimal> exponents = sortedNumericalValues
             .stream()
             .map(d -> BigDecimal.valueOf(dataBinHelper.calcExponent(d)))
@@ -33,20 +31,18 @@ public class ScientificSmallDataBinner
             .collect(Collectors.toList());
 
         Range<BigDecimal> exponentBoxRange = dataBinHelper.calcBoxRange(exponents);
-        
+
         List<BigDecimal> intervals = new ArrayList<>();
 
-        BigDecimal exponentRange = exponentBoxRange == null ? 
+        BigDecimal exponentRange = exponentBoxRange == null ?
             null : exponentBoxRange.upperEndpoint().subtract(exponentBoxRange.lowerEndpoint());
-        
+
         if (exponentRange == null) {
             // data set is not compatible with the scientific small data binner,
             // just set one interval for the entire set
             intervals.add(sortedNumericalValues.get(0));
             intervals.add(sortedNumericalValues.get(sortedNumericalValues.size() - 1));
-        }
-        else if (exponentRange.compareTo(new BigDecimal("1")) == 1)
-        {
+        } else if (exponentRange.compareTo(new BigDecimal("1")) == 1) {
             Integer interval = Math.round(exponentRange.floatValue() / 4);
 
             for (int i = exponentBoxRange.lowerEndpoint().intValue() - interval;
@@ -55,9 +51,7 @@ public class ScientificSmallDataBinner
             {
                 intervals.add(BigDecimal.valueOf(Math.pow(10, i)));
             }
-        }
-        else if (exponentRange.compareTo(new BigDecimal("1")) == 0)
-        {
+        } else if (exponentRange.compareTo(new BigDecimal("1")) == 0) {
             intervals.add(BigDecimal.valueOf(Math.pow(10, exponentBoxRange.lowerEndpoint().doubleValue()) / 3));
 
             for (int i = exponentBoxRange.lowerEndpoint().intValue();
@@ -68,9 +62,7 @@ public class ScientificSmallDataBinner
                 intervals.add(powerTen);
                 intervals.add(powerTen.multiply(new BigDecimal("3")));
             }
-        }
-        else // exponentRange == 0 
-        {
+        } else { // exponentRange == 0
             BigDecimal interval = BigDecimal.valueOf(2 * Math.pow(10, exponentBoxRange.lowerEndpoint().doubleValue()));
 
             for (BigDecimal d =  BigDecimal.valueOf(Math.pow(10, exponentBoxRange.lowerEndpoint().intValue()));

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -29,40 +29,29 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class StudyViewFilterApplier {
-    
+
     private static final String MUTATION_COUNT = "MUTATION_COUNT";
-
     private static final String FRACTION_GENOME_ALTERED = "FRACTION_GENOME_ALTERED";
-
     private SampleService sampleService;
-    
     private MutationService mutationService;
-    
     private DiscreteCopyNumberService discreteCopyNumberService;
-    
     private MolecularProfileService molecularProfileService;
-
     private GenePanelService genePanelService;
-
     private ClinicalDataService clinicalDataService;
-    
     private ClinicalDataEqualityFilterApplier clinicalDataEqualityFilterApplier;
-    
     private ClinicalDataIntervalFilterApplier clinicalDataIntervalFilterApplier;
-    
     private StudyViewFilterUtil studyViewFilterUtil;
 
     @Autowired
-    public StudyViewFilterApplier(SampleService sampleService, 
-                                  MutationService mutationService, 
-                                  DiscreteCopyNumberService discreteCopyNumberService, 
-                                  MolecularProfileService molecularProfileService, 
+    public StudyViewFilterApplier(SampleService sampleService,
+                                  MutationService mutationService,
+                                  DiscreteCopyNumberService discreteCopyNumberService,
+                                  MolecularProfileService molecularProfileService,
                                   GenePanelService genePanelService,
                                   ClinicalDataService clinicalDataService,
-                                  ClinicalDataEqualityFilterApplier clinicalDataEqualityFilterApplier, 
-                                  ClinicalDataIntervalFilterApplier clinicalDataIntervalFilterApplier, 
-                                  StudyViewFilterUtil studyViewFilterUtil) 
-    {
+                                  ClinicalDataEqualityFilterApplier clinicalDataEqualityFilterApplier,
+                                  ClinicalDataIntervalFilterApplier clinicalDataIntervalFilterApplier,
+                                  StudyViewFilterUtil studyViewFilterUtil) {
         this.sampleService = sampleService;
         this.mutationService = mutationService;
         this.discreteCopyNumberService = discreteCopyNumberService;
@@ -75,7 +64,7 @@ public class StudyViewFilterApplier {
     }
 
     Function<Sample, SampleIdentifier> sampleToSampleIdentifier = new Function<Sample, SampleIdentifier>() {
-        
+
         public SampleIdentifier apply(Sample sample) {
             SampleIdentifier sampleIdentifier = new SampleIdentifier();
             sampleIdentifier.setSampleId(sample.getStableId());
@@ -87,7 +76,7 @@ public class StudyViewFilterApplier {
     public List<SampleIdentifier> apply(StudyViewFilter studyViewFilter) {
         return this.apply(studyViewFilter, false);
     }
-    
+
     public List<SampleIdentifier> apply(StudyViewFilter studyViewFilter, Boolean negateFilters) {
 
         List<SampleIdentifier> sampleIdentifiers = new ArrayList<>();
@@ -102,10 +91,10 @@ public class StudyViewFilterApplier {
             sampleIdentifiers = sampleService.fetchSamples(studyIds, sampleIds, Projection.ID.name()).stream()
                 .map(sampleToSampleIdentifier).collect(Collectors.toList());
         } else {
-            sampleIdentifiers = sampleService.getAllSamplesInStudies(studyViewFilter.getStudyIds(), Projection.ID.name(), 
+            sampleIdentifiers = sampleService.getAllSamplesInStudies(studyViewFilter.getStudyIds(), Projection.ID.name(),
                 null, null, null, null).stream().map(sampleToSampleIdentifier).collect(Collectors.toList());
         }
-        
+
         List<ClinicalDataEqualityFilter> clinicalDataEqualityFilters = studyViewFilter.getClinicalDataEqualityFilters();
         if (clinicalDataEqualityFilters != null) {
             sampleIdentifiers = equalityFilterClinicalData(sampleIdentifiers, clinicalDataEqualityFilters, ClinicalDataType.PATIENT, negateFilters);
@@ -145,23 +134,21 @@ public class StudyViewFilterApplier {
 
         return sampleIdentifiers;
     }
-    
+
     private List<SampleIdentifier> intervalFilterClinicalData(List<SampleIdentifier> sampleIdentifiers,
-                                                              List<ClinicalDataIntervalFilter> clinicalDataIntervalFilters, 
+                                                              List<ClinicalDataIntervalFilter> clinicalDataIntervalFilters,
                                                               ClinicalDataType filterClinicalDataType,
-                                                              Boolean negateFilters)
-    {
+                                                              Boolean negateFilters) {
         List<ClinicalDataIntervalFilter> attributes = clinicalDataIntervalFilters.stream()
             .filter(c-> c.getClinicalDataType().equals(filterClinicalDataType)).collect(Collectors.toList());
-        
+
         return clinicalDataIntervalFilterApplier.apply(sampleIdentifiers, attributes, filterClinicalDataType, negateFilters);
     }
 
-    private List<SampleIdentifier> equalityFilterClinicalData(List<SampleIdentifier> sampleIdentifiers, 
-                                                              List<ClinicalDataEqualityFilter> clinicalDataEqualityFilters, 
+    private List<SampleIdentifier> equalityFilterClinicalData(List<SampleIdentifier> sampleIdentifiers,
+                                                              List<ClinicalDataEqualityFilter> clinicalDataEqualityFilters,
                                                               ClinicalDataType filterClinicalDataType,
-                                                              Boolean negateFilters) 
-    {
+                                                              Boolean negateFilters) {
         List<ClinicalDataEqualityFilter> attributes = clinicalDataEqualityFilters.stream()
             .filter(c-> c.getClinicalDataType().equals(filterClinicalDataType)).collect(Collectors.toList());
 
@@ -175,7 +162,7 @@ public class StudyViewFilterApplier {
         List<String> sampleIds = new ArrayList<>();
         studyViewFilterUtil.extractStudyAndSampleIds(sampleIdentifiers, studyIds, sampleIds);
         List<String> firstMutationProfileIds = molecularProfileGetter.apply(studyIds, sampleIds);
-        List<GenePanelData> genePanelDataList = genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(firstMutationProfileIds, 
+        List<GenePanelData> genePanelDataList = genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(firstMutationProfileIds,
             sampleIds).stream().filter(g -> g.getProfiled() == criteria).collect(Collectors.toList());
         return genePanelDataList.stream().map(d -> {
             SampleIdentifier sampleIdentifier = new SampleIdentifier();
@@ -191,9 +178,9 @@ public class StudyViewFilterApplier {
             List<String> sampleIds = new ArrayList<>();
             studyViewFilterUtil.extractStudyAndSampleIds(sampleIdentifiers, studyIds, sampleIds);
             List<Mutation> mutations = mutationService.getMutationsInMultipleMolecularProfiles(molecularProfileService
-                .getFirstMutationProfileIds(studyIds, sampleIds), sampleIds, molecularProfileGeneFilter.getEntrezGeneIds(), 
+                .getFirstMutationProfileIds(studyIds, sampleIds), sampleIds, molecularProfileGeneFilter.getEntrezGeneIds(),
                 Projection.ID.name(), null, null, null, null);
-            
+
             sampleIdentifiers = mutations.stream().map(m -> {
                 SampleIdentifier sampleIdentifier = new SampleIdentifier();
                 sampleIdentifier.setSampleId(m.getSampleId());
@@ -207,11 +194,11 @@ public class StudyViewFilterApplier {
 
     private List<SampleIdentifier> filterCNAGenes(List<CopyNumberGeneFilter> cnaGenes, List<SampleIdentifier> sampleIdentifiers) {
         for (CopyNumberGeneFilter copyNumberGeneFilter : cnaGenes) {
-                
+
             List<String> studyIds = new ArrayList<>();
             List<String> sampleIds = new ArrayList<>();
             studyViewFilterUtil.extractStudyAndSampleIds(sampleIdentifiers, studyIds, sampleIds);
-            List<Integer> ampEntrezGeneIds = copyNumberGeneFilter.getAlterations().stream().filter(a -> 
+            List<Integer> ampEntrezGeneIds = copyNumberGeneFilter.getAlterations().stream().filter(a ->
                 a.getAlteration() == 2).map(CopyNumberGeneFilterElement::getEntrezGeneId).collect(Collectors.toList());
             List<DiscreteCopyNumberData> ampCNAList = new ArrayList<>();
             if (!ampEntrezGeneIds.isEmpty()) {
@@ -220,7 +207,7 @@ public class StudyViewFilterApplier {
                         studyIds, sampleIds), sampleIds, ampEntrezGeneIds, Arrays.asList(2), Projection.ID.name());
             }
 
-            List<Integer> delEntrezGeneIds = copyNumberGeneFilter.getAlterations().stream().filter(a -> 
+            List<Integer> delEntrezGeneIds = copyNumberGeneFilter.getAlterations().stream().filter(a ->
                 a.getAlteration() == -2).map(CopyNumberGeneFilterElement::getEntrezGeneId).collect(Collectors.toList());
             List<DiscreteCopyNumberData> delCNAList = new ArrayList<>();
             if (!delEntrezGeneIds.isEmpty()) {
@@ -247,7 +234,7 @@ public class StudyViewFilterApplier {
         List<String> studyIds = new ArrayList<>();
         List<String> sampleIds = new ArrayList<>();
         studyViewFilterUtil.extractStudyAndSampleIds(sampleIdentifiers, studyIds, sampleIds);
-        List<ClinicalData> clinicalDataList = clinicalDataService.fetchClinicalData(studyIds, sampleIds, 
+        List<ClinicalData> clinicalDataList = clinicalDataService.fetchClinicalData(studyIds, sampleIds,
             Arrays.asList(MUTATION_COUNT, FRACTION_GENOME_ALTERED), ClinicalDataType.SAMPLE.name(), Projection.SUMMARY.name());
         MultiKeyMap clinicalDataMap = new MultiKeyMap();
         for (ClinicalData clinicalData : clinicalDataList) {

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
@@ -9,62 +9,50 @@ import java.math.BigDecimal;
 import java.util.List;
 
 @Component
-public class StudyViewFilterUtil 
-{
-    public void extractStudyAndSampleIds(List<SampleIdentifier> sampleIdentifiers, List<String> studyIds, List<String> sampleIds)
-    {
+public class StudyViewFilterUtil {
+    public void extractStudyAndSampleIds(List<SampleIdentifier> sampleIdentifiers, List<String> studyIds, List<String> sampleIds) {
         for (SampleIdentifier sampleIdentifier : sampleIdentifiers) {
             studyIds.add(sampleIdentifier.getStudyId());
             sampleIds.add(sampleIdentifier.getSampleId());
         }
     }
-    
-    public void removeSelfFromFilter(String attributeId, StudyViewFilter studyViewFilter)
-    {
+
+    public void removeSelfFromFilter(String attributeId, StudyViewFilter studyViewFilter) {
         if (studyViewFilter!= null && studyViewFilter.getClinicalDataEqualityFilters() != null) {
             studyViewFilter.getClinicalDataEqualityFilters().removeIf(f -> f.getAttributeId().equals(attributeId));
         }
-        
+
         if (studyViewFilter!= null && studyViewFilter.getClinicalDataIntervalFilters() != null) {
             studyViewFilter.getClinicalDataIntervalFilters().removeIf(f -> f.getAttributeId().equals(attributeId));
         }
     }
 
-    public Range<BigDecimal> calcRange(BigDecimal start, boolean startInclusive, BigDecimal end, boolean endInclusive)
-    {
+    public Range<BigDecimal> calcRange(BigDecimal start, boolean startInclusive, BigDecimal end, boolean endInclusive) {
         // check for invalid filter (no start or end provided)
         if (start == null && end == null) {
             return null;
-        }
-        else if (start == null) {
+        } else if (start == null) {
             if (endInclusive) {
                 return Range.atMost(end);
-            }
-            else {
+            } else {
                 return Range.lessThan(end);
             }
-        }
-        else if (end == null) {
+        } else if (end == null) {
             if (startInclusive) {
                 return Range.atLeast(start);
-            }
-            else {
+            } else {
                 return Range.greaterThan(start);
             }
-        }
-        else if (startInclusive) {
+        } else if (startInclusive) {
             if (endInclusive) {
                 return Range.closed(start, end);
-            }
-            else {
+            } else {
                 return Range.closedOpen(start, end);
             }
-        }
-        else {
+        } else {
             if (endInclusive) {
                 return Range.openClosed(start, end);
-            }
-            else {
+            } else {
                 return Range.open(start, end);
             }
         }

--- a/web/src/main/java/org/cbioportal/weblegacy/ApiController.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/ApiController.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.cbioportal.weblegacy;
 
 import java.util.ArrayList;
@@ -58,41 +53,51 @@ public class ApiController {
         } else {
             return service.getCancerTypes(cancer_type_ids);
         }
-    }    
-    
+    }
+
     @ApiOperation(value = "Get COSMIC counts for given keywords.", nickname = "getCOSMICCounts", notes="")
     @Transactional
     @RequestMapping(value = "/cosmic_count", method = {RequestMethod.GET, RequestMethod.POST})
-    public @ResponseBody List<CosmicCount> getCosmicCounts(@ApiParam(required = true, value = "COSMIC event keywords, the keyword in a mutation object")
-							  @RequestParam(required = true)
-							  List<String> keywords) {
-	    return service.getCOSMICCountsByKeywords(keywords);
+    public @ResponseBody List<CosmicCount> getCosmicCounts(
+            @ApiParam(required = true, value = "COSMIC event keywords, the keyword in a mutation object")
+            @RequestParam(required = true)
+            List<String> keywords) {
+        return service.getCOSMICCountsByKeywords(keywords);
     }
-    
+
     @ApiOperation(value = "Get mutation count for certain gene. If per_study is true will return count for each study, if false will return the total count. User can specify specifc study set to look for.",
             nickname = "getMutationCount",
             notes = "")
     @Transactional
     @RequestMapping(value = "/mutation_count", method = {RequestMethod.GET, RequestMethod.POST})
     public @ResponseBody List<Map<String, String>> getMutationsCounts(
-        HttpServletRequest request,
-        @ApiParam(required = true, value = "\"count\" or \"frequency\"")
-        @RequestParam(required = true) String type, @RequestParam(required = true) Boolean per_study, @RequestParam(required = false) List<String> studyId, @RequestParam(required = true) List<String> gene, @RequestParam(required = false) List<Integer> start, @RequestParam(required = false) List<Integer> end, @RequestParam(required = false) List<String> echo) {
-        Enumeration<String> parameterNames = request.getParameterNames();
+            HttpServletRequest request,
+            @ApiParam(required = true, value = "\"count\" or \"frequency\"")
+            @RequestParam(required = true)
+            String type,
+            @RequestParam(required = true)
+            Boolean per_study,
+            @RequestParam(required = false)
+            List<String> studyId,
+            @RequestParam(required = true)
+            List<String> gene,
+            @RequestParam(required = false)
+            List<Integer> start,
+            @RequestParam(required = false)
+            List<Integer> end,
+            @RequestParam(required = false) List<String> echo) {
+            Enumeration<String> parameterNames = request.getParameterNames();
         String[] fixedInput = {"type", "per_study", "gene", "start", "end", "echo"};
         Map<String,String[]> customizedAttrs = new HashMap<String,String[]>();
         while (parameterNames.hasMoreElements()) {
             String paramName = parameterNames.nextElement();
-            if(!Arrays.asList(fixedInput).contains(paramName)){
-                
+            if (!Arrays.asList(fixedInput).contains(paramName)) {
                 String[] paramValues = request.getParameterValues(paramName);
                 customizedAttrs.put(paramName, paramValues[0].split(","));
             }
         }
         return service.getMutationsCounts(customizedAttrs, type, per_study, studyId, gene, start, end, echo);
-                
     }
-
 
     @ApiOperation(value = "Get clinical data records, filtered by sample ids",
             nickname = "getSampleClinicalData",
@@ -137,30 +142,29 @@ public class ApiController {
             return service.getPatientClinicalData(study_id, attribute_ids, patient_ids);
         }
     }
-    
+
     @ApiOperation(value = "Get clinical attribute identifiers, filtered by identifier",
             nickname = "getClinicalAttributes",
             notes = "")
     @Transactional
     @RequestMapping(value = "/clinicalattributes", method = {RequestMethod.GET, RequestMethod.POST})
     public @ResponseBody List<DBClinicalField> getClinicalAttributes(
-		@ApiParam(value = "List of attribute ids. If provided, returned clinical attributes will be the ones with matching attribute ids. Empty string returns all clinical attributes if study_id is not present.")
-		@RequestParam(required = false) 
-		List<String> attr_ids, 
-       @ApiParam(value = "Study id. If provided, return clinical attributes will be the ones that this study contains.")
-       @RequestParam(required = false)
-       String study_id) {
-       if (study_id != null) {
+            @ApiParam(value = "List of attribute ids. If provided, returned clinical attributes will be the ones with matching attribute ids. Empty string returns all clinical attributes if study_id is not present.")
+            @RequestParam(required = false)
+            List<String> attr_ids,
+            @ApiParam(value = "Study id. If provided, return clinical attributes will be the ones that this study contains.")
+            @RequestParam(required = false)
+            String study_id) {
+        if (study_id != null) {
            return service.getClinicalAttributes(study_id);
-       }
-       else if (attr_ids == null) {
-		    return service.getClinicalAttributes();
-	    } else {
-		    return service.getClinicalAttributes(attr_ids);
-	    }
+        }
+        if (attr_ids == null) {
+            return service.getClinicalAttributes();
+        } else {
+            return service.getClinicalAttributes(attr_ids);
+        }
     }
-    
-    
+
     @ApiOperation(value = "Get clinical attribute identifiers, filtered by sample",
             nickname = "getSampleClinicalAttributes",
             notes = "")
@@ -175,10 +179,12 @@ public class ApiController {
             List<String> sample_ids) {
         if (sample_ids == null && study_id == null) {
             return service.getSampleClinicalAttributes();
-        } else if (study_id != null && sample_ids != null) {
+        }
+        if (study_id != null && sample_ids != null) {
             return service.getSampleClinicalAttributes(study_id, sample_ids);
-        } else if (sample_ids == null) {
-		return service.getSampleClinicalAttributes(study_id);
+        }
+        if (sample_ids == null) {
+            return service.getSampleClinicalAttributes(study_id);
         } else {
             return new ArrayList<>();
         }
@@ -198,15 +204,17 @@ public class ApiController {
             List<String> patient_ids) {
         if (patient_ids == null && study_id == null) {
             return service.getPatientClinicalAttributes();
-        } else if (study_id != null && patient_ids != null) {
+        }
+        if (study_id != null && patient_ids != null) {
             return service.getPatientClinicalAttributes(study_id, patient_ids);
-        } else if (patient_ids == null) {
+        }
+        if (patient_ids == null) {
             return service.getPatientClinicalAttributes(study_id);
         } else {
             return new ArrayList<>();
         }
     }
-    
+
     @ApiOperation(value = "Get gene meta data by hugo gene symbol lookup",
             nickname = "getGenes",
             notes = "")
@@ -232,11 +240,11 @@ public class ApiController {
             @ApiParam(required = false, value = "List of Entrez gene ids. Unrecognized IDs are silently ignored. Empty list returns all genes.")
             @RequestParam(required = false)
             List<Long> entrez_gene_ids) {
-            if (entrez_gene_ids == null) {
-                    return service.getGenesAliases();
-            } else {
-                    return service.getGenesAliases(entrez_gene_ids);
-            }
+        if (entrez_gene_ids == null) {
+            return service.getGenesAliases();
+        } else {
+            return service.getGenesAliases(entrez_gene_ids);
+        }
     }
 
     @ApiOperation(value = "Get list of genetic profile identifiers by study",
@@ -253,13 +261,14 @@ public class ApiController {
             List<String> genetic_profile_ids) {
         if (study_id != null) {
             return service.getGeneticProfiles(study_id);
-        } else if (genetic_profile_ids != null) {
+        }
+        if (genetic_profile_ids != null) {
             return service.getGeneticProfiles(genetic_profile_ids);
         } else {
             return service.getGeneticProfiles();
         }
     }
-    
+
     @ApiOperation(value = "Get list of sample lists (list name and sample id list) by study",
             nickname = "getSampleLists",
             notes = "")
@@ -274,13 +283,14 @@ public class ApiController {
             List<String> sample_list_ids) {
         if (study_id != null) {
             return service.getSampleLists(study_id);
-        } else if (sample_list_ids != null) {
+        }
+        if (sample_list_ids != null) {
             return service.getSampleLists(sample_list_ids);
         } else {
             return service.getSampleLists();
         }
     }
-    
+
     @ApiOperation(value = "Get patient id list by study or by sample id",
             nickname = "getPatients",
             notes = "")
@@ -298,13 +308,14 @@ public class ApiController {
             List<String> sample_ids) {
         if (patient_ids != null) {
             return service.getPatientsByPatient(study_id, patient_ids);
-        } else if (sample_ids != null) {
+        }
+        if (sample_ids != null) {
             return service.getPatientsBySample(study_id, sample_ids);
         } else {
             return service.getPatients(study_id);
         }
     }
-    
+
     @ApiOperation(value = "Get genetic profile data across samples for given genes, and filtered by sample id or sample list id",
             nickname = "getGeneticProfileData",
             notes = "")
@@ -326,13 +337,14 @@ public class ApiController {
 
         if (sample_ids == null && sample_list_id == null) {
             return service.getGeneticProfileData(genetic_profile_ids, genes);
-        } else if (sample_ids != null) {
+        }
+        if (sample_ids != null) {
             return service.getGeneticProfileDataBySample(genetic_profile_ids, genes, sample_ids);
         } else {
             return service.getGeneticProfileDataBySampleList(genetic_profile_ids, genes, sample_list_id);
         }
     }
-    
+
     @ApiOperation(value = "Get list of samples ids with meta data by study, filtered by sample ids or patient ids",
             nickname = "getSamples",
             notes = "")
@@ -350,14 +362,15 @@ public class ApiController {
             List<String> patient_ids) {
         if (sample_ids != null) {
             return service.getSamplesBySample(study_id, sample_ids);
-        } else if (patient_ids != null) {
-                    return service.getSamplesByPatient(study_id, patient_ids);
+        }
+        if (patient_ids != null) {
+            return service.getSamplesByPatient(study_id, patient_ids);
         } else {
-                return service.getSamples(study_id);
-            }
-            
+            return service.getSamples(study_id);
+        }
+
     }
-     
+
     @ApiOperation(value = "Get studies",
             nickname = "getStudies",
             notes = "")

--- a/web/src/main/java/org/cbioportal/weblegacy/CNSegmentController.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/CNSegmentController.java
@@ -22,18 +22,18 @@ public class CNSegmentController {
 
     @Autowired
     private CNSegmentService cnSegmentService;
- 
+
     @ApiOperation(value = "Get copy number segment data including sample id, chromosome, start position, end position, numProbes and segment mean value",
             nickname = "getCNSegment",
             notes = "")
     @Transactional
     @RequestMapping(method = {RequestMethod.GET, RequestMethod.POST}, value = "/copynumbersegments")
-    public List<CNSegmentData> getCNSegment(@ApiParam(value = "Return segment data related to the study with this cancer study id eg. acc_tcga") @RequestParam(required = true) String cancerStudyId, 
+    public List<CNSegmentData> getCNSegment(@ApiParam(value = "Return segment data related to the study with this cancer study id eg. acc_tcga") @RequestParam(required = true) String cancerStudyId,
         @ApiParam(value = "Return segment data in these chromosomes. If ommitted, return segment data on all chromosomes")  @RequestParam(required = false) List<String> chromosomes,
         @ApiParam(value = "Return the segment data with this list of sampleIds. If omitted, return segment data on all samples")  @RequestParam(required = false) List<String> sampleIds) {
         return cnSegmentService.getCNSegmentData(cancerStudyId, chromosomes, sampleIds);
     }
-    
+
     @ApiOperation(value = "Get copy number segment file",
             nickname = "getSegmentFile",
             notes = "")

--- a/web/src/main/java/org/cbioportal/weblegacy/MutationalSignatureController.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/MutationalSignatureController.java
@@ -55,16 +55,17 @@ public class MutationalSignatureController {
     @Transactional
     @RequestMapping(method = {RequestMethod.GET, RequestMethod.POST}, value = "/mutational-signature")
     public ResponseEntity<List<MutationalSignature>> getMutationalSignatures(@ApiParam(required = true, value = "Study id")
-            @RequestParam(required = true) String study_id,
-	    @ApiParam(required = false, value="List of sample ids. If provided, will return mutational signatures for the given samples. /"
-		    + "Otherwise, will return mutational signatures for all samples in the study.")
-	    @RequestParam(required = false) List<String> sample_ids) {
-	List<MutationalSignature> result;
-	if (sample_ids != null) {
-		result = mutationalSignatureService.getMutationalSignaturesBySampleIds(study_id, sample_ids);
-	} else {
-		result = mutationalSignatureService.getMutationalSignatures(study_id);
-	}
-	return new ResponseEntity(result, HttpStatus.OK);
+            @RequestParam(required = true)
+            String study_id,
+            @ApiParam(required = false, value="List of sample ids. If provided, will return mutational signatures for the given samples. /"
+            + "Otherwise, will return mutational signatures for all samples in the study.")
+            @RequestParam(required = false) List<String> sample_ids) {
+            List<MutationalSignature> result;
+        if (sample_ids != null) {
+            result = mutationalSignatureService.getMutationalSignaturesBySampleIds(study_id, sample_ids);
+        } else {
+            result = mutationalSignatureService.getMutationalSignatures(study_id);
+        }
+        return new ResponseEntity(result, HttpStatus.OK);
     }
 }

--- a/web/src/main/java/org/cbioportal/weblegacy/mixin/SessionMixin.java
+++ b/web/src/main/java/org/cbioportal/weblegacy/mixin/SessionMixin.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class SessionMixin {
 
-	@JsonIgnore
-	private String source;
-	@JsonIgnore
-	private String type;
-	@JsonIgnore
+    @JsonIgnore
+    private String source;
+    @JsonIgnore
+    private String type;
+    @JsonIgnore
     private String checksum;
-	
+
 }

--- a/web/src/test/java/org/cbioportal/web/CacheStatsControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CacheStatsControllerTest.java
@@ -35,17 +35,17 @@ public class CacheStatsControllerTest {
 
     @Autowired
     private WebApplicationContext wac;
-    
+
     private MockMvc mockMvc;
 
     @Autowired
     public CacheStatisticsService cacheStatisticsService;
-    
+
     @Before
     public void setUp() throws Exception {
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Bean
     public static CacheStatisticsService cacheStatisticsService() throws CacheNotFoundException {
         CacheStatisticsService cacheStatisticsServiceMock = Mockito.mock(CacheStatisticsService.class);
@@ -55,7 +55,7 @@ public class CacheStatsControllerTest {
                 String cacheAlias = (String)args[0];
                 if (VALID_CACHE_ALIAS.equals(cacheAlias)) {
                     return new ArrayList<String>();
-                } 
+                }
                 throw new CacheNotFoundException(cacheAlias);
             }
         });
@@ -65,7 +65,7 @@ public class CacheStatsControllerTest {
                 String cacheAlias = (String)args[0];
                 if (VALID_CACHE_ALIAS.equals(cacheAlias)) {
                     return new ArrayList<String>();
-                } 
+                }
                 throw new CacheNotFoundException(cacheAlias);
             }
         });

--- a/web/src/test/java/org/cbioportal/web/ClinicalAttributeControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/ClinicalAttributeControllerTest.java
@@ -34,7 +34,7 @@ import java.util.List;
 @ContextConfiguration("/applicationContext-web-test.xml")
 @Configuration
 public class ClinicalAttributeControllerTest {
-    
+
     private static final String TEST_ATTR_ID_1 = "test_attr_id_1";
     private static final int TEST_CANCER_STUDY_ID_1 = 1;
     private static final String TEST_CANCER_STUDY_IDENTIFIER_1 = "test_study_1";
@@ -77,12 +77,12 @@ public class ClinicalAttributeControllerTest {
         Mockito.reset(clinicalAttributeService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void getAllClinicalAttributesDefaultProjection() throws Exception {
-        
+
         List<ClinicalAttribute> clinicalAttributes = createExampleClinicalAttributes();
-        
+
         Mockito.when(clinicalAttributeService.getAllClinicalAttributes(Mockito.anyString(), Mockito.anyInt(),
             Mockito.anyInt(), Mockito.anyString(), Mockito.anyString())).thenReturn(clinicalAttributes);
 
@@ -128,7 +128,7 @@ public class ClinicalAttributeControllerTest {
 
         List<ClinicalAttribute> clinicalAttributes = createExampleClinicalAttributes();
 
-        Mockito.when(clinicalAttributeService.getAllClinicalAttributesInStudy(Mockito.anyString(), Mockito.anyString(), 
+        Mockito.when(clinicalAttributeService.getAllClinicalAttributesInStudy(Mockito.anyString(), Mockito.anyString(),
             Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
             .thenReturn(clinicalAttributes);
 
@@ -196,7 +196,7 @@ public class ClinicalAttributeControllerTest {
         clinicalAttribute.setDisplayName(TEST_DISPLAY_NAME_1);
         clinicalAttribute.setPatientAttribute(TEST_PATIENT_ATTRIBUTE_1);
         clinicalAttribute.setPriority(TEST_PRIORITY_1);
-        
+
         Mockito.when(clinicalAttributeService.getClinicalAttribute(Mockito.anyString(), Mockito.anyString()))
             .thenReturn(clinicalAttribute);
 
@@ -226,7 +226,7 @@ public class ClinicalAttributeControllerTest {
         List<String> studyIds = new ArrayList<>();
         studyIds.add("study_id_1");
         studyIds.add("study_id_2");
-        
+
         mockMvc.perform(MockMvcRequestBuilders.post("/clinical-attributes/fetch")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
@@ -251,11 +251,11 @@ public class ClinicalAttributeControllerTest {
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].description").value(TEST_DESCRIPTION_2))
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].priority").value(TEST_PRIORITY_2));
     }
-    
-    
+
+
     @Test
     public void getClinicalAttributeCountsBySampleIds() throws Exception {
-        
+
         List<ClinicalAttributeCount> clinicalAttributes = new ArrayList<>();
         ClinicalAttributeCount clinicalAttributeCount1 = new ClinicalAttributeCount();
         clinicalAttributeCount1.setAttrId(TEST_ATTR_ID_1);
@@ -265,10 +265,10 @@ public class ClinicalAttributeControllerTest {
         clinicalAttributeCount2.setAttrId(TEST_ATTR_ID_2);
         clinicalAttributeCount2.setCount(TEST_ATTRIBUTE_COUNT_2);
         clinicalAttributes.add(clinicalAttributeCount2);
-        
-        Mockito.when(clinicalAttributeService.getClinicalAttributeCountsBySampleIds(Mockito.anyListOf(String.class), 
+
+        Mockito.when(clinicalAttributeService.getClinicalAttributeCountsBySampleIds(Mockito.anyListOf(String.class),
             Mockito.anyListOf(String.class))).thenReturn(clinicalAttributes);
-        
+
         ClinicalAttributeCountFilter clinicalAttributeCountFilter = new ClinicalAttributeCountFilter();
         List<SampleIdentifier> sampleIdentifierList = new ArrayList<>();
         SampleIdentifier sampleIdentifier1 = new SampleIdentifier();
@@ -280,7 +280,7 @@ public class ClinicalAttributeControllerTest {
         sampleIdentifier2.setStudyId(TEST_CANCER_STUDY_IDENTIFIER_1);
         sampleIdentifierList.add(sampleIdentifier2);
         clinicalAttributeCountFilter.setSampleIdentifiers(sampleIdentifierList);
-        
+
         mockMvc.perform(MockMvcRequestBuilders.post("/clinical-attributes/counts/fetch")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
@@ -293,10 +293,10 @@ public class ClinicalAttributeControllerTest {
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].clinicalAttributeId").value(TEST_ATTR_ID_2))
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].count").value(TEST_ATTRIBUTE_COUNT_2));
     }
-    
+
     @Test
     public void getClinicalAttributeCountsBySampleListId() throws Exception {
-        
+
         List<ClinicalAttributeCount> clinicalAttributes = new ArrayList<>();
         ClinicalAttributeCount clinicalAttributeCount1 = new ClinicalAttributeCount();
         clinicalAttributeCount1.setAttrId(TEST_ATTR_ID_1);
@@ -306,12 +306,12 @@ public class ClinicalAttributeControllerTest {
         clinicalAttributeCount2.setAttrId(TEST_ATTR_ID_2);
         clinicalAttributeCount2.setCount(TEST_ATTRIBUTE_COUNT_2);
         clinicalAttributes.add(clinicalAttributeCount2);
-        
+
         Mockito.when(clinicalAttributeService.getClinicalAttributeCountsBySampleListId(Mockito.anyString())).thenReturn(clinicalAttributes);
-        
+
         ClinicalAttributeCountFilter clinicalAttributeCountFilter = new ClinicalAttributeCountFilter();
         clinicalAttributeCountFilter.setSampleListId("test_sample_list_id");
-        
+
         mockMvc.perform(MockMvcRequestBuilders.post("/clinical-attributes/counts/fetch")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
@@ -325,7 +325,7 @@ public class ClinicalAttributeControllerTest {
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].clinicalAttributeId").value(TEST_ATTR_ID_2))
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].count").value(TEST_ATTRIBUTE_COUNT_2));
     }
- 
+
     private List<ClinicalAttribute> createExampleClinicalAttributes() {
 
         List<ClinicalAttribute> clinicalAttributeList = new ArrayList<>();

--- a/web/src/test/java/org/cbioportal/web/ClinicalDataControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/ClinicalDataControllerTest.java
@@ -231,7 +231,7 @@ public class ClinicalDataControllerTest {
         patientClinicalData2.setAttrValue(TEST_ATTR_VALUE_2);
         patientClinicalData2.setInternalId(TEST_INTERNAL_ID_2);
         patientClinicalDataList.add(patientClinicalData2);
-        Mockito.when(clinicalDataService.fetchAllClinicalDataInStudy(Mockito.anyString(), 
+        Mockito.when(clinicalDataService.fetchAllClinicalDataInStudy(Mockito.anyString(),
             Mockito.anyListOf(String.class), Mockito.anyListOf(String.class), Mockito.anyString(), Mockito.anyString()))
             .thenReturn(patientClinicalDataList);
 
@@ -267,7 +267,7 @@ public class ClinicalDataControllerTest {
         BaseMeta baseMeta = new BaseMeta();
         baseMeta.setTotalCount(2);
 
-        Mockito.when(clinicalDataService.fetchMetaClinicalDataInStudy(Mockito.anyString(), 
+        Mockito.when(clinicalDataService.fetchMetaClinicalDataInStudy(Mockito.anyString(),
             Mockito.anyListOf(String.class), Mockito.anyListOf(String.class), Mockito.anyString()))
             .thenReturn(baseMeta);
 

--- a/web/src/test/java/org/cbioportal/web/ClinicalEventControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/ClinicalEventControllerTest.java
@@ -216,6 +216,6 @@ public class ClinicalEventControllerTest {
         clinicalEventDataList2.add(clinicalEventData4);
         clinicalEvent2.setAttributes(clinicalEventDataList2);
         clinicalEventList.add(clinicalEvent2);
-        return clinicalEventList;  
+        return clinicalEventList;
     }
 }

--- a/web/src/test/java/org/cbioportal/web/CoExpressionControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CoExpressionControllerTest.java
@@ -65,7 +65,7 @@ public class CoExpressionControllerTest {
         Mockito.reset(coExpressionService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void fetchMolecularProfileCoExpressions() throws Exception {
 
@@ -87,7 +87,7 @@ public class CoExpressionControllerTest {
 
 
         Mockito.when(coExpressionService.fetchCoExpressions(Mockito.anyString(),
-        Mockito.any(CoExpression.GeneticEntityType.class), Mockito.anyListOf(String.class), Mockito.anyString(), Mockito.anyString(), 
+        Mockito.any(CoExpression.GeneticEntityType.class), Mockito.anyListOf(String.class), Mockito.anyString(), Mockito.anyString(),
         Mockito.anyDouble()))
             .thenReturn(coExpressionList);
 

--- a/web/src/test/java/org/cbioportal/web/CopyNumberEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CopyNumberEnrichmentControllerTest.java
@@ -109,7 +109,7 @@ public class CopyNumberEnrichmentControllerTest {
         alterationEnrichment2.setCounts(Arrays.asList(alterationEnrichment2Set1Count,alterationEnrichment2Set2Count));
 
         alterationEnrichments.add(alterationEnrichment2);
-        
+
         Mockito.when(copyNumberEnrichmentService.getCopyNumberEnrichments(
                 Mockito.anyMap(),
                 Mockito.anyListOf(Integer.class),
@@ -125,11 +125,11 @@ public class CopyNumberEnrichmentControllerTest {
         MolecularProfileCasesGroupFilter casesGroup1 = new MolecularProfileCasesGroupFilter();
         casesGroup1.setName("altered group");
         casesGroup1.setMolecularProfileCaseIdentifiers(Arrays.asList(entity1));
-        
+
         MolecularProfileCasesGroupFilter casesGroup2 = new MolecularProfileCasesGroupFilter();
         casesGroup2.setName("unaltered group");
         casesGroup2.setMolecularProfileCaseIdentifiers(Arrays.asList(entity2));
-        
+
         mockMvc.perform(MockMvcRequestBuilders.post(
             "/copy-number-enrichments/fetch")
             .accept(MediaType.APPLICATION_JSON)

--- a/web/src/test/java/org/cbioportal/web/CopyNumberSegmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CopyNumberSegmentControllerTest.java
@@ -54,8 +54,8 @@ public class CopyNumberSegmentControllerTest {
     private static final Integer TEST_END_2 = 34;
     private static final Integer TEST_NUM_PROBES_2 = 5;
     private static final BigDecimal TEST_SEGMENT_MEAN_2 = new BigDecimal(0.4);
-    
-    
+
+
     @Autowired
     private WebApplicationContext wac;
 
@@ -77,14 +77,14 @@ public class CopyNumberSegmentControllerTest {
         Mockito.reset(copyNumberSegmentService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void getCopyNumberSegmentsInSampleInStudyDefaultProjection() throws Exception {
 
         List<CopyNumberSeg> copyNumberSegList = createExampleCopyNumberSegs();
 
-        Mockito.when(copyNumberSegmentService.getCopyNumberSegmentsInSampleInStudy(Mockito.anyString(), 
-            Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(), 
+        Mockito.when(copyNumberSegmentService.getCopyNumberSegmentsInSampleInStudy(Mockito.anyString(),
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(),
             Mockito.anyString(), Mockito.anyString())).thenReturn(copyNumberSegList);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/studies/test_study_id/samples/test_sample_id/copy-number-segments")
@@ -116,7 +116,7 @@ public class CopyNumberSegmentControllerTest {
         BaseMeta baseMeta = new BaseMeta();
         baseMeta.setTotalCount(2);
 
-        Mockito.when(copyNumberSegmentService.getMetaCopyNumberSegmentsInSampleInStudy(Mockito.anyString(), 
+        Mockito.when(copyNumberSegmentService.getMetaCopyNumberSegmentsInSampleInStudy(Mockito.anyString(),
             Mockito.anyString(), Mockito.anyString())).thenReturn(baseMeta);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/studies/test_study_id/samples/test_sample_id/copy-number-segments")
@@ -130,7 +130,7 @@ public class CopyNumberSegmentControllerTest {
 
         List<CopyNumberSeg> copyNumberSegList = createExampleCopyNumberSegs();
 
-        Mockito.when(copyNumberSegmentService.fetchCopyNumberSegments(Mockito.anyListOf(String.class), 
+        Mockito.when(copyNumberSegmentService.fetchCopyNumberSegments(Mockito.anyListOf(String.class),
             Mockito.anyListOf(String.class), Mockito.anyString(), Mockito.anyString())).thenReturn(copyNumberSegList);
 
         List<SampleIdentifier> sampleIdentifiers = new ArrayList<>();

--- a/web/src/test/java/org/cbioportal/web/CosmicCountControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CosmicCountControllerTest.java
@@ -59,7 +59,7 @@ public class CosmicCountControllerTest {
         Mockito.reset(cosmicCountService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void fetchCosmicCounts() throws Exception {
 

--- a/web/src/test/java/org/cbioportal/web/DiscreteCopyNumberControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/DiscreteCopyNumberControllerTest.java
@@ -37,7 +37,7 @@ import java.util.List;
 @ContextConfiguration("/applicationContext-web-test.xml")
 @Configuration
 public class DiscreteCopyNumberControllerTest {
-    
+
     private static final String TEST_MOLECULAR_PROFILE_STABLE_ID_1 = "test_molecular_profile_stable_id_1";
     private static final String TEST_SAMPLE_STABLE_ID_1 = "test_sample_stable_id_1";
     private static final int TEST_ENTREZ_GENE_ID_1 = 1;
@@ -81,14 +81,14 @@ public class DiscreteCopyNumberControllerTest {
         Mockito.reset(discreteCopyNumberService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void getDiscreteCopyNumbersInMolecularProfileBySampleListIdDefaultProjection() throws Exception {
 
         List<DiscreteCopyNumberData> discreteCopyNumberDataList = createExampleDiscreteCopyNumberData();
 
         Mockito.when(discreteCopyNumberService.getDiscreteCopyNumbersInMolecularProfileBySampleListId(
-            Mockito.anyString(), Mockito.anyString(), Mockito.anyListOf(Integer.class), 
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyListOf(Integer.class),
             Mockito.anyListOf(Integer.class), Mockito.anyString())).thenReturn(discreteCopyNumberDataList);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/molecular-profiles/test_molecular_profile_id/discrete-copy-number")
@@ -118,7 +118,7 @@ public class DiscreteCopyNumberControllerTest {
         List<DiscreteCopyNumberData> discreteCopyNumberDataList = createExampleDiscreteCopyNumberDataWithGenes();
 
         Mockito.when(discreteCopyNumberService.getDiscreteCopyNumbersInMolecularProfileBySampleListId(
-            Mockito.anyString(), Mockito.anyString(), Mockito.anyListOf(Integer.class), 
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyListOf(Integer.class),
             Mockito.anyListOf(Integer.class), Mockito.anyString())).thenReturn(discreteCopyNumberDataList);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/molecular-profiles/test_molecular_profile_id/discrete-copy-number")
@@ -154,7 +154,7 @@ public class DiscreteCopyNumberControllerTest {
         baseMeta.setTotalCount(2);
 
         Mockito.when(discreteCopyNumberService.getMetaDiscreteCopyNumbersInMolecularProfileBySampleListId(
-            Mockito.anyString(), Mockito.anyString(), Mockito.anyListOf(Integer.class), 
+            Mockito.anyString(), Mockito.anyString(), Mockito.anyListOf(Integer.class),
             Mockito.anyListOf(Integer.class))).thenReturn(baseMeta);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/molecular-profiles/test_molecular_profile_id/discrete-copy-number")
@@ -208,7 +208,7 @@ public class DiscreteCopyNumberControllerTest {
             .thenReturn(discreteCopyNumberDataList);
 
         DiscreteCopyNumberFilter discreteCopyNumberFilter = createDiscreteCopyNumberFilter();
-        
+
         mockMvc.perform(MockMvcRequestBuilders
             .post("/molecular-profiles/test_molecular_profile_id/discrete-copy-number/fetch")
             .param("discreteCopyNumberEventType", DiscreteCopyNumberEventType.HOMDEL_AND_AMP.name())
@@ -248,7 +248,7 @@ public class DiscreteCopyNumberControllerTest {
             .thenReturn(baseMeta);
 
         DiscreteCopyNumberFilter discreteCopyNumberFilter = createDiscreteCopyNumberFilter();
-        
+
         mockMvc.perform(MockMvcRequestBuilders.
             post("/molecular-profiles/test_molecular_profile_id/discrete-copy-number/fetch")
             .contentType(MediaType.APPLICATION_JSON)
@@ -258,7 +258,7 @@ public class DiscreteCopyNumberControllerTest {
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.header().string(HeaderKeyConstants.TOTAL_COUNT, "2"));
     }
-    
+
     @Test
     public void fetchCopyNumberCounts() throws Exception {
 
@@ -278,7 +278,7 @@ public class DiscreteCopyNumberControllerTest {
         copyNumberCount2.setNumberOfSamplesWithAlterationInGene(TEST_NUMBER_OF_SAMPLES_WITH_ALTERATION_IN_GENE_2);
         copyNumberCountList.add(copyNumberCount2);
 
-        Mockito.when(discreteCopyNumberService.fetchCopyNumberCounts(Mockito.anyString(), 
+        Mockito.when(discreteCopyNumberService.fetchCopyNumberCounts(Mockito.anyString(),
             Mockito.anyListOf(Integer.class), Mockito.anyListOf(Integer.class))).thenReturn(copyNumberCountList);
 
         List<CopyNumberCountIdentifier> copyNumberCountIdentifiers = new ArrayList<>();
@@ -316,7 +316,7 @@ public class DiscreteCopyNumberControllerTest {
     }
 
     private DiscreteCopyNumberFilter createDiscreteCopyNumberFilter() {
-        
+
         List<String> sampleIds = new ArrayList<>();
         sampleIds.add(TEST_SAMPLE_STABLE_ID_1);
         sampleIds.add(TEST_SAMPLE_STABLE_ID_2);
@@ -332,7 +332,7 @@ public class DiscreteCopyNumberControllerTest {
     }
 
     private List<DiscreteCopyNumberData> createExampleDiscreteCopyNumberData() {
-        
+
         List<DiscreteCopyNumberData> discreteCopyNumberDataList = new ArrayList<>();
         DiscreteCopyNumberData discreteCopyNumberData1 = new DiscreteCopyNumberData();
         discreteCopyNumberData1.setMolecularProfileId(TEST_MOLECULAR_PROFILE_STABLE_ID_1);
@@ -346,7 +346,7 @@ public class DiscreteCopyNumberControllerTest {
         discreteCopyNumberData2.setEntrezGeneId(TEST_ENTREZ_GENE_ID_2);
         discreteCopyNumberData2.setAlteration(TEST_ALTERATION_2);
         discreteCopyNumberDataList.add(discreteCopyNumberData2);
-        return discreteCopyNumberDataList;        
+        return discreteCopyNumberDataList;
     }
 
     private List<DiscreteCopyNumberData> createExampleDiscreteCopyNumberDataWithGenes() {

--- a/web/src/test/java/org/cbioportal/web/ExpressionEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/ExpressionEnrichmentControllerTest.java
@@ -67,7 +67,7 @@ public class ExpressionEnrichmentControllerTest {
         Mockito.reset(expressionEnrichmentService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void fetchExpressionEnrichments() throws Exception {
 
@@ -90,8 +90,8 @@ public class ExpressionEnrichmentControllerTest {
         expressionEnrichment1.setpValue(TEST_P_VALUE_1);
         expressionEnrichments.add(expressionEnrichment1);
         expressionEnrichment1.setGroupsStatistics(groupStatistics1);
-        
-        
+
+
         ExpressionEnrichment expressionEnrichment2 = new ExpressionEnrichment();
         expressionEnrichment2.setEntrezGeneId(TEST_ENTREZ_GENE_ID_2);
         expressionEnrichment2.setHugoGeneSymbol(TEST_HUGO_GENE_SYMBOL_2);
@@ -113,14 +113,14 @@ public class ExpressionEnrichmentControllerTest {
 
         Mockito.when(expressionEnrichmentService.getExpressionEnrichments( Mockito.anyString(), Mockito.anyMap(), Mockito.anyString()))
             .thenReturn(expressionEnrichments);
-        
+
         mockMvc.perform(MockMvcRequestBuilders.post(
             "/expression-enrichments/fetch")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
             .content("[{\"molecularProfileCaseIdentifiers\":[{\"caseId\":\"TCGA-OR-A5JH-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"},{\"caseId\":\"TCGA-OR-A5K2-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"}],\"name\":\"altered\"},"
                     + "{\"molecularProfileCaseIdentifiers\":[{\"caseId\":\"TCGA-OR-A5LN-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"},{\"caseId\":\"TCGA-OR-A5LS-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"}],\"name\":\"unaltered\"}]"))
-            .andExpect(MockMvcResultMatchers.status().isOk())        
+            .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneId").value(TEST_ENTREZ_GENE_ID_1))

--- a/web/src/test/java/org/cbioportal/web/GeneControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GeneControllerTest.java
@@ -73,7 +73,7 @@ public class GeneControllerTest {
 
         List<Gene> geneList = createGeneList();
 
-        Mockito.when(geneService.getAllGenes(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), 
+        Mockito.when(geneService.getAllGenes(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(),
             Mockito.anyInt(), Mockito.anyString(), Mockito.anyString())).thenReturn(geneList);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/genes")

--- a/web/src/test/java/org/cbioportal/web/GenePanelControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GenePanelControllerTest.java
@@ -61,7 +61,7 @@ public class GenePanelControllerTest {
     private static final int TEST_ENTREZ_GENE_ID_4 = 400;
     private static final String TEST_HUGO_GENE_SYMBOL_4 = "test_hugo_gene_symbol_4";
     private static final String TEST_SAMPLE_LIST_ID = "test_sample_list_id";
-    
+
     @Autowired
     private WebApplicationContext wac;
 
@@ -83,7 +83,7 @@ public class GenePanelControllerTest {
         Mockito.reset(genePanelService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void getAllGenePanelsDetailedProjection() throws Exception {
 
@@ -122,8 +122,8 @@ public class GenePanelControllerTest {
         genePanelToGeneList2.add(genePanelToGene4);
         genePanel2.setGenes(genePanelToGeneList2);
         genePanelList.add(genePanel2);
-        
-        
+
+
         Mockito.when(genePanelService.getAllGenePanels(Mockito.anyString(), Mockito.anyInt(),
             Mockito.anyInt(), Mockito.anyString(), Mockito.anyString())).thenReturn(genePanelList);
 
@@ -197,7 +197,7 @@ public class GenePanelControllerTest {
         genePanelToGene2.setHugoGeneSymbol(TEST_HUGO_GENE_SYMBOL_2);
         genePanelToGeneList.add(genePanelToGene2);
         genePanel.setGenes(genePanelToGeneList);
-        
+
         Mockito.when(genePanelService.getGenePanel(Mockito.anyString())).thenReturn(genePanel);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/gene-panels/test_gene_panel_id")
@@ -216,9 +216,9 @@ public class GenePanelControllerTest {
 
     @Test
     public void getGenePanelData() throws Exception {
-        
+
         List<GenePanelData> genePanelDataList = createExampleGenePanelData();
-        
+
         Mockito.when(genePanelService.getGenePanelData(Mockito.anyString(), Mockito.anyString())).thenReturn(genePanelDataList);
 
         GenePanelDataFilter genePanelDataFilter = new GenePanelDataFilter();
@@ -248,10 +248,10 @@ public class GenePanelControllerTest {
 
     @Test
     public void fetchGenePanelData() throws Exception {
-        
+
         List<GenePanelData> genePanelDataList = createExampleGenePanelData();
-        
-        Mockito.when(genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(Mockito.anyListOf(String.class), 
+
+        Mockito.when(genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(Mockito.anyListOf(String.class),
             Mockito.anyListOf(String.class))).thenReturn(genePanelDataList);
 
         List<SampleMolecularIdentifier> sampleMolecularIdentifiers = new ArrayList<>();

--- a/web/src/test/java/org/cbioportal/web/GenesetDataControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GenesetDataControllerTest.java
@@ -55,14 +55,14 @@ public class GenesetDataControllerTest {
     public GenesetDataService genesetDataService() {
         return Mockito.mock(GenesetDataService.class);
     }
-    
+
     @Before
     public void setUp() throws Exception {
 
         Mockito.reset(genesetDataService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void fetchGeneticDataItems() throws Exception {
 

--- a/web/src/test/java/org/cbioportal/web/GenesetHierarchyControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GenesetHierarchyControllerTest.java
@@ -47,17 +47,16 @@ public class GenesetHierarchyControllerTest {
     public GenesetHierarchyService genesetHierarchyService() {
         return Mockito.mock(GenesetHierarchyService.class);
     }
-    
+
     @Before
     public void setUp() throws Exception {
 
         Mockito.reset(genesetHierarchyService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void fetchGenesetHierarchyInfo() throws Exception {
-
         List<GenesetHierarchyInfo> genesetHierarchyInfoList = createGenesetHierarchyInfoList();
         Mockito.when(genesetHierarchyService.fetchGenesetHierarchyInfo(Mockito.anyString(), Mockito.anyInt(),
             Mockito.anyDouble(), Mockito.anyDouble())).thenReturn(genesetHierarchyInfoList);

--- a/web/src/test/java/org/cbioportal/web/InfoControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/InfoControllerTest.java
@@ -23,14 +23,14 @@ public class InfoControllerTest {
 
     @Autowired
     private WebApplicationContext wac;
-    
+
     private MockMvc mockMvc;
-    
+
     @Before
     public void setUp() throws Exception {
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void getInfo() throws Exception {
 

--- a/web/src/test/java/org/cbioportal/web/MolecularDataControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MolecularDataControllerTest.java
@@ -75,7 +75,7 @@ public class MolecularDataControllerTest {
 
         List<GeneMolecularData> geneMolecularDataList = createExampleMolecularData();
 
-        Mockito.when(molecularDataService.getMolecularData(Mockito.anyString(), 
+        Mockito.when(molecularDataService.getMolecularData(Mockito.anyString(),
             Mockito.anyString(), Mockito.anyListOf(Integer.class), Mockito.anyString()))
             .thenReturn(geneMolecularDataList);
 
@@ -109,7 +109,7 @@ public class MolecularDataControllerTest {
         GeneMolecularData geneMolecularData2 = new GeneMolecularData();
         geneMolecularDataList.add(geneMolecularData2);
 
-        Mockito.when(molecularDataService.getMolecularData(Mockito.anyString(), Mockito.anyString(), 
+        Mockito.when(molecularDataService.getMolecularData(Mockito.anyString(), Mockito.anyString(),
             Mockito.anyListOf(Integer.class), Mockito.anyString())).thenReturn(geneMolecularDataList);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/molecular-profiles/test_molecular_profile_id/molecular-data")
@@ -128,7 +128,7 @@ public class MolecularDataControllerTest {
         Mockito.when(molecularDataService.fetchMolecularData(Mockito.anyString(),
             Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyString()))
             .thenReturn(geneMolecularDataList);
-        
+
         MolecularDataFilter molecularDataFilter = createMolecularDataFilter();
 
         mockMvc.perform(MockMvcRequestBuilders
@@ -162,7 +162,7 @@ public class MolecularDataControllerTest {
         GeneMolecularData geneMolecularData2 = new GeneMolecularData();
         geneMolecularDataList.add(geneMolecularData2);
 
-        Mockito.when(molecularDataService.fetchMolecularData(Mockito.anyString(), Mockito.anyListOf(String.class), 
+        Mockito.when(molecularDataService.fetchMolecularData(Mockito.anyString(), Mockito.anyListOf(String.class),
             Mockito.anyListOf(Integer.class), Mockito.anyString())).thenReturn(geneMolecularDataList);
 
         MolecularDataFilter molecularDataFilter = createMolecularDataFilter();
@@ -184,12 +184,12 @@ public class MolecularDataControllerTest {
         Mockito.when(molecularDataService.getMolecularDataInMultipleMolecularProfiles(Mockito.anyListOf(String.class),
             Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyString()))
             .thenReturn(geneMolecularDataList);
-        
+
         MolecularDataMultipleStudyFilter molecularDataMultipleStudyFilter = new MolecularDataMultipleStudyFilter();
-        molecularDataMultipleStudyFilter.setMolecularProfileIds(Arrays.asList(TEST_MOLECULAR_PROFILE_STABLE_ID_1, 
+        molecularDataMultipleStudyFilter.setMolecularProfileIds(Arrays.asList(TEST_MOLECULAR_PROFILE_STABLE_ID_1,
             TEST_MOLECULAR_PROFILE_STABLE_ID_2));
         molecularDataMultipleStudyFilter.setEntrezGeneIds(Arrays.asList(TEST_ENTREZ_GENE_ID_1, TEST_ENTREZ_GENE_ID_2));
-        
+
         mockMvc.perform(MockMvcRequestBuilders
             .post("/molecular-data/fetch")
             .accept(MediaType.APPLICATION_JSON)
@@ -211,9 +211,9 @@ public class MolecularDataControllerTest {
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].value").value(2.4))
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].gene").doesNotExist());
     }
-    
+
     private List<GeneMolecularData> createExampleMolecularData() {
-        
+
         List<GeneMolecularData> geneMolecularDataList = new ArrayList<>();
         GeneMolecularData geneMolecularData1 = new GeneMolecularData();
         geneMolecularData1.setMolecularProfileId(TEST_MOLECULAR_PROFILE_STABLE_ID_1);

--- a/web/src/test/java/org/cbioportal/web/MolecularProfileControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MolecularProfileControllerTest.java
@@ -52,7 +52,7 @@ public class MolecularProfileControllerTest {
     private static final String TEST_STUDY_DESCRIPTION_1 = "test_study_description_1";
     private static final Float TEST_STUDY_PIVOT_THRESHOLD_1 = 0.1f;
     private static final String TEST_STUDY_SORTORDER_1 = "ASC";
-    
+
     private static final int TEST_MOLECULAR_PROFILE_ID_2 = 2;
     private static final String TEST_STABLE_ID_2 = "test_stable_id_2";
     private static final int TEST_CANCER_STUDY_ID_2 = 2;
@@ -125,8 +125,8 @@ public class MolecularProfileControllerTest {
                 .value(TEST_SHOW_PROFILE_IN_ANALYSIS_TAB_2))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].pivotThreshold").value(TEST_STUDY_PIVOT_THRESHOLD_2))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].sortOrder").value(TEST_STUDY_SORTORDER_2));
-                
-                
+
+
     }
 
     @Test
@@ -197,7 +197,7 @@ public class MolecularProfileControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.showProfileInAnalysisTab")
                         .value(TEST_SHOW_PROFILE_IN_ANALYSIS_TAB_1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.pivotThreshold").value(TEST_STUDY_PIVOT_THRESHOLD_1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.sortOrder").value(TEST_STUDY_SORTORDER_1))                
+                .andExpect(MockMvcResultMatchers.jsonPath("$.sortOrder").value(TEST_STUDY_SORTORDER_1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.study.cancerStudyId").doesNotExist())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.study.studyId")
                         .value(TEST_CANCER_STUDY_IDENTIFIER_1))
@@ -267,12 +267,12 @@ public class MolecularProfileControllerTest {
 
         List<MolecularProfile> molecularProfileList = createExampleMolecularProfiles();
 
-        Mockito.when(molecularProfileService.getMolecularProfilesInStudies(Mockito.anyListOf(String.class), 
+        Mockito.when(molecularProfileService.getMolecularProfilesInStudies(Mockito.anyListOf(String.class),
             Mockito.anyString())).thenReturn(molecularProfileList);
-        
+
         MolecularProfileFilter molecularProfileFilter = new MolecularProfileFilter();
         molecularProfileFilter.setStudyIds(Arrays.asList(TEST_STUDY_IDENTIFIER_1, TEST_STUDY_IDENTIFIER_2));
-        
+
         mockMvc.perform(MockMvcRequestBuilders
                 .post("/molecular-profiles/fetch")
                 .accept(MediaType.APPLICATION_JSON)

--- a/web/src/test/java/org/cbioportal/web/MutationControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MutationControllerTest.java
@@ -145,9 +145,9 @@ public class MutationControllerTest {
     public void getMutationsInMolecularProfileBySampleListIdDefaultProjection() throws Exception {
 
         List<Mutation> mutationList = createExampleMutations();
-        
-        Mockito.when(mutationService.getMutationsInMolecularProfileBySampleListId(Mockito.anyString(), 
-            Mockito.anyString(), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), Mockito.anyString(), 
+
+        Mockito.when(mutationService.getMutationsInMolecularProfileBySampleListId(Mockito.anyString(),
+            Mockito.anyString(), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), Mockito.anyString(),
             Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString())).thenReturn(mutationList);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/molecular-profiles/test_molecular_profile_id/mutations")
@@ -233,8 +233,8 @@ public class MutationControllerTest {
 
         List<Mutation> mutationList = createExampleMutationsWithGene();
 
-        Mockito.when(mutationService.getMutationsInMolecularProfileBySampleListId(Mockito.anyString(), 
-            Mockito.anyString(), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), Mockito.anyString(), 
+        Mockito.when(mutationService.getMutationsInMolecularProfileBySampleListId(Mockito.anyString(),
+            Mockito.anyString(), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), Mockito.anyString(),
             Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString())).thenReturn(mutationList);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/molecular-profiles/test_molecular_profile_id/mutations")
@@ -326,7 +326,7 @@ public class MutationControllerTest {
         mutationMeta.setTotalCount(2);
         mutationMeta.setSampleCount(3);
 
-        Mockito.when(mutationService.getMetaMutationsInMolecularProfileBySampleListId(Mockito.anyString(), 
+        Mockito.when(mutationService.getMetaMutationsInMolecularProfileBySampleListId(Mockito.anyString(),
             Mockito.anyString(), Mockito.anyListOf(Integer.class))).thenReturn(mutationMeta);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/molecular-profiles/test_molecular_profile_id/mutations")
@@ -442,11 +442,11 @@ public class MutationControllerTest {
 
         List<Mutation> mutationList = createExampleMutations();
 
-        Mockito.when(mutationService.fetchMutationsInMolecularProfile(Mockito.anyString(), 
-            Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), 
+        Mockito.when(mutationService.fetchMutationsInMolecularProfile(Mockito.anyString(),
+            Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(),
             Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
             .thenReturn(mutationList);
-        
+
         List<String> sampleIds = new ArrayList<>();
         sampleIds.add(TEST_SAMPLE_STABLE_ID_1);
         sampleIds.add(TEST_SAMPLE_STABLE_ID_2);
@@ -538,7 +538,7 @@ public class MutationControllerTest {
         List<Mutation> mutationList = createExampleMutationsWithGene();
 
         Mockito.when(mutationService.fetchMutationsInMolecularProfile(Mockito.anyString(),
-            Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(), 
+            Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyBoolean(),
             Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
             .thenReturn(mutationList);
 
@@ -639,7 +639,7 @@ public class MutationControllerTest {
         mutationMeta.setTotalCount(2);
         mutationMeta.setSampleCount(3);
 
-        Mockito.when(mutationService.fetchMetaMutationsInMolecularProfile(Mockito.anyString(), 
+        Mockito.when(mutationService.fetchMetaMutationsInMolecularProfile(Mockito.anyString(),
             Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class))).thenReturn(mutationMeta);
 
         List<String> sampleIds = new ArrayList<>();
@@ -674,7 +674,7 @@ public class MutationControllerTest {
         mutationCountByPosition2.setCount(TEST_MUTATION_COUNT_2);
         mutationCountByPositionList.add(mutationCountByPosition2);
 
-        Mockito.when(mutationService.fetchMutationCountsByPosition(Mockito.anyListOf(Integer.class), 
+        Mockito.when(mutationService.fetchMutationCountsByPosition(Mockito.anyListOf(Integer.class),
             Mockito.anyListOf(Integer.class), Mockito.anyListOf(Integer.class)))
             .thenReturn(mutationCountByPositionList);
 
@@ -778,7 +778,7 @@ public class MutationControllerTest {
         mutation2.setOncotatorProteinPosEnd(TEST_ONCOTATOR_PROTEIN_POS_END_2);
         mutation2.setKeyword(TEST_KEYWORD_2);
         mutationList.add(mutation2);
-        
+
         return mutationList;
     }
 
@@ -795,7 +795,7 @@ public class MutationControllerTest {
         gene2.setHugoGeneSymbol(TEST_HUGO_GENE_SYMBOL_2);
         gene2.setType(TEST_TYPE_2);
         mutationList.get(1).setGene(gene2);
-        
+
         return mutationList;
     }
 }

--- a/web/src/test/java/org/cbioportal/web/MutationEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MutationEnrichmentControllerTest.java
@@ -116,15 +116,15 @@ public class MutationEnrichmentControllerTest {
         MolecularProfileCaseIdentifier entity2 = new MolecularProfileCaseIdentifier();
         entity2.setCaseId("test_sample_id_2");
         entity2.setMolecularProfileId("test_2_mutations");
-        
+
         MolecularProfileCasesGroupFilter casesGroup1 = new MolecularProfileCasesGroupFilter();
         casesGroup1.setName("altered group");
         casesGroup1.setMolecularProfileCaseIdentifiers(Arrays.asList(entity1));
-        
+
         MolecularProfileCasesGroupFilter casesGroup2 = new MolecularProfileCasesGroupFilter();
         casesGroup2.setName("unaltered group");
         casesGroup2.setMolecularProfileCaseIdentifiers(Arrays.asList(entity2));
-        
+
         mockMvc.perform(MockMvcRequestBuilders.post(
             "/mutation-enrichments/fetch")
             .accept(MediaType.APPLICATION_JSON)

--- a/web/src/test/java/org/cbioportal/web/MutationSpectrumControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MutationSpectrumControllerTest.java
@@ -69,10 +69,10 @@ public class MutationSpectrumControllerTest {
         Mockito.reset(mutationSpectrumService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void fetchMutationSpectrums() throws Exception {
-        
+
         List<MutationSpectrum> mutationSpectrumList = new ArrayList<>();
         MutationSpectrum mutationSpectrum1 = new MutationSpectrum();
         mutationSpectrum1.setMolecularProfileId(TEST_MOLECULAR_PROFILE_ID);

--- a/web/src/test/java/org/cbioportal/web/PatientControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/PatientControllerTest.java
@@ -109,7 +109,7 @@ public class PatientControllerTest {
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.header().string(HeaderKeyConstants.TOTAL_COUNT, "2"));
     }
-    
+
     @Test
     public void getAllPatientsInStudyDefaultProjection() throws Exception {
 

--- a/web/src/test/java/org/cbioportal/web/ReferenceGenomeGeneControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/ReferenceGenomeGeneControllerTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 @ContextConfiguration("/applicationContext-web-test.xml")
 @Configuration
 public class ReferenceGenomeGeneControllerTest {
-    
+
     public static final String CYTOBAND_1 = "cytoband_1";
     public static final int LENGTH_1 = 100;
     public static final String CHROMOSOME_1 = "chromosome_1";
@@ -40,13 +40,13 @@ public class ReferenceGenomeGeneControllerTest {
     public static final int REFERENCE_GENOME_ID = 1;
     public static final int ENTREZ_GENE_ID_1 = 1;
     public static final int ENTREZ_GENE_ID_2 = 2;
-    
+
     @Autowired
     private WebApplicationContext wac;
 
     @Autowired
     private ReferenceGenomeGeneService referenceGenomeGeneService;
-    
+
     private ObjectMapper objectMapper = new ObjectMapper();
 
     private MockMvc mockMvc;
@@ -65,7 +65,7 @@ public class ReferenceGenomeGeneControllerTest {
 
     @Test
     public void getGene() throws Exception {
-        
+
         ReferenceGenomeGene gene = new ReferenceGenomeGene();
         gene.setEntrezGeneId(ENTREZ_GENE_ID_1);
         gene.setReferenceGenomeId(REFERENCE_GENOME_ID);
@@ -85,7 +85,7 @@ public class ReferenceGenomeGeneControllerTest {
             .andExpect(MockMvcResultMatchers.jsonPath("$.length").value(LENGTH_1))
             .andExpect(MockMvcResultMatchers.jsonPath("$.chromosome").value(CHROMOSOME_1));
     }
-    
+
 
     @Test
     public void fetchGenesDefaultProjection() throws Exception {
@@ -117,7 +117,7 @@ public class ReferenceGenomeGeneControllerTest {
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].length").value(LENGTH_2))
             .andExpect(MockMvcResultMatchers.jsonPath("$[1].chromosome").value(CHROMOSOME_2));
     }
-    
+
 
     private List<ReferenceGenomeGene> createGeneList() {
         List<ReferenceGenomeGene> geneList = new ArrayList<>();

--- a/web/src/test/java/org/cbioportal/web/SampleListControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/SampleListControllerTest.java
@@ -78,7 +78,7 @@ public class SampleListControllerTest {
         Mockito.reset(sampleListService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void getAllSampleListsDefaultProjection() throws Exception {
 
@@ -315,7 +315,7 @@ public class SampleListControllerTest {
     }
 
     private SampleList createExampleSampleListWithStudy() {
-        
+
         SampleList sampleList = new SampleList();
         sampleList.setListId(TEST_LIST_ID_1);
         sampleList.setStableId(TEST_STABLE_ID_1);

--- a/web/src/test/java/org/cbioportal/web/SignificantCopyNumberRegionControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/SignificantCopyNumberRegionControllerTest.java
@@ -76,7 +76,7 @@ public class SignificantCopyNumberRegionControllerTest {
         Mockito.reset(significantCopyNumberRegionService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void getSignificantCopyNumberRegions() throws Exception {
 

--- a/web/src/test/java/org/cbioportal/web/SignificantlyMutatedGenesControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/SignificantlyMutatedGenesControllerTest.java
@@ -48,7 +48,7 @@ public class SignificantlyMutatedGenesControllerTest {
     private static final int TEST_NUMMUTATIONS_2 = 2;
     private static final BigDecimal TEST_P_VALUE_2 = new BigDecimal(0.2);
     private static final BigDecimal TEST_Q_VALUE_2 = new BigDecimal(0.2);
-    
+
     @Autowired
     private WebApplicationContext wac;
 
@@ -68,7 +68,7 @@ public class SignificantlyMutatedGenesControllerTest {
         Mockito.reset(significantlyMutatedGeneService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void getSignificantlyMutatedGenesDefaultProjection() throws Exception {
 
@@ -96,7 +96,7 @@ public class SignificantlyMutatedGenesControllerTest {
         mutSig2.setqValue(TEST_Q_VALUE_2);
         mutSigList.add(mutSig2);
 
-        Mockito.when(significantlyMutatedGeneService.getSignificantlyMutatedGenes(Mockito.anyString(), 
+        Mockito.when(significantlyMutatedGeneService.getSignificantlyMutatedGenes(Mockito.anyString(),
             Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
             .thenReturn(mutSigList);
 

--- a/web/src/test/java/org/cbioportal/web/StructuralVariantControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StructuralVariantControllerTest.java
@@ -113,7 +113,7 @@ public class StructuralVariantControllerTest {
     @Autowired
     private StructuralVariantService structuralVariantService;
     private MockMvc mockMvc;
-    
+
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Bean
@@ -133,7 +133,7 @@ public class StructuralVariantControllerTest {
 
         List<StructuralVariant> structuralVariant = createExampleStructuralVariant();
 
-        Mockito.when(structuralVariantService.fetchStructuralVariants(Mockito.anyList(), 
+        Mockito.when(structuralVariantService.fetchStructuralVariants(Mockito.anyList(),
                 Mockito.anyList(), Mockito.anyList())).thenReturn(structuralVariant);
 
         StructuralVariantFilter structuralVariantFilter = createStructuralVariantFilterMolecularProfileId();
@@ -199,7 +199,7 @@ public class StructuralVariantControllerTest {
 
         List<StructuralVariant> structuralVariant = createExampleStructuralVariant();
 
-        Mockito.when(structuralVariantService.fetchStructuralVariants(Mockito.anyList(), 
+        Mockito.when(structuralVariantService.fetchStructuralVariants(Mockito.anyList(),
                 Mockito.anyList(), Mockito.anyList())).thenReturn(structuralVariant);
 
         StructuralVariantFilter structuralVariantFilter = createStructuralVariantFilterSampleMolecularIdentifier();
@@ -265,7 +265,7 @@ public class StructuralVariantControllerTest {
 
         List<StructuralVariant> structuralVariant = createExampleStructuralVariant();
 
-        Mockito.when(structuralVariantService.fetchStructuralVariants(Mockito.anyList(), 
+        Mockito.when(structuralVariantService.fetchStructuralVariants(Mockito.anyList(),
                 Mockito.anyList(), Mockito.anyList())).thenReturn(structuralVariant);
 
         StructuralVariantFilter structuralVariantFilter = createStructuralVariantFilterMolecularProfileIdAndSampleMolecularIdentifier();

--- a/web/src/test/java/org/cbioportal/web/StudyControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StudyControllerTest.java
@@ -95,7 +95,7 @@ public class StudyControllerTest {
 
     @Test
     public void getAllStudiesDefaultProjection() throws Exception {
-        
+
         List<CancerStudy> cancerStudyList = createExampleStudies();
 
         Mockito.when(studyService.getAllStudies(Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(),
@@ -228,7 +228,7 @@ public class StudyControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/studies/fetch")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(Arrays.asList(TEST_CANCER_STUDY_IDENTIFIER_1, 
+            .content(objectMapper.writeValueAsString(Arrays.asList(TEST_CANCER_STUDY_IDENTIFIER_1,
                 TEST_CANCER_STUDY_IDENTIFIER_2))))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -275,11 +275,11 @@ public class StudyControllerTest {
                 .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.content().string(TEST_TAGS_1));
     }
-    
+
     @Test
     public void getEmptyTags() throws Exception {
 
-    	Mockito.when(studyService.getTags(Mockito.anyString())).thenReturn(null);
+        Mockito.when(studyService.getTags(Mockito.anyString())).thenReturn(null);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/studies/test_study_id/tags")
                 .accept(MediaType.APPLICATION_JSON))
@@ -307,7 +307,7 @@ public class StudyControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/studies/tags/fetch")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(Arrays.asList(TEST_CANCER_STUDY_IDENTIFIER_1, 
+            .content(objectMapper.writeValueAsString(Arrays.asList(TEST_CANCER_STUDY_IDENTIFIER_1,
                 TEST_CANCER_STUDY_IDENTIFIER_2))))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -356,5 +356,5 @@ public class StudyControllerTest {
         cancerStudyList.add(cancerStudy2);
         return cancerStudyList;
     }
-    
+
 }

--- a/web/src/test/java/org/cbioportal/web/StudyViewControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StudyViewControllerTest.java
@@ -139,8 +139,8 @@ public class StudyViewControllerTest {
         clinicalDataCounts.add(clinicalDataCount2);
         clinicalDataCountItem.setCounts(clinicalDataCounts);
         clinicalDataCountItems.add(clinicalDataCountItem);
-        
-        Mockito.when(clinicalDataService.fetchClinicalDataCounts(Mockito.anyListOf(String.class), Mockito.anyListOf(String.class), 
+
+        Mockito.when(clinicalDataService.fetchClinicalDataCounts(Mockito.anyListOf(String.class), Mockito.anyListOf(String.class),
             Mockito.anyListOf(String.class), Mockito.any(ClinicalDataType.class))).thenReturn(clinicalDataCountItems);
 
         ClinicalDataCountFilter clinicalDataCountFilter = new ClinicalDataCountFilter();
@@ -151,7 +151,7 @@ public class StudyViewControllerTest {
         StudyViewFilter studyViewFilter = new StudyViewFilter();
         studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
         clinicalDataCountFilter.setStudyViewFilter(studyViewFilter);
-        
+
         mockMvc.perform(MockMvcRequestBuilders.post("/clinical-data-counts/fetch")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
@@ -169,7 +169,7 @@ public class StudyViewControllerTest {
     }
 
     @Test
-    public void fetchClinicalDataBinCounts() throws Exception 
+    public void fetchClinicalDataBinCounts() throws Exception
     {
         List<SampleIdentifier> filteredSampleIdentifiers = new ArrayList<>();
         SampleIdentifier sampleIdentifier = new SampleIdentifier();
@@ -264,7 +264,7 @@ public class StudyViewControllerTest {
         mutationCount2.setTotalCount(2);
         mutationCounts.add(mutationCount2);
 
-        Mockito.when(mutationService.getSampleCountInMultipleMolecularProfiles(Mockito.anyListOf(String.class), 
+        Mockito.when(mutationService.getSampleCountInMultipleMolecularProfiles(Mockito.anyListOf(String.class),
             Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyBoolean())).thenReturn(mutationCounts);
 
         StudyViewFilter studyViewFilter = new StudyViewFilter();
@@ -316,7 +316,7 @@ public class StudyViewControllerTest {
         cnaCount2.setAlteration(2);
         cnaCounts.add(cnaCount2);
 
-        Mockito.when(discreteCopyNumberService.getSampleCountInMultipleMolecularProfiles(Mockito.anyListOf(String.class), 
+        Mockito.when(discreteCopyNumberService.getSampleCountInMultipleMolecularProfiles(Mockito.anyListOf(String.class),
             Mockito.anyListOf(String.class), Mockito.anyListOf(Integer.class), Mockito.anyListOf(Integer.class), Mockito.anyBoolean()))
             .thenReturn(cnaCounts);
 
@@ -367,12 +367,12 @@ public class StudyViewControllerTest {
         sample2.setCancerStudyIdentifier(TEST_STUDY_ID);
         filteredSamples.add(sample2);
 
-        Mockito.when(sampleService.fetchSamples(Mockito.anyListOf(String.class), Mockito.anyListOf(String.class), 
+        Mockito.when(sampleService.fetchSamples(Mockito.anyListOf(String.class), Mockito.anyListOf(String.class),
             Mockito.anyString())).thenReturn(filteredSamples);
 
         StudyViewFilter studyViewFilter = new StudyViewFilter();
         studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
-    
+
         mockMvc.perform(MockMvcRequestBuilders.post("/filtered-samples/fetch")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
@@ -426,7 +426,7 @@ public class StudyViewControllerTest {
         Mockito.when(molecularProfileService.getFirstDiscreteCNAProfileIds(Mockito.anyListOf(String.class), Mockito.anyListOf(String.class)))
             .thenReturn(Arrays.asList(TEST_MOLEULAR_PROFILE_ID_2));
 
-        Mockito.when(genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(Mockito.anyListOf(String.class), 
+        Mockito.when(genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(Mockito.anyListOf(String.class),
             Mockito.anyListOf(String.class))).thenReturn(genePanelDataList);
 
         StudyViewFilter studyViewFilter = new StudyViewFilter();
@@ -491,13 +491,13 @@ public class StudyViewControllerTest {
         clinicalData6.setStudyId(TEST_STUDY_ID);
         clinicalData6.setSampleId(TEST_SAMPLE_ID_3);
         clinicalData.add(clinicalData6);
-        
-        Mockito.when(clinicalDataService.fetchClinicalData(Mockito.anyListOf(String.class), Mockito.anyListOf(String.class), 
+
+        Mockito.when(clinicalDataService.fetchClinicalData(Mockito.anyListOf(String.class), Mockito.anyListOf(String.class),
             Mockito.anyListOf(String.class), Mockito.anyString(), Mockito.anyString())).thenReturn(clinicalData);
 
         StudyViewFilter studyViewFilter = new StudyViewFilter();
         studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
-        
+
         mockMvc.perform(MockMvcRequestBuilders.post("/clinical-data-density-plot/fetch")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)

--- a/web/src/test/java/org/cbioportal/web/TreatmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/TreatmentControllerTest.java
@@ -82,7 +82,7 @@ public class TreatmentControllerTest {
     public static final String STUDY_ID_2 = "study_id_2";
 
     private ObjectMapper objectMapper = new ObjectMapper();
-    
+
     @Autowired
     private WebApplicationContext wac;
 
@@ -124,7 +124,7 @@ public class TreatmentControllerTest {
         .thenReturn(treatmentListForStudy);
         Mockito.when(treatmentService.getTreatments(Mockito.anyList(), Mockito.anyString()))
         .thenReturn(treatmentList);
-        
+
     }
 
     @Test

--- a/web/src/test/java/org/cbioportal/web/TreatmentDataControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/TreatmentDataControllerTest.java
@@ -85,14 +85,14 @@ public class TreatmentDataControllerTest {
     public TreatmentDataService treatmentDataService() {
         return Mockito.mock(TreatmentDataService.class);
     }
-    
+
     @Before
     public void setUp() throws Exception {
 
         Mockito.reset(treatmentDataService);
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
     }
-    
+
     @Test
     public void fetchTreatmentGeneticDataItems() throws Exception {
 

--- a/web/src/test/java/org/cbioportal/web/VariantCountControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/VariantCountControllerTest.java
@@ -86,9 +86,9 @@ public class VariantCountControllerTest {
         variantCount2.setNumberOfSamplesWithKeyword(TEST_NUMBER_OF_SAMPLES_WITH_KEYWORD_2);
         variantCountList.add(variantCount2);
 
-        Mockito.when(variantCountService.fetchVariantCounts(Mockito.anyString(), Mockito.anyListOf(Integer.class), 
+        Mockito.when(variantCountService.fetchVariantCounts(Mockito.anyString(), Mockito.anyListOf(Integer.class),
             Mockito.anyListOf(String.class))).thenReturn(variantCountList);
-        
+
         List<VariantCountIdentifier> variantCountIdentifiers = new ArrayList<>();
         VariantCountIdentifier variantCountIdentifier1 = new VariantCountIdentifier();
         variantCountIdentifier1.setEntrezGeneId(TEST_ENTREZ_GENE_ID_1);

--- a/web/src/test/java/org/cbioportal/web/config/RestAuthenticationEntryPoint.java
+++ b/web/src/test/java/org/cbioportal/web/config/RestAuthenticationEntryPoint.java
@@ -42,10 +42,10 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 @Component
-public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint{
- 
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
    @Override
-   public void commence( HttpServletRequest request, HttpServletResponse response, 
+   public void commence( HttpServletRequest request, HttpServletResponse response,
     AuthenticationException authException ) throws IOException{
       response.sendError( HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized" );
    }

--- a/web/src/test/java/org/cbioportal/web/util/DataBinnerTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/DataBinnerTest.java
@@ -15,10 +15,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DataBinnerTest
-{
+public class DataBinnerTest {
     private Map<String, String[]> mockData;
-    
+
     private DataBinner dataBinner;
 
     @Before
@@ -29,15 +28,14 @@ public class DataBinnerTest
         LinearDataBinner linearDataBinner = new LinearDataBinner(dataBinHelper);
         ScientificSmallDataBinner scientificSmallDataBinner = new ScientificSmallDataBinner(dataBinHelper);
         LogScaleDataBinner logScaleDataBinner = new LogScaleDataBinner(dataBinHelper);
-        
+
         dataBinner = new DataBinner(
             dataBinHelper, discreteDataBinner, linearDataBinner, scientificSmallDataBinner, studyViewFilterUtil, logScaleDataBinner);
-        
+
         mockData = initMockData();
     }
-    
-    public Map<String, String[]> initMockData()
-    {
+
+    public Map<String, String[]> initMockData() {
         Map<String, String[]> mockData = new LinkedHashMap<>();
 
         mockData.put("blca_tcga_AGE", new String[] {
@@ -471,13 +469,12 @@ public class DataBinnerTest
         mockData.put("linear_integer_continue", new String[]{
             "1.0", "2.0", "3.0", "4.0", "5.0", "6.0", "7.0", "8.0", "9.0", "10.0", "11.0", "12.0", "13.0", "14.0", "15.0", "16.0", "17.0", "18.0", "19.0", "20.0", "21.0", "22.0", "23.0", "24.0", "25.0", "26.0", "27.0", "28.0", "29.0", "30.0", "31.0", "32.0", "33.0", "34.0", "35.0", "36.0", "37.0", "38.0", "39.0", "40.0", "41.0", "42.0", "43.0", "44.0", "45.0", "46.0", "47.0", "48.0", "49.0", "50.0", "51.0", "52.0", "53.0", "54.0", "55.0", "56.0", "57.0", "58.0", "59.0", "60.0", "61.0", "62.0", "63.0", "64.0", "65.0", "66.0", "67.0", "68.0", "69.0", "70.0", "71.0", "72.0", "73.0", "74.0", "75.0", "76.0", "77.0", "78.0", "79.0", "80.0", "81.0", "82.0", "83.0", "84.0", "85.0", "86.0", "87.0", "88.0", "89.0", "90.0", "91.0", "92.0", "93.0", "94.0", "95.0", "96.0", "97.0", "98.0", "99.0", "100.0"
         });
-        
+
         return mockData;
     }
-    
+
     @Test
-    public void testLinearDataBinner()
-    {
+    public void testLinearDataBinner() {
         String studyId = "blca_tcga";
         String attributeId = "AGE";
         String[] values = mockData.get("blca_tcga_AGE");
@@ -487,11 +484,11 @@ public class DataBinnerTest
 
         List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = clinicalData.stream().map(ClinicalData::getPatientId).collect(Collectors.toList());
-        
+
         List<DataBin> dataBins = dataBinner.calculateClinicalDataBins(clinicalDataBinFilter, clinicalData, patientIds);
 
         Assert.assertEquals(11, dataBins.size());
-        
+
         Assert.assertEquals("<=", dataBins.get(0).getSpecialValue());
         Assert.assertEquals(new BigDecimal("40.0"), dataBins.get(0).getEnd());
         Assert.assertEquals(2, dataBins.get(0).getCount().intValue());
@@ -539,8 +536,7 @@ public class DataBinnerTest
 
 
     @Test
-    public void testLinearDataBinnerWithRange()
-    {
+    public void testLinearDataBinnerWithRange() {
         String studyId = "random";
         String attributeId = "random";
         String[] values = mockData.get("linear_integer_continue");
@@ -575,8 +571,7 @@ public class DataBinnerTest
 
 
     @Test
-    public void testLinearDataBinnerWithRangeOne()
-    {
+    public void testLinearDataBinnerWithRangeOne() {
         String studyId = "random";
         String attributeId = "random";
         String[] values = mockData.get("linear_integer_continue");
@@ -610,8 +605,7 @@ public class DataBinnerTest
     }
 
     @Test
-    public void testLinearDataBinnerWithRangeTwo()
-    {
+    public void testLinearDataBinnerWithRangeTwo() {
         String studyId = "random";
         String attributeId = "random";
         String[] values = mockData.get("linear_integer_continue");
@@ -642,15 +636,14 @@ public class DataBinnerTest
         Assert.assertEquals(new BigDecimal("75.0"), dataBins.get(7).getStart());
         Assert.assertEquals(new BigDecimal("80.0"), dataBins.get(7).getEnd());
         Assert.assertEquals(5, dataBins.get(7).getCount().intValue());
-        
+
         Assert.assertEquals(new BigDecimal("80.0"), dataBins.get(8).getStart());
         Assert.assertEquals(">", dataBins.get(8).getSpecialValue());
         Assert.assertEquals(1, dataBins.get(8).getCount().intValue());
     }
 
     @Test
-    public void testLinearDataBinnerWithRangeAndCustomrBins()
-    {
+    public void testLinearDataBinnerWithRangeAndCustomrBins() {
         String studyId = "random";
         String attributeId = "random";
         String[] values = mockData.get("linear_integer_continue");
@@ -685,34 +678,33 @@ public class DataBinnerTest
     }
 
     @Test
-    public void testStaticDataBinnerFilter()
-    {
+    public void testStaticDataBinnerFilter() {
         String studyId = "blca_tcga";
         String attributeId = "AGE";
         String[] values = mockData.get("blca_tcga_AGE");
-        
+
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
         clinicalDataBinFilter.setClinicalDataType(ClinicalDataType.PATIENT);
 
         List<ClinicalData> unfilteredClinicalData = mockClinicalData(attributeId, studyId, values);
-        List<String> unfilteredPatientIds = 
+        List<String> unfilteredPatientIds =
             unfilteredClinicalData.stream().map(ClinicalData::getPatientId).collect(Collectors.toList());
         List<DataBin> unfilteredDataBins = dataBinner.calculateClinicalDataBins(
             clinicalDataBinFilter, unfilteredClinicalData, unfilteredPatientIds);
-        
+
         List<ClinicalData> filteredClinicalData = unfilteredClinicalData.subList(0, 108); // (0, 60] interval
         List<String> filteredPatientIds =
             filteredClinicalData.stream().map(ClinicalData::getPatientId).collect(Collectors.toList());
         List<DataBin> filteredDataBins = dataBinner.calculateClinicalDataBins(
             clinicalDataBinFilter, filteredClinicalData, unfilteredClinicalData, filteredPatientIds, unfilteredPatientIds);
-        
+
         // same number of bins for both
         Assert.assertEquals(11, unfilteredDataBins.size());
         Assert.assertEquals(11, filteredDataBins.size());
 
         // same start/end/special values for all bins
-        
+
         Assert.assertEquals("<=", filteredDataBins.get(0).getSpecialValue());
         Assert.assertEquals("<=", unfilteredDataBins.get(0).getSpecialValue());
         Assert.assertEquals(new BigDecimal("40.0"), filteredDataBins.get(0).getEnd());
@@ -747,9 +739,9 @@ public class DataBinnerTest
         Assert.assertEquals(new BigDecimal("85.0"), unfilteredDataBins.get(10).getStart());
         Assert.assertEquals(new BigDecimal("90.0"), filteredDataBins.get(10).getEnd());
         Assert.assertEquals(new BigDecimal("90.0"), unfilteredDataBins.get(10).getEnd());
-        
+
         // same counts until the bin (60-65]
-        
+
         Assert.assertEquals(2, filteredDataBins.get(0).getCount().intValue());
         Assert.assertEquals(2, unfilteredDataBins.get(0).getCount().intValue());
 
@@ -776,8 +768,7 @@ public class DataBinnerTest
     }
 
     @Test
-    public void testLinearDataBinnerWithPediatricAge()
-    {
+    public void testLinearDataBinnerWithPediatricAge() {
         String studyId = "skcm_broad";
         String attributeId = "AGE_AT_PROCUREMENT";
         String[] values = mockData.get("skcm_broad_AGE_AT_PROCUREMENT");
@@ -838,8 +829,7 @@ public class DataBinnerTest
     }
 
     @Test
-    public void testLinearDataBinnerWithPediatricAgeCustomBinsTest1()
-    {
+    public void testLinearDataBinnerWithPediatricAgeCustomBinsTest1() {
         String studyId = "skcm_broad";
         String attributeId = "AGE_AT_PROCUREMENT";
         String[] values = mockData.get("skcm_broad_AGE_AT_PROCUREMENT");
@@ -900,8 +890,7 @@ public class DataBinnerTest
     }
 
     @Test
-    public void testLinearDataBinnerWithPediatricAgeCustomBinsTest2()
-    {
+    public void testLinearDataBinnerWithPediatricAgeCustomBinsTest2() {
         String studyId = "skcm_broad";
         String attributeId = "AGE_AT_PROCUREMENT";
         String[] values = mockData.get("skcm_broad_AGE_AT_PROCUREMENT");
@@ -944,10 +933,9 @@ public class DataBinnerTest
         Assert.assertEquals("NA", dataBins.get(5).getSpecialValue());
         Assert.assertEquals(4, dataBins.get(5).getCount().intValue());
     }
-    
+
     @Test
-    public void testLinearDataBinnerWithPredefinedAttribute() 
-    {
+    public void testLinearDataBinnerWithPredefinedAttribute() {
         String studyId = "crc_msk_2018";
         String attributeId = "MSI_SCORE";
         String[] values = mockData.get("crc_msk_2018_MSI_SCORE");
@@ -993,8 +981,7 @@ public class DataBinnerTest
     }
 
     @Test
-    public void testLinearDataBinnerWithNA()
-    {
+    public void testLinearDataBinnerWithNA() {
         String studyId = "blca_tcga";
         String attributeId = "LYMPH_NODE_EXAMINED_COUNT";
         String[] values = mockData.get("blca_tcga_LYMPH_NODE_EXAMINED_COUNT");
@@ -1064,14 +1051,13 @@ public class DataBinnerTest
         Assert.assertEquals(new BigDecimal("65.0"), dataBins.get(13).getStart());
         Assert.assertEquals(">", dataBins.get(13).getSpecialValue());
         Assert.assertEquals(28, dataBins.get(13).getCount().intValue());
-        
+
         Assert.assertEquals("NA", dataBins.get(14).getSpecialValue());
         Assert.assertEquals(109, dataBins.get(14).getCount().intValue());
     }
 
     @Test
-    public void testLinearDataBinnerWithZeroIQR()
-    {
+    public void testLinearDataBinnerWithZeroIQR() {
         String studyId = "impact";
         String attributeId = "DNA_INPUT";
         String[] values = mockData.get("impact_DNA_INPUT");
@@ -1091,14 +1077,13 @@ public class DataBinnerTest
 
         Assert.assertEquals(new BigDecimal("60.0"), dataBins.get(1).getStart());
         Assert.assertEquals(new BigDecimal("70.0"), dataBins.get(1).getEnd());
-        
+
         Assert.assertEquals(new BigDecimal("230.0"), dataBins.get(18).getStart());
         Assert.assertEquals(new BigDecimal("240.0"), dataBins.get(18).getEnd());
     }
 
     @Test
-    public void testLinearDataBinnerWithAlwaysZeroIQR()
-    {
+    public void testLinearDataBinnerWithAlwaysZeroIQR() {
         String studyId = "unknown";
         String attributeId = "DNA_INPUT";
         String[] values = mockData.get("recursively_always_zero_IQR");
@@ -1118,10 +1103,9 @@ public class DataBinnerTest
         Assert.assertEquals("all values should be included in a single bin",
             values.length, dataBins.get(0).getCount().intValue());
     }
-    
+
     @Test
-    public void testDiscreteDataBinner()
-    {
+    public void testDiscreteDataBinner() {
         String studyId = "acyc_fmi_2014";
         String attributeId = "ACTIONABLE_ALTERATIONS";
         String[] values = mockData.get("acyc_fmi_2014_ACTIONABLE_ALTERATIONS");
@@ -1135,7 +1119,7 @@ public class DataBinnerTest
         List<DataBin> dataBins = dataBinner.calculateClinicalDataBins(clinicalDataBinFilter, clinicalData, sampleIds);
 
         Assert.assertEquals(5, dataBins.size());
-        
+
         Assert.assertEquals(new BigDecimal("0.0"), dataBins.get(0).getStart());
         Assert.assertEquals(new BigDecimal("0.0"), dataBins.get(0).getEnd());
         Assert.assertEquals(16, dataBins.get(0).getCount().intValue());
@@ -1158,8 +1142,7 @@ public class DataBinnerTest
     }
 
     @Test
-    public void testScientificDataBinner()
-    {
+    public void testScientificDataBinner() {
         String studyId = "blca_dfarber_mskcc_2014";
         String attributeId = "SILENT_RATE";
         String[] values = mockData.get("blca_dfarber_mskcc_2014_SILENT_RATE");
@@ -1197,10 +1180,9 @@ public class DataBinnerTest
         Assert.assertEquals("NA", dataBins.get(4).getSpecialValue());
         Assert.assertEquals(3 + 6, dataBins.get(4).getCount().intValue());
     }
-    
+
     @Test
-    public void testLogScaleDataBinner()
-    {
+    public void testLogScaleDataBinner() {
         String studyId = "ampca_bcm_2016";
         String attributeId = "DAYS_TO_LAST_FOLLOWUP";
         String[] values = mockData.get("ampca_bcm_2016_DAYS_TO_LAST_FOLLOWUP");
@@ -1222,7 +1204,7 @@ public class DataBinnerTest
         Assert.assertEquals(new BigDecimal("10.0"), dataBins.get(1).getStart());
         Assert.assertEquals(new BigDecimal("31.0"), dataBins.get(1).getEnd());
         Assert.assertEquals(3, dataBins.get(1).getCount().intValue());
-        
+
         Assert.assertEquals(new BigDecimal("31.0"), dataBins.get(2).getStart());
         Assert.assertEquals(new BigDecimal("100.0"), dataBins.get(2).getEnd());
         Assert.assertEquals(5, dataBins.get(2).getCount().intValue());
@@ -1245,8 +1227,7 @@ public class DataBinnerTest
     }
 
     @Test
-    public void testLogScaleDisabledDataBinner()
-    {
+    public void testLogScaleDisabledDataBinner() {
         String studyId = "ampca_bcm_2016";
         String attributeId = "DAYS_TO_LAST_FOLLOWUP";
         String[] values = mockData.get("ampca_bcm_2016_DAYS_TO_LAST_FOLLOWUP");
@@ -1276,8 +1257,7 @@ public class DataBinnerTest
     }
 
     @Test
-    public void testNegativeLogScaleDataBinner()
-    {
+    public void testNegativeLogScaleDataBinner() {
         String studyId = "acc_tcga";
         String attributeId = "DAYS_TO_BIRTH";
         String[] values = mockData.get("acc_tcga_DAYS_TO_BIRTH");
@@ -1295,15 +1275,14 @@ public class DataBinnerTest
         Assert.assertEquals(new BigDecimal("-31622.0"), dataBins.get(0).getStart());
         Assert.assertEquals(new BigDecimal("-10000.0"), dataBins.get(0).getEnd());
         Assert.assertEquals(78, dataBins.get(0).getCount().intValue());
-        
+
         Assert.assertEquals(new BigDecimal("-10000.0"), dataBins.get(1).getStart());
         Assert.assertEquals(new BigDecimal("-3162.0"), dataBins.get(1).getEnd());
         Assert.assertEquals(14, dataBins.get(1).getCount().intValue());
     }
 
     @Test
-    public void testLogScaleDataBinnerWithSpecialOutliers()
-    {
+    public void testLogScaleDataBinnerWithSpecialOutliers() {
         String studyId = "genie";
         String attributeId = "INT_DOD";
         String[] values = mockData.get("genie_INT_DOD");
@@ -1330,15 +1309,14 @@ public class DataBinnerTest
 
         Assert.assertEquals(new BigDecimal("31622.0"), dataBins.get(3).getStart());
         Assert.assertEquals(new BigDecimal("32485.0"), dataBins.get(3).getEnd());
-        
+
         Assert.assertEquals(new BigDecimal("32485.0"), dataBins.get(4).getStart());
         Assert.assertEquals(">", dataBins.get(4).getSpecialValue());
         Assert.assertEquals(5, dataBins.get(4).getCount().intValue());
     }
-    
+
     @Test
-    public void testNegativeLogScaleDisabledDataBinner()
-    {
+    public void testNegativeLogScaleDisabledDataBinner() {
         String studyId = "acc_tcga";
         String attributeId = "DAYS_TO_BIRTH";
         String[] values = mockData.get("acc_tcga_DAYS_TO_BIRTH");
@@ -1360,24 +1338,23 @@ public class DataBinnerTest
         Assert.assertEquals(new BigDecimal("-6000.0"), dataBins.get(13).getStart());
         Assert.assertEquals(">", dataBins.get(13).getSpecialValue());
     }
-    
-    private List<ClinicalData> mockClinicalData(String attributeId, String studyId, String[] values)
-    {
+
+    private List<ClinicalData> mockClinicalData(String attributeId, String studyId, String[] values) {
         List<ClinicalData> clinicalDataList =  new ArrayList<>();
-        
-        for (int index = 0; index < values.length; index++) 
+
+        for (int index = 0; index < values.length; index++)
         {
             ClinicalData clinicalData = new ClinicalData();
-            
+
             clinicalData.setAttrId(attributeId);
             clinicalData.setStudyId(studyId);
             clinicalData.setSampleId(studyId + "_sample_" + index);
             clinicalData.setPatientId(studyId + "_patient_" + index);
             clinicalData.setAttrValue(values[index]);
-            
+
             clinicalDataList.add(clinicalData);
         }
-        
+
         return clinicalDataList;
     }
 }

--- a/web/src/test/java/org/cbioportal/web/util/StudyViewFilterApplierTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/StudyViewFilterApplierTest.java
@@ -50,7 +50,7 @@ public class StudyViewFilterApplierTest {
 
     //@InjectMocks -- TODO enable this after refactoring the tests
     private StudyViewFilterApplier studyViewFilterApplier;
-    
+
     @Mock
     private SampleService sampleService;
     @Mock
@@ -81,13 +81,13 @@ public class StudyViewFilterApplierTest {
     public void setup() {
         // manually setup studyViewFilterApplier, since we need combination of mocks and spies
         MockitoAnnotations.initMocks(this);
-        
+
         studyViewFilterApplier = new StudyViewFilterApplier(
-            sampleService, mutationService, discreteCopyNumberService, 
-            molecularProfileService, genePanelService, clinicalDataService, clinicalDataEqualityFilterApplier, 
+            sampleService, mutationService, discreteCopyNumberService,
+            molecularProfileService, genePanelService, clinicalDataService, clinicalDataEqualityFilterApplier,
             clinicalDataIntervalFilterApplier, studyViewFilterUtil);
     }
-    
+
     @Test
     public void apply() throws Exception {
 
@@ -97,7 +97,7 @@ public class StudyViewFilterApplierTest {
         studyIds.add(STUDY_ID);
         studyIds.add(STUDY_ID);
         studyIds.add(STUDY_ID);
-    
+
         StudyViewFilter studyViewFilter = new StudyViewFilter();
         List<String> sampleIds = new ArrayList<>();
         sampleIds.add(SAMPLE_ID1);
@@ -238,10 +238,10 @@ public class StudyViewFilterApplierTest {
         updatedSamples.add(sample2);
         updatedSamples.add(sample4);
         updatedSamples.add(sample5);
-        
+
         Mockito.when(sampleService.getSamplesOfPatientsInMultipleStudies(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID),
             updatedPatientIds, "ID")).thenReturn(updatedSamples);
-        
+
         List<ClinicalData> sampleClinicalDataList = new ArrayList<>();
         ClinicalData sampleClinicalData1 = new ClinicalData();
         sampleClinicalData1.setAttrId(CLINICAL_ATTRIBUTE_ID_1);
@@ -279,7 +279,7 @@ public class StudyViewFilterApplierTest {
         updatedSampleIds.add(SAMPLE_ID2);
         updatedSampleIds.add(SAMPLE_ID4);
         updatedSampleIds.add(SAMPLE_ID5);
-        
+
         Mockito.when(clinicalDataService.fetchClinicalData(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID),
             updatedSampleIds, Arrays.asList(CLINICAL_ATTRIBUTE_ID_1), "SAMPLE", "SUMMARY")).thenReturn(sampleClinicalDataList);
 
@@ -297,10 +297,10 @@ public class StudyViewFilterApplierTest {
         updatedPatient3.setCancerStudyIdentifier(STUDY_ID);
         updatedPatients.add(updatedPatient3);
 
-        Mockito.when(patientService.getPatientsOfSamples(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID), 
+        Mockito.when(patientService.getPatientsOfSamples(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID),
             updatedSampleIds)).thenReturn(updatedPatients);
 
-        Mockito.when(molecularProfileService.getFirstMutationProfileIds(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID), 
+        Mockito.when(molecularProfileService.getFirstMutationProfileIds(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID),
             updatedSampleIds)).thenReturn(Arrays.asList(MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1));
 
         List<Mutation> mutations = new ArrayList<>();
@@ -321,8 +321,8 @@ public class StudyViewFilterApplierTest {
         mutation4.setStudyId(STUDY_ID);
         mutations.add(mutation4);
 
-        Mockito.when(mutationService.getMutationsInMultipleMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID_1, 
-            MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1), updatedSampleIds, 
+        Mockito.when(mutationService.getMutationsInMultipleMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID_1,
+            MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1), updatedSampleIds,
             Arrays.asList(ENTREZ_GENE_ID_1), "ID", null, null, null, null)).thenReturn(mutations);
 
         updatedSampleIds = new ArrayList<>();
@@ -330,7 +330,7 @@ public class StudyViewFilterApplierTest {
         updatedSampleIds.add(SAMPLE_ID2);
         updatedSampleIds.add(SAMPLE_ID4);
 
-        Mockito.when(molecularProfileService.getFirstDiscreteCNAProfileIds(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID), 
+        Mockito.when(molecularProfileService.getFirstDiscreteCNAProfileIds(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID),
             updatedSampleIds)).thenReturn(Arrays.asList(MOLECULAR_PROFILE_ID_2, MOLECULAR_PROFILE_ID_2, MOLECULAR_PROFILE_ID_2));
 
         List<DiscreteCopyNumberData> discreteCopyNumberDataList = new ArrayList<>();
@@ -348,9 +348,9 @@ public class StudyViewFilterApplierTest {
         discreteCopyNumberDataList.add(discreteCopyNumberData3);
 
         Mockito.when(discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfiles(Arrays.asList(
-            MOLECULAR_PROFILE_ID_2, MOLECULAR_PROFILE_ID_2, MOLECULAR_PROFILE_ID_2), updatedSampleIds, 
+            MOLECULAR_PROFILE_ID_2, MOLECULAR_PROFILE_ID_2, MOLECULAR_PROFILE_ID_2), updatedSampleIds,
             Arrays.asList(ENTREZ_GENE_ID_2), Arrays.asList(-2), "ID")).thenReturn(discreteCopyNumberDataList);
-        
+
         List<SampleIdentifier> result = studyViewFilterApplier.apply(studyViewFilter);
         Assert.assertEquals(2, result.size());
         Assert.assertEquals(SAMPLE_ID1, result.get(0).getSampleId());
@@ -359,7 +359,7 @@ public class StudyViewFilterApplierTest {
 
     @Test
     public void applyIntervalFilters() throws Exception {
-        
+
         List<String> studyIds = new ArrayList<>();
         studyIds.add(STUDY_ID);
         studyIds.add(STUDY_ID);
@@ -467,7 +467,7 @@ public class StudyViewFilterApplierTest {
         clinicalDataIntervalFilter1.setValues(Collections.singletonList(filterValue1));
         clinicalDataIntervalFilters.add(clinicalDataIntervalFilter1);
         studyViewFilter.setClinicalDataIntervalFilters(clinicalDataIntervalFilters);
-        
+
         List<SampleIdentifier> result1 = studyViewFilterApplier.apply(studyViewFilter);
         Assert.assertEquals(1, result1.size());
 
@@ -475,7 +475,7 @@ public class StudyViewFilterApplierTest {
         filterValue2.setStart(new BigDecimal("6.66"));
         filterValue2.setEnd(new BigDecimal("66.6"));
         clinicalDataIntervalFilter1.setValues(Arrays.asList(filterValue1, filterValue2));
-        
+
         List<SampleIdentifier> result2 = studyViewFilterApplier.apply(studyViewFilter);
         Assert.assertEquals(2, result2.size());
 

--- a/web/src/test/java/org/cbioportal/weblegacy/ApiControllerConfig.java
+++ b/web/src/test/java/org/cbioportal/weblegacy/ApiControllerConfig.java
@@ -56,14 +56,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 @EnableWebMvc
 @ComponentScan(basePackages = {"org.mskcc.cbio.portal.web.api", "org.mskcc.cbio.portal.persistence", "org.mskcc.cbio.portal.service"})
 public class ApiControllerConfig extends WebMvcConfigurerAdapter {
-    
+
     @Bean
     public CosmicCountService cosmicCountService() {
-	return Mockito.mock(CosmicCountService.class);
+        return Mockito.mock(CosmicCountService.class);
     }
     @Bean
     public CosmicCountMapperLegacy cosmicCountMapper() {
-	return Mockito.mock(CosmicCountMapperLegacy.class);
+        return Mockito.mock(CosmicCountMapperLegacy.class);
     }
     @Bean
     public MutationMapperLegacy mutationMapper() {

--- a/web/src/test/java/org/cbioportal/weblegacy/GenePanelControllerLegacyTest.java
+++ b/web/src/test/java/org/cbioportal/weblegacy/GenePanelControllerLegacyTest.java
@@ -73,7 +73,7 @@ public class GenePanelControllerLegacyTest {
     private GenePanel genePanel2;
     private Gene egfr;
     private Gene braf;
-    
+
     @Before
     public void setup() {
         Mockito.reset(genePanelServiceLegacyMock);
@@ -124,7 +124,7 @@ public class GenePanelControllerLegacyTest {
     public void genePanelsByProfilesNoIntersection() throws Exception {
         List<GenePanelWithSamples> mockResponse = new ArrayList<>();
         GenePanelWithSamples gpq1 = new GenePanelWithSamples();
-        List<String> samples = new ArrayList<>(); 
+        List<String> samples = new ArrayList<>();
         samples.add("SAMPLEID1");
         samples.add("SAMPLEID2");
         gpq1.setSamples(samples);
@@ -145,14 +145,14 @@ public class GenePanelControllerLegacyTest {
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].samples", Matchers.hasSize(2)))
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].samples[0]").value("SAMPLEID1"));
     }
-    
+
     @Test
     public void genePanelsByProfilesPartialIntersection() throws Exception {
         List<GenePanelWithSamples> mockResponse = new ArrayList<>();
         GenePanelWithSamples gpq1 = new GenePanelWithSamples();
         List<Gene> panelGenes = new ArrayList<>();
         panelGenes.add(braf);
-        List<String> samples = new ArrayList<>(); 
+        List<String> samples = new ArrayList<>();
         samples.add("SAMPLEID1");
         gpq1.setSamples(samples);
         gpq1.setStableId("GENEPANEL2");
@@ -174,7 +174,7 @@ public class GenePanelControllerLegacyTest {
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].samples", Matchers.hasSize(1)))
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].samples[0]").value("SAMPLEID1"));
     }
-    
+
     @Test
     public void genePanelsByProfilesFullIntersection() throws Exception {
         List<GenePanelWithSamples> mockResponse = new ArrayList<>();
@@ -182,7 +182,7 @@ public class GenePanelControllerLegacyTest {
         List<Gene> panelGenes = new ArrayList<>();
         panelGenes.add(braf);
         panelGenes.add(egfr);
-        List<String> samples = new ArrayList<>(); 
+        List<String> samples = new ArrayList<>();
         samples.add("SAMPLEID1");
         gpq1.setSamples(samples);
         gpq1.setStableId("GENEPANEL2");
@@ -203,7 +203,7 @@ public class GenePanelControllerLegacyTest {
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].genes[0].hugoGeneSymbol").value("BRAF"))
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].samples", Matchers.hasSize(1)))
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].samples[0]").value("SAMPLEID1"));
-    }    
+    }
 
     @Test
     public void genePanel() throws Exception {

--- a/web/src/test/java/org/cbioportal/weblegacy/MutationalSignatureControllerTest.java
+++ b/web/src/test/java/org/cbioportal/weblegacy/MutationalSignatureControllerTest.java
@@ -58,83 +58,84 @@ import org.springframework.web.context.WebApplicationContext;
 @WebAppConfiguration
 @ContextConfiguration(classes = {MutationalSignatureControllerConfig.class, CustomObjectMapper.class, CacheMapUtilConfig.class})
 public class MutationalSignatureControllerTest {
+
     @Autowired
     private WebApplicationContext webApplicationContext;
+
     @Autowired
     private MutationalSignatureService mutationalSignatureServiceMock;
     private MockMvc mockMvc;
-    
+
     private MutationalSignature signature1;
     private MutationalSignature signature2;
-    
+
     private static final String[] CANONICAL_SNP_TYPES = new String[]{"C>A", "C>G", "C>T", "T>A", "T>C", "T>G"};
-    
+
     @Before
     public void setup() {
         Mockito.reset(mutationalSignatureServiceMock);
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
-	
-	signature1 = new MutationalSignature(CANONICAL_SNP_TYPES, "sample1", new int[]{40,0,0,0,0,1});
-	signature2 = new MutationalSignature(CANONICAL_SNP_TYPES, "sample2", new int[]{1,2,99,6,4,1});
+        signature1 = new MutationalSignature(CANONICAL_SNP_TYPES, "sample1", new int[]{40,0,0,0,0,1});
+        signature2 = new MutationalSignature(CANONICAL_SNP_TYPES, "sample2", new int[]{1,2,99,6,4,1});
     }
-    
-    @Test
+
+   @Test
    public void mutationalSignaturesBySampleIdTest() throws Exception {
-		List<MutationalSignature> mockResponse = new ArrayList<>();
-		mockResponse.add(signature1);
-		Mockito.when(mutationalSignatureServiceMock.getMutationalSignaturesBySampleIds(org.mockito.Matchers.anyString(), org.mockito.Matchers.anyList()))
-			.thenReturn(mockResponse);
+        List<MutationalSignature> mockResponse = new ArrayList<>();
+        mockResponse.add(signature1);
+        Mockito.when(mutationalSignatureServiceMock.getMutationalSignaturesBySampleIds(org.mockito.Matchers.anyString(), org.mockito.Matchers.anyList()))
+            .thenReturn(mockResponse);
 
-		String[] sample_ids = new String[]{"sample1"};
+        String[] sample_ids = new String[]{"sample1"};
 
-		this.mockMvc.perform(
-			MockMvcRequestBuilders.get("/mutational-signature")
-			.accept(MediaType.parseMediaType("application/json;charset=UTF-8"))
-			.param("study_id", "msk")
-			.param("sample_ids", sample_ids))
-			.andExpect(MockMvcResultMatchers.status().isOk())
-			.andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith("application/json;charset=UTF-8"))
-			.andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(1)))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].sample").value("sample1"))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[0]").value(40))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[1]").value(0))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[2]").value(0))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[3]").value(0))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[4]").value(0))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[5]").value(1))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].mutationTypes", Matchers.hasSize(6)));
-	}
-    
+        this.mockMvc.perform(
+            MockMvcRequestBuilders.get("/mutational-signature")
+            .accept(MediaType.parseMediaType("application/json;charset=UTF-8"))
+            .param("study_id", "msk")
+            .param("sample_ids", sample_ids))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith("application/json;charset=UTF-8"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(1)))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].sample").value("sample1"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[0]").value(40))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[1]").value(0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[2]").value(0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[3]").value(0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[4]").value(0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[5]").value(1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].mutationTypes", Matchers.hasSize(6)));
+    }
+
     @Test
     public void mutationalSignaturesByStudyTest() throws Exception {
-	    List<MutationalSignature> mockResponse = new ArrayList<>();
-		mockResponse.add(signature1);
-		mockResponse.add(signature2);
-		Mockito.when(mutationalSignatureServiceMock.getMutationalSignatures(org.mockito.Matchers.anyString()))
-			.thenReturn(mockResponse);
+        List<MutationalSignature> mockResponse = new ArrayList<>();
+        mockResponse.add(signature1);
+        mockResponse.add(signature2);
+        Mockito.when(mutationalSignatureServiceMock.getMutationalSignatures(org.mockito.Matchers.anyString()))
+            .thenReturn(mockResponse);
 
-		this.mockMvc.perform(
-			MockMvcRequestBuilders.get("/mutational-signature")
-			.accept(MediaType.parseMediaType("application/json;charset=UTF-8"))
-			.param("study_id", "msk"))
-			.andExpect(MockMvcResultMatchers.status().isOk())
-			.andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith("application/json;charset=UTF-8"))
-			.andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].sample").value("sample1"))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[0]").value(40))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[1]").value(0))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[2]").value(0))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[3]").value(0))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[4]").value(0))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[5]").value(1))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].mutationTypes", Matchers.hasSize(6)))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[0].sample").value("sample1"))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[0]").value(1))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[1]").value(2))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[2]").value(99))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[3]").value(6))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[4]").value(4))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[5]").value(1))
-			.andExpect(MockMvcResultMatchers.jsonPath("$[1].mutationTypes", Matchers.hasSize(6)));
+        this.mockMvc.perform(
+            MockMvcRequestBuilders.get("/mutational-signature")
+            .accept(MediaType.parseMediaType("application/json;charset=UTF-8"))
+            .param("study_id", "msk"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith("application/json;charset=UTF-8"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].sample").value("sample1"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[0]").value(40))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[1]").value(0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[2]").value(0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[3]").value(0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[4]").value(0))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[5]").value(1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].mutationTypes", Matchers.hasSize(6)))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].sample").value("sample1"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[0]").value(1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[1]").value(2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[2]").value(99))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[3]").value(6))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[4]").value(4))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[5]").value(1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].mutationTypes", Matchers.hasSize(6)));
     }
 }


### PR DESCRIPTION
Fix missing security filtering for StructuralVariant endpoint on authenticated portals

Describe changes proposed in this pull request:
- first commit contains whitespace cleanup and style standardization
- second commit contains the following:
- annotated handler with @PreAuthorize
- added Attributes to handler (extracted by interceptor), and use intercepted body instead of actual body parameter
- make request body parameter optional (because interceptor has consumed it)
- make StructuralVariantFilter model serializable
- added handling of endpoint /structuralvariant/fetch to InvolvedCancerStudyExtractorInterceptor
    - extract involved cancer studies based on SampleMolecularIdentifiers (if present) ... otherwise on MolecularProfileIds (from filter argument)

# Checks
- [ ] Runs on heroku
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!