### PR TITLE
Re-enable support for posted query data

### DIFF
--- a/portal/src/main/webapp/index.jsp
+++ b/portal/src/main/webapp/index.jsp
@@ -1,10 +1,31 @@
+<%@ taglib prefix = "c" uri = "http://java.sun.com/jsp/jstl/core" %>
+<%@ page import="org.mskcc.cbio.portal.util.GlobalProperties" %>
+<%@ page import="java.util.HashMap" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="java.util.Enumeration" %>
+<%@ page import="org.json.simple.JSONObject" %>
+
 <%
     String url = request.getRequestURL().toString();
     String baseUrl = url.substring(0, url.length() - request.getRequestURI().length()) + request.getContextPath();
     baseUrl = baseUrl.replace("https://", "").replace("http://", "");
+    
+    // to support posted query data (when data would exceed URL length)
+    // write all post params to json on page where it can be consumed
+    String paramsJsonString = "null";
+    if (request.getMethod().equals("POST")) {
+        Enumeration enumeration = request.getParameterNames();
+        JSONObject paramsJson = new JSONObject();
+        while (enumeration.hasMoreElements()) {
+            String parameterName = (String) enumeration.nextElement();
+            paramsJson.put(parameterName, request.getParameter(parameterName));
+        }
+        paramsJsonString = paramsJson.toString();
+    }
+    
 %>
-<%@ taglib prefix = "c" uri = "http://java.sun.com/jsp/jstl/core" %>
-<%@ page import="org.mskcc.cbio.portal.util.GlobalProperties" %>
+
+
 <!DOCTYPE html>
 <html class="cbioportal-frontend">
 <head>
@@ -18,6 +39,9 @@
     <title>cBioPortal for Cancer Genomics</title>
     
     <script>
+        
+        var postData = <%=paramsJsonString%>;
+        
         window.frontendConfig = {
             configurationServiceUrl:"//" + '<%=baseUrl%>' +  "/config_service.jsp",
             appVersion:'<%=GlobalProperties.getAppVersion()%>',


### PR DESCRIPTION
Portal queries often contain too much data to represent in URL.  In the past the portal allowed users to post query data to the results page, which would treat posted parameters the same as if they were in URL.   We stopped support for this when we switched to SPA.  This PR (and an associated frontend PR) will resume this feature.