### PR TITLE
/health moves to /api/health for consistency with no-security portals

### DIFF
--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -99,7 +99,7 @@
     <http pattern="/reactapp/**" security="none"/>
     <http pattern="/api/swagger-resources/**" security="none"/>
     <http pattern="/api/swagger-ui.html" security="none"/>
-    <http pattern="/health" security="none"/>
+    <http pattern="/api/health" security="none"/>
 
     <!-- This must come before the default entry point which will capture everything not matched by pattern -->
     <http use-expressions="true" pattern="/api/**" entry-point-ref="restAuthenticationEntryPoint" create-session="never">


### PR DESCRIPTION
For consistency with unprotected portals.

fixes #6916