### PR TITLE
Sample Quicksearch nolonger 403s

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SampleRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SampleRepository.java
@@ -9,10 +9,10 @@ import java.util.List;
 
 public interface SampleRepository {
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
-    List<Sample> getAllSamples(String keyword, String projection, Integer pageSize,
+    List<Sample> getAllSamples(String keyword, List<String> studyIds, String projection, Integer pageSize,
                                Integer pageNumber, String sort, String direction);
 
-    BaseMeta getMetaSamples(String keyword);
+    BaseMeta getMetaSamples(String keyword, List<String> studyIds);
 
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<Sample> getAllSamplesInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepository.java
@@ -20,15 +20,19 @@ public class SampleMyBatisRepository implements SampleRepository {
     private OffsetCalculator offsetCalculator;
 
     @Override
-    public List<Sample> getAllSamples(String keyword, String projection, Integer pageSize, Integer pageNumber, String sort, String direction) {
-        
-        return sampleMapper.getSamples(null, null, null, keyword, projection, pageSize,
-            offsetCalculator.calculate(pageSize, pageNumber), sort, direction);
+    public List<Sample> getAllSamples(
+        String keyword, List<String> studyIds, String projection,
+        Integer pageSize, Integer pageNumber, String sort, String direction
+    ) {
+        return sampleMapper.getSamples(
+            studyIds, null, null, keyword, projection, pageSize,
+            offsetCalculator.calculate(pageSize, pageNumber), sort, direction
+        );
     }
 
     @Override
-    public BaseMeta getMetaSamples(String keyword) {
-        return sampleMapper.getMetaSamples(null, null, null, keyword);
+    public BaseMeta getMetaSamples(String keyword, List<String> studyIds) {
+        return sampleMapper.getMetaSamples(studyIds, null, null, keyword);
     }
 
     @Override

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleMapper.xml
@@ -33,9 +33,14 @@
         <where>
             <if test="sampleIds == null and studyIds != null">
                 cancer_study.CANCER_STUDY_IDENTIFIER IN
-                <foreach item="item" collection="studyIds" open="(" separator="," close=")">
-                    #{item}
-                </foreach>
+                <if test="studyIds.isEmpty()">
+                    (NULL)
+                </if>
+                <if test="!studyIds.isEmpty()">
+                    <foreach item="item" collection="studyIds" open="(" separator="," close=")">
+                        #{item}
+                    </foreach>
+                </if>
             </if>
             <if test="sampleIds != null">
                 <if test="@java.util.Arrays@stream(studyIds.toArray()).distinct().count() == 1">
@@ -56,6 +61,7 @@
                 AND patient.STABLE_ID = #{patientId}
             </if>
             <if test="keyword != null">
+                AND
                 <foreach item="item" collection="keyword.split(' ')" open="(" separator=") AND (" close=")">
                     sample.STABLE_ID like CONCAT('%', #{item}, '%')
                 </foreach>

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepositoryTest.java
@@ -340,7 +340,7 @@ public class SampleMyBatisRepositoryTest {
      
     @Test
     public void getSamplesByKeyword() {
-         List<Sample> result = sampleMyBatisRepository.getAllSamples("TCGA-A1-A0SB", "SUMMARY", 10, 0, null, null);
+         List<Sample> result = sampleMyBatisRepository.getAllSamples("TCGA-A1-A0SB", null, "SUMMARY", 10, 0, null, null);
          List<String> actual = result.stream().map((Sample::getStableId)).collect(Collectors.toList());
          List<String> expected = Arrays.asList("TCGA-A1-A0SB-01", "TCGA-A1-A0SB-01", "TCGA-A1-A0SB-02");
 
@@ -349,7 +349,7 @@ public class SampleMyBatisRepositoryTest {
      
     @Test
     public void getMetaSamplesByKeyword() {
-        BaseMeta actual = sampleMyBatisRepository.getMetaSamples("TCGA-A1-A0SB");
+        BaseMeta actual = sampleMyBatisRepository.getMetaSamples("TCGA-A1-A0SB", null);
         Integer expected = 3;
         
         Assert.assertEquals(expected, actual.getTotalCount());

--- a/service/src/main/java/org/cbioportal/service/SampleService.java
+++ b/service/src/main/java/org/cbioportal/service/SampleService.java
@@ -41,8 +41,8 @@ public interface SampleService {
 
     List<Sample> getSamplesByInternalIds(List<Integer> internalIds);
 
-    List<Sample> getAllSamples(String keyword, String projection, Integer pageSize,
-                               Integer pageNumber, String sort, String direction);
+    List<Sample> getAllSamples(String keyword, List<String> studyIds, String projection,
+                               Integer pageSize, Integer pageNumber, String sort, String direction);
 
-    BaseMeta getMetaSamples(String keyword);
+    BaseMeta getMetaSamples(String keyword, List<String> studyIds);
 }

--- a/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
@@ -13,7 +13,9 @@ import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -36,16 +38,16 @@ public class SampleServiceImpl implements SampleService {
     private CopyNumberSegmentRepository copyNumberSegmentRepository;
     
     @Override
-    public List<Sample> getAllSamples(String keyword, String projection, Integer pageSize,
-                                      Integer pageNumber, String sort, String direction) {
-        List<Sample> samples = sampleRepository.getAllSamples(keyword, projection, pageSize, pageNumber, sort, direction);
+    public List<Sample> getAllSamples(String keyword, List<String> studyIds, String projection,
+                                      Integer pageSize, Integer pageNumber, String sort, String direction) {
+        List<Sample> samples = sampleRepository.getAllSamples(keyword, studyIds, projection, pageSize, pageNumber, sort, direction);
         processSamples(samples, projection);
         return samples;
     }
 
     @Override
-    public BaseMeta getMetaSamples(String keyword) {
-        return sampleRepository.getMetaSamples(keyword);
+    public BaseMeta getMetaSamples(String keyword, List<String> studyIds) {
+        return sampleRepository.getMetaSamples(keyword, studyIds);
     }
     
     @Override

--- a/service/src/test/java/org/cbioportal/service/impl/SampleServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/SampleServiceImplTest.java
@@ -53,10 +53,10 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
             createSample(SAMPLE_ID3), createSample(SAMPLE_ID4)
         );
         Mockito
-            .when(sampleRepository.getAllSamples("sample_id", PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION))
+            .when(sampleRepository.getAllSamples("sample_id", null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION))
             .thenReturn(samples);
 
-        List<Sample> result = sampleService.getAllSamples("sample_id", PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+        List<Sample> result = sampleService.getAllSamples("sample_id", null, PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
         List<String> actual = result.stream().map(Sample::getStableId).collect(Collectors.toList());
         List<String> expected = Arrays.asList(SAMPLE_ID1, SAMPLE_ID2, SAMPLE_ID3, SAMPLE_ID4);
         
@@ -67,9 +67,9 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
     public void getAllMetaSamples() {
         BaseMeta baseMeta = new BaseMeta();
         baseMeta.setTotalCount(4);
-        Mockito.when(sampleRepository.getMetaSamples("sample_id")).thenReturn(baseMeta);
+        Mockito.when(sampleRepository.getMetaSamples("sample_id", null)).thenReturn(baseMeta);
 
-        BaseMeta result = sampleService.getMetaSamples("sample_id");
+        BaseMeta result = sampleService.getMetaSamples("sample_id", null);
         Integer actual = result.getTotalCount();
         Integer expected = 4;
 

--- a/web/src/test/java/org/cbioportal/web/SampleControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/SampleControllerTest.java
@@ -127,7 +127,7 @@ public class SampleControllerTest {
         
         Mockito
             .when(sampleService.getAllSamples(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(),
+                Mockito.anyString(), Mockito.anyObject(), Mockito.anyString(), Mockito.anyInt(),
                 Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()
             )).thenReturn(samples);
         


### PR DESCRIPTION
Fix #6745
Describe changes proposed in this pull request:
- moved filtering to service layer to avoid 403

How can we verify that this works? Right now this is unverified.
