### PR TITLE
Persistent Cache Timestamp API

### DIFF
--- a/docs/Deploy-Using-Docker.md
+++ b/docs/Deploy-Using-Docker.md
@@ -29,7 +29,9 @@ docker network create "cbio-net"
 
 ## 2. Database Setup
 
-As of this writing, the cBioPortal software runs properly on MySQL version 5.0.x. The software can be found and downloaded from the [MySQL website](https://www.mysql.com).
+The cBioPortal software should run properly on MySQL version 5.7.x. Versions higher than 5.7.x can cause an issue
+while loading the database schema. Minor versions lower than 5.7.x will cause issues with persistent cache invalidation.
+The software can be found and downloaded from the [MySQL website](http://www.mysql.com/).
 
 There are two options to set up the cBioPortal Database:    
 2.1 Run MySQL on the host.    

--- a/docs/Software-Requirements.md
+++ b/docs/Software-Requirements.md
@@ -4,7 +4,8 @@ This page describes various system software required to run the cBioPortal.
 
 ## MySQL
 
-The cBioPortal software should run properly on MySQL version 5.x.x; to avoid a known issue while loading the database schema, 5.7.x or lower is recommended.
+The cBioPortal software should run properly on MySQL version 5.7.x. Versions higher than 5.7.x can cause an issue
+while loading the database schema. Minor versions lower than 5.7.x will cause issues with persistent cache invalidation.
 The software can be found and downloaded from the [MySQL website](http://www.mysql.com/).
 
 On Ubuntu:  ```sudo apt-get install mysql-server```

--- a/model/src/main/java/org/cbioportal/model/TableTimestampPair.java
+++ b/model/src/main/java/org/cbioportal/model/TableTimestampPair.java
@@ -1,0 +1,26 @@
+package org.cbioportal.model;
+
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+
+public class TableTimestampPair implements Serializable {
+    @NotNull
+    private String tableName;
+    private String updateTime;
+
+    public String getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(String updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/StaticDataTimeStampRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/StaticDataTimeStampRepository.java
@@ -1,0 +1,10 @@
+package org.cbioportal.persistence;
+
+import org.cbioportal.model.TableTimestampPair;
+
+import java.util.Date;
+import java.util.List;
+
+public interface StaticDataTimeStampRepository {
+    List<TableTimestampPair> getTimestamps(List<String> tables);
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StaticDataTimeStampMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StaticDataTimeStampMyBatisRepository.java
@@ -1,0 +1,23 @@
+package org.cbioportal.persistence.mybatis;
+
+import org.cbioportal.model.TableTimestampPair;
+import org.cbioportal.persistence.StaticDataTimeStampRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class StaticDataTimeStampMyBatisRepository implements StaticDataTimeStampRepository {
+    @Value("${db.portal_db_name:}")
+    private String dbName;
+    
+    @Autowired
+    private StaticDataTimestampMapper staticDataTimestampMapper;
+
+    @Override
+    public List<TableTimestampPair> getTimestamps(List<String> tableNames) {
+        return staticDataTimestampMapper.getTimestamps(tableNames, dbName);
+    }
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StaticDataTimestampMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StaticDataTimestampMapper.java
@@ -1,0 +1,9 @@
+package org.cbioportal.persistence.mybatis;
+
+import org.cbioportal.model.TableTimestampPair;
+
+import java.util.List;
+
+public interface StaticDataTimestampMapper {
+    List<TableTimestampPair> getTimestamps(List<String> tables, String dbName);
+}

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StaticDataTimestampMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StaticDataTimestampMapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.cbioportal.persistence.mybatis.StaticDataTimestampMapper">
+    <select id="getTimestamps" resultType="org.cbioportal.model.TableTimestampPair">
+        <if test="dbName != null">
+            SELECT
+                TABLE_NAME AS tableName,
+                COALESCE(UPDATE_TIME, CREATE_TIME) AS updateTime
+            FROM information_schema.tables
+            WHERE
+                TABLE_SCHEMA=#{dbName}
+                <if test="tables != null and !tables.isEmpty()">
+                    AND TABLE_NAME IN
+                    <foreach item="item" collection="tables" open="(" separator="," close=");">
+                        #{item}
+                    </foreach>
+                </if>    
+        </if>
+        
+    </select>
+</mapper>

--- a/service/src/main/java/org/cbioportal/service/StaticDataTimestampService.java
+++ b/service/src/main/java/org/cbioportal/service/StaticDataTimestampService.java
@@ -1,0 +1,11 @@
+package org.cbioportal.service;
+
+import org.cbioportal.model.TableTimestampPair;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+public interface StaticDataTimestampService {
+    Map<String, String> getTimestamps(List<String> tables);
+}

--- a/service/src/main/java/org/cbioportal/service/impl/StaticDataTimestampServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/StaticDataTimestampServiceImpl.java
@@ -1,0 +1,28 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.model.TableTimestampPair;
+import org.cbioportal.service.StaticDataTimestampService;
+import org.cbioportal.persistence.StaticDataTimeStampRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class StaticDataTimestampServiceImpl implements StaticDataTimestampService {
+    @Autowired
+    private StaticDataTimeStampRepository staticDataTimeStampRepository;
+
+    @Override
+    public Map<String, String> getTimestamps(List<String> tables) {
+        List<TableTimestampPair> timestamps = staticDataTimeStampRepository.getTimestamps(tables);
+        return timestamps.stream()
+                .collect(Collectors.toMap(
+                        TableTimestampPair::getTableName,
+                        TableTimestampPair::getUpdateTime));
+    }
+}
+
+

--- a/service/src/test/java/org/cbioportal/service/impl/StaticDataTimestampServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/StaticDataTimestampServiceImplTest.java
@@ -1,0 +1,39 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.model.TableTimestampPair;
+import org.cbioportal.persistence.StaticDataTimeStampRepository;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StaticDataTimestampServiceImplTest extends BaseServiceImplTest {
+    @InjectMocks
+    private StaticDataTimestampServiceImpl infoService;
+
+    @Mock
+    private StaticDataTimeStampRepository repository;
+
+    @Test
+    public void TestGetTimestamps() {
+        HashMap<String, String> pairs = new HashMap<>();
+        pairs.put("gene", "2019-11-11 08:41:15");
+        TableTimestampPair pair = new TableTimestampPair();
+        pair.setTableName("gene");
+        pair.setUpdateTime("2019-11-11 08:41:15");
+        
+        Mockito.when(repository.getTimestamps(Mockito.anyList())).thenReturn(
+                Collections.singletonList(pair));
+        
+        Assert.assertEquals(
+                infoService.getTimestamps(Collections.singletonList("gene")),
+                pairs);
+    }
+}

--- a/web/src/main/java/org/cbioportal/web/StaticDataTimestampController.java
+++ b/web/src/main/java/org/cbioportal/web/StaticDataTimestampController.java
@@ -1,0 +1,34 @@
+package org.cbioportal.web;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.cbioportal.model.TableTimestampPair;
+import org.cbioportal.service.StaticDataTimestampService;
+import org.cbioportal.web.config.annotation.InternalApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.*;
+
+@InternalApi
+@RestController
+@Validated
+@Api(tags = "Timestamps", description = " ")
+public class StaticDataTimestampController {
+    private static final List<String> tables = Arrays.asList("gene", "reference_genome_gene");
+    @Autowired
+    private StaticDataTimestampService service;
+    
+    @RequestMapping(value = "/timestamps", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Get the last time each static resource was updated")
+    public ResponseEntity<Map<String, String>> getAllTimestamps() {
+        return new ResponseEntity<>(service.getTimestamps(tables), HttpStatus.OK);
+    }
+    
+}

--- a/web/src/test/java/org/cbioportal/web/StaticDataTimestampControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StaticDataTimestampControllerTest.java
@@ -1,0 +1,59 @@
+package org.cbioportal.web;
+
+import org.cbioportal.service.StaticDataTimestampService;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.HashMap;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration("/applicationContext-web-test.xml")
+@Configuration
+public class StaticDataTimestampControllerTest {
+    @Autowired
+    private WebApplicationContext wac;
+    
+    @Autowired
+    private StaticDataTimestampService service;
+    
+    private MockMvc mockMvc;
+    
+    @Bean
+    public StaticDataTimestampService staticDataTimestampService() {
+        return Mockito.mock(StaticDataTimestampService.class);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        Mockito.reset(service);
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+    }
+
+    @Test
+    public void getAllTimestamps() throws Exception {
+        HashMap<String, String> pairs = new HashMap<>();
+        pairs.put("gene", "1997-08-13 22:00:00");
+        Mockito.when(service.getTimestamps(Mockito.anyList())).thenReturn(pairs);
+        
+        mockMvc.perform(MockMvcRequestBuilders.get("/timestamps")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.gene").value("1997-08-13 22:00:00"));
+    }
+}


### PR DESCRIPTION
Fix #6635

Describe changes proposed in this pull request:
- New endpoint
    - For every table that has endpoints that are being persistently
    cached the endpoint returns a table name timestamp pair of the
    last time the table was updated
    - If the table has never been updated, it instead returns
    the creation date of the table
- This feature requires SQL 5.7.2+ because the InnoDb engine did not
update this column correctly before then
    - updated the requirements in the docs to require 5.7 rather than 5.x

# Checks
- [ ] Runs on heroku
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.