### PR TITLE
Fix the oncokb proxy issue

### DIFF
--- a/web/src/main/java/org/cbioportal/proxy/ProxyController.java
+++ b/web/src/main/java/org/cbioportal/proxy/ProxyController.java
@@ -96,7 +96,7 @@ public class ProxyController {
     public class OncoKBServiceIsDisabledException extends RuntimeException {
     }
 
-    @ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "No OncoKB access token is provided")
+    @ResponseStatus(code = HttpStatus.FORBIDDEN, reason = "No OncoKB access token is provided")
     public class NOOncoKBTokenProvidedException extends RuntimeException {
     }
 


### PR DESCRIPTION
This fix #7146 
We think at the time when we parse the response from the proxy to Object.class, it broke the chunk which causes ERR_INVALID_CHUNKED_ENCODING error. But it still does not explain why it works on public portal not MSK portal.
Solution is not returning ResponseEntity, only return the body as String. 

The reason we wanted to include the ResponseEntity in the first place is because we can attach a  different http response code when token/show.oncokb is not desired.
The reason we do not return as String but Object is that the ResponseEntity does not return string in the body which the frontend client is relaying on.
