### PR TITLE
Fix generic assay import issue

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -4079,6 +4079,8 @@ class GenericAssayWiseFileValidator(FeaturewiseFileValidator):
     def __init__(self, *args, **kwargs):
         """Initialize the instance attributes of the data file validator."""
         super(GenericAssayWiseFileValidator, self).__init__(*args, **kwargs)
+        # reset REQUIRED_HEADERS for each generic assay meta file, and then add headers defined in generic_entity_meta_properties
+        self.REQUIRED_HEADERS = ['ENTITY_STABLE_ID']
         self.REQUIRED_HEADERS.extend([x.strip() for x in self.meta_dict['generic_entity_meta_properties'].split(',')])
 
     REQUIRED_HEADERS = ['ENTITY_STABLE_ID']


### PR DESCRIPTION
Found a bug when trying to import multiple data files with different `generic_entity_meta_properties`. The validator will require all files contains the same header in the data file. This will fix the problem by resetting the `REQUIRED_HEADERS`.