### PR TITLE
Allow 'ALL' or 'NONE' SV site 1 and 2 Ensembl transcript ids/exons info for import

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/StructuralVariantUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/StructuralVariantUtil.java
@@ -150,11 +150,49 @@ public class StructuralVariantUtil {
         return index;
     }
 
+    /**
+     * Determines whether the structural variant record meets the minimal requirements for import.
+     *
+     * Structural variant records are valid if:
+     *   (1) Neither Site 1 or Site 2 Ensembl transcript IDs and exons are defined in the record.
+     *   (2) Both Site 1 and Site 2 Ensmebl transcript IDs and exons are defined in the record.
+     *
+     * If a structural variant record has a mix of defined and missing values for Site 1 or Site 2
+     * Ensembl transcript IDs and/or exons then the structural variant record will not be imported.
+     *
+     * Example (assuming that site 1 and site 2 hugo symbol and/or entrez id are present):
+     *
+     * Valid Record:
+     *     Site 1 Transcript: EST0000024958
+     *     Site 1 Exon: 4
+     *     Site 2 Transcript: EST0001651651
+     *     Site 1 Exon: 2
+     *
+     * Valid Record:
+     *     Site 1 Transcript: NA
+     *     Site 1 Exon: -1
+     *     Site 2 Transcript: NA
+     *     Site 1 Exon: -1
+     *
+     * INVALID Record:
+     *     Site 1 Transcript: EST0000024958
+     *     Site 1 Exon: -1
+     *     Site 2 Transcript: EST0001651651
+     *     Site 1 Exon: -1
+     *
+     * @param record
+     * @return
+     */
     public Boolean hasRequiredStructuralVariantFields(StructuralVariant record) {
-        return !record.getSite1EnsemblTranscriptId().equalsIgnoreCase(TabDelimitedFileUtil.NA_STRING) &&
+        Boolean hasNoEnsemblExonValues = (record.getSite1EnsemblTranscriptId().equalsIgnoreCase(TabDelimitedFileUtil.NA_STRING) &&
+                record.getSite2EnsemblTranscriptId().equalsIgnoreCase(TabDelimitedFileUtil.NA_STRING) &&
+                record.getSite1Exon() == -1 &&
+                record.getSite2Exon() == -1);
+        Boolean hasAllEnsemblExonValues = (!record.getSite1EnsemblTranscriptId().equalsIgnoreCase(TabDelimitedFileUtil.NA_STRING) &&
                 !record.getSite2EnsemblTranscriptId().equalsIgnoreCase(TabDelimitedFileUtil.NA_STRING) &&
                 record.getSite1Exon() != -1 &&
-                record.getSite2Exon() != -1 &&
+                record.getSite2Exon() != -1);
+        return ( hasNoEnsemblExonValues || hasAllEnsemblExonValues ) &&
                 (record.getSite1EntrezGeneId() != Long.MIN_VALUE || !record.getSite1HugoSymbol().equalsIgnoreCase(TabDelimitedFileUtil.NA_STRING)) &&
                 (record.getSite2EntrezGeneId() != Long.MIN_VALUE || !record.getSite2HugoSymbol().equalsIgnoreCase(TabDelimitedFileUtil.NA_STRING));
     }

--- a/core/src/test/java/org/mskcc/cbio/portal/util/TestStructuralVariantUtil.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/util/TestStructuralVariantUtil.java
@@ -11,7 +11,7 @@ public class TestStructuralVariantUtil {
     private StructuralVariantUtil structuralVariantUtil = new StructuralVariantUtil();
 
     @Test
-    public void testValidStructuralVariantRecord() {
+    public void testValidStructuralVariantRecordWithCompleteGeneTranscriptInfo() {
         // confirm that record meets minimum requirements for import
         // record has site 1 entrez id and missing site 1 hugo symbol
         // and missing site 2 entrez id but present site 2 hugo symbol
@@ -28,8 +28,8 @@ public class TestStructuralVariantUtil {
     }
 
     @Test
-    public void testInvalidStructuralVariantRecord() {
-        // confirm that record does not meet minimum requires for import
+    public void testInvalidStructuralVariantRecordWithIncompleteTranscriptInfo() {
+        // confirm that record does not meet minimum requirements for import
         // this record is same as above but missing site 2 ensembl transcript id
         StructuralVariant record = new StructuralVariant();
         record.setSite1EntrezGeneId(654684L);
@@ -43,4 +43,54 @@ public class TestStructuralVariantUtil {
         Assert.assertFalse(structuralVariantUtil.hasRequiredStructuralVariantFields(record));
     }
 
+    @Test
+    public void testInvalidStructuralVariantRecordMissingGeneInfo() {
+        // confirm that record does not meet minimum requirements for import
+        // record is missing site 1 gene info (renders record invalid)
+        // and missing site 2 entrez id but present site 2 hugo symbol
+        StructuralVariant record = new StructuralVariant();
+        record.setSite1EntrezGeneId(Long.MIN_VALUE);
+        record.setSite1HugoSymbol("NA");
+        record.setSite1EnsemblTranscriptId("ENST29O3403");
+        record.setSite1Exon(2);
+        record.setSite2EntrezGeneId(Long.MIN_VALUE);
+        record.setSite2HugoSymbol("ALK1");
+        record.setSite2EnsemblTranscriptId("ENST2843757657");
+        record.setSite2Exon(1);
+        Assert.assertFalse(structuralVariantUtil.hasRequiredStructuralVariantFields(record));
+    }
+
+    @Test
+    public void testInvalidStructuralVariantRecordMissingGeneAndTranscriptInfo() {
+        // confirm that record does not meet minimum requirements for import
+        // record is missing site 1 gene info (renders record invalid)
+        // and missing site 2 entrez id but present site 2 hugo symbol
+        StructuralVariant record = new StructuralVariant();
+        record.setSite1EntrezGeneId(Long.MIN_VALUE);
+        record.setSite1HugoSymbol("NA");
+        record.setSite1EnsemblTranscriptId("NA");
+        record.setSite1Exon(-1);
+        record.setSite2EntrezGeneId(Long.MIN_VALUE);
+        record.setSite2HugoSymbol("ALK1");
+        record.setSite2EnsemblTranscriptId("ENST2843757657");
+        record.setSite2Exon(1);
+        Assert.assertFalse(structuralVariantUtil.hasRequiredStructuralVariantFields(record));
+    }
+
+    @Test
+    public void testValidStructuralVariantRecordMissingTranscriptInfo() {
+        // confirm that record meets minimum requirements for import
+        // record has site 1 entrez id and missing site 1 hugo symbol
+        // and missing site 2 entrez id but present site 2 hugo symbol
+        StructuralVariant record = new StructuralVariant();
+        record.setSite1EntrezGeneId(654684L);
+        record.setSite1HugoSymbol("NA");
+        record.setSite1EnsemblTranscriptId("NA");
+        record.setSite1Exon(-1);
+        record.setSite2EntrezGeneId(Long.MIN_VALUE);
+        record.setSite2HugoSymbol("ALK1");
+        record.setSite2EnsemblTranscriptId("NA");
+        record.setSite2Exon(-1);
+        Assert.assertTrue(structuralVariantUtil.hasRequiredStructuralVariantFields(record));
+    }
 }


### PR DESCRIPTION
Allow 'ALL' or 'NONE' SV site 1 and 2 Ensembl transcript ids/exons info for import

     * Structural variant records are valid if:
     *   (1) Neither Site 1 or Site 2 Ensembl transcript IDs and exons are defined in the record.
     *   (2) Both Site 1 and Site 2 Ensmebl transcript IDs and exons are defined in the record.
     *
     * If a structural variant record has a mix of defined and missing values for Site 1 or Site 2
     * Ensembl transcript IDs and/or exons then the structural variant record will not be imported.
     *
     * Example (assuming that site 1 and site 2 hugo symbol and/or entrez id are present):
     *
     * Valid Record:
     *     Site 1 Transcript: EST0000024958
     *     Site 1 Exon: 4
     *     Site 2 Transcript: EST0001651651
     *     Site 1 Exon: 2
     *
     * Valid Record:
     *     Site 1 Transcript: NA
     *     Site 1 Exon: -1
     *     Site 2 Transcript: NA
     *     Site 1 Exon: -1
     *
     * INVALID Record:
     *     Site 1 Transcript: EST0000024958
     *     Site 1 Exon: -1
     *     Site 2 Transcript: EST0001651651
     *     Site 1 Exon: -1

Co-authored by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
Co-authored by: Robert Sheridan <7747489+sheridancbio@users.noreply.github.com>
Co-authored by: Avery Wang <18199796+averyniceday@users.noreply.github.com>

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>

