### PR TITLE
Skip SV records with invalid exon/ensembl transcript ids

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportStructuralVariantData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportStructuralVariantData.java
@@ -27,7 +27,6 @@ import java.util.*;
 import org.mskcc.cbio.maf.*;
 import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.*;
-import org.mskcc.cbio.portal.model.ExtendedMutation.MutationEvent;
 import org.mskcc.cbio.portal.util.*;
 
 /**
@@ -36,65 +35,17 @@ import org.mskcc.cbio.portal.util.*;
  */
 
 public class ImportStructuralVariantData {
-    // Column names structural variant file
-    public static final String SAMPLE_ID = "Sample_ID";
-    public static final String SITE1_ENTREZ_GENE_ID = "Site1_Entrez_Gene_Id";
-    public static final String SITE1_HUGO_SYMBOL = "Site1_Hugo_Symbol";
-    public static final String SITE1_ENSEMBL_TRANSCRIPT_ID = "Site1_Ensembl_Transcript_Id";
-    public static final String SITE1_EXON = "Site1_Exon";
-    public static final String SITE1_CHROMOSOME = "Site1_Chromosome";
-    public static final String SITE1_POSITION = "Site1_Position";
-    public static final String SITE1_DESCRIPTION = "Site1_Description";
-    public static final String SITE2_ENTREZ_GENE_ID = "Site2_Entrez_Gene_Id";
-    public static final String SITE2_HUGO_SYMBOL = "Site2_Hugo_Symbol";
-    public static final String SITE2_ENSEMBL_TRANSCRIPT_ID = "Site2_Ensembl_Transcript_Id";
-    public static final String SITE2_EXON = "Site2_Exon";
-    public static final String SITE2_CHROMOSOME = "Site2_Chromosome";
-    public static final String SITE2_POSITION = "Site2_Position";
-    public static final String SITE2_DESCRIPTION = "Site2_Description";
-    public static final String SITE2_EFFECT_ON_FRAME = "Site2_Effect_On_Frame";
-    public static final String NCBI_BUILD = "NCBI_Build";
-    public static final String DNA_SUPPORT = "DNA_Support";
-    public static final String RNA_SUPPORT = "RNA_Support";
-    public static final String NORMAL_READ_COUNT = "Normal_Read_Count";
-    public static final String TUMOR_READ_COUNT = "Tumor_Read_Count";
-    public static final String NORMAL_VARIANT_COUNT = "Normal_Variant_Count";
-    public static final String TUMOR_VARIANT_COUNT = "Tumor_Variant_Count";
-    public static final String NORMAL_PAIRED_END_READ_COUNT = "Normal_Paired_End_Read_Count";
-    public static final String TUMOR_PAIRED_END_READ_COUNT = "Tumor_Paired_End_Read_Count";
-    public static final String NORMAL_SPLIT_READ_COUNT = "Normal_Split_Read_Count";
-    public static final String TUMOR_SPLIT_READ_COUNT = "Tumor_Split_Read_Count";
-    public static final String ANNOTATION = "Annotation";
-    public static final String BREAKPOINT_TYPE = "Breakpoint_Type";
-    public static final String CENTER = "Center";
-    public static final String CONNECTION_TYPE = "Connection_Type";
-    public static final String EVENT_INFO = "Event_Info";
-    public static final String VARIANT_CLASS = "Class";
-    public static final String LENGTH = "Length";
-    public static final String COMMENTS = "Comments";
-    public static final String EXTERNAL_ANNOTATION = "External_Annotation";
-    public static final String DRIVER_FILTER = "cbp_driver";
-    public static final String DRIVER_FILTER_ANNOTATION = "cbp_driver_annotation";
-    public static final String DRIVER_TIERS_FILTER = "cbp_driver_tiers";
-    public static final String DRIVER_TIERS_FILTER_ANNOTATION = "cbp_driver_tiers_annotation";
-
-    // Other constants
-    public static final String PROTEIN_CHANGE_FUSION = "FUSION";
 
     // Initialize variables
     private File structuralVariantFile;
     private int geneticProfileId;
-    private int mutationGeneticProfileId;
     private String genePanel;
     private Set<String> sampleSet  = new HashSet<>();
-    private HashMap<String, Integer> columnIndexMap;
-
 
     public ImportStructuralVariantData(File structuralVariantFile, int geneticProfileId, String genePanel) throws DaoException {
         this.structuralVariantFile = structuralVariantFile;
         this.geneticProfileId = geneticProfileId;
         this.genePanel = genePanel;
-        this.columnIndexMap = new HashMap<String, Integer>();
     }
 
     public void importData() throws IOException, DaoException {
@@ -102,68 +53,28 @@ public class ImportStructuralVariantData {
         FileReader reader = new FileReader(this.structuralVariantFile);
         BufferedReader buf = new BufferedReader(reader);
         DaoGeneOptimized daoGene = DaoGeneOptimized.getInstance();
+        String line = buf.readLine();
+        StructuralVariantUtil structuralVariantUtil = new StructuralVariantUtil(line);
 
-        // Read header of file
-        String headerParts[] = buf.readLine().trim().split("\t");
-
-        // Find header indices
-        for (int i=0; i<headerParts.length; i++) {
-            // Put the index in the map
-            this.columnIndexMap.put(headerParts[i].toLowerCase(), i);
-        }
-
+        int recordCount = 0;
         // Genetic profile is read in first
         GeneticProfile geneticProfile = DaoGeneticProfile.getGeneticProfileById(geneticProfileId);
-        String line = new String();
         ArrayList <Integer> orderedSampleList = new ArrayList<Integer>();
         while ((line = buf.readLine()) != null) {
             ProgressMonitor.incrementCurValue();
             ConsoleUtil.showProgress();
             if( !line.startsWith("#") && line.trim().length() > 0) {
+                recordCount++;
                 String parts[] = line.split("\t", -1);
-                StructuralVariant structuralVariant = new StructuralVariant();
-
+                StructuralVariant structuralVariant = structuralVariantUtil.parseStructuralVariantRecord(parts);
                 structuralVariant.setGeneticProfileId(geneticProfileId);
-                structuralVariant.setSampleId(TabDelimitedFileUtil.getPartString(getColumnIndex(SAMPLE_ID), parts));
-                structuralVariant.setSite1EntrezGeneId(TabDelimitedFileUtil.getPartLong(getColumnIndex(SITE1_ENTREZ_GENE_ID), parts));
-                structuralVariant.setSite1HugoSymbol(TabDelimitedFileUtil.getPartString(getColumnIndex(SITE1_HUGO_SYMBOL), parts));
-                structuralVariant.setSite1EnsemblTranscriptId(TabDelimitedFileUtil.getPartString(getColumnIndex(SITE1_ENSEMBL_TRANSCRIPT_ID), parts));
-                structuralVariant.setSite1Exon(TabDelimitedFileUtil.getPartInt(getColumnIndex(SITE1_EXON), parts));
-                structuralVariant.setSite1Chromosome(TabDelimitedFileUtil.getPartString(getColumnIndex(SITE1_CHROMOSOME), parts));
-                structuralVariant.setSite1Position(TabDelimitedFileUtil.getPartInt(getColumnIndex(SITE1_POSITION), parts));
-                structuralVariant.setSite1Description(TabDelimitedFileUtil.getPartString(getColumnIndex(SITE1_DESCRIPTION), parts));
-                structuralVariant.setSite2EntrezGeneId(TabDelimitedFileUtil.getPartLong(getColumnIndex(SITE2_ENTREZ_GENE_ID), parts));
-                structuralVariant.setSite2HugoSymbol(TabDelimitedFileUtil.getPartString(getColumnIndex(SITE2_HUGO_SYMBOL), parts));
-                structuralVariant.setSite2EnsemblTranscriptId(TabDelimitedFileUtil.getPartString(getColumnIndex(SITE2_ENSEMBL_TRANSCRIPT_ID), parts));
-                structuralVariant.setSite2Exon(TabDelimitedFileUtil.getPartInt(getColumnIndex(SITE2_EXON), parts));
-                structuralVariant.setSite2Chromosome(TabDelimitedFileUtil.getPartString(getColumnIndex(SITE2_CHROMOSOME), parts));
-                structuralVariant.setSite2Position(TabDelimitedFileUtil.getPartInt(getColumnIndex(SITE2_POSITION), parts));
-                structuralVariant.setSite2Description(TabDelimitedFileUtil.getPartString(getColumnIndex(SITE2_DESCRIPTION), parts));
-                structuralVariant.setSite2EffectOnFrame(TabDelimitedFileUtil.getPartString(getColumnIndex(SITE2_EFFECT_ON_FRAME), parts));
-                structuralVariant.setNcbiBuild(TabDelimitedFileUtil.getPartString(getColumnIndex(NCBI_BUILD), parts));
-                structuralVariant.setDnaSupport(TabDelimitedFileUtil.getPartString(getColumnIndex(DNA_SUPPORT), parts));
-                structuralVariant.setRnaSupport(TabDelimitedFileUtil.getPartString(getColumnIndex(RNA_SUPPORT), parts));
-                structuralVariant.setNormalReadCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(NORMAL_READ_COUNT), parts));
-                structuralVariant.setTumorReadCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(TUMOR_READ_COUNT), parts));
-                structuralVariant.setNormalVariantCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(NORMAL_VARIANT_COUNT), parts));
-                structuralVariant.setTumorVariantCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(TUMOR_VARIANT_COUNT), parts));
-                structuralVariant.setNormalPairedEndReadCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(NORMAL_PAIRED_END_READ_COUNT), parts));
-                structuralVariant.setTumorPairedEndReadCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(TUMOR_PAIRED_END_READ_COUNT), parts));
-                structuralVariant.setNormalSplitReadCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(NORMAL_SPLIT_READ_COUNT), parts));
-                structuralVariant.setTumorSplitReadCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(TUMOR_SPLIT_READ_COUNT), parts));
-                structuralVariant.setAnnotation(TabDelimitedFileUtil.getPartString(getColumnIndex(ANNOTATION), parts));
-                structuralVariant.setBreakpointType(TabDelimitedFileUtil.getPartString(getColumnIndex(BREAKPOINT_TYPE), parts));
-                structuralVariant.setCenter(TabDelimitedFileUtil.getPartString(getColumnIndex(CENTER), parts));
-                structuralVariant.setConnectionType(TabDelimitedFileUtil.getPartString(getColumnIndex(CONNECTION_TYPE), parts));
-                structuralVariant.setEventInfo(TabDelimitedFileUtil.getPartString(getColumnIndex(EVENT_INFO), parts));
-                structuralVariant.setVariantClass(TabDelimitedFileUtil.getPartString(getColumnIndex(VARIANT_CLASS), parts));
-                structuralVariant.setLength(TabDelimitedFileUtil.getPartInt(getColumnIndex(LENGTH), parts));
-                structuralVariant.setComments(TabDelimitedFileUtil.getPartString(getColumnIndex(COMMENTS), parts));
-                structuralVariant.setExternalAnnotation(TabDelimitedFileUtil.getPartString(getColumnIndex(EXTERNAL_ANNOTATION), parts));
-                structuralVariant.setDriverFilter(TabDelimitedFileUtil.getPartString(getColumnIndex(DRIVER_FILTER), parts));
-                structuralVariant.setDriverFilterAnn(TabDelimitedFileUtil.getPartString(getColumnIndex(DRIVER_FILTER_ANNOTATION), parts));
-                structuralVariant.setDriverTiersFilter(TabDelimitedFileUtil.getPartString(getColumnIndex(DRIVER_TIERS_FILTER), parts));
-                structuralVariant.setDriverTiersFilterAnn(TabDelimitedFileUtil.getPartString(getColumnIndex(DRIVER_TIERS_FILTER_ANNOTATION), parts));
+                if (!structuralVariantUtil.hasRequiredStructuralVariantFields(structuralVariant)) {
+                    ProgressMonitor.logWarning("Invalid Site 1 or 2 Ensembl transcript ID or exon found, ignoring structural variant for SV record #" +
+                            recordCount + " (sample, site 1 gene, site 2 gene):  (" +
+                            structuralVariant.getSampleId() + ", " + structuralVariant.getSite1HugoSymbol() +
+                            ", " + structuralVariant.getSite2HugoSymbol() + ")");
+                    continue;
+                }
 
                 // get sample
                 Sample sample = DaoSample.getSampleByCancerStudyAndSampleId(
@@ -184,7 +95,7 @@ public class ImportStructuralVariantData {
                     String site2HugoSymbol = structuralVariant.getSite2HugoSymbol();
                     long site1EntrezGeneId = structuralVariant.getSite1EntrezGeneId();
                     long site2EntrezGeneId = structuralVariant.getSite2EntrezGeneId();
-                    
+
                     CanonicalGene site1CanonicalGene = setCanonicalGene(site1EntrezGeneId, site1HugoSymbol, daoGene);
                     CanonicalGene site2CanonicalGene = setCanonicalGene(site2EntrezGeneId, site2HugoSymbol, daoGene);
 
@@ -231,7 +142,7 @@ public class ImportStructuralVariantData {
 
     private CanonicalGene setCanonicalGene(long siteEntrezGeneId, String siteHugoSymbol, DaoGeneOptimized daoGene) {
         CanonicalGene siteCanonicalGene = null;
-    
+
         // If the Entrez Gene Id is not "NA" set the canonical gene.
         if (siteEntrezGeneId != TabDelimitedFileUtil.NA_LONG) {
             siteCanonicalGene = daoGene.getGene(siteEntrezGeneId);
@@ -243,14 +154,5 @@ public class ImportStructuralVariantData {
         }
 
         return siteCanonicalGene;
-
-    }
-
-    private int getColumnIndex(String colName) {
-        Integer index = this.columnIndexMap.get(colName.toLowerCase());
-        if (index == null) {
-            index = -1;
-        }
-        return index;
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/portal/util/StructuralVariantUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/StructuralVariantUtil.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2019 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.mskcc.cbio.portal.util;
+
+import java.util.HashMap;
+import org.mskcc.cbio.maf.TabDelimitedFileUtil;
+import org.mskcc.cbio.portal.model.StructuralVariant;
+
+/**
+ * @author ochoaa
+ */
+public class StructuralVariantUtil {
+    private HashMap<String, Integer> columnIndexMap;
+
+    // Column names structural variant file
+    public static final String SAMPLE_ID = "Sample_ID";
+    public static final String SITE1_ENTREZ_GENE_ID = "Site1_Entrez_Gene_Id";
+    public static final String SITE1_HUGO_SYMBOL = "Site1_Hugo_Symbol";
+    public static final String SITE1_ENSEMBL_TRANSCRIPT_ID = "Site1_Ensembl_Transcript_Id";
+    public static final String SITE1_EXON = "Site1_Exon";
+    public static final String SITE1_CHROMOSOME = "Site1_Chromosome";
+    public static final String SITE1_POSITION = "Site1_Position";
+    public static final String SITE1_DESCRIPTION = "Site1_Description";
+    public static final String SITE2_ENTREZ_GENE_ID = "Site2_Entrez_Gene_Id";
+    public static final String SITE2_HUGO_SYMBOL = "Site2_Hugo_Symbol";
+    public static final String SITE2_ENSEMBL_TRANSCRIPT_ID = "Site2_Ensembl_Transcript_Id";
+    public static final String SITE2_EXON = "Site2_Exon";
+    public static final String SITE2_CHROMOSOME = "Site2_Chromosome";
+    public static final String SITE2_POSITION = "Site2_Position";
+    public static final String SITE2_DESCRIPTION = "Site2_Description";
+    public static final String SITE2_EFFECT_ON_FRAME = "Site2_Effect_On_Frame";
+    public static final String NCBI_BUILD = "NCBI_Build";
+    public static final String DNA_SUPPORT = "DNA_Support";
+    public static final String RNA_SUPPORT = "RNA_Support";
+    public static final String NORMAL_READ_COUNT = "Normal_Read_Count";
+    public static final String TUMOR_READ_COUNT = "Tumor_Read_Count";
+    public static final String NORMAL_VARIANT_COUNT = "Normal_Variant_Count";
+    public static final String TUMOR_VARIANT_COUNT = "Tumor_Variant_Count";
+    public static final String NORMAL_PAIRED_END_READ_COUNT = "Normal_Paired_End_Read_Count";
+    public static final String TUMOR_PAIRED_END_READ_COUNT = "Tumor_Paired_End_Read_Count";
+    public static final String NORMAL_SPLIT_READ_COUNT = "Normal_Split_Read_Count";
+    public static final String TUMOR_SPLIT_READ_COUNT = "Tumor_Split_Read_Count";
+    public static final String ANNOTATION = "Annotation";
+    public static final String BREAKPOINT_TYPE = "Breakpoint_Type";
+    public static final String CENTER = "Center";
+    public static final String CONNECTION_TYPE = "Connection_Type";
+    public static final String EVENT_INFO = "Event_Info";
+    public static final String VARIANT_CLASS = "Class";
+    public static final String LENGTH = "Length";
+    public static final String COMMENTS = "Comments";
+    public static final String EXTERNAL_ANNOTATION = "External_Annotation";
+    public static final String DRIVER_FILTER = "cbp_driver";
+    public static final String DRIVER_FILTER_ANNOTATION = "cbp_driver_annotation";
+    public static final String DRIVER_TIERS_FILTER = "cbp_driver_tiers";
+    public static final String DRIVER_TIERS_FILTER_ANNOTATION = "cbp_driver_tiers_annotation";
+
+    public StructuralVariantUtil(){}
+
+    public StructuralVariantUtil(String line) {
+        this.columnIndexMap = new HashMap<String, Integer>();
+        String[] headerParts = line.trim().split("\t");
+
+        // Find header indices
+        for (int i=0; i<headerParts.length; i++) {
+            // Put the index in the map
+            this.columnIndexMap.put(headerParts[i].toLowerCase(), i);
+        }
+    }
+
+    public StructuralVariant parseStructuralVariantRecord(String[] parts) {
+        StructuralVariant structuralVariant = new StructuralVariant();
+        structuralVariant.setSampleId(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.SAMPLE_ID), parts));
+        structuralVariant.setSite1EntrezGeneId(TabDelimitedFileUtil.getPartLong(getColumnIndex(StructuralVariantUtil.SITE1_ENTREZ_GENE_ID), parts));
+        structuralVariant.setSite1HugoSymbol(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.SITE1_HUGO_SYMBOL), parts));
+        structuralVariant.setSite1EnsemblTranscriptId(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.SITE1_ENSEMBL_TRANSCRIPT_ID), parts));
+        structuralVariant.setSite1Exon(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.SITE1_EXON), parts));
+        structuralVariant.setSite1Chromosome(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.SITE1_CHROMOSOME), parts));
+        structuralVariant.setSite1Position(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.SITE1_POSITION), parts));
+        structuralVariant.setSite1Description(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.SITE1_DESCRIPTION), parts));
+        structuralVariant.setSite2EntrezGeneId(TabDelimitedFileUtil.getPartLong(getColumnIndex(StructuralVariantUtil.SITE2_ENTREZ_GENE_ID), parts));
+        structuralVariant.setSite2HugoSymbol(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.SITE2_HUGO_SYMBOL), parts));
+        structuralVariant.setSite2EnsemblTranscriptId(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.SITE2_ENSEMBL_TRANSCRIPT_ID), parts));
+        structuralVariant.setSite2Exon(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.SITE2_EXON), parts));
+        structuralVariant.setSite2Chromosome(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.SITE2_CHROMOSOME), parts));
+        structuralVariant.setSite2Position(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.SITE2_POSITION), parts));
+        structuralVariant.setSite2Description(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.SITE2_DESCRIPTION), parts));
+        structuralVariant.setSite2EffectOnFrame(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.SITE2_EFFECT_ON_FRAME), parts));
+        structuralVariant.setNcbiBuild(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.NCBI_BUILD), parts));
+        structuralVariant.setDnaSupport(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.DNA_SUPPORT), parts));
+        structuralVariant.setRnaSupport(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.RNA_SUPPORT), parts));
+        structuralVariant.setNormalReadCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.NORMAL_READ_COUNT), parts));
+        structuralVariant.setTumorReadCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.TUMOR_READ_COUNT), parts));
+        structuralVariant.setNormalVariantCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.NORMAL_VARIANT_COUNT), parts));
+        structuralVariant.setTumorVariantCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.TUMOR_VARIANT_COUNT), parts));
+        structuralVariant.setNormalPairedEndReadCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.NORMAL_PAIRED_END_READ_COUNT), parts));
+        structuralVariant.setTumorPairedEndReadCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.TUMOR_PAIRED_END_READ_COUNT), parts));
+        structuralVariant.setNormalSplitReadCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.NORMAL_SPLIT_READ_COUNT), parts));
+        structuralVariant.setTumorSplitReadCount(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.TUMOR_SPLIT_READ_COUNT), parts));
+        structuralVariant.setAnnotation(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.ANNOTATION), parts));
+        structuralVariant.setBreakpointType(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.BREAKPOINT_TYPE), parts));
+        structuralVariant.setCenter(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.CENTER), parts));
+        structuralVariant.setConnectionType(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.CONNECTION_TYPE), parts));
+        structuralVariant.setEventInfo(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.EVENT_INFO), parts));
+        structuralVariant.setVariantClass(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.VARIANT_CLASS), parts));
+        structuralVariant.setLength(TabDelimitedFileUtil.getPartInt(getColumnIndex(StructuralVariantUtil.LENGTH), parts));
+        structuralVariant.setComments(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.COMMENTS), parts));
+        structuralVariant.setExternalAnnotation(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.EXTERNAL_ANNOTATION), parts));
+        structuralVariant.setDriverFilter(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.DRIVER_FILTER), parts));
+        structuralVariant.setDriverFilterAnn(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.DRIVER_FILTER_ANNOTATION), parts));
+        structuralVariant.setDriverTiersFilter(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.DRIVER_TIERS_FILTER), parts));
+        structuralVariant.setDriverTiersFilterAnn(TabDelimitedFileUtil.getPartString(getColumnIndex(StructuralVariantUtil.DRIVER_TIERS_FILTER_ANNOTATION), parts));
+        return structuralVariant;
+    }
+
+    public int getColumnIndex(String colName) {
+        Integer index = this.columnIndexMap.get(colName.toLowerCase());
+        if (index == null) {
+            index = -1;
+        }
+        return index;
+    }
+
+    public Boolean hasRequiredStructuralVariantFields(StructuralVariant record) {
+        return !record.getSite1EnsemblTranscriptId().equalsIgnoreCase(TabDelimitedFileUtil.NA_STRING) &&
+                !record.getSite2EnsemblTranscriptId().equalsIgnoreCase(TabDelimitedFileUtil.NA_STRING) &&
+                record.getSite1Exon() != -1 &&
+                record.getSite2Exon() != -1 &&
+                (record.getSite1EntrezGeneId() != Long.MIN_VALUE || !record.getSite1HugoSymbol().equalsIgnoreCase(TabDelimitedFileUtil.NA_STRING)) &&
+                (record.getSite2EntrezGeneId() != Long.MIN_VALUE || !record.getSite2HugoSymbol().equalsIgnoreCase(TabDelimitedFileUtil.NA_STRING));
+    }
+
+}

--- a/core/src/test/java/org/mskcc/cbio/portal/util/TestStructuralVariantUtil.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/util/TestStructuralVariantUtil.java
@@ -1,0 +1,46 @@
+package org.mskcc.cbio.portal.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mskcc.cbio.portal.model.StructuralVariant;
+
+/**
+ * @author ochoaa
+ */
+public class TestStructuralVariantUtil {
+    private StructuralVariantUtil structuralVariantUtil = new StructuralVariantUtil();
+
+    @Test
+    public void testValidStructuralVariantRecord() {
+        // confirm that record meets minimum requirements for import
+        // record has site 1 entrez id and missing site 1 hugo symbol
+        // and missing site 2 entrez id but present site 2 hugo symbol
+        StructuralVariant record = new StructuralVariant();
+        record.setSite1EntrezGeneId(654684L);
+        record.setSite1HugoSymbol("NA");
+        record.setSite1EnsemblTranscriptId("ENST29O3403");
+        record.setSite1Exon(2);
+        record.setSite2EntrezGeneId(-1L);
+        record.setSite2HugoSymbol("ALK1");
+        record.setSite2EnsemblTranscriptId("ENST2843757657");
+        record.setSite2Exon(1);
+        Assert.assertTrue(structuralVariantUtil.hasRequiredStructuralVariantFields(record));
+    }
+
+    @Test
+    public void testInvalidStructuralVariantRecord() {
+        // confirm that record does not meet minimum requires for import
+        // this record is same as above but missing site 2 ensembl transcript id
+        StructuralVariant record = new StructuralVariant();
+        record.setSite1EntrezGeneId(654684L);
+        record.setSite1HugoSymbol("NA");
+        record.setSite1EnsemblTranscriptId("ENST29O3403");
+        record.setSite1Exon(2);
+        record.setSite2EntrezGeneId(-1L);
+        record.setSite2HugoSymbol("ALK1");
+        record.setSite2EnsemblTranscriptId("NA");
+        record.setSite2Exon(1);
+        Assert.assertFalse(structuralVariantUtil.hasRequiredStructuralVariantFields(record));
+    }
+
+}


### PR DESCRIPTION
Addresses Problem:
SV visualization in beta portal breaks if SV record is missing either site1 or site2 ensembl transcript id.

Describe changes proposed in this pull request:
**Skip SV records with invalid exon/ensembl transcript ids**

Skip records in Structural Variant data file that are missing any of the following required fields:
- site 1 and 2 exon (default is -1, these will be skipped)
- site 1 and 2 ensembl transcript ids (default to NA if missing, these will be skipped)
- site 1 and 2 entrez id/hugo symbol (records missing both of these will be skipped)

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>


# Checks
- [ ] Runs on heroku
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
