### PR TITLE
Allow values other than 'Fusion' for 'Event_Info' in SV data

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -2971,13 +2971,9 @@ class StructuralVariantValidator(Validator):
         site2_entrez_gene_id = checkPresenceValue('Site2_Entrez_Gene_Id', self, data)
         self.checkGeneIdentification(site2_hugo_symbol, site2_entrez_gene_id)
 
-        # Validate fusion events
+        # Validate fusion events if Event_Info is 'Fusion'
         if data[self.cols.index('Event_Info')] == 'Fusion':
             checkFusionValues(self, data)
-        else:
-            self.logger.error('Validation and functionality for other structural variant events are not implemented '
-                              'yet. Event_Info must be "Fusion"',
-                              extra={'cause': self.cols.index('Event_Info')})
 
     def onComplete(self):
         """Perform final validations based on the data parsed."""


### PR DESCRIPTION
Structural Variant validator only accepts value "Fusion" for "Event_Info" field. This PR removes this restriction. Records with "Event_Info" values other than "Fusion" will skip the step to validate the fusion event information like exons and ensembl transcript ids.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>

