### PR TITLE
Sample Quick Search 500s

### DIFF
--- a/web/src/main/java/org/cbioportal/web/SampleController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleController.java
@@ -100,7 +100,7 @@ public class SampleController {
             studyIds = studyService
                 .getAllStudies(
                     null,
-                    projection.name(),
+                    Projection.SUMMARY.name(), // force to summary so that post filter doesn't NPE
                     PagingConstants.MAX_PAGE_SIZE,
                     0,
                     null,


### PR DESCRIPTION
Fix #6813 (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- Cause
    - The sample quick search endpoint was breaking when given a request
    in an environment that requires auth and with a projection of META
    - It was breaking because the study service method it calls has a
    post filter that calls `split` on the study groups. When the projection
    was META, the groups field was `null` and the filter NPEed
- Solution
    - Make the study service request with a projection of SUMMARY
    regardless of the main request's projection
