### PR TITLE
Frontend Config Additions

### DIFF
--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -278,3 +278,13 @@ ehcache.cache_type=none
 
 # ensembl URL template for transcript lookup in Mutations tab. Default is http://grch37.ensembl.org/homo_sapiens/Transcript/Summary?t=<%= transcriptId %>
 #ensembl.transcript_url=http://ensembl.org/homo_sapiens/Transcript/Summary?t=<%= transcriptId %>
+
+# Enable/disable Persistent Cache (true, false)
+# The Persistent Cache is a frontend feature that is used to cache semi static
+# data produced by APIs. It uses IndexedDB as a means for persistent storage.
+# This feature is disabled by default.
+# enable_persistent_cache=true
+
+# Limit the size of gene queries (number). gene count * sample count < query_product_limit
+# This limit is enforced on the frontend.
+query_product_limit=1000000


### PR DESCRIPTION
Fix #6635

Describe changes proposed in this pull request:
- query_product_limit: Limits the size of gene queries
    - Didn't this happen a while ago? Yes. This was released in
    3.1.1, but I didn't know I needed to change this. Sorry.
- persistent_cache: Enables the frontend persistent cache