### PR TITLE
filter internalId and geneticEntityId from Treatment responses

### DIFF
--- a/model/src/main/java/org/cbioportal/model/Treatment.java
+++ b/model/src/main/java/org/cbioportal/model/Treatment.java
@@ -45,14 +45,14 @@ public class Treatment implements Serializable {
     /**
      * @return the id
      */
-    public int getInternalId() {
+    public int getId() {
         return id;
     }
 
     /**
      * @param id the id to set
      */
-    public void setInternalId(int id) {
+    public void setId(int id) {
         this.id = id;
     }
 

--- a/service/src/test/java/org/cbioportal/service/impl/TreatmentServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/TreatmentServiceImplTest.java
@@ -143,12 +143,12 @@ public class TreatmentServiceImplTest extends BaseServiceImplTest {
         List<Treatment> treatmentList = new ArrayList<>();
 
         Treatment treatment1 = new Treatment();
-        treatment1.setInternalId(INTERNAL_ID_1);
+        treatment1.setId(INTERNAL_ID_1);
         treatment1.setStableId(TREATMENT_ID_1);
         treatmentList.add(treatment1);
 
         Treatment treatment2 = new Treatment();
-        treatment2.setInternalId(INTERNAL_ID_2);
+        treatment2.setId(INTERNAL_ID_2);
         treatment2.setStableId(TREATMENT_ID_2);
         treatmentList.add(treatment2);
         return treatmentList;

--- a/web/src/main/java/org/cbioportal/web/mixin/TreatmentMixin.java
+++ b/web/src/main/java/org/cbioportal/web/mixin/TreatmentMixin.java
@@ -7,6 +7,8 @@ public class TreatmentMixin {
 
     @JsonIgnore
     private Integer id;
+    @JsonIgnore
+    private int geneticEntityId;
     @JsonProperty("treatmentId")
     private String stableId;
 }

--- a/web/src/test/java/org/cbioportal/web/TreatmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/TreatmentControllerTest.java
@@ -263,7 +263,7 @@ public class TreatmentControllerTest {
         List<Treatment> treatmentList = new ArrayList<>();
 
         Treatment treatment1 = new Treatment();
-        treatment1.setInternalId(INTERNAL_ID_1);
+        treatment1.setId(INTERNAL_ID_1);
         treatment1.setStableId(TREATMENT_ID_1);
         treatment1.setName(TREATMENT_ID_1);
         treatment1.setDescription(DESCRIPTION_1);
@@ -271,7 +271,7 @@ public class TreatmentControllerTest {
         treatmentList.add(treatment1);
 
         Treatment treatment2 = new Treatment();
-        treatment2.setInternalId(INTERNAL_ID_2);
+        treatment2.setId(INTERNAL_ID_2);
         treatment2.setStableId(TREATMENT_ID_2);
         treatment2.setName(TREATMENT_ID_2);
         treatment2.setDescription(DESCRIPTION_2);
@@ -286,7 +286,7 @@ public class TreatmentControllerTest {
         List<Treatment> treatmentList = new ArrayList<>();
 
         Treatment treatment3 = new Treatment();
-        treatment3.setInternalId(INTERNAL_ID_3);
+        treatment3.setId(INTERNAL_ID_3);
         treatment3.setStableId(TREATMENT_ID_3);
         treatment3.setName(TREATMENT_ID_3);
         treatment3.setDescription(DESCRIPTION_3);


### PR DESCRIPTION
Fix #6665

Describe changes proposed in this pull request:
- model class adjusted to a standard pojo so that internalId is properly filtered by mixin
- added @JsonIgnore for geneticEntityId in mixin

# Checks
- [ ] Runs on heroku
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!