### PR TITLE
Add Ensembl URL template property

### DIFF
--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -2,6 +2,7 @@ This page describes the main properties within portal.properties.
 
 - [Database Settings](#database-settings)
 - [cBioPortal Customization](#cbioportal-customization)
+- [Ensembl transcript lookup URL](#ensembl-transcript-lookup)
 - [Segment File URL](#segment-file-url)
 - [Bitly API Username and Key](#bitly-api-username-and-key)
 - [Google Analytics](#google-analytics)
@@ -147,6 +148,13 @@ Different samples of a patient may have been analyzed with different gene panels
 ```
 skin.patientview.filter_genes_profiled_all_samples=
 ```
+# Ensembl transcript lookup URL
+The Mutations tab contains various links, redirecting the user to external information resources regarding the displayed transcript. The Ensembl template URL can be customized by modifying the property:
+```
+ensembl.transcript_url=
+```
+The default setting is `http://ensembl.org/homo_sapiens/Transcript/Summary?t=<%= transcriptId %>`. The `<%= transcriptId %>` is substituted by the frontend code into respective transcript ID.
+
 
 # Segment File URL
 

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -102,7 +102,8 @@
             "bitly.api_key",
             "bitly.user",
             "bitly.access.token",
-            "oncoprint.custom_driver_annotation.tiers.default"
+            "oncoprint.custom_driver_annotation.tiers.default",
+            "ensembl.transcript_url"
            
         }; 
     

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -279,3 +279,6 @@ matchminer.token=
 # see: https://github.com/vy/hrrs/blob/master/README.md
 #hrrs.logging.filepath=
 #hrrs.enable.logging=false
+
+# ensembl URL template for transcript lookup in Mutations tab. Default is http://grch37.ensembl.org/homo_sapiens/Transcript/Summary?t=<%= transcriptId %>
+#ensembl.transcript_url=http://ensembl.org/homo_sapiens/Transcript/Summary?t=<%= transcriptId %>


### PR DESCRIPTION
@onursumer adjusted the frontend code to make the Ensembl Transcript URL in the Mutations tab customizable (see https://github.com/cBioPortal/cbioportal-frontend/pull/2885 and https://github.com/cBioPortal/cbioportal/issues/6828).

This PR contains corresponding backend changes.
- the property `ensembl.transcript_url` is parsed from `portal.properties`, and forwarded to the frontend.
- documentation updates.

Successfully tested on local frontend deploy.
