### PR TITLE
Travis fixes related to oraclejdk8 deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: required
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 services:
 - docker
+- mysql
 cache:
   directories:
   - $HOME/.m2
@@ -24,15 +25,6 @@ install:
           wget -O - http://www-us.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
               tar -C ~/maven/$MAVEN_VERSION --strip-components=1 -xzf -; }
   fi
-- |
-  if [[ "${TEST}" == python-validator ]]
-  then
-      sudo apt-get install python3.4-venv
-      python3.4 -m venv ~/python-env-validator
-      source ~/python-env-validator/bin/activate
-      trap 'deactivate' EXIT
-      pip install -r requirements.txt
-  fi
 before_script:
 - |
   if [[ "${TEST}" == core ]]
@@ -46,14 +38,14 @@ script:
 - |
   if [[ "${TEST}" == python-validator ]]
   then
-      source ~/python-env-validator/bin/activate
-      trap 'deactivate' EXIT
-      export PYTHONPATH="$PWD/core/src/main/scripts:$PYTHONPATH" && \
-      pushd core/src/test/scripts/ && \
-      python unit_tests_validate_data.py && \
-      python system_tests_validate_data.py && \
-      python system_tests_validate_studies.py && \
-      popd
+      docker run -v ${PWD}:/cbioportal python:3.4 /bin/sh -c '
+        cd /cbioportal &&
+        pip install -r requirements.txt &&
+        export PYTHONPATH=/cbioportal/core/src/main/scripts &&
+        cd /cbioportal/core/src/test/scripts/ &&
+        python unit_tests_validate_data.py &&
+        python system_tests_validate_data.py &&
+        python system_tests_validate_studies.py'
   fi
 - |
   if [[ "${TEST}" == sanity-checks ]]
@@ -85,6 +77,7 @@ script:
   if [[ "${TEST}" == end-to-end ]]
   then
       ~/maven/$MAVEN_VERSION/bin/mvn \
+          -q \
           -U \
           -Ppublic \
           -DskipTests \


### PR DESCRIPTION
The oraclejdk8 we were using was deprecated. Switching to openjdk8
requires a new Ubuntu image, which required several changes.

- add mysql service on travis
- use docker to use python 3.4 on Travis. The new Ubuntu image has 3.5
by default, but the assert_called method in the tests does not exist
there. They do exist in version 3.6 and 3.7 but those currently aren't
easily installed through apt-get i.e. one needs to add a non-default
repo to download it
- quiet maven when building Travis for e2e compilation. Apparently there
is a limit on the Travis log size for each build. When building the
portal for e2e tests the log limit on Travis gets reached resulting in
an error.