### PR TITLE
Add appropriate content type attributes to script tags for frontend js

### DIFF
--- a/portal/src/main/webapp/js/src/load-frontend.js
+++ b/portal/src/main/webapp/js/src/load-frontend.js
@@ -38,8 +38,8 @@ window.loadReactApp = function(config) {
     if (window.localdev || window.localdist || localStorage.netlify) {
         showFrontendPopup(window.frontendConfig.frontendUrl);
     }
-    document.write('<script src="' + window.frontendConfig.frontendUrl + 'reactapp/common.bundle.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');
-    document.write('<script src="' + window.frontendConfig.frontendUrl + 'reactapp/main.app.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');
+    document.write('<script type="text/javascript" charset="UTF-8" src="' + window.frontendConfig.frontendUrl + 'reactapp/common.bundle.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');
+    document.write('<script type="text/javascript" charset="UTF-8" src="' + window.frontendConfig.frontendUrl + 'reactapp/main.app.js?'+ window.frontendConfig.appVersion +'"></scr' + 'ipt>');
 
 };
 


### PR DESCRIPTION
Some unicode characters embedded in templates were getting corrupted because script tags didn't declare content type appropriately