### PR TITLE
Fix #6642 Internal Links within the File Formats Markdown Page

### DIFF
--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -31,7 +31,7 @@ This page describes the file formats that cancer study data should assume in ord
 
 As described in the [Data Loading tool](Data-Loading.md) page, the following file is needed to describe the cancer study:
 
-#### Meta file
+### Meta file
 This file contains metadata about the cancer study. The file contains the following fields:
 
 1. **type_of_cancer**: The cancer type abbreviation, e.g., "brca".  This should be the same cancer type as specified in the `meta_cancer_type.txt` file, if available. The type can be "mixed" for studies with multiple cancer types.
@@ -45,7 +45,7 @@ This file contains metadata about the cancer study. The file contains the follow
 9. **add_global_case_list (Optional)**: set to 'true' if you would like the "All samples" case list to be generated automatically for you. See also [Case lists](#case-lists).
 10. **tags_file (Optional)**: the file name containing custom study tags for the [study tags](#study-tags-file).
 
-##### Example  
+### Example  
 An example meta_study.txt file would be:
 ```
 type_of_cancer: brca
@@ -59,14 +59,14 @@ add_global_case_list: true
 ## Cancer Type
 If the type_of_cancer specified in the meta_study.txt does not yet exist in the `type_of_cancer` database table, a `meta_cancer_type.txt` file is also mandatory.
 
-#### Meta file
+### Meta file
 The file is comprised of the following fields:
 
 1. **genetic_alteration_type**: CANCER_TYPE
 2. **datatype**: CANCER_TYPE
 3. **data_filename**: your datafile
 
-##### Example
+### Example
 An example meta_cancer_type.txt file would be:
 ```
 genetic_alteration_type: CANCER_TYPE
@@ -74,7 +74,7 @@ datatype: CANCER_TYPE
 data_filename: cancer_type.txt
 ```
 
-#### Data file
+### Data file
 The file is comprised of the following columns in the order specified:
 
 1. **type_of_cancer**: The cancer type abbreviation, e.g., "brca".
@@ -83,7 +83,7 @@ The file is comprised of the following columns in the order specified:
 4. **dedicated_color**: CSS color name of the color associated with this cancer study, e.g., "HotPink". See [this list](https://www.w3.org/TR/css3-color/#svg-color) for supported names, and follow the [awareness ribbons](http://en.wikipedia.org/wiki/List_of_awareness_ribbons) color schema. This color is associated with the cancer study on various web pages within the cBioPortal.
 5. **parent_type_of_cancer**:  The `type_of_cancer` field of the cancer type of which this is a subtype, e.g., "Breast". :information_source: : you can set parent to `tissue`, which is the reserved word to place the given cancer type at "root" level in the "studies oncotree" that will be generated in the homepage (aka query page) of the portal. 
 
-##### Example
+### Example
 An example record would be:
 ```
 brca<TAB>Breast Invasive Carcinoma<TAB>breast,breast invasive<TAB>HotPink<TAB>Breast
@@ -95,7 +95,7 @@ The clinical data is used to capture both clinical attributes and the mapping be
 
 As of March 2016, the clinical file is split into a patient clinical file and a sample clinical file. The *sample* file is required, whereas the *patient* file is optional. cBioPortal has specific functionality for a core set of patient and sample columns, but can also display custom columns (see section ["Custom columns in clinical data"](#custom-columns-in-clinical-data)).
 
-#### Meta files
+### Meta files
 The two clinical metadata files (or just one metadata file if you choose to leave the *patient* file out) have to contain the following fields:
 
 1. **cancer_study_identifier**: same value specified in meta_study.txt
@@ -103,7 +103,7 @@ The two clinical metadata files (or just one metadata file if you choose to leav
 3. **datatype**: PATIENT_ATTRIBUTES or SAMPLE_ATTRIBUTES
 4. **data_filename**: your datafile
 
-##### Examples
+### Examples
 An example metadata file, e.g. named meta_clinical_sample.txt, would be:
 ```
 cancer_study_identifier: brca_tcga_pub
@@ -120,7 +120,7 @@ datatype: PATIENT_ATTRIBUTES
 data_filename: data_clinical_patient.txt
 ```
 
-#### Data files
+### Data files
 For both patients and samples, the clinical data file is a two dimensional matrix with multiple clinical attributes. When the attributes are defined in the *patient* file they are considered to be patient attributes; when they are defined in the *sample* file they are considered to be sample attributes. 
 
 The first four rows of the clinical data file contain tab-delimited metadata about the clinical attributes. These rows **have to start with a '#' symbol**. Each of these four rows contain different type of information regarding each of the attributes that are defined in the fifth row:
@@ -158,7 +158,7 @@ The first four rows of the clinical data file contain tab-delimited metadata abo
 - Row 6: This is the first row that contains actual data.
 
 
-#### Example clinical header
+### Example clinical header
 Below is an example of the first 4 rows with the respective metadata for the attributes defined in the 5th row. 
 ```
 #Patient Identifier<TAB>Overall Survival Status<TAB>Overall Survival (Months)<TAB>Disease Free Status<TAB>Disease Free (Months)<TAB>...
@@ -171,7 +171,7 @@ data - see examples below
 ....
 ```
 
-#### Clinical patient columns
+### Clinical patient columns
 The file containing the patient attributes has one **required** column:
 - **PATIENT_ID (required)**: a unique patient ID. This field allows only numbers, letters, points, underscores and hyphens.
 
@@ -195,7 +195,7 @@ These columns, when provided, add additional information to the patient descript
 Custom attributes:
 - **Custom Clinical Attribute Headers**: Any other custom attribute can be added as well. See section ["Custom columns in clinical data"](#custom-columns-in-clinical-data).
 
-###### Example *patient* data file
+### Example *patient* data file
 ```
 #Patient Identifier<TAB>Overall Survival Status<TAB>Overall Survival (Months)<TAB>Disease Free Status<TAB>Disease Free (Months)<TAB>...
 #Patient identifier<TAB>Overall survival status<TAB>Overall survival in months since diagnosis<TAB>Disease free status<TAB>Disease free in months since treatment<TAB>...
@@ -207,7 +207,7 @@ PATIENT_ID_2<TAB>LIVING<TAB>63.01<TAB>DiseaseFree<TAB>63.01<TAB>...
 ...
 ```
 
-##### Clinical sample columns
+### Clinical sample columns
 The file containing the sample attributes has two **required** columns:
 - **PATIENT_ID (required)**: A patient ID. This field can only contain numbers, letters, points, underscores and hyphens.
 - **SAMPLE_ID (required)**: A sample ID. This field can only contain numbers, letters, points, underscores and hyphens.
@@ -233,7 +233,7 @@ The following columns additionally affect the [Timeline data](#timeline-data) vi
 Custom attributes:
 - **Custom Clinical Attribute Headers**: Any other custom attribute can be added as well. See section ["Custom columns in clinical data"](#custom-columns-in-clinical-data).
 
-###### Example sample data file
+### Example sample data file
 ```
 #Patient Identifier<TAB>Sample Identifier<TAB>Subtype<TAB>...
 #Patient identifier<TAB>Sample Identifier<TAB>Subtype description<TAB>...
@@ -245,7 +245,7 @@ PATIENT_ID_2<TAB>SAMPLE_ID_2<TAB>Her2 enriched<TAB>...
 ...
 ```
 
-##### Columns with specific functionality
+### Columns with specific functionality
 These columns can be in either the patient or sample file.
 - **CANCER_TYPE**: Overrides study wide cancer type
 - **CANCER_TYPE_DETAILED**
@@ -260,18 +260,18 @@ These columns can be in either the patient or sample file.
 - **SERUM_PSA**
 - **DRIVER_MUTATIONS**
 
-##### Custom columns in clinical data
+### Custom columns in clinical data
 cBioPortal supports custom columns with clinical data in either the patient or sample file. They should follow the previously described 5-row header format. Be sure to provide the correct `Datatype`, for optimal search, sorting, filtering (in [clinical data tab](https://www.cbioportal.org/study?id=brca_tcga#clinical)) and visualization.
 
 The Clinical Data Dictionary from MSKCC is used to normalize clinical data, and should be followed to make the clinical data comparable between studies. This dictionary provides a definition whether an attribute should be defined on the patient or sample level, as well as provides a name, description and datatype. The data curator can choose to ignore these proposed definitions, but not following this dictionary might make comparing data between studies more difficult. It should however not break any cBioPortal functionality. See GET /api/ at [http://oncotree.mskcc.org/cdd/swagger-ui.html#/](http://oncotree.mskcc.org/cdd/swagger-ui.html#/) for the data dictionary of all known clinical attributes.
 
-##### Banned column names
+### Banned column names
 `MUTATION_COUNT` and `FRACTION_GENOME_ALTERED` are auto populated clinical attributes, and should therefore not be present in clinical data files.
 
 ## Discrete Copy Number Data
 The discrete copy number data file contain values that would be derived from copy-number analysis algorithms like [GISTIC 2.0](http://www.ncbi.nlm.nih.gov/sites/entrez?term=18077431) or [RAE](http://www.ncbi.nlm.nih.gov/sites/entrez?term=18784837). GISTIC 2.0 can be [installed](http://www.broadinstitute.org/cgi-bin/cancer/publications/pub_paper.cgi?mode=view&paper_id=216&p=t) or run online using the GISTIC 2.0 module on [GenePattern](https://cloud.genepattern.org). For some help on using GISTIC 2.0, check the [Data Loading: Tips and Best Practices](Data-Loading-Tips-and-Best-Practices.md) page. When loading case list data, the `_cna` case list is required. See the [case list section](#case-lists).
 
-##### Meta file 
+### Meta file 
 The meta file is comprised of the following fields:
 
 1. **cancer_study_identifier**: same value as specified in [study meta file](#cancer-study)
@@ -284,7 +284,7 @@ The meta file is comprised of the following fields:
 8. **data_filename**: your datafile
 9. **gene_panel (Optional)**:  gene panel stable id
 
-##### Example
+### Example
 An example metadata file could be named meta_CNA.txt and its contents could be:
 ```
 cancer_study_identifier: brca_tcga_pub
@@ -297,7 +297,7 @@ profile_description: Putative copy-number from GISTIC 2.0. Values: -2 = homozygo
 data_filename: data_CNA.txt
 ```
 
-#### Data file
+### Data file
 
 For each gene (row) in the data file, the following columns are required in the order specified:
 
@@ -315,7 +315,7 @@ For each gene-sample combination, a copy number level is specified:
 - "1" indicates a low-level gain
 - "2" is a high-level amplification.
 
-#### Example
+### Example
 An example data file which includes the required column header would look like:
 ```
 Hugo_Symbol<TAB>Entrez_Gene_Id<TAB>SAMPLE_ID_1<TAB>SAMPLE_ID_2<TAB>...
@@ -325,7 +325,7 @@ AGRN<TAB>375790<TAB>2<TAB>0<TAB>...
 ...
 ```
 
-#### GISTIC 2.0 Format
+### GISTIC 2.0 Format
 GISTIC 2.0 outputs a tabular file similarly formatted to the cBioPortal format, called `<prefix>_all_thresholded.by_genes.txt`.
 In this file the gene symbol is found in the `Gene Symbol` column, while Entrez gene IDs are in the `Gene ID` or 
 `Locus ID` column. Please rename `Gene Symbol` to `Hugo_Symbol` and `Gene ID` or `Locus ID` to `Entrez_Gene_Id`. The 
@@ -335,7 +335,7 @@ the seed database.
 
 ## Continuous Copy Number Data
 
-#### Meta file
+### Meta file
 The continuous copy number metadata file should contain the following fields:
 
 1. **cancer_study_identifier**: same value as specified in [study meta file](#cancer-study)
@@ -353,7 +353,7 @@ cBioPortal also supports log2 copy number data. If your data is in log2, change 
 3. **datatype**: LOG2-VALUE
 4. **stable_id**: log2CNA 
 
-##### Example
+### Example
 An example metadata file, e.g. meta_CNA_log2.txt, would be:
 ```
 cancer_study_identifier: brca_tcga_pub
@@ -366,11 +366,11 @@ profile_name: Log2 copy-number values
 data_filename: data_log2CNA.txt
 ```
 
-#### Data file
+### Data file
 
 The log2 copy number data file follows the same format as expression data files.  See [Expression Data](#expression-data) for a description of the expression data file format.
 
-#### GISTIC 2.0 Format
+### GISTIC 2.0 Format
 GISTIC 2.0 outputs a tabular file similarly formatted to the cBioPortal format, called `<prefix>_all_data_by_genes.txt`. 
 In this file the gene symbol is found in the `Gene Symbol` column, while Entrez gene IDs are in the `Gene ID` or 
 `Locus ID` column. Please rename `Gene Symbol` to `Hugo_Symbol` and `Gene ID` or `Locus ID` to `Entrez_Gene_Id`. The 
@@ -383,7 +383,7 @@ the seed database.
 
 A SEG file (segmented data; .seg or .cbs) is a tab-delimited text file that lists loci and associated numeric values. The segmented data file format is the output of the Circular Binary Segmentation algorithm (Olshen et al., 2004).  **Segment data for import into the cBioPortal should be based on build 37 (hg19)**. This Segment data enables the 'CNA' lane in the Genomic overview of the Patient view (as [can be seen in this example](https://www.cbioportal.org/patient?sampleId=TCGA-BH-A0E6-01&studyId=brca_tcga)). 
 
-#### Meta file
+### Meta file
 The segmented metadata file should contain the following fields:
 
 1. **cancer_study_identifier**: same value as specified in [study meta file](#cancer-study)
@@ -393,7 +393,7 @@ The segmented metadata file should contain the following fields:
 5. **description**: A description of the segmented data, e.g., "Segment data for the XYZ cancer study.".
 6. **data_filename**: your datafile
 
-#### Example:
+### Example:
 An example metadata file, e.g. meta_cna_seg.txt, would be:
 ```
 cancer_study_identifier: brca_tcga_pub
@@ -404,11 +404,11 @@ description: Somatic CNA data (copy number ratio from tumor samples minus ratio 
 data_filename: brca_tcga_data_cna_hg19.seg
 ```
 
-#### Data file
+### Data file
 
 The first row contains column headings and each subsequent row contains a locus and an associated numeric value. See also the [Broad IGV page on this format](https://www.broadinstitute.org/software/igv/SEG).
 
-#### Example:
+### Example:
 
 An example data file which includes the required column header would look like:
 ```
@@ -425,7 +425,7 @@ SAMPLE_ID_2<TAB>2<TAB>5512374<TAB>159004775<TAB>80678<TAB>-0.0013
 
 An expression data file is a two dimensional matrix with a gene per row and a sample per column.  For each gene-sample pair, a real number represents the gene expression in that sample.  
 
-#### Meta file
+### Meta file
 
 The expression metadata file should contain the following fields:
 
@@ -440,7 +440,7 @@ The expression metadata file should contain the following fields:
 8. **data_filename**: your datafile
 9. **gene_panel (Optional)**:  gene panel stable id
 
-#### Supported stable_id values for MRNA_EXPRESSION
+### Supported stable_id values for MRNA_EXPRESSION
 For historical reasons, cBioPortal expects the `stable_id` to be one of those listed in the following static set.
 The stable_id for continuous RNA-seq data has two options: `rna_seq_mrna` or `rna_seq_v2_mrna`. These options were added to distinguish between two different TCGA pipelines, which perform different types of normalization (RPKM and RSEM). However, for custom datasets either one of these `stable_id` can be chosen.
 
@@ -466,7 +466,7 @@ The stable_id for continuous RNA-seq data has two options: `rna_seq_mrna` or `rn
 </table>
 
 
-#### Example
+### Example
 
 An example metadata, e.g. meta_expression_file.txt file would be:
 ```
@@ -480,7 +480,7 @@ profile_description: Expression levels
 data_filename: data_expression_file.txt
 ```
 
-#### Data file
+### Data file
 
 For each gene (row) in the data file, the following columns are required in the order specified:
 
@@ -495,7 +495,7 @@ For each gene-sample combination, a value is specified:
 - A real number for each sample id (column) in the dataset, representing the expression value for the gene in the respective sample.
 - or `NA` for when the expression value for the gene in the respective sample could not (or was not) be measured (or detected).
 
-##### z-score instructions
+### z-score instructions
 
 For mRNA expression data, we typically expect the relative expression of an individual gene and tumor to the gene's expression distribution in a reference population. That reference population is either all tumors that are diploid for the gene in question, or, when available, normal adjacent tissue. The returned value indicates the number of standard deviations away from the mean of expression in the reference population (Z-score). This measure is useful to determine whether a gene is up- or down-regulated relative to the normal samples or all other tumor samples.  **Note, the importer tool can create normalized (z-score) expression data on your behalf.  Please visit the [Z-Score normalization script](Z-Score-normalization-script.md) wiki page for more information.
 A corresponding z-score metadata file would be something like**:
@@ -510,7 +510,7 @@ profile_description: Expression levels z-scores
 data_filename: data_expression_zscores_file.txt
 ```
 
-#### Examples of data files: 
+### Examples of data files: 
 
 An example data file which includes the required column header and *leaves out Hugo_Symbol* (recommended) would look like:
 
@@ -560,27 +560,27 @@ The mutation metadata file should contain the following fields:
 11. **variant_classification_filter (optional)**: List of `Variant_Classifications` values to be filtered out.
 12. **namespaces (optional)**: Comma-delimited list of `namespaces` to import. 
 
-#### Gene panels for mutation data
+### Gene panels for mutation data
 Using the `gene_panel` property it is possible to annotate **all samples in the MAF file** as being profiled on the **same** specified gene panel. 
 
 Please use the [Gene Panel Matrix file](#gene-panel-matrix-file) when:
 - Data contains samples that are profiled but no mutations are called. Also please add these to the `_sequenced` case list. 
 - Multiple gene panels are used to profile the samples in the MAF file.
 
-#### Variant classification filter
+### Variant classification filter
 The `variant_classification_filter` field can be used to filter out specific mutations. This field should contain a comma separated list of `Variant_Classification` values. By default, cBioPortal filters out `Silent, Intron, IGR, 3'UTR, 5'UTR, 3'Flank and 5'Flank`, except for the promoter mutations of the TERT gene. For no filtering, include this field in the metadata file, but leave it empty. For cBioPortal default filtering, do not include this field in the metadata file.
 Allowed values to filter out (mainly from [Mutation Annotation Format page](https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/)): `Frame_Shift_Del, Frame_Shift_Ins, In_Frame_Del, In_Frame_Ins, Missense_Mutation, Nonsense_Mutation, Silent, Splice_Site, Translation_Start_Site, Nonstop_Mutation, 3'UTR, 3'Flank, 5'UTR, 5'Flank, IGR, Intron, RNA, Targeted_Region, De_novo_Start_InFrame, De_novo_Start_OutOfFrame, Splice_Region and Unknown`
 
-#### Tumor seq allele ambiguity
+### Tumor seq allele ambiguity
 Bugs may exist in MAF data that make it ambiguous as to whether `Tumor_Seq_Allele1` or `Tumor_Seq_Allele2` should be seen as the variant allele to be used when a new mutation record is created and imported in cBioPortal. In such cases, preference is given to the tumor seq allele value that matches a valid nucleotide pattern `^[ATGC]*$` versus a null or empty value, or "-".
 For example, given `Reference_Allele` = "G", `Tumor_Seq_Allele` = "-", and `Tumor_Seq_Allele2` = "A", preference will be given to `Tumor_Seq_Allele2`. Using this same example with `Tumor_Seq_Allele1` = "T", preference will be given to `Tumor_Seq_Allele1` if it does not match `Reference_Allele`, which in this case it does not.
 
 When curating MAF data, it is best practice to leave `Tumor_Seq_Allele1` empty if this information is not provided in your data source to avoid this ambiguity.
 
-#### Namespaces
+### Namespaces
 The `namespaces` field can be used to specify additional MAF columns for import. This field should contain a comma seperated list of namespaces. Namespaces can be identified as prefixes to an arbitrary set of additional MAF columns (seperated with a period e.g `ASCN.total_copy_number`, `ASCN.minor_copy_number`). All columns with a prefix matching a namespace specified in the metafile will be imported; columns with an unspecified namespace will be ignored. If no additional columns beyond the required set need to be imported, the field should be left blank. 
 
-#### Example
+### Example
 An example metadata file would be:
 ```
 cancer_study_identifier: brca_tcga_pub
@@ -599,7 +599,7 @@ The mutation data file extends the [Mutation Annotation Format](https://docs.gdc
 1. A minimal MAF file with only the columns required for cBioPortal.
 2. An extended MAF file created with [vcf2maf or maf2maf](https://github.com/mskcc/vcf2maf).
 
-#### Minimal MAF format
+### Minimal MAF format
 A minimal mutation annotations file can contain just three of the MAF columns plus one annotation column. From this minimal MAF, it is possible to create an extended MAF by running maf2maf.
 1. **Hugo_Symbol (Required)**: (MAF column) A [HUGO](http://www.genenames.org/) gene symbol.
 2. **Tumor_Sample_Barcode (Required)**: (MAF column) This is the sample ID as listed in the clinical data file.
@@ -615,10 +615,10 @@ The following extra annotation columns are important for making sure mutation sp
 6. **Protein_position (Optional)**: (annotation column) Required to initialize the 3D viewer in [mutations view](https://www.cbioportal.org/index.do?cancer_study_list=brca_tcga_pub&cancer_study_id=brca_tcga_pub&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=brca_tcga_pub_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=brca_tcga_pub_gistic&genetic_profile_ids_PROFILE_MRNA_EXPRESSION=brca_tcga_pub_mrna_median_Zscores&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&data_priority=0&case_set_id=brca_tcga_pub_complete&case_ids=&patient_case_select=sample&gene_set_choice=prostate-cancer%3A-ar-signaling-%2810-genes%29&gene_list=TP53&clinical_param_selection=null&tab_index=tab_visualize&Action=Submit#mutation_details)
 7. **SWISSPROT (Optional)**: (annotation column) UniProtKB/SWISS-PROT name (formerly called ID) or accession code depending on the value of the `swissprot_identifier` metadatum, e.g. O11H1_HUMAN or Q8NG94. Is not required, but not having it may result in inconsistent PDB structure matching in [mutations view](https://www.cbioportal.org/index.do?cancer_study_list=brca_tcga_pub&cancer_study_id=brca_tcga_pub&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=brca_tcga_pub_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=brca_tcga_pub_gistic&genetic_profile_ids_PROFILE_MRNA_EXPRESSION=brca_tcga_pub_mrna_median_Zscores&Z_SCORE_THRESHOLD=2.0&RPPA_SCORE_THRESHOLD=2.0&data_priority=0&case_set_id=brca_tcga_pub_complete&case_ids=&patient_case_select=sample&gene_set_choice=prostate-cancer%3A-ar-signaling-%2810-genes%29&gene_list=TP53&clinical_param_selection=null&tab_index=tab_visualize&Action=Submit#mutation_details).
 
-#### Creating an extended MAF file with vcf2maf or maf2maf
+### Creating an extended MAF file with vcf2maf or maf2maf
 If your mutation data is already in [VCF](http://www.1000genomes.org/wiki/Analysis/Variant%20Call%20Format/vcf-variant-call-format-version-41) format (which most variant callers produce by default) you can use the [vcf2maf](https://github.com/mskcc/vcf2maf) converter. This tool parses VCF and MAF files, runs Ensembl Variant Effect Predictor (VEP) and selects a single effect per variant. Protein identifiers should be mapped to UniProt canonical isoforms by adding the `--custom-enst` flag and [this mapping file](https://github.com/mskcc/vcf2maf/blob/master/data/isoform_overrides_uniprot). This will override the Ensembl canonical isoforms with UniProt canonical isoforms, which ensures the SWISSPROT column can be used correctly by cBioPortal.
 
-#### Extended MAF format
+### Extended MAF format
 The extended MAF format recognized by the portal has:
 * 32 columns from the [TCGA MAF format](https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format/).
 * 1 column with the amino acid change.
@@ -664,7 +664,7 @@ The extended MAF format recognized by the portal has:
 
 <sup>**1**</sup> These columns are currently not shown in the Mutation tab and Patient view.
 
-#### Custom driver annotations
+### Custom driver annotations
 It is possible to manually add columns for defining custom driver annotations. These annotations can be used to complement or replace default driver annotation resources OncoKB and HotSpots.
 
 38. **cbp_driver (Optional)**: "Putative_Driver", "Putative_Passenger", "Unknown", "NA" or "" (empty value).
@@ -677,17 +677,17 @@ The `cbp_driver` column flags the mutation as either driver or passenger. In cBi
 You can learn more about configuring these annotations in the [portal.properties documentation](portal.properties-Reference.md#custom-annotation). When properly configured, the customized annotations appear in the "Mutation Color" menu of the OncoPrint view: \
 ![schreenshot mutation color menu](images/screenshot-mutation-color-menu.png) 
 
-#### Example MAF
+### Example MAF
 An example MAF can be found in the cBioPortal test study [study_es_0](https://github.com/cBioPortal/cbioportal/blob/master/core/src/test/scripts/test_data/study_es_0/data_mutations_extended.maf).
 
-#### Filtered mutations
+### Filtered mutations
 A special case for **Entrez_Gene_Id=0** and **Hugo_Symbol=Unknown**: when this combination is given, the record is parsed in the same way as **Variant_Classification=IGR** and therefore filtered out.
 
 
 ## Methylation Data
 The Portal expects a single value for each gene in each sample, usually a beta-value from the Infinium methylation array platform.
 
-#### Meta file
+### Meta file
 
 The methylation metadata file should contain the following fields:
 
@@ -702,7 +702,7 @@ The methylation metadata file should contain the following fields:
 9. **gene_panel (Optional)**:  gene panel stable id
 
 
-#### Example
+### Example
 
 An example metadata file would be:
 ```
@@ -716,7 +716,7 @@ profile_description: Methylation beta-values (HM27 platform). For genes with mul
 data_filename: data_methylation_hm27.txt
 ```
 
-#### Data file
+### Data file
 
 The methylation data file follows the same format as expression data files. See [Expression Data](#expression-data) for a description of the expression data file format. The Portal expects a single value for each gene in each sample, usually a beta-value from the Infinium methylation array platform.
 
@@ -725,7 +725,7 @@ The methylation data file follows the same format as expression data files. See 
 
 Protein expression measured by reverse-phase protein array or mass spectrometry. Antibody-sample pairs, with a real number representing the protein level for that sample.
 
-#### Meta file
+### Meta file
 
 The protein level metadata file should contain the following fields:
 
@@ -764,11 +764,11 @@ profile_description: Protein expression Z-scores (RPPA)
 profile_name: Protein expression Z-scores (RPPA)
 ```
 
-#### Data file
+### Data file
 
 A protein level data file is a two dimensional matrix with a RPPA antibody per row and a sample per column. For each antibody-sample pair, a real number represents the protein level for that sample.  The antibody information can contain one or more HUGO gene symbols and/or entrez gene identifiers, separated by a space, and an antibody ID pair separated by the "|" symbol.
 
-#### Example 
+### Example 
 
 An example data file which includes the required column header would look like:
 
@@ -783,7 +783,7 @@ AKT1 AKT2 10000|AKT<TAB>0.17071492725<TAB>0.264067254391
 
 ## Fusion Data  
 
-#### Meta file
+### Meta file
 The fusion metadata file should contain the following fields:
 
 1. **cancer_study_identifier**: same value as specified in [study meta file](#cancer-study)
@@ -796,7 +796,7 @@ The fusion metadata file should contain the following fields:
 8. **data_filename**: your datafile
 9. **gene_panel (Optional)**:  gene panel stable id
 
-#### Example
+### Example
 An example metadata file would be:
 ```
 cancer_study_identifier: brca_tcga_pub
@@ -809,7 +809,7 @@ profile_description: Fusion data.
 data_filename: data_fusions.txt
 ```
 
-#### Data file
+### Data file
 A fusion data file is a two dimensional matrix with one gene per row.  For each gene (row) in the data file, the following tab-delimited values are required in the order specified:
 
 1. **Hugo_Symbol**: A [HUGO](http://www.genenames.org/) gene symbol.
@@ -847,7 +847,7 @@ The case list file should contain the following fields:
 5. **case_list_ids**: A tab-delimited list of sample ids from the dataset.
 6. **case_list_category**: Optional *alternative* way of linking your case list to a specific molecular profile. E.g. setting this to `all_cases_with_cna_data` will signal to the portal that this is the list of samples to be associated with CNA data in *some* of the analysis. 
 
-#### Example
+### Example
 An example case list file would be:
 ```
 cancer_study_identifier: brca_tcga_pub
@@ -857,7 +857,7 @@ case_list_description: Custom subset of samples (825 samples)
 case_list_ids: SAMPLE_ID_1<TAB>SAMPLE_ID_2<TAB>SAMPLE_ID_3<TAB>...
 ```
 
-#### Case list stable id suffixes
+### Case list stable id suffixes
 In order for sample counts to propagate to the data sets widget on the home page and the table on the [Data Sets](https://www.cbioportal.org/data_sets.jsp) page, the following case list suffixes need to be used in the stable_id property (e.g. `brca_tcga_pub_sequenced`). This is also needed for correct statistics in the Study view page when calculating the frequency of CNA and of mutations per gene in the respective summary tables.
 
 * **Sequenced**: `_sequenced` . When only a mutation profile is selected on the query page, this is the default case list. Also used in the Study Summary to calculate the proportion of samples with mutations.
@@ -874,14 +874,14 @@ In order for sample counts to propagate to the data sets widget on the home page
 * **SV**: `_sv` . When a structural variant profile is selected on the query page, this is the default case list. Also used in the Study Summary to calculate the proportion of samples with fusions.
 * **All**: `_all`. If you are not using *add_global_case_list* attribute in [Study metadata](#cancer-study), you need to add this case list.
 
-#### Required case lists
+### Required case lists
 Some case lists are required:
 
 - `_all`. This can be generated by the importer if you set the attribute `add_global_case_list` to `true` in the [Study metadata](#cancer-study).
 - `_sequenced`. This case list is required when loading mutation data.
 - `_cna`. This case list is required when loading discrete cna data.
 
-#### Case list categories
+### Case list categories
 These are the valid case lists categories for `case_list_category: ` in the meta file.
 - `all_cases_in_study`
 - `all_cases_with_mutation_data`
@@ -905,7 +905,7 @@ The timeline data is a representation of the various events that occur during th
 
 This type data is not yet being validated. It can, however, be uploaded.
 
-#### Meta file
+### Meta file
 Each event type requires its own meta file. A timeline meta file should contain the following fields:
 
 1. **cancer_study_identifier**: same value as specified in [study meta file](#cancer-study)
@@ -922,7 +922,7 @@ data_filename: data_timeline_imaging.txt
 ```
 
 
-#### Data file
+### Data file
 Each event type requires its own data file, which contains all the events that each patient undergoes. The data format used for timeline data is extremely flexible. There are three required columns:
 
 1. **PATIENT_ID**: the patient ID from the dataset
@@ -934,7 +934,7 @@ And one optional columns with a special effect:
 
 1. **SPECIMEN_REFERENCE_NUMBER**: when this column has values that match the SAMPLE_ID/OTHER_SAMPLE_ID (defined in the clinical data file), the timeline will show case labels with black/red/etc 1, 2, 3, 4 circles. This only works for the first track and only if no STOP_DATE is set.
 
-##### Event Types
+### Event Types
 As previously mentioned, the EVENT_TYPE can be anything. However, several event types have columns with special effects. Furthermore, for some event types cBioPortal has column naming suggestions.
 
 _**EVENT_TYPE: TREATMENT**_
@@ -988,7 +988,7 @@ Suggested columns
 
 Special: when the SPECIMEN_REFERENCE_NUMBER column has values that match the SAMPLE_ID/OTHER_SAMPLE_ID (defined in the clinical data file), the timeline will show case labels with black/red/etc 1, 2, 3, 4 circles. This only works for the first track and only if no STOP_DATE is set.
 
-##### Clinical Track Ordering
+### Clinical Track Ordering
 Clinical tracks are ordered as follows (if available):
 
 1. Specimen
@@ -1002,7 +1002,7 @@ Clinical tracks are ordered as follows (if available):
 9. First custom event
 10. etc.
 
-#### Example
+### Example
 
 An example timeline file for SPECIMEN would be:
 ```
@@ -1028,7 +1028,7 @@ Running GISTIC 2.0 on e.g. [GenePattern](https://cloud.genepattern.org) not only
 
 After uploading a gistic_amp and/or gistic_del file, a new button becomes available in the Enter Gene Set section, called "Select Genes from Recurrent CNAs (Gistic)". 
 
-#### Meta file
+### Meta file
 The Gistic metadata file should contain the following fields:
 
 1. **cancer_study_identifier**: same value as specified in [study meta file](#cancer-study)
@@ -1046,7 +1046,7 @@ reference_genome_id: hg19
 data_filename: data_gistic_genes_amp.txt
 ```
 
-#### Data file
+### Data file
 
 The following fields from the generated Gistic file are used by the cBioPortal importer:
 
@@ -1058,7 +1058,7 @@ The following fields from the generated Gistic file are used by the cBioPortal i
 * **cytoband**: cytogenetic band specification of the region, including chromosome (Giemsa stain)
 * **q_value**: the q-value of the peak region
 
-#### Example 
+### Example 
 An example data file which includes the required column header would look like:
 
 ```
@@ -1080,7 +1080,7 @@ After uploading a MutSig file, a new button becomes available in the Enter Gene 
 
 This type data is not yet being validated. It can, however, be uploaded.
 
-#### Meta file
+### Meta file
 The MutSig metadata file should contain the following fields:
 
 1. **cancer_study_identifier**: same value as specified in [study meta file](#cancer-study)
@@ -1097,7 +1097,7 @@ data_filename: data_mutsig.txt
 ```
 
 
-#### Data file
+### Data file
 
 The following fields from a MutSig file are used by the cBioPortal importer:
 * **rank**
@@ -1108,7 +1108,7 @@ The following fields from a MutSig file are used by the cBioPortal importer:
 * **q**: p value correct for multiple testing
 
 
-#### Example 
+### Example 
 
 An example data file which includes the required column header would look like:
 
@@ -1127,15 +1127,15 @@ To include gene panel data in your instance, the following data and/or configura
 2. **Gene panel matrix file**: This file is used to specify which samples are sequenced on which gene panel in which genetic profile. This is recommended for mutation and fusion data, because the MAF and fusion formats are unable to include samples which are sequenced but contain no called mutations, and only a single gene panel can be defined in the meta file. For other genetic profiles, columns can be added to specify their gene panel, but a property can also be added to their respective meta file, because these data files contain all profiled samples. Although the gene panel matrix functionality overlaps with the case list functionality, a case list for mutations (`_sequenced`) is also required.
 3. **Gene panel property in meta file**: Adding the `gene_panel:` property to the meta file of data profile will assign all samples from that profile to the gene panel. In this case it is not necessary to include a column for this profile in the gene panel matrix file.
 
-#### Gene Panel Matrix file
+### Gene Panel Matrix file
 
-#### Columns and rows
+### Columns and rows
 The gene panel matrix file contains a list of samples in the first column, and an additional column for each profile in the study using the stable_id as the column header. These stable_id's should match the ones in their respective meta files, for example `mutations` for mutation data and `gistic` for discrete CNA data. Columns should be separated by tabs. Fusion events are saved in the mutation table in the cBioPortal database, so they should be included in the `mutations` column. As described above, genetic profiles other than mutation and fusion data profiles can use the `gene_panel:` meta property if all samples are profiled on the same gene panel.
 
-#### Values
+### Values
 For each sample-profile combination, a gene panel should be specified. Please make sure this gene panel is imported before loading the study data. When the sample is not profiled on a gene panel, or if the sample is not profiled at all, use `NA` as value. If the sample is profiled for mutations, make sure it is also in the `_sequenced` case list. 
 
-#### Example 
+### Example 
 An example file would look like this:
 
 | SAMPLE_ID   | mutations | gistic    |
@@ -1144,7 +1144,7 @@ An example file would look like this:
 | SAMPLE_ID_2 | IMPACT410 | IMPACT410 |
 | SAMPLE_ID_3 | NA       | NA        |
 
-#### Meta file
+### Meta file
 The gene panel matrix file requires a meta file, which should contain the following fields:
 
 1. **cancer_study_identifier**: same value as specified in [study meta file](#cancer-study)
@@ -1160,7 +1160,7 @@ datatype: GENE_PANEL_MATRIX
 data_filename: data_gene_matrix.txt
 ```
 
-#### Gene panel property in meta file
+### Gene panel property in meta file
 If all samples in a genetic profile have the same gene panel associated with them, an optional field can be specified in the meta data file of that datatype called **gene_panel:**. If this is present, all samples in this data file will be assigned to this gene panel for this specific profile.
 
 ## Gene Set Data
@@ -1296,10 +1296,10 @@ pivot_threshold_value: 0.1
 value_sort_order: ASC
 ```
 
-#### Note on `value_sort_order`
+### Note on `value_sort_order`
 When values are sorted based on the `value_sort_order`, data points at the start of the sequence are considered more significant than data points at the end. This concept is used by the oncoprint when aggregating treatment response data from multiple samples from a single patient. When `value_sort_order` is `ASC` the sample with the smallest response value will be shown for that patient. When `value_sort_order` is `DESC` the sample with the largest response value will be shown for that patient.
 
-#### Note on `TREATMENT` genetic_alteration_type and `LIMIT-VALUE` datatype
+### Note on `TREATMENT` genetic_alteration_type and `LIMIT-VALUE` datatype
 Treatment response data is registered to be of the `TREATMENT` genetic_alteration_type and data type `LIMIT-VALUE`. This alteration and data type is intended to be used for any numerical data set with similar structure (entities measured in samples).
 
 ### Treatment response data file
@@ -1348,13 +1348,13 @@ show_profile_in_analysis_tab: true
 generic_entity_meta_properties: NAME,DESCRIPTION
 ```
 
-#### Note on `stable_id`
+### Note on `stable_id`
 The `stable_id` for the generic assay datatype is a user defined field. The only requirement is that the `stable_id` is unique across all metafiles in the study.
 
-#### Note on `generic_entity_meta_properties`
+### Note on `generic_entity_meta_properties`
 All meta properties must be specified in the `generic_entity_meta_properties` field. Every meta property listed here must appear as a column header in the corresponding data file.
 
-#### Note on `Generic Assay` genetic_alteration_type and `LIMIT-VALUE` datatype
+### Note on `Generic Assay` genetic_alteration_type and `LIMIT-VALUE` datatype
 All generic assay data is registered to be of the type of `genetic_alteration_type` and data type `LIMIT-VALUE`. This alteration and data type is intended to be used for any numerical data set with similar structure (entities measured in samples). The `LIMIT-VALUE` is validated to contain any continuous number optionally prefixed with a '>' or '<' threshold symbol (e.g., '>8.00'). If the value for the generic entity in the respective sample could not (or was not) be measured (or detected), the value should be 'NA'.
 
 ### Generic Assay data file


### PR DESCRIPTION
Fix #6642: Internal Links within the File Formats Markdown Page

The Diagnosis:
- #6642 describes internal links that do not work.  I first verified that the internal links actually work when viewed via github, e.g. https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md and via Markdown preview within VS Code.  This led me to believe that the problem was specific to gitbook.
- To investigate further, I then created a sandbox repo on gitbook and determined that within gitbook, internal links to h1, h2, h3 sections do work, but internal links to >h3 do not work.

The Fix:
- I reported the bug to gitbook, but since we don't really need such a deep level of headers within this page, I simply modified the Markdown page to limit sections to h3, and this fixes the internal links.
- To verify that this fixed the issue I created a sandbox repo on gitbook:  https://cerami.gitbook.io/sandbox/, and verified that the bug is now fixed.

# Notify reviewers
@inodb @tmazor 