### PR TITLE
Add portal/common/FreeSans.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ portal/Portal-Google-Code.ipr
 portal/Portal-Google-Code.iws
 portal/Portal.iml
 portal/portal.log
+portal/common/FreeSans.json
 portal/nbproject
 portal/build
 portal/images


### PR DESCRIPTION


Fix # (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- This font file pops up every time I build and I
am sick of deleting it
- It looks like its being used in the frontend by
`svgToPdfDownload`, so I think it has a right to be
here