### PR TITLE
Improve maven dependency caching Dockerfile

### DIFF
--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -8,9 +8,9 @@
 #
 # docker build -f docker/web-and-data/Dockerfile -t cbioportal-container:tag-name .
 #
-# WARNING: Be careful about publishing images generated like this publicly
-# because your .git folder is exposed in the build step. We are not sure if
-# this is a security risk: stackoverflow.com/questions/56278325
+# NOTE: the .git folder is included in the build stage, but excluded 
+# from the final image. No confidential information is exposed.
+# (see: stackoverflow.com/questions/56278325)
 FROM maven:3.5.4 as build
 
 # download maven dependencies first to take advantage of docker caching


### PR DESCRIPTION
Building the docker image from `/docker/web-and-data/Dockerfile` takes longer than needed after code updates because it does not take advantage of docker caching.

### Fix
- We have updated the Dockerfile to cache downloading of mvn dependencies. This means that instead of a build time of 6'30'' after a code update the build time is reduced to 1'30''.
- Also we updated the message on exposure of the .git folder in the image (which does not occur, due to a multilayered build).