### PR TITLE
Disable study cache warming if auth present

### DIFF
--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -68,10 +68,12 @@ public class StudyController {
     
     @PostConstruct
     private void warmDefaultResponseCache() {
-        defaultResponse = studyService.getAllStudies(
-            null, Projection.SUMMARY.name(),
-            10000000, 0,
-            null, Direction.ASC.name());
+        if (!usingAuth()) {
+            defaultResponse = studyService.getAllStudies(
+                null, Projection.SUMMARY.name(),
+                10000000, 0,
+                null, Direction.ASC.name());
+        }
     }
 
     @Autowired


### PR DESCRIPTION


Fix #6977
Describe changes proposed in this pull request:
- Problem:
    - Server was catching on fire on start up
    - Cache warming method was trying to get all studies
    when it didn't have permission
- Solution:
    - Study cache warming disabled if auth present
    - The cache itself was not used if auth was present,
    so this was the correct thing to do even if the method
    didn't break everything

# Checks
- [x] Tested locally with auth