### PR TITLE
Bugfix: Sample Quicksearch broke on string of " "

### DIFF
--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/SampleMapper.xml
@@ -62,7 +62,7 @@
             </if>
             <if test="keyword != null">
                 AND
-                <foreach item="item" collection="keyword.split(' ')" open="(" separator=") AND (" close=")">
+                <foreach item="item" collection="keyword.trim().split(' ')" open="(" separator=") AND (" close=")">
                     sample.STABLE_ID like CONCAT('%', #{item}, '%')
                 </foreach>
             </if>

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepositoryTest.java
@@ -347,6 +347,17 @@ public class SampleMyBatisRepositoryTest {
 
          Assert.assertEquals(expected, actual);
      }
+
+    @Test
+    public void getSamplesByEmptyKeyword() {
+        List<Sample> result = sampleMyBatisRepository.getAllSamples(" ", null, "SUMMARY", 10, 0, null, null);
+        List<String> actual = result.stream().map((Sample::getStableId)).collect(Collectors.toList());
+        List<String> expected = Arrays.asList(
+                "TCGA-A1-A0SB-01", "TCGA-A1-A0SB-01", "TCGA-A1-A0SB-02", "TCGA-A1-A0SD-01", "TCGA-A1-A0SE-01",
+                "TCGA-A1-A0SF-01", "TCGA-A1-A0SG-01", "TCGA-A1-A0SH-01", "TCGA-A1-A0SI-01", "TCGA-A1-A0SJ-01");
+
+        Assert.assertEquals(expected, actual);
+    }
     
     @Test
     public void getSamplesByKeywordFilterByStudies() {


### PR DESCRIPTION
Fix #7241
Describe changes proposed in this pull request:
- Trimmed the string
- Added a test

# Checks
- [x] Runs on heroku
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.