### PR TITLE
Gene info parser fix

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGeneData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGeneData.java
@@ -104,13 +104,13 @@ public class ImportGeneData extends ConsoleRunnable {
                     Set<String> aliases = new HashSet<String>();
 
                     // try to get chr from other column if needed
-                    if (chr.equals("-") && !parts[6].equals("-")) {
-                        chr = parts[6];
-                     } else {
-                        // skip line if still unable to parse chr
-                        continue;
+                    if (chr.equals("-")) {
+                        if (!parts[6].equals("-")) {
+                            chr = parts[6];
+                        } else { 
+                            continue; // skip if both columns are absent
+                        }
                     }
-
                     if (!locusTag.equals("-")) {
                         aliases.add(locusTag);
                     }

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGeneData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGeneData.java
@@ -104,13 +104,11 @@ public class ImportGeneData extends ConsoleRunnable {
                     Set<String> aliases = new HashSet<String>();
 
                     // try to get chr from other column if needed
-                    if (chr.equals("-")) {
-                        if (!parts[6].equals("-")) {
-                            chr = parts[6];
-                        } else {
-                            // skip line if still unable to parse chr
-                            continue;
-                        }
+                    if (chr.equals("-") && !parts[6].equals("-")) {
+                        chr = parts[6];
+                     } else {
+                        // skip line if still unable to parse chr
+                        continue;
                     }
 
                     if (!locusTag.equals("-")) {
@@ -515,14 +513,16 @@ public class ImportGeneData extends ConsoleRunnable {
         DaoGeneOptimized daoGeneOptimized = DaoGeneOptimized.getInstance();
         CanonicalGene gene = daoGeneOptimized.getNonAmbiguousGene(symbol);
         
-        if (gene==null) {
+        boolean lengthUpdated = false;
+
+        if (gene == null) {
             ProgressMonitor.logWarning("Unable to retrieve gene by symbol: " +symbol);
-            return false;
+            return lengthUpdated;
         }
 
         System.out.println(" --> update reference genome gene:  " + gene.getHugoGeneSymbolAllCaps());
         DaoReferenceGenomeGene daoReferenceGenomeGene = DaoReferenceGenomeGene.getInstance();
-        boolean lengthUpdated = false;
+
         /// Check if the gene is in the database
         ReferenceGenomeGene refGene = daoReferenceGenomeGene.getGene(gene.getEntrezGeneId(), refreneceGenomeId);
         /// If it's not in the database, don't add it


### PR DESCRIPTION
I ran into some problems while building a hg38 seed database:

Sometimes the file `Homo_sapiens.gene_info` contains missing values in the `map_location` and/or `chromosome` columns. This file is downloaded from NCBI and required when updating genes and gene aliases.
Additionally, sometimes a particular symbol from the GenCode annotation file is not in the info file, causing a `NullPointerException`.

Changes:
- When the chromosome can't be parsed from the `map_location` column, try the `chromosome` column. If that also fails, skip gene.
- prevent `NullPointerException` when the gene symbol can't be found, and instead showing a warning, and skipping the gene.