### PR TITLE
limit 1 Stale action per hour / 24 per day

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,3 +17,5 @@ markComment: >
   for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 1


### PR DESCRIPTION
It is overwhelming to see too many actions from the Stale app.