### PR TITLE
remove frontend references to heroku

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -95,9 +95,6 @@ window.localdist = localStorage.getItem("localdist") === "true";
 
 if (window.localdist || window.localdev) {
 	window.frontendConfig.frontendUrl = '//localhost:3000/'
-} else if (localStorage.heroku) {
-	var herokuInstance = '//' + localStorage.getItem('heroku') + '.herokuapp.com/';
-	window.frontendConfig.frontendUrl = herokuInstance;
 } else if (localStorage.netlify) {
 	var netlifyInstance = '//' + localStorage.getItem('netlify') + '.netlify.com/';
 	window.frontendConfig.frontendUrl = netlifyInstance;

--- a/portal/src/main/webapp/index.jsp
+++ b/portal/src/main/webapp/index.jsp
@@ -62,14 +62,10 @@
         }
         window.localdev = localStorage.localdev === 'true';
         window.localdist = localStorage.localdist === 'true';
-        window.heroku = localStorage.heroku;
         window.netlify = localStorage.netlify;
         
         if (window.localdev || window.localdist) {
             window.frontendConfig.frontendUrl = "//localhost:3000/"
-            localStorage.setItem("e2etest", "true");
-        } else if (window.heroku) {
-            window.frontendConfig.frontendUrl = ['//',localStorage.heroku,'.herokuapp.com','/'].join('');
             localStorage.setItem("e2etest", "true");
         } else if (window.netlify) {
             window.frontendConfig.frontendUrl = ['//',localStorage.netlify,'.netlify.com','/'].join('');

--- a/portal/src/main/webapp/js/src/load-frontend.js
+++ b/portal/src/main/webapp/js/src/load-frontend.js
@@ -2,7 +2,6 @@
 function clearDevState(e){
     localStorage.removeItem('localdev');
     localStorage.removeItem('localdist');
-    localStorage.removeItem('heroku');
     localStorage.removeItem('netlify');
     window.location.reload();
 }
@@ -36,7 +35,7 @@ window.loadReactApp = function(config) {
             console.log('ERROR: No frontend URL defined, should at least be empty string');
         }
     }
-    if (window.localdev || window.localdist || localStorage.heroku || localStorage.netlify) {
+    if (window.localdev || window.localdist || localStorage.netlify) {
         showFrontendPopup(window.frontendConfig.frontendUrl);
     }
     document.write('<script src="' + window.frontendConfig.frontendUrl + 'reactapp/common.bundle.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');


### PR DESCRIPTION
We are now only using netlify to deploy dev instances of the frontend.
Disable mounting of frontends from heroku