### PR TITLE
Attach auth header when using oncokb service

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -39,6 +39,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ResourceUtils;
+import org.springframework.util.StringUtils;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -142,7 +143,6 @@ public class GlobalProperties {
     public static final String STUDY_VIEW_MDACC_HEATMAP_URL = "mdacc.heatmap.study.url";
     public static final String STUDY_VIEW_MDACC_HEATMAP_META_URL = "mdacc.heatmap.study.meta.url";
 
-    public static final String ONCOKB_PUBLIC_API_URL = "oncokb.public_api.url";
     public static final String SHOW_ONCOKB = "show.oncokb";
 
     private static String sessionServiceURL;
@@ -856,28 +856,6 @@ public class GlobalProperties {
     public static String getSessionServicePassword()
     {
         return sessionServicePassword;
-    }
-
-    public static String getOncoKBPublicApiUrl()
-    {
-        String oncokbApiUrl = portalProperties.getProperty(ONCOKB_PUBLIC_API_URL);
-        String showOncokb = portalProperties.getProperty(SHOW_ONCOKB);
-        
-        if(showOncokb == null || showOncokb.isEmpty()) {
-                    showOncokb = "true";
-        }
-        
-        // Empty string should be used if you want to disable the OncoKB annotation.
-        if(oncokbApiUrl == null || oncokbApiUrl.isEmpty()) {
-            oncokbApiUrl = "oncokb.org/api/v1";
-        }
-        
-        if(showOncokb.equals("true")) {
-           return oncokbApiUrl;
-        } else {
-           return "";
-        }
-        
     }
 
     public static String getCivicUrl() {

--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -9,7 +9,6 @@ window.legacySupportFrontendConfig = {
     appVersion : '<%=GlobalProperties.getAppVersion()%>',
     maxTreeDepth : <%=GlobalProperties.getMaxTreeDepth()%>,
     showOncoKB : <%=GlobalProperties.showOncoKB()%>,
-    oncoKBApiUrl : '<%=GlobalProperties.getOncoKBPublicApiUrl()%>',
     genomeNexusApiUrl : '<%=GlobalProperties.getGenomeNexusApiUrl()%>',
     showCivic : <%=GlobalProperties.showCivic()%>,
     showHotspot : <%=GlobalProperties.showHotspot()%>,

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -55,6 +55,12 @@
             org.apache.commons.fileupload.servlet.FileCleanerCleanup
         </listener-class>
     </listener>
+    <!-- App custom context listener -->
+    <listener>
+        <listener-class>
+            org.cbioportal.web.config.WebServletContextListener
+        </listener-class>
+    </listener>
     <!-- custom location for log4j config -->
     <listener>
       <listener-class>org.springframework.web.util.Log4jConfigListener</listener-class>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -159,6 +159,10 @@ segfile.url=http://cbio.mskcc.org/cancergenomics/gdac-portal/seg/
 # Enable OncoKB annotation (true, false)
 show.oncokb=true
 
+# OncoKB API Token, for more information please check https://www.oncokb.org/dataAccess
+# The token is required if you want to use OncoKB service
+oncokb.token=
+
 # Enable Chang's hotspot list (true, false)
 show.hotspot=true
 hotspots.url=https://www.cancerhotspots.org/api/

--- a/web/src/main/java/org/cbioportal/proxy/ProxyController.java
+++ b/web/src/main/java/org/cbioportal/proxy/ProxyController.java
@@ -1,10 +1,11 @@
 package org.cbioportal.proxy;
 
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,22 +18,60 @@ import java.nio.charset.StandardCharsets;
 
 @RestController
 public class ProxyController {
+    @Value("${show.oncokb:true}")
+    private Boolean showOncokb;
+    @Value("${oncokb.token:}")
+    private String oncokbToken;
+    @Value("${oncokb.public_api.url:www.oncokb.org}")
+    private String oncokbPublicApiUrl;
+
+    private Logger LOG = LoggerFactory.getLogger(ProxyController.class);
 
     @RequestMapping("/**")
     public String proxy(@RequestBody(required = false) String body, HttpMethod method, HttpServletRequest request)
         throws URISyntaxException {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        String contentType = request.getHeader("Content-Type");
+        if (contentType != null) {
+            httpHeaders.setContentType(MediaType.valueOf(contentType));
+        }
+        return exchangeData(body, buildUri(request.getPathInfo(), request.getQueryString(), false), method, httpHeaders).getBody();
+    }
 
-        String queryString = request.getQueryString();
-        URI uri = new URI("http:/" + request.getPathInfo() + (queryString == null ? "" : "?" + queryString));
+    @RequestMapping("/oncokb/**")
+    public ResponseEntity<String> proxyOncokb(@RequestBody(required = false) String body, HttpMethod method, HttpServletRequest request)
+        throws URISyntaxException {
+        if (!this.showOncokb) {
+            return new ResponseEntity<>("OncoKB service is disabled.", HttpStatus.NOT_FOUND);
+        }
 
         HttpHeaders httpHeaders = new HttpHeaders();
         String contentType = request.getHeader("Content-Type");
         if (contentType != null) {
             httpHeaders.setContentType(MediaType.valueOf(contentType));
         }
+        if (!StringUtils.isEmpty(this.oncokbToken)) {
+            httpHeaders.add("Authorization", "Bearer " + this.oncokbToken);
+        }
+        String oncokbApiUrl = this.oncokbPublicApiUrl;
+        if(StringUtils.isEmpty(oncokbApiUrl)) {
+            if (StringUtils.isEmpty(oncokbToken)) {
+                // this is a legacy endpoint which does not accept any data updates
+                oncokbApiUrl = "oncokb.org";
+            } else {
+                oncokbApiUrl = "www.oncokb.org";
+            }
+        }
+        return exchangeData(body, buildUri(oncokbApiUrl, request.getQueryString(), true), method, httpHeaders);
+    }
 
+    private URI buildUri(String path, String queryString, boolean useSecureProtocol) throws URISyntaxException {
+        return new URI((useSecureProtocol ? "https" : "http") + ":/" + path + (queryString == null ? "" : "?" + queryString));
+    }
+
+    private ResponseEntity<String> exchangeData(String body, URI uri, HttpMethod method, HttpHeaders httpHeaders) {
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.getMessageConverters().add(0, new StringHttpMessageConverter(StandardCharsets.UTF_8));
-        return restTemplate.exchange(uri, method, new HttpEntity<>(body, httpHeaders), String.class).getBody();
+        return restTemplate.exchange(uri, method, new HttpEntity<>(body, httpHeaders), String.class);
     }
 }

--- a/web/src/main/java/org/cbioportal/proxy/ProxyController.java
+++ b/web/src/main/java/org/cbioportal/proxy/ProxyController.java
@@ -40,6 +40,9 @@ public class ProxyController {
         if (!this.showOncokb) {
             return new ResponseEntity<>("OncoKB service is disabled.", HttpStatus.NOT_FOUND);
         }
+        else if (StringUtils.isEmpty(oncokbToken)) {
+            return new ResponseEntity<>("No OncoKB access token is provided.", HttpStatus.NOT_FOUND);
+        }
 
         HttpHeaders httpHeaders = initHeaders(request);
         
@@ -48,12 +51,7 @@ public class ProxyController {
         }
         String oncokbApiUrl = this.oncokbPublicApiUrl;
         if (StringUtils.isEmpty(oncokbApiUrl)) {
-            if (StringUtils.isEmpty(oncokbToken)) {
-                // this is a legacy endpoint which does not accept any data updates
-                oncokbApiUrl = "https://oncokb.org/api/v1";
-            } else {
-                oncokbApiUrl = "https://www.oncokb.org/api/v1";
-            }
+            oncokbApiUrl = "https://www.oncokb.org/api/v1";
         }
         return exchangeData(body, buildUri(oncokbApiUrl + request.getPathInfo().replaceFirst("/oncokb", ""), request.getQueryString()), method, httpHeaders);
     }

--- a/web/src/main/java/org/cbioportal/web/config/WebServletContextListener.java
+++ b/web/src/main/java/org/cbioportal/web/config/WebServletContextListener.java
@@ -32,7 +32,6 @@ public class WebServletContextListener implements ServletContextListener, Initia
         this.oncokbToken = getProperty("oncokb.token", "");
 
         if (this.showOncokb) {
-            System.out.println(this.properties.toString());
             checkOncokbInfo();
         }
     }

--- a/web/src/main/java/org/cbioportal/web/config/WebServletContextListener.java
+++ b/web/src/main/java/org/cbioportal/web/config/WebServletContextListener.java
@@ -1,0 +1,97 @@
+package org.cbioportal.web.config;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.InitializingBean;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import java.io.*;
+import java.util.Properties;
+
+/**
+ * Created by Hongxin Zhang on 11/15/19.
+ */
+public class WebServletContextListener implements ServletContextListener, InitializingBean {
+    private Boolean showOncokb;
+    
+    private String oncokbToken;
+    
+    private Properties properties;
+
+    @Override
+    public void contextDestroyed(ServletContextEvent arg0) {
+        System.out.println("ServletContextListener destroyed");
+    }
+
+    //Run this before web application is started
+    @Override
+    public void contextInitialized(ServletContextEvent arg0) {
+        this.properties = loadProperties(getResourceStream("portal.properties"));
+        
+        this.showOncokb = Boolean.parseBoolean(getProperty("show.oncokb", "true"));
+        this.oncokbToken = getProperty("oncokb.token", "");
+
+        if (this.showOncokb) {
+            System.out.println(this.properties.toString());
+            checkOncokbInfo();
+        }
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+    }
+
+    private void checkOncokbInfo() {
+        if(StringUtils.isEmpty(this.oncokbToken)) {
+            System.out.println("----------------------------------------------------------------------------------------------------------------");
+            // oncokb.org is deprecated, www.oncokb.org should be used
+            System.out.println("-- OncoKB requires a token to access the latest data.");
+            System.out.println("-- Please review oncokb terms(https://www.oncokb.org/terms) and register an account accordingly.");
+            System.out.println("-- For now, we will redirect the requests to a legacy instance which will not accept any new data changes.");
+            System.out.println("-- Thank you.");
+            System.out.println("----------------------------------------------------------------------------------------------------------------");
+        }
+    }
+    
+    private String getProperty(String key, String defaultValue) {
+        String propertyValue = this.properties.getProperty(key, defaultValue);
+        return System.getProperty(key, propertyValue);
+    }
+
+    private InputStream getResourceStream(String propertiesFileName)
+    {
+        String resourceFilename = null;
+        InputStream resourceFIS = null;
+
+        try {
+            String home = System.getenv("PORTAL_HOME");
+            if (home != null) {
+                resourceFilename =
+                    home + File.separator + propertiesFileName;
+                resourceFIS = new FileInputStream(resourceFilename);
+            }
+        } catch (FileNotFoundException e) {
+        }
+
+        if (resourceFIS == null) {
+            resourceFIS = this.getClass().getClassLoader().
+                getResourceAsStream(propertiesFileName);
+        }
+
+        return resourceFIS;
+    }
+    private Properties loadProperties(InputStream resourceInputStream)
+    {
+        Properties properties = new Properties();
+
+        try {
+            properties.load(resourceInputStream);
+            resourceInputStream.close();
+        }
+        catch (IOException e) {
+            System.out.println("Error loading properties file: " + e.getMessage());
+        }
+
+        return properties;
+    }
+}

--- a/web/src/main/java/org/cbioportal/web/config/WebServletContextListener.java
+++ b/web/src/main/java/org/cbioportal/web/config/WebServletContextListener.java
@@ -45,8 +45,8 @@ public class WebServletContextListener implements ServletContextListener, Initia
             System.out.println("----------------------------------------------------------------------------------------------------------------");
             // oncokb.org is deprecated, www.oncokb.org should be used
             System.out.println("-- OncoKB requires a token to access the latest data.");
-            System.out.println("-- Please review oncokb terms(https://www.oncokb.org/terms) and register an account accordingly.");
-            System.out.println("-- For now, we will redirect the requests to a legacy instance which will not accept any new data changes.");
+            System.out.println("-- You will not be able to use OncoKB service within your instance without an access token.");
+            System.out.println("-- Please review OncoKB terms(https://www.oncokb.org/terms) and register an account accordingly.");
             System.out.println("-- Thank you.");
             System.out.println("----------------------------------------------------------------------------------------------------------------");
         }

--- a/web/src/main/resources/applicationContext-proxy.xml
+++ b/web/src/main/resources/applicationContext-proxy.xml
@@ -9,6 +9,21 @@
      http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
      http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
+    <bean id="propertyPlaceholderConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE" />
+        <property name="searchSystemEnvironment" value="true" />
+        <property name="ignoreResourceNotFound" value="true" />
+        <property name="ignoreUnresolvablePlaceholders" value="true" />
+        <property name="locations">
+            <list>
+                <value>file:///${PORTAL_HOME}/portal.properties</value>
+                <value>classpath:portal.properties</value>
+                <value>classpath:maven.properties</value>
+                <value>classpath:git.properties</value>
+            </list>
+        </property>
+    </bean>
+
     <context:component-scan base-package="org.cbioportal.proxy" />
 
     <mvc:annotation-driven/>


### PR DESCRIPTION
fixes: #6950 
What the workflow is trying to do:
- Add an additional property to specify the oncokb token when using www.oncokb.org
- If the token is not specified, use a legacy instance(legacy.oncokb.org) and give a warning when building war file, and when deploy to the server(this is particularly important for docker instance)