### PR TITLE
Configure Ehcache using runtime properties

### DIFF
--- a/docs/Caching.md
+++ b/docs/Caching.md
@@ -2,16 +2,36 @@
 cBioPortal provides the option of caching information on the backend to improve performance. Without caching, every time a request is received by the backend, a query is sent to the database system for information, and the returned data is processed to construct a response. This may lead to performance issues as the entire process can be rather costly, especially for queries on larger studies. With caching turned on, query responses can be taken directly from the cache if they have already been constructed. They would only be constructed for the initial query.
 
 ## Cache Configuration
-The portal is configured to use Ehcache for backend caching; caching configuration is specified inside an xml file under `persistence/persistence-api/src/main/resources`. The default configuration is a hybrid (disk + heap); however, Ehcache supports both a disk-only and heap-only mode. Refer to comments in `ehcache.xml` to switch between cache configurations. The configuration files also specify which caches to create. Additional specifications such as cache size and location are set inside `portal.properties` (more information [here](portal.properties-Reference.md#ehcache-settings)).
+The portal is configured to use Ehcache for backend caching. Ehcache supports a hybrid (disk + heap), disk-only, and heap-only mode; this, along with additional specifications such as cache size and location, are set inside `portal.properties`(more information [here](portal.properties-Reference.md#ehcache-settings)). 
  
 ## Creating additional caches
-The default configuration initializes two separate caches. However, you may wish to introduce new caches with different policies (e.g expiration policy) for different datatypes. To create additional caches (e.g creating a cache specifically for clinical data), a new cache must be added to the Ehcache xml configuration file. The `@Cacheable` annotation must also be added (or adjusted) to function declarations to indicate which functions are to be cached. Those might look like this example:
+Cache initialization is handled inside the [CustomEhCachingProvider](../persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java). The default configuration initializes two seperate caches; however, you may wish to introduce new caches for different datatypes. To create additional caches (e.g creating a cache specifically for clinical data), new code must be added to the CustomEhCachingProvider.
+
+Within the `CustomEhCachingProvider`, initialize a new `ResourcePoolsBuilder` for the new cache and set the resources accordingly. 
+```
+ResourcePoolsBuilder clinicalDataCacheResourcePoolsBuilder = ResourcePoolsBuilder.newResourcePoolsBuilder();
+clinicalDataCacheResourcePoolsBuilder = clinicalDataCacheResourcePoolsBuilder.heap(clinicalDataCacheHeapSize, MemoryUnit.MB);
+clinicalDataCacheResourcePoolsBuilder = clinicalDataCacheResourcePoolsBuilder.disk(clinicalDataCacheDiskSize, MemoryUnit.MB);
+```
+After initialzing the `ResourcePoolsBuilder`, create a CacheConfiguration for the new cache using the new `ResourcePoolsBuilder` just created.
+```
+CacheConfiguration<Object, Object> clinicalDataCacheConfiguration = xmlConfiguration.newCacheConfigurationBuilderFromTemplate("RepositoryCacheTemplate", 
+Object.class, Object.class, clinicalDataCacheResourcePoolsBuilder)
+.withSizeOfMaxObjectGraph(Long.MAX_VALUE)
+.withSizeOfMaxObjectSize(Long.MAX_VALUE, MemoryUnit.B)
+.build();
+```
+Finally, add the new `CacheConfiguration` to the map of managed caches with a name for the cache. 
+```
+caches.put("ClinicalDataCache", ClinicalDataCacheConfiguration);
+```
+The `@Cacheable` annotation must also be added (or adjusted) to function declarations to indicate which functions are to be cached. Those might look like this example:
 ``` 
 @Cacheable(cacheNames = "ClinicalDataCache", condition = "@cacheEnabledConfig.getEnabled()")
 public String getDataFromClinicalDataRepository(String param) {}
 ```
-Additionally, new properties for setting cache sizes should be added to `portal.properties`. Alternatively, values may also be hardcoded directly into the Ehcache xml configuration file. 
+Additionally, new properties for setting cache sizes should be added to `portal.properties` and loaded into the [CustomEhCachingProvider](../persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java). Alternatively, values may be hardcoded directly inside [CustomEhCachingProvider](../persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java).
 
-For more information on constructing an Ehcache xml configuration file, refer to the documentation [here](https://www.ehcache.org/documentation/3.7/xml.html). 
+For more information on cache templates and the Ehcache xml configuration file, refer to the documentation [here](https://www.ehcache.org/documentation/3.7/xml.html). 
 
 For more information on linking caches to functions, refer to the documentation [here](https://spring.io/guides/gs/caching/).

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -284,12 +284,12 @@ This gene set will add the following in the query box:
 # Ehcache Settings
 cBioPortal is supported on the backend with Ehcache. The configuration, size, and location of these caches are configurable from within portal.properties through the following properties.
 
-Caching is disabled by default. When caching is disabled, no respones will be stored in cache. To turn on caching set `ehcache.cache_enabled` to true.  
+The cache type is set using `ehcache.cache_type`. Valid values are `none`, `heap` (heap-only), `disk` (disk-only), and `hybrid` (disk + heap). By default, `ehcache.cache_type` is set to `none` which disables the cache. When the cache is disabled, no responses will be stored in the cache. 
 ```
-ehcache.cache_enabled=true
+ehcache.cache_type=[none or heap or disk or hybrid]
 ```
 
-When caching is enabled, set a cache configuration using `ehcache.xml_configuration`. This should be the name of an Ehcache xml configuration file; the default provided is `ehcache.xml` which configures a hybrid (disk + heap) cache. To change caching configuration, directly edit `/ehcache.xml`. Alternatively, you can create your own Ehcache xml configuration file, place it under `/persistence/persistence-api/src/main/resources/` and set `ehcache.xml_configuration` to `/[Ehcache xml configuration filename]`.  
+Ehcache initializes caches using a template found in an Ehcache xml configuration file. When caching is enabled, set `ehcache.xml_configuration` to the name of the Ehcache xml configuration file. The default provided is `ehcache.xml`; to change the cache template, directly edit this file. Alternatively, you can create your own Ehcache xml configuration file, place it under `/persistence/persistence-api/src/main/resources/` and set `ehcache.xml_configuration` to `/[Ehcache xml configuration filename]`.  
 ```
 ehcache.xml_configuration=
 ```
@@ -308,9 +308,8 @@ ehcache.static_repository_cache_one.max_mega_bytes_heap=
 ehcache.static_repository_cache_one.max_mega_bytes_local_disk=
 ```
 
-Additional properties can be specified for cache statistics monitoring. To log metrics regarding memory usage, set `ehcache.statistics_enabled` to true. Logged metrics and additional information such as cache size and cached keys are available through an optional endpoint. The optional endpoint is turned off by default but can be turned on by setting `cache.statistics_endpoint_enabled` to true. 
+Logged metrics and additional information such as cache size and cached keys are available through an optional endpoint. The optional endpoint is turned off by default but can be turned on by setting `cache.statistics_endpoint_enabled` to true.
 ```
-ehcache.statistics_enabled=true[true or false]
 cache.statistics_endpoint_enabled=false[true or false]
 ```
 The cache statistics endpoint is hidden on the api page; users must directly access the URL to view the response. The cache statistics endpoint can be accessed in the following ways.

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CacheEnabledConfig.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CacheEnabledConfig.java
@@ -1,13 +1,30 @@
 package org.cbioportal.persistence;
 
 import org.springframework.beans.factory.annotation.Value;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 public class CacheEnabledConfig {
 
     private boolean enabled;
+    
+    public static final String DISK = "disk";
+    public static final String HEAP = "heap";
+    public static final String HYBRID = "hybrid";
 
-    public CacheEnabledConfig(String cacheEnabled) {
-        this.enabled = Boolean.parseBoolean(cacheEnabled);
+    public static ArrayList<String> validCacheTypes = new ArrayList<String>(Arrays.asList(DISK, HEAP, HYBRID));
+
+    public CacheEnabledConfig(String cacheType) {
+        this.enabled = enableCache(cacheType);
+    }
+
+    public static boolean enableCache(String cacheType) {
+        for (String validCacheType : validCacheTypes) {
+            if (validCacheType.equalsIgnoreCase(cacheType)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public String getEnabled() {

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomEhCachingProvider.java
@@ -32,6 +32,9 @@
 
 package org.cbioportal.persistence.util;
 
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.*;
 import javax.cache.CacheManager;
 import org.ehcache.config.CacheConfiguration;
@@ -40,35 +43,96 @@ import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.config.Configuration;
 import org.ehcache.config.units.MemoryUnit;
+import org.ehcache.xml.XmlConfiguration;
 import org.ehcache.core.config.DefaultConfiguration;
 import org.ehcache.jsr107.EhcacheCachingProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.ehcache.impl.config.persistence.DefaultPersistenceConfiguration;
+import org.cbioportal.persistence.CacheEnabledConfig;
 
 public class CustomEhCachingProvider extends EhcacheCachingProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(CustomEhCachingProvider.class);
 
     @Value("${ehcache.xml_configuration:/ehcache.xml}")
-    private String xmlConfiguration;
+    private String xmlConfigurationFile;
 
-    @Value("${ehcache.cache_enabled:false}")
-    private Boolean cacheEnabled;
+    @Value("${ehcache.cache_type:none}")
+    private String cacheType;
+
+    @Value("${ehcache.general_repository_cache.max_mega_bytes_heap:1024}")
+    private Integer generalRepositoryCacheMaxMegaBytes;
+
+    @Value("${ehcache.static_repository_cache_one.max_mega_bytes_heap:30}")
+    private Integer staticRepositoryCacheOneMaxMegaBytes;
+
+    @Value("${ehcache.persistence_path:/tmp/}")
+    private String persistencePath;
+
+    @Value("${ehcache.general_repository_cache.max_mega_bytes_local_disk:4096}")
+    private Integer generalRepositoryCacheMaxMegaBytesLocalDisk;
+
+    @Value("${ehcache.static_repository_cache_one.max_mega_bytes_local_disk:32}")
+    private Integer staticRepositoryCacheOneMaxMegaBytesLocalDisk;
 
     @Override
     public CacheManager getCacheManager() {
 
         CacheManager toReturn = null;
-         try {
-            if (cacheEnabled != null && cacheEnabled) {
-                LOG.info("Caching is enabled, using '" + xmlConfiguration + "' for configuration");
-                toReturn = this.getCacheManager(getClass().getResource(xmlConfiguration).toURI(),
-                                            getClass().getClassLoader());
+        try {
+            if (CacheEnabledConfig.enableCache(cacheType)) {
+                LOG.info("Caching is enabled, using '" + xmlConfigurationFile + "' for configuration");
+                XmlConfiguration xmlConfiguration = new XmlConfiguration(getClass().getResource(xmlConfigurationFile));
+
+                // initilize configurations specific to each individual cache (by template)
+                // to add new cache - create cache configuration with its own resource pool + template
+                ResourcePoolsBuilder generalRepositoryCacheResourcePoolsBuilder = ResourcePoolsBuilder.newResourcePoolsBuilder();
+                ResourcePoolsBuilder staticRepositoryCacheOneResourcePoolsBuilder = ResourcePoolsBuilder.newResourcePoolsBuilder();
+        
+                // Set up heap resources as long as not disk-only
+                if (!cacheType.equalsIgnoreCase(CacheEnabledConfig.DISK)) {
+                    generalRepositoryCacheResourcePoolsBuilder = generalRepositoryCacheResourcePoolsBuilder.heap(generalRepositoryCacheMaxMegaBytes, MemoryUnit.MB);
+                    staticRepositoryCacheOneResourcePoolsBuilder = staticRepositoryCacheOneResourcePoolsBuilder.heap(staticRepositoryCacheOneMaxMegaBytes, MemoryUnit.MB);
+                }
+                // Set up disk resources as long as not heap-only
+                // will default to using /tmp -- let Ehcache throw exception if persistence path is invalid (locked or otherwise)
+                if (!cacheType.equalsIgnoreCase(CacheEnabledConfig.HEAP)) {
+                    generalRepositoryCacheResourcePoolsBuilder = generalRepositoryCacheResourcePoolsBuilder.disk(generalRepositoryCacheMaxMegaBytesLocalDisk, MemoryUnit.MB);
+                    staticRepositoryCacheOneResourcePoolsBuilder = staticRepositoryCacheOneResourcePoolsBuilder.disk(staticRepositoryCacheOneMaxMegaBytesLocalDisk, MemoryUnit.MB);
+                }
+
+                CacheConfiguration<Object, Object> generalRepositoryCacheConfiguration = xmlConfiguration.newCacheConfigurationBuilderFromTemplate("RepositoryCacheTemplate", 
+                        Object.class, Object.class, generalRepositoryCacheResourcePoolsBuilder)
+                    .withSizeOfMaxObjectGraph(Long.MAX_VALUE)
+                    .withSizeOfMaxObjectSize(Long.MAX_VALUE, MemoryUnit.B)
+                    .build();
+                CacheConfiguration<Object, Object> staticRepositoryCacheOneConfiguration = xmlConfiguration.newCacheConfigurationBuilderFromTemplate("RepositoryCacheTemplate", 
+                        Object.class, Object.class, staticRepositoryCacheOneResourcePoolsBuilder)
+                    .withSizeOfMaxObjectGraph(Long.MAX_VALUE)
+                    .withSizeOfMaxObjectSize(Long.MAX_VALUE, MemoryUnit.B)
+                    .build();
+
+                // places caches in a map which will be used to create cache manager
+                Map<String, CacheConfiguration<?, ?>> caches = new HashMap<>();
+                caches.put("GeneralRepositoryCache", generalRepositoryCacheConfiguration);
+                caches.put("StaticRepositoryCacheOne", staticRepositoryCacheOneConfiguration);
+
+                Configuration configuration = null;
+                if (cacheType.equalsIgnoreCase(CacheEnabledConfig.HEAP)) {
+                    configuration = new DefaultConfiguration(caches, this.getDefaultClassLoader());
+                } else { // add persistence configuration if cacheType is either disk-only or hybrid
+                    File persistenceFile = new File(persistencePath);
+                    configuration = new DefaultConfiguration(caches, this.getDefaultClassLoader(), new DefaultPersistenceConfiguration(persistenceFile));
+                }
+
+                toReturn = this.getCacheManager(this.getDefaultURI(), configuration);
             } else {
                 LOG.info("Caching is disabled");
                 // we can not really disable caching,
-                // we can not make a cache of 0 objects, 
+                // we can not make a cache of 0 objects,
                 // and we can not make a heap of memory size 0, so make a tiny heap
                 CacheConfiguration<Object, Object> generalRepositoryCacheConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class,
                     Object.class,
@@ -76,7 +140,7 @@ public class CustomEhCachingProvider extends EhcacheCachingProvider {
                 CacheConfiguration<Object, Object> staticRepositoryCacheOneConfiguration = CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class,
                     Object.class,
                     ResourcePoolsBuilder.newResourcePoolsBuilder().heap(1, MemoryUnit.B)).build();
-                
+
                 Map<String, CacheConfiguration<?, ?>> caches = new HashMap<>();
                 caches.put("GeneralRepositoryCache", generalRepositoryCacheConfiguration);
                 caches.put("StaticRepositoryCacheOne", staticRepositoryCacheOneConfiguration);
@@ -88,9 +152,11 @@ public class CustomEhCachingProvider extends EhcacheCachingProvider {
         }
         catch (Exception e) {
             LOG.error(e.getClass().getName() + ": " + e.getMessage());
-            e.printStackTrace();
+            StringWriter stackTrace = new StringWriter();
+            e.printStackTrace(new PrintWriter(stackTrace));
+            LOG.error(stackTrace.toString());
         }
         return toReturn;
     }
 }
- 
+

--- a/persistence/persistence-api/src/main/resources/applicationContext-ehcache.xml
+++ b/persistence/persistence-api/src/main/resources/applicationContext-ehcache.xml
@@ -12,7 +12,7 @@
     <cache:annotation-driven cache-manager="cacheManager" key-generator="customKeyGenerator"/>
 
     <bean id="cacheEnabledConfig" class="org.cbioportal.persistence.CacheEnabledConfig">
-        <constructor-arg value="${ehcache.cache_enabled:false}"/>
+        <constructor-arg value="${ehcache.cache_type:none}"/>
     </bean>
 
     <bean id="customEhCacheProvider" class="org.cbioportal.persistence.util.CustomEhCachingProvider"/>

--- a/persistence/persistence-api/src/main/resources/ehcache.xml
+++ b/persistence/persistence-api/src/main/resources/ehcache.xml
@@ -8,18 +8,7 @@
     http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd
     http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
 
-    <ehcache:service>
-      <jcache:defaults enable-management="true" enable-statistics="${ehcache.statistics_enabled}"/>
-    </ehcache:service>
-
-    <ehcache:persistence directory="${ehcache.persistence_path}"/><!-- remove if using a heap-only cache -->
-
-    <ehcache:heap-store>
-      <ehcache:max-object-graph-size>9223372036854775807</ehcache:max-object-graph-size><!-- using Long.MAX_VALUE -->
-      <ehcache:max-object-size>9223372036854775807</ehcache:max-object-size><!-- using Long.MAX_VALUE -->
-    </ehcache:heap-store>
-
-    <ehcache:cache alias="GeneralRepositoryCache">
+    <ehcache:cache-template name="RepositoryCacheTemplate">
       <ehcache:expiry>
         <ehcache:none></ehcache:none>
       </ehcache:expiry>
@@ -35,32 +24,6 @@
           <ehcache:events-to-fire-on>UPDATED</ehcache:events-to-fire-on>
         </ehcache:listener>
       </ehcache:listeners>
-      <ehcache:resources>
-        <ehcache:heap unit="MB">${ehcache.general_repository_cache.max_mega_bytes_heap}</ehcache:heap><!-- remove if using a disk-only cache -->
-        <ehcache:disk unit="MB" persistent="false">${ehcache.general_repository_cache.max_mega_bytes_local_disk}</ehcache:disk><!-- remove if using a heap-only cache -->
-      </ehcache:resources>
-    </ehcache:cache>
-
-    <ehcache:cache alias="StaticRepositoryCacheOne">
-      <ehcache:expiry>
-        <ehcache:none></ehcache:none>
-      </ehcache:expiry>
-      <ehcache:listeners>
-        <ehcache:listener>
-          <ehcache:class>org.cbioportal.persistence.util.CacheEventLogger</ehcache:class>
-          <ehcache:event-firing-mode>ASYNCHRONOUS</ehcache:event-firing-mode>
-          <ehcache:event-ordering-mode>UNORDERED</ehcache:event-ordering-mode>
-          <ehcache:events-to-fire-on>CREATED</ehcache:events-to-fire-on>
-          <ehcache:events-to-fire-on>REMOVED</ehcache:events-to-fire-on>
-          <ehcache:events-to-fire-on>EXPIRED</ehcache:events-to-fire-on>
-          <ehcache:events-to-fire-on>EVICTED</ehcache:events-to-fire-on>
-          <ehcache:events-to-fire-on>UPDATED</ehcache:events-to-fire-on>
-        </ehcache:listener>
-      </ehcache:listeners>
-      <ehcache:resources>
-        <ehcache:heap unit="MB">${ehcache.static_repository_cache_one.max_mega_bytes_heap}</ehcache:heap><!-- remove if using a disk-only cache -->
-        <ehcache:disk unit="MB" persistent="false">${ehcache.static_repository_cache_one.max_mega_bytes_local_disk}</ehcache:disk><!-- remove if using a heap-only cache -->
-      </ehcache:resources>
-    </ehcache:cache>
+    </ehcache:cache-template>
 
 </ehcache:config>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -231,10 +231,9 @@ oncoprint.hotspots.default=true
 # Custom gene sets
 # querypage.setsofgenes.location=file:/<path>
 
-# to enable use of Ehcache, set ehcache.cache_enabled to true and uncomment all Ehcache properties
-ehcache.cache_enabled=false
+# valid cache types are (heap, disk, hybrid), or use 'none' to disable use of Ehcache
+ehcache.cache_type=none
 #ehcache.xml_configuration=/ehcache.xml
-#ehcache.statistics_enabled=true
 # Enable cache statistics endpoint for Ehcache monitoring
 #cache.statistics_endpoint_enabled=false
 


### PR DESCRIPTION
Fixes #6631 

We have switched from an Ehcache XML configuration to a primarily Java configuration so that we can configure Ehcache using runtime properties rather than relying on Maven filtering.  For example, `-Dehcache.cache_type=hybrid`.

- ehcache.xml switched to a more general template instead of initiailizing each individual cache
 - properties now auto-wired in through CustomEhCacheProvider
 - allow for disk-only/heap-only/hybrid config to all be controlled from portal.properties `ehcache.cache_type`
 - update properties docs
 - update caching documentation

Co-authored by: Avery Wang <18199796+averyniceday@users.noreply.github.com>