### PR TITLE
Reference app.name correctly

### DIFF
--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -51,7 +51,7 @@ public class StudyController {
     @Value("${authenticate:false}")
     private String authenticate;
 
-    @Value("${app.name:unknown")
+    @Value("${app.name:unknown}")
     private String appName;
     
     private boolean usingAuth() {


### PR DESCRIPTION
I made an update previously to cache a problematic studies request. It is not being cached because I missed a `}` in an annotation.