### PR TITLE
Bug fix in SV validator

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -2949,7 +2949,7 @@ class StructuralVariantValidator(Validator):
             self.structural_variant_entries[self.line_number]['Site1_Exon'] = site1_exon
             self.structural_variant_entries[self.line_number]['Site2_Ensembl_Transcript_Id'] = site2_transcript
             self.structural_variant_entries[self.line_number]['Site2_Exon'] = site2_exon
-            self.structural_variant_entries[self.line_number]['NCBI_Build'] = ncbi_build
+            self.structural_variant_entries[self.line_number]['NCBI_Build'] = self.ncbi_build
             self.structural_variant_entries[self.line_number]['Event_Info'] = 'Fusion'
             return
 


### PR DESCRIPTION
Describe changes proposed in this pull request:
Fixes `NameError` exception thrown at 
```
cbioportal/core/src/main/scripts/importer/validateData.py", line 2952, in checkFusionValues
```
> NameError: free variable 'ncbi_build' referenced before assignment in enclosing scope


Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
