### PR TITLE
Add configuration option for mdacc ngchm button in oncoprint heatmap menu

### DIFF
--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -215,6 +215,13 @@ The CIViC API url is set to https://civic.genome.wustl.edu/api/ by default. It c
 civic.url=
 ```
 
+# MDACC Heatmap Integration
+
+MDACC Heatmap integration (button in OncoPrint heatmap dropdown and tab on Study page can be turned on or off by setting the following property:
+```
+show.mdacc.heatmap=true
+```
+
 # OncoPrint
 
 The default view in OncoPrint ("patient" or "sample") can be set with the following option. The default is "patient".

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -51,6 +51,7 @@
             "mdacc.heatmap.patient.url",
             "mdacc.heatmap.study.meta.url",
             "mdacc.heatmap.study.url",
+            "show.mdacc.heatmap",
             "oncoprint.custom_driver_annotation.tiers.menu_label",
             "priority_studies",
             "show.hotspot",

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -142,8 +142,9 @@ dat.jwt.secret_key=
 # study view settings
 # always show studies with this group
 always_show_study_group=
-mdacc.heatmap.study.meta.url=//bioinformatics.mdanderson.org/study2url?studyid=
-mdacc.heatmap.study.url=//bioinformatics.mdanderson.org/TCGA/NGCHMPortal/?
+
+# mdacc heatmap integration
+#show.mdacc.heatmap=true
 
 # patient view settings
 patient_view_placeholder=false
@@ -151,8 +152,6 @@ digitalslidearchive.iframe.url=http://cancer.digitalslidearchive.net/index_mskcc
 digitalslidearchive.meta.url=http://cancer.digitalslidearchive.net/local_php/get_slide_list_from_db_groupid_not_needed.php?slide_name_filter=
 tumor_image.url=http://cbio.mskcc.org/cancergenomics/tcga-tumor-images/
 tcga_path_report.url=https://github.com/cbioportal/datahub/raw/master/tcga/pathology_reports/pathology_reports.txt
-mdacc.heatmap.patient.url=//bioinformatics.mdanderson.org/TCGA/NGCHMPortal/?participant=
-mdacc.heatmap.meta.url=//bioinformatics.mdanderson.org/participant2maps?participant=
 
 # various url's
 segfile.url=http://cbio.mskcc.org/cancergenomics/gdac-portal/seg/


### PR DESCRIPTION
https://github.com/cBioPortal/cbioportal/issues/6306

Add setting to enable/disable NG-CHM link in oncoprint heatmap menu.