### PR TITLE
comment out query_product_limit in EXAMPLE

### DIFF
--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -286,4 +286,4 @@ ehcache.cache_type=none
 
 # Limit the size of gene queries (number). gene count * sample count < query_product_limit
 # This limit is enforced on the frontend.
-query_product_limit=1000000
+# query_product_limit=1000000


### PR DESCRIPTION
this way it'll use the default defined in the frontend. We don't really expect people to change this unless they're certain what they're doing so maybe better to keep control over this default on the frontend