### PR TITLE
Allow dots in id validation (for gene sets)

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -3810,7 +3810,7 @@ class MultipleDataFileValidator(FeaturewiseFileValidator, metaclass=ABCMeta):
 
         """Check the feature id column."""
 
-        ALLOWED_CHARACTERS = r'[^A-Za-z0-9_-]'
+        ALLOWED_CHARACTERS = r'[^A-Za-z0-9_.-]'
 
         feature_id = nonsample_col_vals[0].strip()
 
@@ -3821,7 +3821,7 @@ class MultipleDataFileValidator(FeaturewiseFileValidator, metaclass=ABCMeta):
         elif re.search(ALLOWED_CHARACTERS, feature_id) is not None:
             self.logger.error('Feature id contains one or more illegal characters',
                                 extra={'line_number': self.line_number,
-                                        'cause': 'id was`'+feature_id+'` and only alpha-numeric, _ and - are allowed.'})
+                                        'cause': 'id was`'+feature_id+'` and only alpha-numeric, _, . and - are allowed.'})
         else:
             # Check if this is the second data file
             if self.get_prior_validated_feature_ids() is not None:


### PR DESCRIPTION
@pvannierop introduced a bug when refactoring the validation of gene sets ([here](https://github.com/cBioPortal/cbioportal/commit/005f1ab03916298b954893c40a78abd5999d4781#diff-fee5ab3c72d7aa124ff0d2d3b199c68bR3724)). He was assuming the allowed characters for gene set IDs are `A-Za-z0-9_-`, but he was missing the `.`. This PR corrects this issue.