### PR TITLE
Reintroduction of Cursor code to optimization memory usage of CoExpression Service

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
@@ -21,6 +21,10 @@ public interface MolecularDataRepository {
                                                               String projection);
 
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    Iterable<GeneMolecularAlteration> getGeneMolecularAlterationsIterable(String molecularProfileId, List<Integer> entrezGeneIds,
+                                                                          String projection);
+
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                                          List<Integer> entrezGeneIds,
                                                                                          String projection);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
@@ -6,6 +6,7 @@ import org.cbioportal.model.GenesetMolecularAlteration;
 import org.cbioportal.model.TreatmentMolecularAlteration;
 
 import java.util.List;
+import org.apache.ibatis.cursor.Cursor;
 
 public interface MolecularDataMapper {
 
@@ -13,6 +14,9 @@ public interface MolecularDataMapper {
 
     List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
                                                               String projection);
+
+    Cursor<GeneMolecularAlteration> getGeneMolecularAlterationsIter(String molecularProfileId, List<Integer> entrezGeneIds,
+                                                                    String projection);
 
     List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
                                                                                          List<Integer> entrezGeneIds, String projection);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
@@ -40,6 +40,16 @@ public class MolecularDataMyBatisRepository implements MolecularDataRepository {
     }
 
     @Override
+    // In order to return a cursor/iterator to the service layer, we need a transaction setup in the service
+    // layer. Currently, the bottom stackframe is CoExpressionService:getCoExpressions.  It is there where
+    // you will find the transaction created.
+    public Iterable<GeneMolecularAlteration> getGeneMolecularAlterationsIterable(String molecularProfileId, 
+                                                                                 List<Integer> entrezGeneIds, String projection) {
+
+        return molecularDataMapper.getGeneMolecularAlterationsIter(molecularProfileId, entrezGeneIds, projection);
+    }
+
+    @Override
     public List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
                                                                                                 List<Integer> entrezGeneIds, 
                                                                                                 String projection) {

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
@@ -63,6 +63,36 @@
         </where>
     </select>
 
+    <!-- This routine is a copy of getGeneMolecularAlterations above.  This copy is necessary because
+         it is backing a corresponding method in MolecularDataMapper.java which returns a Cursor as
+         opposed to a List. This method should be kept in sync with getGeneMolecularAlterations above.
+         (Attempts where made to share getGeneMolecularAlterations between methods in MolecularDataMapper.java
+         all of which have failed).
+    -->
+    <select id="getGeneMolecularAlterationsIter" resultType="org.cbioportal.model.GeneMolecularAlteration">
+        SELECT
+        gene.ENTREZ_GENE_ID AS entrezGeneId,
+        genetic_alteration.VALUES AS "values"
+        <if test="projection == 'DETAILED'">
+            ,
+            <include refid="org.cbioportal.persistence.mybatis.GeneMapper.select">
+                <property name="prefix" value="gene."/>
+            </include>
+        </if>
+        FROM genetic_alteration
+        INNER JOIN genetic_profile ON genetic_alteration.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
+        INNER JOIN gene ON genetic_alteration.GENETIC_ENTITY_ID = gene.GENETIC_ENTITY_ID
+        <where>
+            genetic_profile.STABLE_ID = #{molecularProfileId}
+            <if test="entrezGeneIds != null and !entrezGeneIds.isEmpty()">
+                AND gene.ENTREZ_GENE_ID IN
+                <foreach item="item" collection="entrezGeneIds" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+            </if>
+        </where>
+    </select>
+
     <select id="getGeneMolecularAlterationsInMultipleMolecularProfiles" resultType="org.cbioportal.model.GeneMolecularAlteration">
         SELECT
         gene.ENTREZ_GENE_ID AS entrezGeneId,

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepositoryTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -18,10 +19,10 @@ import java.util.List;
 @ContextConfiguration("/testContextDatabase.xml")
 @Configurable
 public class MolecularDataMyBatisRepositoryTest {
-    
+
     @Autowired
     private MolecularDataMyBatisRepository molecularDataMyBatisRepository;
-    
+
     @Test
     public void getCommaSeparatedSampleIdsOfMolecularProfile() throws Exception {
 
@@ -48,20 +49,43 @@ public class MolecularDataMyBatisRepositoryTest {
         List<Integer> entrezGeneIds = new ArrayList<>();
         entrezGeneIds.add(207);
         entrezGeneIds.add(208);
-        
+
         List<GeneMolecularAlteration> result = molecularDataMyBatisRepository.getGeneMolecularAlterations("study_tcga_pub_gistic",
             entrezGeneIds, "SUMMARY");
-        
+
+        getGeneMolecularAlterationsCommonTest(result);
+    }
+
+    @Test
+    @Transactional(readOnly=true)
+    public void getGeneMolecularAlterationsIterable() throws Exception {
+
+        List<Integer> entrezGeneIds = new ArrayList<>();
+        entrezGeneIds.add(207);
+        entrezGeneIds.add(208);
+
+        List<GeneMolecularAlteration> result = new ArrayList<>();
+        Iterable<GeneMolecularAlteration> gmaItr = molecularDataMyBatisRepository.getGeneMolecularAlterationsIterable("study_tcga_pub_gistic",
+                                                                                                                      entrezGeneIds, "SUMMARY");
+        for (GeneMolecularAlteration gma : gmaItr) {
+            result.add(gma);
+        }
+
+        getGeneMolecularAlterationsCommonTest(result);
+    }
+
+    private void getGeneMolecularAlterationsCommonTest(List<GeneMolecularAlteration> result) {
+
         Assert.assertEquals(2, result.size());
         GeneMolecularAlteration molecularAlteration1 = result.get(0);
         Assert.assertEquals((Integer) 207, molecularAlteration1.getEntrezGeneId());
         String[] expected = {"-0.4674","-0.6270","-1.2266","-1.2479","-1.2262","0.6962","-0.3338","-0.1264","0.7559","-1.1267","-0.5893",
-        "-1.1546","-1.0027","-1.3157",""};
+                             "-1.1546","-1.0027","-1.3157",""};
         Assert.assertArrayEquals(expected, molecularAlteration1.getSplitValues());
         GeneMolecularAlteration molecularAlteration2 = result.get(1);
         Assert.assertEquals((Integer) 208, molecularAlteration2.getEntrezGeneId());
         String[] expected2 = {"1.4146","-0.0662","-0.8585","-1.6576","-0.3552","-0.8306","0.8102","0.1146","0.3498","0.0349","0.4927",
-                "-0.8665","-0.4754","-0.7221",""};
+                              "-0.8665","-0.4754","-0.7221",""};
         Assert.assertArrayEquals(expected2, molecularAlteration2.getSplitValues());
     }
 
@@ -71,11 +95,11 @@ public class MolecularDataMyBatisRepositoryTest {
         List<Integer> entrezGeneIds = new ArrayList<>();
         entrezGeneIds.add(207);
         entrezGeneIds.add(208);
-        
+
         List<GeneMolecularAlteration> result = molecularDataMyBatisRepository
             .getGeneMolecularAlterationsInMultipleMolecularProfiles(Arrays.asList("study_tcga_pub_gistic", "study_tcga_pub_mrna"),
             entrezGeneIds, "SUMMARY");
-        
+
         Assert.assertEquals(3, result.size());
         GeneMolecularAlteration molecularAlteration1 = result.get(0);
         Assert.assertEquals((Integer) 207, molecularAlteration1.getEntrezGeneId());

--- a/service/src/main/java/org/cbioportal/service/MolecularDataService.java
+++ b/service/src/main/java/org/cbioportal/service/MolecularDataService.java
@@ -9,27 +9,27 @@ import java.util.List;
 
 public interface MolecularDataService {
 
-    List<GeneMolecularData> getMolecularData(String molecularProfileId, String sampleListId, 
-                                             List<Integer> entrezGeneIds, String projection) 
+    List<GeneMolecularData> getMolecularData(String molecularProfileId, String sampleListId,
+                                             List<Integer> entrezGeneIds, String projection)
         throws MolecularProfileNotFoundException;
 
-    BaseMeta getMetaMolecularData(String molecularProfileId, String sampleListId, List<Integer> entrezGeneIds) 
-        throws MolecularProfileNotFoundException;
-    
-    List<GeneMolecularData> fetchMolecularData(String molecularProfileId, List<String> sampleIds, 
-                                               List<Integer> entrezGeneIds, String projection) 
+    BaseMeta getMetaMolecularData(String molecularProfileId, String sampleListId, List<Integer> entrezGeneIds)
         throws MolecularProfileNotFoundException;
 
-    BaseMeta fetchMetaMolecularData(String molecularProfileId, List<String> sampleIds, List<Integer> entrezGeneIds) 
+    List<GeneMolecularData> fetchMolecularData(String molecularProfileId, List<String> sampleIds,
+                                               List<Integer> entrezGeneIds, String projection)
         throws MolecularProfileNotFoundException;
 
-   List<GeneMolecularAlteration> getMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds, 
-                                                         String projection) throws MolecularProfileNotFoundException;
-    
+    BaseMeta fetchMetaMolecularData(String molecularProfileId, List<String> sampleIds, List<Integer> entrezGeneIds)
+        throws MolecularProfileNotFoundException;
+
+    Iterable<GeneMolecularAlteration> getMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
+                                                              String projection) throws MolecularProfileNotFoundException;
+
     Integer getNumberOfSamplesInMolecularProfile(String molecularProfileId);
 
-    List<GeneMolecularData> getMolecularDataInMultipleMolecularProfiles(List<String> molecularProfileIds, 
-                                                                        List<String> sampleIds, List<Integer> entrezGeneIds, 
+    List<GeneMolecularData> getMolecularDataInMultipleMolecularProfiles(List<String> molecularProfileIds,
+                                                                        List<String> sampleIds, List<Integer> entrezGeneIds,
                                                                         String projection);
 
 	BaseMeta getMetaMolecularDataInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,

--- a/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java
@@ -8,11 +8,10 @@ import org.cbioportal.model.*;
 import org.cbioportal.model.CoExpression.GeneticEntityType;
 import org.cbioportal.persistence.MolecularDataRepository;
 import org.cbioportal.persistence.SampleListRepository;
-import org.cbioportal.model.CoExpression;
 import org.cbioportal.service.*;
 import org.cbioportal.service.exception.*;
-import org.cbioportal.service.CoExpressionService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -37,24 +36,13 @@ public class CoExpressionServiceImpl implements CoExpressionService {
     private SampleService sampleService;
 
     @Override
-    public List<CoExpression> getCoExpressions(String molecularProfileId, String sampleListId, String geneticEntityId,
-            CoExpression.GeneticEntityType geneticEntityType, Double threshold)
-            throws MolecularProfileNotFoundException, GenesetNotFoundException, GeneNotFoundException {
-
-        List<String> sampleIds = sampleListRepository.getAllSampleIdsInSampleList(sampleListId);
-        if (sampleIds.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        return fetchCoExpressions(molecularProfileId, sampleIds, geneticEntityId, geneticEntityType, threshold);
-    }
-
-    @Override
+    // transaction needs to be setup here in order to return Iterable from molecularDataService in fetchCoExpressions
+    @Transactional(readOnly=true)
     public List<CoExpression> getCoExpressions(String geneticEntityId, CoExpression.GeneticEntityType geneticEntityType,
             String sampleListId, String molecularProfileIdA, String molecularProfileIdB, Double threshold)
             throws MolecularProfileNotFoundException, SampleListNotFoundException, GenesetNotFoundException,
             GeneNotFoundException {
-        
+
         if (molecularProfileIdA.equals(molecularProfileIdB)) {
             return getCoExpressions(molecularProfileIdA, sampleListId, geneticEntityId, geneticEntityType, threshold);
         }
@@ -94,30 +82,48 @@ public class CoExpressionServiceImpl implements CoExpressionService {
     }
 
     @Override
+    public List<CoExpression> getCoExpressions(String molecularProfileId, String sampleListId, String geneticEntityId,
+                                               CoExpression.GeneticEntityType geneticEntityType, Double threshold)
+        throws MolecularProfileNotFoundException, GenesetNotFoundException, GeneNotFoundException {
+
+        List<String> sampleIds = sampleListRepository.getAllSampleIdsInSampleList(sampleListId);
+        if (sampleIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return fetchCoExpressions(molecularProfileId, sampleIds, geneticEntityId, geneticEntityType, threshold);
+    }
+
+    @Override
     public List<CoExpression> fetchCoExpressions(String molecularProfileId, List<String> sampleIds, 
                                                  String queryGeneticEntityId, CoExpression.GeneticEntityType geneticEntityType, 
                                                  Double threshold)
         throws MolecularProfileNotFoundException, GenesetNotFoundException, GeneNotFoundException {
-        
-        List<? extends MolecularAlteration> molecularAlterations = null;
+
+        // For the purpose of the CoExpression computation, we separate the MolecularAlteration
+        // (genetic_alteration table record) for the query gene/geneset from the MolecularAlteration(s)
+        // for the remaining genes/geneset in the profile.
+        MolecularAlteration queryMolecularDataList = null;
+        Iterable<? extends MolecularAlteration> maItr = null;
         if (geneticEntityType.equals(GeneticEntityType.GENE)) {
-            molecularAlterations = molecularDataService.getMolecularAlterations(
-                molecularProfileId, null, "SUMMARY");
+            List<Integer> queryGeneticEntityIds = Arrays.asList(Integer.valueOf(queryGeneticEntityId));
+            maItr = molecularDataService.getMolecularAlterations(molecularProfileId, queryGeneticEntityIds, "SUMMARY");
         } else if (geneticEntityType.equals(GeneticEntityType.GENESET)) {
-            molecularAlterations = genesetDataService.getGenesetAlterations(
-                molecularProfileId, null);
+            List<String> queryGeneticEntityIds = Arrays.asList(queryGeneticEntityId);
+            maItr = genesetDataService.getGenesetAlterations(molecularProfileId, queryGeneticEntityIds);
         }
-
-        Map<String, MolecularAlteration> molecularDataMap = molecularAlterations.stream()
-                .collect(Collectors.toMap(MolecularAlteration::getStableId, Function.identity()));
-        MolecularAlteration queryMolecularDataList = molecularDataMap.remove(queryGeneticEntityId);
-        
-        List<CoExpression> coExpressionList = new ArrayList<>();
-
+        for (MolecularAlteration ma : maItr) {
+            queryMolecularDataList = ma;
+        }
         if (queryMolecularDataList == null) {
-            return coExpressionList;
+            return Collections.emptyList();
         }
 
+        // These next few lines are used to build a map of internal sample ids to
+        // indices into the genetic_alteration.VALUES column. Recall this column
+        // of the genetic_alteration table is a comma separated list of scalar values.
+        // Each value in this list is associated with a sample at the same position found in
+        // the genetic_profile_samples.ORDERED_SAMPLE_LIST column.
         String commaSeparatedSampleIdsOfMolecularProfile = molecularDataRepository
             .getCommaSeparatedSampleIdsOfMolecularProfile(molecularProfileId);
         List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfile.split(","))
@@ -127,6 +133,9 @@ public class CoExpressionServiceImpl implements CoExpressionService {
             internalSampleIdToIndexMap.put(internalSampleIds.get(lc), lc);
         }
 
+        // These next few lines build a list of Sample from the sampleIds method parameter (the user query).
+        // A map is then built of internal sample ids to indices into the Sample list (although the map is
+        // only used to quickly identify if a sample in the molecular profile is part of the user query - see below).
         MolecularProfile molecularProfile = molecularProfileService.getMolecularProfile(molecularProfileId);
         List<String> studyIds = new ArrayList<>();
         sampleIds.forEach(s -> studyIds.add(molecularProfile.getCancerStudyIdentifier()));
@@ -136,32 +145,56 @@ public class CoExpressionServiceImpl implements CoExpressionService {
             selectedSampleIdsMap.put(samples.get(lc).getInternalId(), lc);
         }
 
+        // These next few lines build a list of indices into the genetic_alteration.VALUES
+        // column by iterating over all the samples in the molecular profile (method parameter)
+        // and selecting only samples that are included in the user query.
         Set<Integer> includedIndexes = new HashSet<>();
         for (Integer internalSampleId : internalSampleIds) {
             if (selectedSampleIdsMap.containsKey(internalSampleId)) {
                 includedIndexes.add(internalSampleIdToIndexMap.get(internalSampleId));
             }
         }
-        
+
         Boolean isMolecularProfileBOfGenesetType = molecularProfile.getMolecularAlterationType()
-                .equals(MolecularProfile.MolecularAlterationType.GENESET_SCORE);
+            .equals(MolecularProfile.MolecularAlterationType.GENESET_SCORE);
+
+
+        // These next few lines filter out genetic_alteration values from the query gene/geneset
+        // genetic_alteration.VALUES column by considering only the indices of the samples in the user query.
         List<String> queryValues = Arrays.asList(queryMolecularDataList.getSplitValues());
         List<String> includedQueryValues = includedIndexes.stream().map(index -> queryValues.get(index))
-                .collect(Collectors.toList());
+            .collect(Collectors.toList());
 
-        Map<String,List<String>> values = new HashMap<String,List<String>>();
-        for (String entityId : molecularDataMap.keySet()) {
-            List<String> internalValues = new ArrayList<>(
-                    Arrays.asList(molecularDataMap.get(entityId).getSplitValues()));
-            List<String> includedInternalValues = includedIndexes.stream().map(index -> internalValues.get(index))
-                    .collect(Collectors.toList());
-            values.put(entityId, includedInternalValues);
+        // Get an iterator to all the MolecularAlteration (genetic_alteration table records) in the profile
+        if (geneticEntityType.equals(GeneticEntityType.GENE)) {
+            maItr = molecularDataService.getMolecularAlterations(molecularProfileId, null, "SUMMARY");
+        } else if (geneticEntityType.equals(GeneticEntityType.GENESET)) {
+            maItr = genesetDataService.getGenesetAlterations(molecularProfileId, null);
         }
-        coExpressionList = computeCoExpressions(values, includedQueryValues, isMolecularProfileBOfGenesetType, threshold, molecularProfileId);
-        return coExpressionList;
+
+        // For each MolecularAlteration in the profile, compute a CoExpression to return.
+        // If the MolecularAlteration is for the query gene/geneset, skip it.  Otherwise,
+        // filter out genetic_alteration values from genetic_alteration.VALUES
+        // by considering oly the indices of the samples in the user query.
+        List<CoExpression> toReturn = new ArrayList<>();
+        for (MolecularAlteration ma : maItr) {
+            String entityId = ma.getStableId();
+            if (entityId.equals(queryGeneticEntityId)) {
+                continue;
+            }
+            List<String> internalValues = new ArrayList<>(Arrays.asList(ma.getSplitValues()));
+            List<String> values = includedIndexes.stream().map(index -> internalValues.get(index)).collect(Collectors.toList());
+            CoExpression ce = computeCoExpressions(entityId, values, includedQueryValues, isMolecularProfileBOfGenesetType, threshold, molecularProfileId);
+            if (ce != null) {
+                toReturn.add(ce);
+            }
+        }
+        return toReturn;
     }
 
     @Override
+    // transaction needs to be setup here in order to return Iterable from molecularDataService in fetchCoExpressions
+    @Transactional(readOnly=true)
     public List<CoExpression> fetchCoExpressions(String geneticEntityId,
             CoExpression.GeneticEntityType geneticEntityType, List<String> sampleIds, String molecularProfileIdB,
             String molecularProfileIdA, Double threshold) throws MolecularProfileNotFoundException, GenesetNotFoundException, GeneNotFoundException {
@@ -199,87 +232,82 @@ public class CoExpressionServiceImpl implements CoExpressionService {
     private List<CoExpression> computeCoExpressionsFromMolecularData(List<? extends MolecularData> molecularDataListB,
             Boolean isMolecularProfileBOfGenesetType, List<? extends MolecularData> molecularDataListA,
             String queryGeneticEntityId, Double threshold, String molecularProfileId) throws GenesetNotFoundException, GeneNotFoundException {
-        
+
         Map<String , List<MolecularData>> molecularDataMapA = molecularDataListA.stream()
             .collect(Collectors.groupingBy(MolecularData::getStableId));
         Map<String , List<MolecularData>> molecularDataMapB = molecularDataListB.stream()
             .collect(Collectors.groupingBy(MolecularData::getStableId));
-        
-        List<CoExpression> coExpressionList = new ArrayList<>();
-        
+
         if (!molecularDataMapA.keySet().contains(queryGeneticEntityId)) {
-            return coExpressionList;
+            return Collections.emptyList();
         }
 
         List<? extends MolecularData> finalMolecularDataListA = (List<? extends MolecularData>)molecularDataMapA.remove(queryGeneticEntityId);
         if (molecularDataMapB.get(queryGeneticEntityId) != null) {
             List<? extends MolecularData> finalMolecularDataListB = (List<? extends MolecularData>)molecularDataMapB.remove(queryGeneticEntityId);
             if (finalMolecularDataListB == null) {
-                return coExpressionList;
+                return Collections.emptyList();
             }
         }
 
-        Map<String,List<String>> values = new HashMap<String,List<String>>();
+        List<CoExpression> coExpressionList = new ArrayList<>();
+        List<String> valuesB = finalMolecularDataListA.stream().map(g -> g.getValue()).collect(Collectors.toList());
         for (String entityId : molecularDataMapB.keySet()) {
             List<String> internalValues = molecularDataMapB.get(entityId).stream().map(g -> g.getValue())
                 .collect(Collectors.toList());
-            values.put(entityId, internalValues);
+            CoExpression co = computeCoExpressions(entityId, internalValues, valuesB, isMolecularProfileBOfGenesetType, threshold, molecularProfileId);
+            if (co != null) {
+                coExpressionList.add(co);
+            }
         }
-        List<String> valuesB = finalMolecularDataListA.stream().map(g -> g.getValue()).collect(Collectors.toList());
-        coExpressionList = computeCoExpressions(values, valuesB, isMolecularProfileBOfGenesetType, threshold, molecularProfileId);
 
         return coExpressionList;
 
     }
 
-    private List<CoExpression> computeCoExpressions(Map<String, List<String>> valuesA, List<String> valuesB, 
+    private CoExpression computeCoExpressions(String entityId, List<String> valuesA, List<String> valuesB, 
             Boolean isMolecularProfileBOfGenesetType, Double threshold, String molecularProfileId) throws GenesetNotFoundException, GeneNotFoundException {
 
-        List<CoExpression> coExpressionList = new ArrayList<>();
-        for (String entityId : valuesA.keySet()) {
-            List<String> values = valuesA.get(entityId);
-            List<String> valuesBCopy = new ArrayList<>(valuesB);
+        List<String> valuesACopy = new ArrayList<>(valuesA);
+        List<String> valuesBCopy = new ArrayList<>(valuesB);
 
-            List<Integer> valuesToRemove = new ArrayList<>();
-            for (int i = 0; i < valuesBCopy.size(); i++) {
-                if (!NumberUtils.isNumber(valuesBCopy.get(i)) || !NumberUtils.isNumber(values.get(i))) {
-                    valuesToRemove.add(i);
-                }
+        List<Integer> valuesToRemove = new ArrayList<>();
+        for (int i = 0; i < valuesBCopy.size(); i++) {
+            if (!NumberUtils.isNumber(valuesBCopy.get(i)) || !NumberUtils.isNumber(valuesACopy.get(i))) {
+                valuesToRemove.add(i);
             }
-
-            for (int i = 0; i < valuesToRemove.size(); i++) {
-                int valueToRemove = valuesToRemove.get(i) - i;
-                valuesBCopy.remove(valueToRemove);
-                values.remove(valueToRemove);
-            }
-            
-            CoExpression coExpression = new CoExpression();
-            coExpression.setGeneticEntityId(entityId);
-            
-            double[] valuesBNumber = valuesBCopy.stream().mapToDouble(Double::parseDouble).toArray();
-            double[] valuesNumber = values.stream().mapToDouble(Double::parseDouble).toArray();
-
-            if (valuesNumber.length <= 2) {
-                continue;
-            }
-            
-            double[][] arrays = new double[2][valuesNumber.length];
-            arrays[0] = valuesBNumber;
-            arrays[1] = valuesNumber;
-            SpearmansCorrelation spearmansCorrelation = new SpearmansCorrelation((new Array2DRowRealMatrix(arrays, false)).transpose());
-
-            double spearmansValue = spearmansCorrelation.correlation(valuesBNumber, valuesNumber);
-            if (Double.isNaN(spearmansValue) || Math.abs(spearmansValue) < threshold) {
-                continue;
-            }
-            coExpression.setSpearmansCorrelation(BigDecimal.valueOf(spearmansValue));
-
-            RealMatrix resultMatrix = spearmansCorrelation.getRankCorrelation().getCorrelationPValues();
-            coExpression.setpValue(BigDecimal.valueOf(resultMatrix.getEntry(0, 1)));
-            
-            coExpressionList.add(coExpression);
         }
-        
-        return coExpressionList;
+
+        for (int i = 0; i < valuesToRemove.size(); i++) {
+            int valueToRemove = valuesToRemove.get(i) - i;
+            valuesBCopy.remove(valueToRemove);
+            valuesACopy.remove(valueToRemove);
+        }
+
+        CoExpression coExpression = new CoExpression();
+        coExpression.setGeneticEntityId(entityId);
+
+        double[] valuesBNumber = valuesBCopy.stream().mapToDouble(Double::parseDouble).toArray();
+        double[] valuesANumber = valuesACopy.stream().mapToDouble(Double::parseDouble).toArray();
+
+        if (valuesANumber.length <= 2) {
+            return null;
+        }
+
+        double[][] arrays = new double[2][valuesANumber.length];
+        arrays[0] = valuesBNumber;
+        arrays[1] = valuesANumber;
+        SpearmansCorrelation spearmansCorrelation = new SpearmansCorrelation((new Array2DRowRealMatrix(arrays, false)).transpose());
+
+        double spearmansValue = spearmansCorrelation.correlation(valuesBNumber, valuesANumber);
+        if (Double.isNaN(spearmansValue) || Math.abs(spearmansValue) < threshold) {
+            return null;
+        }
+        coExpression.setSpearmansCorrelation(BigDecimal.valueOf(spearmansValue));
+
+        RealMatrix resultMatrix = spearmansCorrelation.getRankCorrelation().getCorrelationPValues();
+        coExpression.setpValue(BigDecimal.valueOf(resultMatrix.getEntry(0, 1)));
+
+        return coExpression;
     }
 }

--- a/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
@@ -36,7 +36,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
     public List<GeneMolecularData> getMolecularData(String molecularProfileId, String sampleListId,
                                                     List<Integer> entrezGeneIds, String projection)
         throws MolecularProfileNotFoundException {
-        
+
         validateMolecularProfile(molecularProfileId);
         List<String> sampleIds = sampleListRepository.getAllSampleIdsInSampleList(sampleListId);
         if (sampleIds.isEmpty()) {
@@ -48,7 +48,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
     @Override
     public BaseMeta getMetaMolecularData(String molecularProfileId, String sampleListId, List<Integer> entrezGeneIds) 
         throws MolecularProfileNotFoundException {
-        
+
         BaseMeta baseMeta = new BaseMeta();
         baseMeta.setTotalCount(getMolecularData(molecularProfileId, sampleListId, entrezGeneIds, "ID").size());
         return baseMeta;
@@ -86,7 +86,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
 
         List<GeneMolecularAlteration> molecularAlterations = molecularDataRepository.getGeneMolecularAlterations(
             molecularProfileId, entrezGeneIds, projection);
-        
+
         for (Sample sample : samples) {
             Integer indexOfSampleId = internalSampleIdsMap.get(sample.getInternalId());
             if (indexOfSampleId != null) {
@@ -103,26 +103,26 @@ public class MolecularDataServiceImpl implements MolecularDataService {
                 }
             }
         }
-        
+
         return molecularDataList;
     }
 
     @Override
     public BaseMeta fetchMetaMolecularData(String molecularProfileId, List<String> sampleIds, 
                                            List<Integer> entrezGeneIds) throws MolecularProfileNotFoundException {
-        
+
         BaseMeta baseMeta = new BaseMeta();
         baseMeta.setTotalCount(fetchMolecularData(molecularProfileId, sampleIds, entrezGeneIds, "ID").size());
         return baseMeta;
     }
 
     @Override
-    public List<GeneMolecularAlteration> getMolecularAlterations(String molecularProfileId, 
-                                                                 List<Integer> entrezGeneIds, String projection)
+    public Iterable<GeneMolecularAlteration> getMolecularAlterations(String molecularProfileId, 
+                                                                     List<Integer> entrezGeneIds, String projection)
         throws MolecularProfileNotFoundException {
 
         validateMolecularProfile(molecularProfileId);
-        return molecularDataRepository.getGeneMolecularAlterations(molecularProfileId, entrezGeneIds, projection);
+        return molecularDataRepository.getGeneMolecularAlterationsIterable(molecularProfileId, entrezGeneIds, projection);
     }
 
     @Override
@@ -133,7 +133,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
         if (commaSeparatedSampleIdsOfMolecularProfile == null) {
             return null;
         }
-        
+
         return commaSeparatedSampleIdsOfMolecularProfile.split(",").length;
     }
 
@@ -149,7 +149,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
 
         Map<String, Map<Integer, Integer>> internalSampleIdsMap = new HashMap<>();
         List<Integer> allInternalSampleIds = new ArrayList<>();
-        
+
         for (int i = 0; i < distinctMolecularProfileIds.size(); i++) {
             List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfiles.get(i).split(","))
                 .mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
@@ -188,7 +188,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
             .getGeneMolecularAlterationsInMultipleMolecularProfiles(distinctMolecularProfileIds, entrezGeneIds, projection);
         Map<String, List<GeneMolecularAlteration>> molecularAlterationsMap = molecularAlterations.stream().collect(
             Collectors.groupingBy(GeneMolecularAlteration::getMolecularProfileId));
-        
+
         for (Sample sample : samples) {
             for (MolecularProfile molecularProfile : molecularProfileMapByStudyId.get(sample.getCancerStudyIdentifier())) {
                 String molecularProfileId = molecularProfile.getStableId();
@@ -212,7 +212,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
                 }
             }
         }
-        
+
         return molecularDataList;
 	}
 
@@ -220,7 +220,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
     @PreAuthorize("hasPermission(#molecularProfileIds, 'Collection<MolecularProfileId>', 'read')")
 	public BaseMeta getMetaMolecularDataInMultipleMolecularProfiles(List<String> molecularProfileIds,
 			List<String> sampleIds, List<Integer> entrezGeneIds) {
-                
+
 		BaseMeta baseMeta = new BaseMeta();
         baseMeta.setTotalCount(getMolecularDataInMultipleMolecularProfiles(molecularProfileIds, sampleIds, entrezGeneIds, "ID")
             .size());


### PR DESCRIPTION
As a follow-up to the investigation of crashes on public portal backend (the source of which has now been identified as requests to the CoExpression service), the PR reintroduces the use of Cursors as a way to limit the amount of heap used by the CoExpression service implementation.

The following screen shots were made by profiling the CoExpression service satisfying requests against the Cancer Cell Line Encyclopedia (Broad, 2019) with a query gene of SCML2.

On multiple occasions, at its peak memory usage, the CoExpression services uses over 7GB to satisfy a request.  The is the result of an accumulation of GeneMolecularAlteration instances and a pileup of [calls to string splitting](https://github.com/cBioPortal/cbioportal/blob/master/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java#L155).   In this case, we have ~33k instances of GeneMolecularAlteration instances, each of which contains > 1500 alteration measurements (string splitting results in close to 50 million strings made for each entity-sample measurement). The GeneMolecularAlteration instances (and resultant genetic alteration strings due to string splitting) are accumulated in memory before any spearman correlation computations are made.  

The following screenshot is an example memory telemetries which highlights the peak memory (7.89GB) consumption of a CoExpression service call (this was the greatest peak capture during profiling):

![image](https://user-images.githubusercontent.com/366003/69080535-2f6f5e80-0a0a-11ea-9521-bc2093804d64.png)


With the introduction of cursors, there is only a single GeneMolecularAlteration instance is in memory at any one moment in time (well two, because the one representing the "query" entity is kept in memory for the correlation computation).  Once the spearman correlation is made for this GeneMolecularAlteration instance, the instance is discarded and the next one is fetched from memory.

This screenshot is an example memory telemetry which highlights peak memory (5.73 GB) consumption with the introduction of cursors:

![image](https://user-images.githubusercontent.com/366003/69080630-5af24900-0a0a-11ea-94c2-4c6cf46e9a1d.png)

Timings captured indicated that cursors do not add any overhead to satisfying the CoExpression request.  In all captured cases, cursors outperformed the not-cursor implementation 

In this example, pre-cursor code completes in ~41 seconds

![image](https://user-images.githubusercontent.com/366003/69081059-3054c000-0a0b-11ea-9636-39ee821f6fd7.png)

With cursor code, the request takes 38 seconds:

![image](https://user-images.githubusercontent.com/366003/69081103-511d1580-0a0b-11ea-80df-69f5bd4f9bfa.png)

While results will probably vary based on the host environment and datasets evaluated, the introduction of cursors do seem to benefit the CoExpression service implementation.


