### PR TITLE
Performance optimization for ProfiledCasesCounter

### DIFF
--- a/docs/docker/using-keycloak.md
+++ b/docs/docker/using-keycloak.md
@@ -73,4 +73,4 @@ docker run -d --restart=always \
     -p 8081:8080 \
     cbioportal/cbioportal:latest \
     /bin/sh -c 'java ${JAVA_OPTS} -jar webapp-runner.jar /cbioportal-webapp'
-<pre>
+</pre>


### PR DESCRIPTION
Fix #7072  (see https://help.github.com/en/articles/closing-issues-using-keywords)

Left some print statements in there in case we want to do additional optimizations. Will remove after discussing whether or not this can be merged without additional code changes. 

Issue:
- Study Summary Page took ~3-5 minutes to run when loading for a large study (e.g GENIE)
- Profiled code and identified segment inside the ProfiledCasesCounter that processes data AFTER retrieving records from DB (meaning current EHCache placement will not help improve performance). 
- This segment of code took around 90-120 seconds to run.
- Portion of code was recalculating cases for gene panels.

Describe changes proposed in this pull request:
- Cache/store gene panel cases and reuse instead of recalculating
- Other cleanup related to creating maps to store reused objects

Involved endpoint is the `mutated-genes/fetch` endpoint. Current runtime is now ~5 seconds w/ EHCache turned on. Can test login and test [here](https://dashi-dev.cbio.mskcc.org:8080/security-test/api/mutated-genes/fetch) w/ `genie_private` if you have permissions.
# Checks
- [ ] Runs on heroku
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
