### PR TITLE
Impl. non-authorized ServerStatus (/health) endpoint

### DIFF
--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -251,6 +251,7 @@
     <servlet-mapping>
         <servlet-name>api</servlet-name>
         <url-pattern>/api/*</url-pattern>
+        <url-pattern>/health</url-pattern>
     </servlet-mapping>
 
     <servlet>

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -99,6 +99,7 @@
     <http pattern="/reactapp/**" security="none"/>
     <http pattern="/api/swagger-resources/**" security="none"/>
     <http pattern="/api/swagger-ui.html" security="none"/>
+    <http pattern="/health" security="none"/>
 
     <!-- This must come before the default entry point which will capture everything not matched by pattern -->
     <http use-expressions="true" pattern="/api/**" entry-point-ref="restAuthenticationEntryPoint" create-session="never">

--- a/service/src/main/java/org/cbioportal/service/ServerStatusService.java
+++ b/service/src/main/java/org/cbioportal/service/ServerStatusService.java
@@ -1,0 +1,7 @@
+package org.cbioportal.service;
+
+import org.cbioportal.service.impl.ServerStatusServiceImpl.ServerStatusMessage;
+
+public interface ServerStatusService {
+    ServerStatusMessage getServerStatus();
+}

--- a/service/src/main/java/org/cbioportal/service/impl/ServerStatusServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ServerStatusServiceImpl.java
@@ -1,0 +1,49 @@
+package org.cbioportal.service.impl;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.cbioportal.model.TypeOfCancer;
+import org.cbioportal.persistence.CancerTypeRepository;
+import org.cbioportal.service.ServerStatusService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+
+@Service
+public class ServerStatusServiceImpl implements  ServerStatusService {
+
+    public static final String MESSAGE_RUNNING = "UP";
+    public static final String MESSAGE_DOWN = "DOWN";
+    
+    private static final ServerStatusMessage objRunning = new ServerStatusMessage(MESSAGE_RUNNING);
+    private static final ServerStatusMessage objDown = new ServerStatusMessage(MESSAGE_DOWN);
+
+    @Autowired
+    private CancerTypeRepository cancerTypeRepository;
+
+    @Override
+    public ServerStatusMessage getServerStatus() {
+        List<TypeOfCancer> allCancerTypes = cancerTypeRepository.getAllCancerTypes("SUMMARY", null, null, null, null);
+        if (allCancerTypes.size() > 0) {
+            return objRunning;
+        }
+        return objDown;
+    }
+
+    public final static class ServerStatusMessage implements Serializable {
+        
+        private static final long serialVersionUID = 1L;
+        String status;
+        
+        ServerStatusMessage(String message) {
+            this.status = message;
+        }
+
+        public String getStatus() {
+            return this.status;
+        }
+
+    }
+
+}

--- a/service/src/test/java/org/cbioportal/service/impl/ServerStatusServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ServerStatusServiceImplTest.java
@@ -1,0 +1,50 @@
+package org.cbioportal.service.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.cbioportal.model.TypeOfCancer;
+import org.cbioportal.persistence.CancerTypeRepository;
+import org.cbioportal.service.impl.ServerStatusServiceImpl.ServerStatusMessage;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServerStatusServiceImplTest extends BaseServiceImplTest {
+
+    @InjectMocks
+    private ServerStatusServiceImpl serverStatusService;
+
+    @Mock
+    private CancerTypeRepository cancerTypeRepository;
+
+    @Test
+    public void getServerStatusSuccess() throws Exception {
+
+        List<TypeOfCancer> cancerList = new ArrayList<>();
+        TypeOfCancer typeOfCancer = new TypeOfCancer();
+        cancerList.add(typeOfCancer);
+
+        Mockito.when(cancerTypeRepository.getAllCancerTypes("SUMMARY", null, null, null, null))
+                .thenReturn(cancerList);
+
+        Assert.assertEquals(ServerStatusServiceImpl.MESSAGE_RUNNING, serverStatusService.getServerStatus().status);
+    }
+
+    @Test
+    public void getServerStatusFailure() throws Exception {
+
+        List<TypeOfCancer> cancerList = new ArrayList<>();
+
+        Mockito.when(cancerTypeRepository.getAllCancerTypes("SUMMARY", null, null, null, null))
+                .thenReturn(cancerList);
+
+        Assert.assertEquals(ServerStatusServiceImpl.MESSAGE_DOWN, serverStatusService.getServerStatus().status);
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/web/ServerStatusController.java
+++ b/web/src/main/java/org/cbioportal/web/ServerStatusController.java
@@ -1,0 +1,33 @@
+package org.cbioportal.web;
+
+import org.cbioportal.service.ServerStatusService;
+import org.cbioportal.service.impl.ServerStatusServiceImpl.ServerStatusMessage;
+import org.cbioportal.web.config.annotation.InternalApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@InternalApi
+@RestController
+@Validated
+@Api(tags = "Server running status", description = "This end point does not require authentication")
+public class ServerStatusController {
+
+    @Autowired
+    private ServerStatusService serverStatusService;
+
+    @RequestMapping(value = "/health", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Get the running status of the server")
+    public ResponseEntity<ServerStatusMessage> getServerStatus() {
+        return new ResponseEntity<>(serverStatusService.getServerStatus(), HttpStatus.OK);
+    }
+
+}


### PR DESCRIPTION
# Background
For instances that use authorization, the health of cBioPortal cannot be probed since endpoints are shielded.

# Fix
This PR will implement an open `/health` endpoint that does not require authentication. It will return `{"status": "UP"}` when the cancer types can be retrieved from the database. If not, it will return `{"status": "DOWN"}` (or nothing when cBioPortal is down entirely :) ).