### PR TITLE
When a gene does not exist in a group, the profiledCount should be th…

### DIFF
--- a/service/src/main/java/org/cbioportal/service/util/AlterationEnrichmentUtil.java
+++ b/service/src/main/java/org/cbioportal/service/util/AlterationEnrichmentUtil.java
@@ -69,7 +69,7 @@ public class AlterationEnrichmentUtil {
                                 .getOrDefault(group, new HashMap<Integer, AlterationCountByGene>()).get(gene.getEntrezGeneId());
                       
                         Integer alteredCount = mutationCountByGene != null ? mutationCountByGene.getNumberOfAlteredCases() : 0;
-                        Integer profiledCount = mutationCountByGene != null ? mutationCountByGene.getNumberOfProfiledCases() : 0;
+                        Integer profiledCount = mutationCountByGene != null ? mutationCountByGene.getNumberOfProfiledCases() : molecularProfileCaseSets.get(group).size();
                         groupCasesCount.setName(group);
                         groupCasesCount.setAlteredCount(alteredCount);
                         groupCasesCount.setProfiledCount(profiledCount);


### PR DESCRIPTION
…e group size

The issue was introduced in https://github.com/cBioPortal/cbioportal/pull/6563