### PR TITLE
Cache problematic default request for all studies

### DIFF
--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -14,6 +14,7 @@ import org.cbioportal.web.parameter.PagingConstants;
 import org.cbioportal.web.parameter.Projection;
 import org.cbioportal.web.parameter.sort.StudySortBy;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 
+import javax.annotation.PostConstruct;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
@@ -46,6 +48,31 @@ import java.util.Map;
 @Validated
 @Api(tags = "B. Studies", description = " ")
 public class StudyController {
+    @Value("${authenticate:false}")
+    private String authenticate;
+
+    @Value("${app.name:unknown")
+    private String appName;
+    
+    private boolean usingAuth() {
+        return !authenticate.isEmpty()
+            && !authenticate.equals("false")
+            && !authenticate.contains("social_auth");
+    }
+    
+    // This is a stop-gap solution because this endpoint needs caching
+    // Right now this method has spontaneous performance problems
+    // for the default query. We felt the best stop gap would be
+    // to just manually cache that one response.
+    private static List<CancerStudy> defaultResponse;
+    
+    @PostConstruct
+    private void warmDefaultResponseCache() {
+        defaultResponse = studyService.getAllStudies(
+            null, Projection.SUMMARY.name(),
+            10000000, 0,
+            null, Direction.ASC.name());
+    }
 
     @Autowired
     private StudyService studyService;
@@ -68,6 +95,20 @@ public class StudyController {
         @RequestParam(required = false) StudySortBy sortBy,
         @ApiParam("Direction of the sort")
         @RequestParam(defaultValue = "ASC") Direction direction) {
+        
+        // Only use this feature on the public portal and make sure it is never used
+        // on portals using auth, as in auth setting, different users will have different
+        // results.
+        if (!usingAuth()
+                && appName.equals("public-portal")
+                && keyword == null
+                && projection == Projection.SUMMARY
+                && pageSize == 10000000
+                && pageNumber == 0
+                && sortBy == null
+                && direction == Direction.ASC) {
+            return new ResponseEntity<>(defaultResponse, HttpStatus.OK);
+        }
 
         if (projection == Projection.META) {
             HttpHeaders responseHeaders = new HttpHeaders();


### PR DESCRIPTION


Fix #6917
Describe changes proposed in this pull request:
- Requests for all studies with default args sometimes bloat wildly
- Fix that by caching the response (it's static)