### PR TITLE
frontend v3.2.4 + 2 fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
   </profiles>
 
   <properties>
-    <frontend.version>v3.2.3</frontend.version>
+    <frontend.version>658480832a9b940d57180b0612d2c2e674ecd307</frontend.version>
     <frontend.groupId>com.github.cbioportal</frontend.groupId>
     <slf4j.version>1.6.6</slf4j.version>
     <spring.version>4.3.14.RELEASE</spring.version>


### PR DESCRIPTION
Update frontend to a few commits after v3.2.4 which includes the fixes to

- build on jitpack (react-table typing issue) (https://github.com/cBioPortal/cbioportal-frontend/pull/3078)
- bug fix related to oncokb anotation (https://github.com/cBioPortal/cbioportal-frontend/pull/3079)