### PR TITLE
Memoize full genome response

### DIFF
--- a/service/src/main/java/org/cbioportal/service/GeneMemoizerService.java
+++ b/service/src/main/java/org/cbioportal/service/GeneMemoizerService.java
@@ -1,0 +1,11 @@
+package org.cbioportal.service;
+
+import org.cbioportal.model.ReferenceGenomeGene;
+
+import java.util.List;
+
+public interface GeneMemoizerService {
+    List<ReferenceGenomeGene> fetchGenes(String genomeName);
+    
+    void cacheGenes(List<ReferenceGenomeGene> genes, String genomeName); 
+}

--- a/service/src/main/java/org/cbioportal/service/StaticDataTimestampService.java
+++ b/service/src/main/java/org/cbioportal/service/StaticDataTimestampService.java
@@ -8,4 +8,6 @@ import java.util.Map;
 
 public interface StaticDataTimestampService {
     Map<String, String> getTimestamps(List<String> tables);
+    
+    Map<String, Date> getTimestampsAsDates(List<String> tables);
 }

--- a/service/src/main/java/org/cbioportal/service/impl/GeneMemoizerServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GeneMemoizerServiceImpl.java
@@ -1,0 +1,48 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.model.ReferenceGenomeGene;
+import org.cbioportal.service.GeneMemoizerService;
+import org.cbioportal.service.StaticDataTimestampService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class GeneMemoizerServiceImpl implements GeneMemoizerService {
+    @Autowired
+    private StaticDataTimestampService timestampService;
+    
+    private static final List<String> TABLES = Arrays.asList("gene", "reference_genome_gene");
+
+    private static final Map<String, List<ReferenceGenomeGene>> memoization = new HashMap<>();
+    private static final Map<String, Date> expiry = new HashMap<>();
+    private static final Object lock = new Object();    
+    
+    @Override
+    public List<ReferenceGenomeGene> fetchGenes(String genomeName) {
+        synchronized (lock) {
+            if (memoization.containsKey(genomeName) && allTablesUpToDate(expiry.get(genomeName))) {
+                return memoization.get(genomeName);
+            }
+        }
+        
+        return null;
+    }
+    
+    private boolean allTablesUpToDate(Date expiration) {
+        Map<String, Date> timestamps = timestampService.getTimestampsAsDates(TABLES);
+        return TABLES.stream()
+            .map((table) -> timestamps.containsKey(table) && timestamps.get(table).before(expiration))
+            .reduce((all, next) -> all && next)
+            .orElse(false);
+    }
+    
+    @Override
+    public void cacheGenes(List<ReferenceGenomeGene> genes, String genomeName) {
+        synchronized (lock) {
+            expiry.put(genomeName, new Date());
+            memoization.put(genomeName, genes);
+        }
+    }
+}

--- a/service/src/main/java/org/cbioportal/service/impl/StaticDataTimestampServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/StaticDataTimestampServiceImpl.java
@@ -6,6 +6,9 @@ import org.cbioportal.persistence.StaticDataTimeStampRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -22,6 +25,23 @@ public class StaticDataTimestampServiceImpl implements StaticDataTimestampServic
                 .collect(Collectors.toMap(
                         TableTimestampPair::getTableName,
                         TableTimestampPair::getUpdateTime));
+    }
+    
+    @Override
+    public Map<String, Date> getTimestampsAsDates(List<String> tables) {
+        List<TableTimestampPair> timestamps = staticDataTimeStampRepository.getTimestamps(tables);
+        return timestamps.stream()
+            .collect(Collectors.toMap(
+                TableTimestampPair::getTableName,
+                (pair) -> toDate(pair.getUpdateTime())));
+    }
+    
+    private Date toDate(String date) {
+        try {
+            return new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.sss").parse(date);
+        } catch (ParseException ignored) {
+            return new Date();
+        }
     }
 }
 

--- a/service/src/test/java/org/cbioportal/service/impl/GeneMemoizerServiceTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GeneMemoizerServiceTest.java
@@ -1,0 +1,86 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.model.ReferenceGenomeGene;
+import org.cbioportal.service.StaticDataTimestampService;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GeneMemoizerServiceTest {
+    @Mock
+    private StaticDataTimestampService timestampService;
+
+    @InjectMocks
+    private GeneMemoizerServiceImpl geneMemoizerService;
+
+    private static final String GENOME = "hg19";
+    private static final List<ReferenceGenomeGene> GENES = Arrays.asList(
+        gene("BRAF"),
+        gene("NRAS"),
+        gene("KRAS"),
+        gene("SUGT1P4-STRA6LP-CCDC180")
+    );
+    
+    private static ReferenceGenomeGene gene(String name) {
+        ReferenceGenomeGene referenceGenomeGene = new ReferenceGenomeGene();
+        referenceGenomeGene.setHugoGeneSymbol(name);
+        return referenceGenomeGene;
+    }
+    
+    @Test
+    public void shouldReturnNullWhenUncached() throws Exception {
+        initializeTimestamps(new Date(), new Date());
+
+        List<ReferenceGenomeGene> actual = geneMemoizerService.fetchGenes("hg19");
+        
+        Assert.assertEquals(null, actual);
+    }
+
+    @Test
+    public void shouldReturnCachedWhenNeitherExpired() throws Exception {
+        initializeTimestamps(new Date(0L), new Date(0L));
+        geneMemoizerService.cacheGenes(GENES, GENOME);
+        
+        List<ReferenceGenomeGene> actual = geneMemoizerService.fetchGenes("hg19");
+
+        Assert.assertEquals(GENES, actual);
+    }
+
+    @Test
+    public void shouldReturnNullWhenGeneExpired() throws Exception {
+        initializeTimestamps(new Date(Long.MAX_VALUE), new Date(0L));
+        geneMemoizerService.cacheGenes(GENES, GENOME);
+
+        List<ReferenceGenomeGene> actual = geneMemoizerService.fetchGenes("hg19");
+
+        Assert.assertEquals(null, actual);
+    }
+
+    @Test
+    public void shouldReturnNullWhenGenomeExpired() throws Exception {
+        initializeTimestamps(new Date(0L), new Date(Long.MAX_VALUE));
+        geneMemoizerService.cacheGenes(GENES, GENOME);
+
+        List<ReferenceGenomeGene> actual = geneMemoizerService.fetchGenes("hg19");
+
+        Assert.assertEquals(null, actual);
+    }
+
+    private void initializeTimestamps(Date gene, Date referenceGenomeGene) {
+        HashMap<String, Date> timestamps = new HashMap<>();
+        timestamps.put("gene", gene);
+        timestamps.put("reference_genome_gene", referenceGenomeGene);
+        Mockito.when(timestampService.getTimestampsAsDates(Mockito.anyList()))
+            .thenReturn(timestamps);
+    }
+}

--- a/web/src/main/java/org/cbioportal/web/StaticDataTimestampController.java
+++ b/web/src/main/java/org/cbioportal/web/StaticDataTimestampController.java
@@ -2,7 +2,6 @@ package org.cbioportal.web;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import org.cbioportal.model.TableTimestampPair;
 import org.cbioportal.service.StaticDataTimestampService;
 import org.cbioportal.web.config.annotation.InternalApi;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,14 +20,14 @@ import java.util.*;
 @Validated
 @Api(tags = "Timestamps", description = " ")
 public class StaticDataTimestampController {
-    private static final List<String> tables = Arrays.asList("gene", "reference_genome_gene");
+    public static final List<String> TIMESTAMP_TABLES = Arrays.asList("gene", "reference_genome_gene");
     @Autowired
     private StaticDataTimestampService service;
     
     @RequestMapping(value = "/timestamps", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get the last time each static resource was updated")
     public ResponseEntity<Map<String, String>> getAllTimestamps() {
-        return new ResponseEntity<>(service.getTimestamps(tables), HttpStatus.OK);
+        return new ResponseEntity<>(service.getTimestamps(TIMESTAMP_TABLES), HttpStatus.OK);
     }
     
 }

--- a/web/src/test/java/org/cbioportal/web/StaticDataTimestampControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StaticDataTimestampControllerTest.java
@@ -33,11 +33,6 @@ public class StaticDataTimestampControllerTest {
     private StaticDataTimestampService service;
     
     private MockMvc mockMvc;
-    
-    @Bean
-    public StaticDataTimestampService staticDataTimestampService() {
-        return Mockito.mock(StaticDataTimestampService.class);
-    }
 
     @Before
     public void setUp() throws Exception {

--- a/web/src/test/java/org/cbioportal/web/config/CacheMapUtilConfig.java
+++ b/web/src/test/java/org/cbioportal/web/config/CacheMapUtilConfig.java
@@ -23,6 +23,7 @@ import org.cbioportal.persistence.PatientRepository;
 import org.cbioportal.persistence.SampleListRepository;
 import org.cbioportal.persistence.StudyRepository;
 import org.cbioportal.persistence.mybatis.util.CacheMapUtil;
+import org.cbioportal.service.StaticDataTimestampService;
 import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -56,5 +57,10 @@ public class CacheMapUtilConfig {
     @Bean
     public SampleListRepository sampleListRepository() {
         return Mockito.mock(SampleListRepository.class);
+    }
+
+    @Bean
+    public StaticDataTimestampService staticDataTimestampService() {
+        return Mockito.mock(StaticDataTimestampService.class);
     }
 }


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Create primitive caching for problematic endpoint
- To be removed when Ehcache works
- Necessary if we are going to allow the frontend to
use this endpoint again

# Performance Comparison

## Overview
Significant improvement in response time. Similar but more stable CPU and memory performance.

## Response Time (seconds)
Before:
sDev: `41.199290` Mean: `50.419510`
After:
sDev: `0.223303` Mean: `0.126702`

[Raw data](https://docs.google.com/spreadsheets/d/12wQtqmklUjWQPhXFdjWG9Pj2sG1D-90EG1Bfe1hyx4s/edit?usp=sharing)

## Memory
Before: 
![bad_memory](https://user-images.githubusercontent.com/20069833/70811691-1dc47100-1d94-11ea-8878-ee68efe33655.png)


After:
![good-memory](https://user-images.githubusercontent.com/20069833/70811596-e6ee5b00-1d93-11ea-8f96-c6d9bd391789.png)


## CPU
Before:
![bad_cpu](https://user-images.githubusercontent.com/20069833/70811613-f2da1d00-1d93-11ea-959a-ab4bd06d2f44.png)


After:
![good-cpu](https://user-images.githubusercontent.com/20069833/70811624-f8376780-1d93-11ea-8cfc-2012515cf095.png)
