### PR TITLE
Update generic assay importer (provide updateInfo option when import)

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
@@ -540,8 +540,6 @@ public final class DaoCancerStudy {
     public static void deleteCancerStudy(int internalCancerStudyId) throws DaoException {
         String[] deleteStudyStatements = {
                 "DELETE FROM sample_cna_event WHERE GENETIC_PROFILE_ID IN (SELECT GENETIC_PROFILE_ID FROM genetic_profile WHERE CANCER_STUDY_ID=?)",
-                "DELETE FROM generic_entity_properties WHERE GENETIC_ENTITY_ID IN (SELECT GENETIC_ENTITY_ID FROM genetic_alteration WHERE GENETIC_PROFILE_ID IN (SELECT GENETIC_PROFILE_ID FROM genetic_profile WHERE CANCER_STUDY_ID=?))",
-                "DELETE FROM genetic_entity WHERE ID IN (SELECT GENETIC_ENTITY_ID FROM genetic_alteration WHERE GENETIC_PROFILE_ID IN (SELECT GENETIC_PROFILE_ID FROM genetic_profile WHERE CANCER_STUDY_ID=? AND GENETIC_ALTERATION_TYPE='GENERIC_ASSAY'))",
                 "DELETE FROM genetic_alteration WHERE GENETIC_PROFILE_ID IN (SELECT GENETIC_PROFILE_ID FROM genetic_profile WHERE CANCER_STUDY_ID=?)",
                 "DELETE FROM genetic_profile_samples WHERE GENETIC_PROFILE_ID IN (SELECT GENETIC_PROFILE_ID FROM genetic_profile WHERE CANCER_STUDY_ID=?)",
                 "DELETE FROM sample_profile WHERE GENETIC_PROFILE_ID IN (SELECT GENETIC_PROFILE_ID FROM genetic_profile WHERE CANCER_STUDY_ID=?)",
@@ -577,6 +575,7 @@ public final class DaoCancerStudy {
         ResultSet rs = null;
         try {
             con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
+            deleteGenericAssayMeta(internalCancerStudyId);
             for (String statementString : deleteStudyStatements) {
                 pstmt = con.prepareStatement(statementString);
                 if (statementString.contains("?")) {
@@ -614,6 +613,37 @@ public final class DaoCancerStudy {
                 pstmt = con.prepareStatement(statementString);
                 pstmt.executeUpdate();
                 pstmt.close();
+            }
+        } catch (SQLException e) {
+            throw new DaoException(e);
+        } finally {
+            JdbcUtil.closeAll(DaoCancerStudy.class, con, pstmt, rs);
+        }
+    }
+
+    /**
+     * delete generic assay meta records if meta is not shared with other studies
+     * @throws DaoException
+     */
+    public static void deleteGenericAssayMeta(int internalCancerStudyId) throws DaoException {
+        String[] deleteGenericAssayStatements = {
+                "DELETE FROM generic_entity_properties WHERE GENETIC_ENTITY_ID IN (SELECT GENETIC_ENTITY_ID FROM genetic_alteration WHERE GENETIC_PROFILE_ID IN (SELECT GENETIC_PROFILE_ID FROM genetic_profile WHERE CANCER_STUDY_ID=?))",
+                "DELETE FROM genetic_entity WHERE ID IN (SELECT GENETIC_ENTITY_ID FROM genetic_alteration WHERE GENETIC_PROFILE_ID IN (SELECT GENETIC_PROFILE_ID FROM genetic_profile WHERE CANCER_STUDY_ID=? AND GENETIC_ALTERATION_TYPE='GENERIC_ASSAY'))"
+                };
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+        try {
+            con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
+            if (DaoGenericAssay.shouldGenericAssayMetaBeDeleted(internalCancerStudyId)) {
+                for (String statementString : deleteGenericAssayStatements) {
+                    pstmt = con.prepareStatement(statementString);
+                    if (statementString.contains("?")) {
+                        pstmt.setInt(1, internalCancerStudyId);
+                    }
+                    pstmt.executeUpdate();
+                    pstmt.close();
+                }
             }
         } catch (SQLException e) {
             throw new DaoException(e);

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
@@ -574,8 +574,11 @@ public final class DaoCancerStudy {
         PreparedStatement pstmt = null;
         ResultSet rs = null;
         try {
+            // check whether should delete generic assay meta
+            if (DaoGenericAssay.geneticEntitiesOnlyExistInSingleStudy(internalCancerStudyId)) {
+                deleteGenericAssayMeta(internalCancerStudyId);
+            }
             con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
-            deleteGenericAssayMeta(internalCancerStudyId);
             for (String statementString : deleteStudyStatements) {
                 pstmt = con.prepareStatement(statementString);
                 if (statementString.contains("?")) {
@@ -635,15 +638,13 @@ public final class DaoCancerStudy {
         ResultSet rs = null;
         try {
             con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
-            if (DaoGenericAssay.shouldGenericAssayMetaBeDeleted(internalCancerStudyId)) {
-                for (String statementString : deleteGenericAssayStatements) {
-                    pstmt = con.prepareStatement(statementString);
-                    if (statementString.contains("?")) {
-                        pstmt.setInt(1, internalCancerStudyId);
-                    }
-                    pstmt.executeUpdate();
-                    pstmt.close();
+            for (String statementString : deleteGenericAssayStatements) {
+                pstmt = con.prepareStatement(statementString);
+                if (statementString.contains("?")) {
+                    pstmt.setInt(1, internalCancerStudyId);
                 }
+                pstmt.executeUpdate();
+                pstmt.close();
             }
         } catch (SQLException e) {
             throw new DaoException(e);

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGenericAssay.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGenericAssay.java
@@ -85,4 +85,29 @@ public class DaoGenericAssay {
             JdbcUtil.closeAll(DaoGeneticEntity.class, con, pstmt, rs);
         }
     }
+
+    public static boolean shouldGenericAssayMetaBeDeleted(int cancerStudyId) throws DaoException {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+
+        try {
+            con = JdbcUtil.getDbConnection(DaoGeneticEntity.class);
+            pstmt = con.prepareStatement("SELECT DISTINCT CANCER_STUDY_ID FROM genetic_profile WHERE GENETIC_PROFILE_ID IN (SELECT GENETIC_PROFILE_ID FROM genetic_alteration WHERE GENETIC_ENTITY_ID IN (SELECT GENETIC_ENTITY_ID FROM genetic_alteration WHERE GENETIC_PROFILE_ID IN (SELECT GENETIC_PROFILE_ID FROM genetic_profile WHERE CANCER_STUDY_ID=?)))");
+            pstmt.setInt(1, cancerStudyId);
+            rs = pstmt.executeQuery();
+
+            List<Integer> studies = new ArrayList<Integer>();
+            while(rs.next()) {
+                studies.add(rs.getInt("CANCER_STUDY_ID"));
+            }
+            return studies.size() == 1;
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            JdbcUtil.closeAll(DaoGeneticEntity.class, con, pstmt, rs);
+        }
+        // do not update if there is an error
+        return false;
+    }
 }

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGenericAssay.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGenericAssay.java
@@ -86,7 +86,7 @@ public class DaoGenericAssay {
         }
     }
 
-    public static boolean shouldGenericAssayMetaBeDeleted(int cancerStudyId) throws DaoException {
+    public static boolean geneticEntitiesOnlyExistInSingleStudy(int cancerStudyId) throws DaoException {
         Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
@@ -101,6 +101,7 @@ public class DaoGenericAssay {
             while(rs.next()) {
                 studies.add(rs.getInt("CANCER_STUDY_ID"));
             }
+            // check if entities only exist in single study
             return studies.size() == 1;
         } catch (SQLException e) {
             e.printStackTrace();

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGenericAssay.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGenericAssay.java
@@ -64,4 +64,25 @@ public class DaoGenericAssay {
         }
         return null;
     }
+
+    public static void deleteGenericEntityPropertiesByStableId(String stableId) throws DaoException {
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;     
+
+        try {
+            con = JdbcUtil.getDbConnection(DaoGeneticEntity.class);
+            pstmt = con.prepareStatement("DELETE FROM generic_entity_properties WHERE GENETIC_ENTITY_ID=?");
+            GeneticEntity entity = DaoGeneticEntity.getGeneticEntityByStableId(stableId);
+            if (entity == null) {
+                return;
+            }
+            pstmt.setInt(1, entity.getId());
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            JdbcUtil.closeAll(DaoGeneticEntity.class, con, pstmt, rs);
+        }
+    }
 }

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenericAssayEntity.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenericAssayEntity.java
@@ -121,10 +121,10 @@ public class ImportGenericAssayEntity extends ConsoleRunnable {
                 "'entityType' argument required");
             }
             
-            // Check options, set default as true
-            boolean updateInfo = true;
-            if (options.has("update-info") && (options.valueOf(updateInfoArg).equalsIgnoreCase("false") || options.valueOf(updateInfoArg).equals("0"))) {
-                updateInfo = false;
+            // Check options, set default as false
+            boolean updateInfo = false;
+            if (options.has("update-info") && (options.valueOf(updateInfoArg).equalsIgnoreCase("true") || options.valueOf(updateInfoArg).equals("1"))) {
+                updateInfo = true;
             }
             
             ProgressMonitor.setCurrentMessage("Adding new generic assay to the database\n");

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenericAssayEntity.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenericAssayEntity.java
@@ -39,7 +39,9 @@ package org.mskcc.cbio.portal.scripts;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import org.cbioportal.model.EntityType;
 import org.cbioportal.model.GeneticEntity;
@@ -90,6 +92,10 @@ public class ImportGenericAssayEntity extends ConsoleRunnable {
             // don't require additional properties
             OptionSpec<String> additionalProperties = parser.accepts("additional-properties", "Additional properties need to be imported")
             .withOptionalArg().ofType(String.class);
+
+            // don't require updateInfo, default as true
+            OptionSpec<String> updateInfoArg = parser.accepts("update-info", "Update information for existing entities in the database")
+            .withOptionalArg().ofType(String.class);
             
             OptionSet options = null;
             try {
@@ -115,8 +121,11 @@ public class ImportGenericAssayEntity extends ConsoleRunnable {
                 "'entityType' argument required");
             }
             
-            // Check options
-            boolean updateInfo = options.has("update-info");
+            // Check options, set default as true
+            boolean updateInfo = true;
+            if (options.has("update-info") && (options.valueOf(updateInfoArg).equalsIgnoreCase("false") || options.valueOf(updateInfoArg).equals("0"))) {
+                updateInfo = false;
+            }
             
             ProgressMonitor.setCurrentMessage("Adding new generic assay to the database\n");
             startImport(options, data, entityType, additionalProperties, updateInfo);
@@ -138,7 +147,7 @@ public class ImportGenericAssayEntity extends ConsoleRunnable {
             File genericAssayFile = new File(options.valueOf(data));
             GeneticAlterationType geneticAlterationTypeArg = GeneticAlterationType.valueOf(options.valueOf(geneticAlterationType));
             String additionalPropertiesArg = options.valueOf(additionalProperties);
-            importData(genericAssayFile, geneticAlterationTypeArg, additionalPropertiesArg);
+            importData(genericAssayFile, geneticAlterationTypeArg, additionalPropertiesArg, updateInfo);
         }
     }
     
@@ -150,7 +159,7 @@ public class ImportGenericAssayEntity extends ConsoleRunnable {
     * @param additionalProperties
     * @throws Exception
     */
-    public static void importData(File dataFile, GeneticAlterationType geneticAlterationType, String additionalProperties) throws Exception {
+    public static void importData(File dataFile, GeneticAlterationType geneticAlterationType, String additionalProperties, boolean updateInfo) throws Exception {
         
         ProgressMonitor.setCurrentMessage("Reading data from: " + dataFile.getCanonicalPath());
         
@@ -163,6 +172,11 @@ public class ImportGenericAssayEntity extends ConsoleRunnable {
         // read generic assay data
         int indexStableIdField = getStableIdIndex(headerNames);
 
+        // entities have been overriden
+        List<String> updatedEntities = new ArrayList<>();
+        List<String> notUpdatedEntities = new ArrayList<>();
+        List<String> newEntities = new ArrayList<>();
+        
         currentLine = buf.readLine();
         
         while (currentLine != null) {
@@ -172,6 +186,7 @@ public class ImportGenericAssayEntity extends ConsoleRunnable {
             // get stableId and get the meta by the stableId
             String genericAssayMetaStableId = parts[indexStableIdField];
             GenericAssayMeta genericAssayMeta = DaoGenericAssay.getGenericAssayMetaByStableId(genericAssayMetaStableId);
+            GeneticEntity genericAssayEntity = DaoGeneticEntity.getGeneticEntityByStableId(genericAssayMetaStableId);
             
             // generic assay meta are always updated to based on the current import;
             // also when present in db a new record is created.
@@ -191,10 +206,23 @@ public class ImportGenericAssayEntity extends ConsoleRunnable {
 
             // log for the existing entities
             if (genericAssayMeta != null) {
-                ProgressMonitor.setCurrentMessage("Cannot add new entity, entity exists: " + genericAssayMetaStableId);
+                if (updateInfo) {
+                    updatedEntities.add(stableId);
+                    DaoGenericAssay.deleteGenericEntityPropertiesByStableId(stableId);
+                    propertiesMap.forEach((k, v) -> {	
+                        try {	
+                            DaoGenericAssay.setGenericEntityProperty(genericAssayEntity.getId(), k, v);	
+                        } catch (DaoException e) {	
+                            e.printStackTrace();	
+                        }	
+                    });
+                } else {
+                    notUpdatedEntities.add(stableId);
+                }
             }
             // create a new generic assay meta and add to the database
             else {
+                newEntities.add(stableId);
                 GeneticEntity newGeneticEntity = new GeneticEntity(geneticAlterationType.name(), stableId);
                 GeneticEntity createdGeneticEntity = DaoGeneticEntity.addNewGeneticEntity(newGeneticEntity);
                 propertiesMap.forEach((k, v) -> {
@@ -208,6 +236,14 @@ public class ImportGenericAssayEntity extends ConsoleRunnable {
 
             currentLine = buf.readLine();
         }
+        
+        // show import message
+        if (updateInfo) {
+            ProgressMonitor.setCurrentMessage(updatedEntities.size() + " generic entities existing in the database that were overridden during import.");
+        } else {
+            ProgressMonitor.setCurrentMessage(notUpdatedEntities.size() + " generic entities existing in the database that were not overridden during import.");
+        }
+        ProgressMonitor.setCurrentMessage(newEntities.size() + " generic entities have been imported into database during import.");
         
         reader.close();
         

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenericAssayEntity.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenericAssayEntity.java
@@ -237,13 +237,16 @@ public class ImportGenericAssayEntity extends ConsoleRunnable {
             currentLine = buf.readLine();
         }
         
-        // show import message
-        if (updateInfo) {
-            ProgressMonitor.setCurrentMessage(updatedEntities.size() + " generic entities existing in the database that were overridden during import.");
-        } else {
-            ProgressMonitor.setCurrentMessage(notUpdatedEntities.size() + " generic entities existing in the database that were not overridden during import.");
+        // show import result message
+        if (updatedEntities.size() > 0) {
+            ProgressMonitor.setCurrentMessage("--> Entities updated: " + updatedEntities.size() + " generic entities existing in the database that were overridden during import.");
         }
-        ProgressMonitor.setCurrentMessage(newEntities.size() + " generic entities have been imported into database during import.");
+        if (notUpdatedEntities.size() > 0) {
+            ProgressMonitor.setCurrentMessage("--> Entities not updated: " + notUpdatedEntities.size() + " generic entities existing in the database that were not overridden during import.");
+        }
+        if (newEntities.size() > 0) {
+            ProgressMonitor.setCurrentMessage("--> New Entities: " + newEntities.size() + " generic entities have been imported into database during import.");
+        }
         
         reader.close();
         

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportProfileData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportProfileData.java
@@ -100,7 +100,7 @@ public class ImportProfileData extends ConsoleRunnable {
                 importer.importData();
             } else if (geneticProfile.getGeneticAlterationType() == GeneticAlterationType.GENERIC_ASSAY) {
                 // add all missing `genetic_entities` for this assay to the database
-                ImportGenericAssayEntity.importData(dataFile, geneticProfile.getGeneticAlterationType(), geneticProfile.getOtherMetaDataField("generic_entity_meta_properties"));
+                ImportGenericAssayEntity.importData(dataFile, geneticProfile.getGeneticAlterationType(), geneticProfile.getOtherMetaDataField("generic_entity_meta_properties"), true);
                 
                 ImportTabDelimData genericAssayProfileImporter = new ImportTabDelimData(dataFile, geneticProfile.getTargetLine(), geneticProfile.getGeneticProfileId(), genePanel, geneticProfile.getOtherMetaDataField("generic_entity_meta_properties"));
                 genericAssayProfileImporter.importData(numLines);

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportProfileData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportProfileData.java
@@ -56,9 +56,14 @@ public class ImportProfileData extends ConsoleRunnable {
             // Parse arguments
             // using a real options parser, helps avoid bugs
             String description = "Import 'profile' files that contain data matrices indexed by gene, case";
-            OptionSet options = ConsoleUtil.parseStandardDataAndMetaOptions(args, description, true);
+            OptionSet options = ConsoleUtil.parseStandardDataAndMetaUpdateOptions(args, description, true);
             File dataFile = new File((String) options.valueOf("data"));
             File descriptorFile = new File((String) options.valueOf( "meta" ) );
+            // Check options, set default as true
+            boolean updateInfo = true;
+            if (options.has("update-info") && (((String) options.valueOf("update-info")).equalsIgnoreCase("false") || options.valueOf("update-info").equals("0"))) {
+                updateInfo = false;
+            }
             SpringUtil.initDataSource();
             ProgressMonitor.setCurrentMessage("Reading data from:  " + dataFile.getAbsolutePath());
             // Load genetic profile and gene panel
@@ -100,7 +105,7 @@ public class ImportProfileData extends ConsoleRunnable {
                 importer.importData();
             } else if (geneticProfile.getGeneticAlterationType() == GeneticAlterationType.GENERIC_ASSAY) {
                 // add all missing `genetic_entities` for this assay to the database
-                ImportGenericAssayEntity.importData(dataFile, geneticProfile.getGeneticAlterationType(), geneticProfile.getOtherMetaDataField("generic_entity_meta_properties"), true);
+                ImportGenericAssayEntity.importData(dataFile, geneticProfile.getGeneticAlterationType(), geneticProfile.getOtherMetaDataField("generic_entity_meta_properties"), updateInfo);
                 
                 ImportTabDelimData genericAssayProfileImporter = new ImportTabDelimData(dataFile, geneticProfile.getTargetLine(), geneticProfile.getGeneticProfileId(), genePanel, geneticProfile.getOtherMetaDataField("generic_entity_meta_properties"));
                 genericAssayProfileImporter.importData(numLines);

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportProfileData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportProfileData.java
@@ -59,10 +59,10 @@ public class ImportProfileData extends ConsoleRunnable {
             OptionSet options = ConsoleUtil.parseStandardDataAndMetaUpdateOptions(args, description, true);
             File dataFile = new File((String) options.valueOf("data"));
             File descriptorFile = new File((String) options.valueOf( "meta" ) );
-            // Check options, set default as true
-            boolean updateInfo = true;
-            if (options.has("update-info") && (((String) options.valueOf("update-info")).equalsIgnoreCase("false") || options.valueOf("update-info").equals("0"))) {
-                updateInfo = false;
+            // Check options, set default as false
+            boolean updateInfo = false;
+            if (options.has("update-info") && (((String) options.valueOf("update-info")).equalsIgnoreCase("true") || options.valueOf("update-info").equals("1"))) {
+                updateInfo = true;
             }
             SpringUtil.initDataSource();
             ProgressMonitor.setCurrentMessage("Reading data from:  " + dataFile.getAbsolutePath());

--- a/core/src/main/scripts/importer/cbioportalImporter.py
+++ b/core/src/main/scripts/importer/cbioportalImporter.py
@@ -114,10 +114,10 @@ def import_study_data(jvm_args, meta_filename, data_filename, update_generic_ass
     # Retrieve meta file type
     meta_file_type = meta_file_dictionary['meta_file_type']
 
-    # Update entities by default
-    shouldUpdateGenericAssayEntities = True
-    if update_generic_assay_entity != None and update_generic_assay_entity.casefold() == "False".casefold():
-        shouldUpdateGenericAssayEntities = False
+    # Do not update entities by default
+    shouldUpdateGenericAssayEntities = False
+    if update_generic_assay_entity != None and update_generic_assay_entity.casefold() == "True".casefold():
+        shouldUpdateGenericAssayEntities = True
 
     # invalid file, skip
     if meta_file_type is None:

--- a/core/src/main/scripts/importer/cbioportalImporter.py
+++ b/core/src/main/scripts/importer/cbioportalImporter.py
@@ -102,7 +102,7 @@ def remove_study_id(jvm_args, study_id):
     run_java(*args)
 
 
-def import_study_data(jvm_args, meta_filename, data_filename, meta_file_dictionary = None):
+def import_study_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity, meta_file_dictionary = None):
     args = jvm_args.split(' ')
 
     # In case the meta file is already parsed in a previous function, it is not
@@ -113,6 +113,11 @@ def import_study_data(jvm_args, meta_filename, data_filename, meta_file_dictiona
 
     # Retrieve meta file type
     meta_file_type = meta_file_dictionary['meta_file_type']
+
+    # Update entities by default
+    shouldUpdateGenericAssayEntities = True
+    if update_generic_assay_entity != None and update_generic_assay_entity.casefold() == "False".casefold():
+        shouldUpdateGenericAssayEntities = False
 
     # invalid file, skip
     if meta_file_type is None:
@@ -133,6 +138,12 @@ def import_study_data(jvm_args, meta_filename, data_filename, meta_file_dictiona
         args.append(meta_filename)
         args.append("--loadMode")
         args.append("bulkload")
+    if importer == "org.mskcc.cbio.portal.scripts.ImportProfileData" and shouldUpdateGenericAssayEntities:
+        args.append("--update-info")
+        args.append("True")
+    elif importer == "org.mskcc.cbio.portal.scripts.ImportProfileData" and not shouldUpdateGenericAssayEntities:
+        args.append("--update-info")
+        args.append("False")
     if importer in ("org.mskcc.cbio.portal.scripts.ImportMutSigData", "org.mskcc.cbio.portal.scripts.ImportGisticData"):
         args.append("--data")
         args.append(data_filename)
@@ -186,7 +197,7 @@ def process_case_lists(jvm_args, case_list_dir):
         if not (case_list.startswith('.') or case_list.endswith('~')):
             import_case_list(jvm_args, os.path.join(case_list_dir, case_list))
 
-def process_command(jvm_args, command, meta_filename, data_filename, study_ids):
+def process_command(jvm_args, command, meta_filename, data_filename, study_ids, update_generic_assay_entity = None):
     if command == IMPORT_CANCER_TYPE:
         import_cancer_type(jvm_args, data_filename)
     elif command == IMPORT_STUDY:
@@ -201,11 +212,11 @@ def process_command(jvm_args, command, meta_filename, data_filename, study_ids):
         else:
             raise RuntimeError('Your command uses both -id and -meta. Please, use only one of the two parameters.')
     elif command == IMPORT_STUDY_DATA:
-        import_study_data(jvm_args, meta_filename, data_filename)
+        import_study_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity)
     elif command == IMPORT_CASE_LIST:
         import_case_list(jvm_args, meta_filename)
 
-def process_directory(jvm_args, study_directory):
+def process_directory(jvm_args, study_directory, update_generic_assay_entity = None):
     """
     Import an entire study directory based on meta files found.
 
@@ -338,47 +349,47 @@ def process_directory(jvm_args, study_directory):
         raise RuntimeError('No sample attribute file found')
     else:
         meta_filename, data_filename = sample_attr_filepair
-        import_study_data(jvm_args, meta_filename, data_filename, study_meta_dictionary[meta_filename])
+        import_study_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity, study_meta_dictionary[meta_filename])
 
     # Next, we need to import resource definitions for resource data
     if resource_definition_filepair is not None:
         meta_filename, data_filename = resource_definition_filepair
-        import_study_data(jvm_args, meta_filename, data_filename, study_meta_dictionary[meta_filename])
+        import_study_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity, study_meta_dictionary[meta_filename])
 
     # Next, we need to import sample definitions for resource data
     if sample_resource_filepair is not None:
         meta_filename, data_filename = sample_resource_filepair
-        import_study_data(jvm_args, meta_filename, data_filename, study_meta_dictionary[meta_filename])
+        import_study_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity, study_meta_dictionary[meta_filename])
 
     # Next, import everything else except gene panel, fusion data, GSVA and
     # z-score expression. If in the future more types refer to each other, (like
     # in a tree structure) this could be programmed in a recursive fashion.
     for meta_filename, data_filename in regular_filepairs:
-        import_study_data(jvm_args, meta_filename, data_filename, study_meta_dictionary[meta_filename])
+        import_study_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity, study_meta_dictionary[meta_filename])
 
     # Import fusion data (after mutation)
     if fusion_filepair is not None:
         meta_filename, data_filename = fusion_filepair
-        import_study_data(jvm_args, meta_filename, data_filename, study_meta_dictionary[meta_filename])
+        import_study_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity, study_meta_dictionary[meta_filename])
 
     # Import expression z-score (after expression)
     for meta_filename, data_filename in zscore_filepairs:
-        import_study_data(jvm_args, meta_filename, data_filename, study_meta_dictionary[meta_filename])
+        import_study_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity, study_meta_dictionary[meta_filename])
 
     # Import GSVA genetic profiles (after expression and z-scores)
     if gsva_score_filepair is not None:
 
         # First import the GSVA score data
         meta_filename, data_filename = gsva_score_filepair
-        import_study_data(jvm_args, meta_filename, data_filename, study_meta_dictionary[meta_filename])
+        import_study_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity, study_meta_dictionary[meta_filename])
 
         # Second import the GSVA p-value data
         meta_filename, data_filename = gsva_pvalue_filepair
-        import_study_data(jvm_args, meta_filename, data_filename, study_meta_dictionary[meta_filename])
+        import_study_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity, study_meta_dictionary[meta_filename])
 
     if gene_panel_matrix_filepair is not None:
         meta_filename, data_filename = gene_panel_matrix_filepair
-        import_study_data(jvm_args, meta_filename, data_filename, study_meta_dictionary[meta_filename])
+        import_study_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity, study_meta_dictionary[meta_filename])
 
     # Import the case lists
     case_list_dirname = os.path.join(study_directory, 'case_lists')
@@ -456,6 +467,8 @@ def interface():
     parser.add_argument('-id', '--study_ids', type=str, required=False,
                         help='Cancer Study IDs for `remove-study` command, comma separated')
     
+    parser.add_argument('-update', '--update_generic_assay_entity', type=str, required=False,
+                        help='Set as True to update the existing generic assay entities, set as False to keep the existing generic assay entities for generic assay')
     # TODO - add same argument to metaimporter
     # TODO - harmonize on - and _
 
@@ -517,11 +530,11 @@ def main(args):
 
     if study_directory != None:
         check_dir(study_directory)
-        process_directory(jvm_args, study_directory)
+        process_directory(jvm_args, study_directory, args.update_generic_assay_entity)
     else:
         check_args(args.command)
         check_files(args.meta_filename, args.data_filename)
-        process_command(jvm_args, args.command, args.meta_filename, args.data_filename, args.study_ids)
+        process_command(jvm_args, args.command, args.meta_filename, args.data_filename, args.study_ids, args.update_generic_assay_entity)
 
 # ------------------------------------------------------------------------------
 # ready to roll

--- a/core/src/main/scripts/importer/metaImport.py
+++ b/core/src/main/scripts/importer/metaImport.py
@@ -105,7 +105,7 @@ def interface():
                              'report. For example, set this to a high number to '
                              'report all genes that could not be loaded, instead '
                              'of reporting "(GeneA, GeneB, GeneC, 213 more)".')
-    parser.add_argument('-update', '--update_generic_assay_entity', type=str, required=False, default="True",
+    parser.add_argument('-update', '--update_generic_assay_entity', type=str, required=False, default="False",
                         help='Set as True to update the existing generic assay entities, set as False to keep the existing generic assay entities for generic assay')
     parser = parser.parse_args()
     return parser

--- a/core/src/main/scripts/importer/metaImport.py
+++ b/core/src/main/scripts/importer/metaImport.py
@@ -105,6 +105,8 @@ def interface():
                              'report. For example, set this to a high number to '
                              'report all genes that could not be loaded, instead '
                              'of reporting "(GeneA, GeneB, GeneC, 213 more)".')
+    parser.add_argument('-update', '--update_generic_assay_entity', type=str, required=False, default="True",
+                        help='Set as True to update the existing generic assay entities, set as False to keep the existing generic assay entities for generic assay')
     parser = parser.parse_args()
     return parser
 

--- a/core/src/test/java/org/mskcc/cbio/portal/scripts/TestImportGenericAssayData.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/scripts/TestImportGenericAssayData.java
@@ -69,7 +69,7 @@ public class TestImportGenericAssayData {
         File file = new File("src/test/resources/treatments/data_treatment_ic50.txt");
         
         // import data and test all treatments were added
-        ImportGenericAssayEntity.importData(file, GeneticAlterationType.GENERIC_ASSAY, "NAME,DESCRIPTION,URL");
+        ImportGenericAssayEntity.importData(file, GeneticAlterationType.GENERIC_ASSAY, "NAME,DESCRIPTION,URL", true);
         assertEquals(10, getNumRecordsForGenericAssay());
  
         // test wether a record can be retrieved via stable id 
@@ -80,6 +80,12 @@ public class TestImportGenericAssayData {
         assertEquals("Name of Irinotecan", treatment1.getGenericEntityMetaProperties().get("NAME"));
         assertEquals("Desc of Irinotecan", treatment1.getGenericEntityMetaProperties().get("DESCRIPTION"));
         assertEquals("Url of Irinotecan", treatment1.getGenericEntityMetaProperties().get("URL"));
+
+        // test fields are updated after loading new treatment file
+        File fileNewDesc = new File("src/test/resources/treatments/data_treatment_ic50_newdesc.txt");
+        ImportGenericAssayEntity.importData(fileNewDesc, GeneticAlterationType.GENERIC_ASSAY, "NAME,DESCRIPTION,URL", true);
+        GenericAssayMeta treatment2 = DaoGenericAssay.getGenericAssayMetaByStableId("Irinotecan");
+        assertEquals("New desc of Irinotecan", treatment2.getGenericEntityMetaProperties().get("DESCRIPTION"));
     }
 
     @Test
@@ -91,7 +97,7 @@ public class TestImportGenericAssayData {
         File file = new File("src/test/resources/data_mutational_signature.txt");
         
         // import data and test all mutational signatures were added
-        ImportGenericAssayEntity.importData(file, GeneticAlterationType.GENERIC_ASSAY, "name,description");
+        ImportGenericAssayEntity.importData(file, GeneticAlterationType.GENERIC_ASSAY, "name,description", false);
         assertEquals(61, getNumRecordsForGenericAssay());
  
         // test wether a record can be retrieved via stable id 
@@ -101,6 +107,18 @@ public class TestImportGenericAssayData {
         // Test whether fields were populated correctly
         assertEquals("mean_1", genericAssayMeta1.getGenericEntityMetaProperties().get("name"));
         assertEquals("mean_1", genericAssayMeta1.getGenericEntityMetaProperties().get("description"));
+
+        // // test fields should not be updated after loading new generic assay meta file
+        File fileNewDesc = new File("src/test/resources/data_mutational_signature_new.txt");
+        ImportGenericAssayEntity.importData(fileNewDesc, GeneticAlterationType.GENERIC_ASSAY, "name,description", false);
+        GenericAssayMeta genericAssayMeta2 = DaoGenericAssay.getGenericAssayMetaByStableId("mean_1");
+        assertEquals("mean_1", genericAssayMeta2.getGenericEntityMetaProperties().get("description"));
+
+        // // test fields should be updated after loading new generic assay meta file
+        ImportGenericAssayEntity.importData(fileNewDesc, GeneticAlterationType.GENERIC_ASSAY, "name,description", true);
+        GenericAssayMeta genericAssayMeta3 = DaoGenericAssay.getGenericAssayMetaByStableId("mean_1");
+        assertEquals("new mean_1", genericAssayMeta3.getGenericEntityMetaProperties().get("description"));
+
     }
 
     private int getNumRecordsForGenericAssay() {


### PR DESCRIPTION
Provide override option when import generic assay data

related [document](https://docs.google.com/document/d/1f3JFG7tPiYXcQsJr5GHRzOK-ko_epBhOjDJa1ppgdsA/edit?disco=AAAADg3rhvo) updated here.

Changes in this pr:
1. add Provide override option (`updateInfo`) when import generic assay data (set `false` as default).
2. log the import results after import
3. Add one more method in DaoGenericAssay to support update of the entities.
4. Do not delete entities if shared with other studies.