### PR TITLE
Move loadFrontend invocation into body to fix 3rd party library depen…

### DIFF
--- a/portal/src/main/webapp/index.jsp
+++ b/portal/src/main/webapp/index.jsp
@@ -95,10 +95,6 @@
         });
     </script>
     
-    <script>
-            loadReactApp(window.frontendConfig);
-    </script>
-    
     <%@include file="./tracking_include.jsp" %>
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css" rel="stylesheet" />
@@ -106,9 +102,11 @@
 </head>
 
 <body>
+    <script>
+        loadReactApp(window.frontendConfig);
+    </script>
+
     <div id="reactRoot"></div>
-    
-    
-    
+
 </body>
 </html>


### PR DESCRIPTION
A library used in frontend project (measure-text) requires that document.body be available at parse time (immediately after js is loaded into page).  Recent changes to our loading js packaging  strategy (having to do with monorepo) moved the library to a different bundle that gets loaded sooner in lifecycle.  For this reason, we need to move the loadFrontend call into `<body>` tag.
