### PR TITLE
Fix: make PortalDump respect persistence Mixin's for JSON output

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -288,6 +288,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.mskcc.cbio</groupId>
+      <artifactId>web</artifactId>
+      <version>${project.version}</version>
+   </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.cbioportal.web.config.CustomObjectMapper;
 
 import org.mskcc.cbio.portal.util.SpringUtil;
 import org.mskcc.cbio.portal.util.ProgressMonitor;
@@ -66,7 +67,7 @@ public class DumpPortalInfo extends ConsoleRunnable {
     private static void writeJsonFile(
             List<? extends Serializable> objectList,
             File outputFile) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
+            ObjectMapper mapper = new CustomObjectMapper();
             try {
                 mapper.writeValue(outputFile, objectList);
             } catch (JsonProcessingException e) {


### PR DESCRIPTION
When using `dumpPortalInfo.pl` to download info from the api in JSON format, the resulting JSON files were in a different format than when approaching the api through URL. This problem originated from a wrong Spring object mapper.

Credits to @pvannierop for the solution.