### PR TITLE
Fix error while fetching multiple molecular profile samples

### DIFF
--- a/model/src/main/java/org/cbioportal/model/MolecularProfileSamples.java
+++ b/model/src/main/java/org/cbioportal/model/MolecularProfileSamples.java
@@ -1,0 +1,46 @@
+package org.cbioportal.model;
+
+import java.io.Serializable;
+
+public class MolecularProfileSamples implements Serializable {
+
+    private String molecularProfileId;
+    private String commaSeparatedSampleIds;
+    private String[] splitSampleIds = null;
+
+    public String getMolecularProfileId() {
+        return molecularProfileId;
+    }
+
+    public void setMolecularProfileId(String molecularProfileId) {
+        this.molecularProfileId = molecularProfileId;
+    }
+
+    public String getCommaSeparatedSampleIds() {
+        return commaSeparatedSampleIds;
+    }
+
+    /**
+     * Set the values for all samples.
+     * 
+     * @param values: string with list of values, comma (,) separated
+     */
+    public void setCommaSeparatedSampleIds(String commaSeparatedSampleIds) {
+        this.commaSeparatedSampleIds = commaSeparatedSampleIds;
+    }
+
+    /**
+     * Returns the values attribute split on (,).
+     * 
+     * Remembers last .split to avoid repeating this costly operation.
+     * 
+     * @return list of values for all samples
+     */
+    public String[] getSplitSampleIds() {
+        if (splitSampleIds == null) {
+            splitSampleIds = commaSeparatedSampleIds.split(",");
+        }
+        return splitSampleIds;
+    }
+
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
@@ -1,19 +1,21 @@
 package org.cbioportal.persistence;
 
 import java.util.List;
+import java.util.Map;
 
 import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GenericAssayMolecularAlteration;
 import org.cbioportal.model.GenesetMolecularAlteration;
 import org.springframework.cache.annotation.Cacheable;
+import org.cbioportal.model.MolecularProfileSamples;
 
 public interface MolecularDataRepository {
 
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
-    String getCommaSeparatedSampleIdsOfMolecularProfile(String molecularProfileId);
+    MolecularProfileSamples getCommaSeparatedSampleIdsOfMolecularProfile(String molecularProfileId);
 
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
-    List<String> getCommaSeparatedSampleIdsOfMolecularProfiles(List<String> molecularProfileIds);
+    Map<String, MolecularProfileSamples> commaSeparatedSampleIdsOfMolecularProfilesMap(List<String> molecularProfileIds);
 
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
@@ -4,13 +4,14 @@ package org.cbioportal.persistence.mybatis;
 import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GenericAssayMolecularAlteration;
 import org.cbioportal.model.GenesetMolecularAlteration;
+import org.cbioportal.model.MolecularProfileSamples;
 
 import java.util.List;
 import org.apache.ibatis.cursor.Cursor;
 
 public interface MolecularDataMapper {
 
-    List<String> getCommaSeparatedSampleIdsOfMolecularProfiles(List<String> molecularProfileIds);
+    List<MolecularProfileSamples> getCommaSeparatedSampleIdsOfMolecularProfiles(List<String> molecularProfileIds);
 
     List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
                                                               String projection);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
@@ -3,12 +3,14 @@ package org.cbioportal.persistence.mybatis;
 import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GenericAssayMolecularAlteration;
 import org.cbioportal.model.GenesetMolecularAlteration;
+import org.cbioportal.model.MolecularProfileSamples;
 import org.cbioportal.persistence.MolecularDataRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.*;
 import org.springframework.stereotype.Repository;
 
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Repository
 public class MolecularDataMyBatisRepository implements MolecularDataRepository {
@@ -17,7 +19,7 @@ public class MolecularDataMyBatisRepository implements MolecularDataRepository {
     private MolecularDataMapper molecularDataMapper;
 
     @Override
-    public String getCommaSeparatedSampleIdsOfMolecularProfile(String molecularProfileId) {
+    public MolecularProfileSamples getCommaSeparatedSampleIdsOfMolecularProfile(String molecularProfileId) {
         try {
             return molecularDataMapper.getCommaSeparatedSampleIdsOfMolecularProfiles(
                 Arrays.asList(molecularProfileId)).get(0);
@@ -27,9 +29,11 @@ public class MolecularDataMyBatisRepository implements MolecularDataRepository {
     }
 
     @Override
-    public List<String> getCommaSeparatedSampleIdsOfMolecularProfiles(List<String> molecularProfileIds) {
+    public Map<String, MolecularProfileSamples> commaSeparatedSampleIdsOfMolecularProfilesMap(List<String> molecularProfileIds) {
 
-        return molecularDataMapper.getCommaSeparatedSampleIdsOfMolecularProfiles(molecularProfileIds);
+        return molecularDataMapper.getCommaSeparatedSampleIdsOfMolecularProfiles(molecularProfileIds)
+                .stream()
+                .collect(Collectors.toMap(MolecularProfileSamples::getMolecularProfileId, Function.identity()));
     }
 
     @Override

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
@@ -21,8 +21,10 @@
         </where>
     </sql>
 
-    <select id="getCommaSeparatedSampleIdsOfMolecularProfiles" resultType="string">
-        SELECT genetic_profile_samples.ORDERED_SAMPLE_LIST
+    <select id="getCommaSeparatedSampleIdsOfMolecularProfiles" resultType="org.cbioportal.model.MolecularProfileSamples">
+        SELECT 
+        genetic_profile.STABLE_ID AS molecularProfileId,
+        genetic_profile_samples.ORDERED_SAMPLE_LIST AS "commaSeparatedSampleIds"
         FROM genetic_profile_samples
         INNER JOIN genetic_profile ON genetic_profile_samples.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
         <where>
@@ -33,9 +35,6 @@
                 </foreach>
             </if>
         </where>
-        <!-- It seems like in Java, `_` comes before letters when sorted, but in MySQL it comes after. 
-        The code depends on them being the same order, so this is done to make the MySQL ordering same with Java. -->
-        ORDER BY REPLACE(genetic_profile.STABLE_ID, '_', ' '), genetic_profile.STABLE_ID ASC
     </select>
     
     <!-- Any changes to this routine should be kept in sync with getGeneMolecularAlterationsIter below -->

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepositoryTest.java
@@ -2,6 +2,7 @@ package org.cbioportal.persistence.mybatis;
 
 import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GenesetMolecularAlteration;
+import org.cbioportal.model.MolecularProfileSamples;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,6 +15,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/testContextDatabase.xml")
@@ -26,21 +28,21 @@ public class MolecularDataMyBatisRepositoryTest {
     @Test
     public void getCommaSeparatedSampleIdsOfMolecularProfile() throws Exception {
 
-        String result = molecularDataMyBatisRepository
+        MolecularProfileSamples result = molecularDataMyBatisRepository
             .getCommaSeparatedSampleIdsOfMolecularProfile("study_tcga_pub_gistic");
 
-        Assert.assertEquals("1,2,3,4,5,6,7,8,9,10,11,12,13,14,", result);
+        Assert.assertEquals("1,2,3,4,5,6,7,8,9,10,11,12,13,14,", result.getCommaSeparatedSampleIds());
     }
 
     @Test
     public void getCommaSeparatedSampleIdsOfMolecularProfiles() throws Exception {
 
-        List<String> result = molecularDataMyBatisRepository
-            .getCommaSeparatedSampleIdsOfMolecularProfiles(Arrays.asList("study_tcga_pub_mrna", "study_tcga_pub_m_na"));
+        Map<String, MolecularProfileSamples> result = molecularDataMyBatisRepository
+            .commaSeparatedSampleIdsOfMolecularProfilesMap(Arrays.asList("study_tcga_pub_mrna", "study_tcga_pub_m_na"));
 
         Assert.assertEquals(2, result.size());
-        Assert.assertEquals("1,2,3,4,5,6,7,8,9,10,11,", result.get(0));
-        Assert.assertEquals("2,3,6,8,9,10,12,13,", result.get(1));
+        Assert.assertEquals("1,2,3,4,5,6,7,8,9,10,11,", result.get("study_tcga_pub_m_na").getCommaSeparatedSampleIds());
+        Assert.assertEquals("2,3,6,8,9,10,12,13,", result.get("study_tcga_pub_mrna").getCommaSeparatedSampleIds());
     }
 
     @Test

--- a/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java
@@ -123,9 +123,9 @@ public class CoExpressionServiceImpl implements CoExpressionService {
         // of the genetic_alteration table is a comma separated list of scalar values.
         // Each value in this list is associated with a sample at the same position found in
         // the genetic_profile_samples.ORDERED_SAMPLE_LIST column.
-        String commaSeparatedSampleIdsOfMolecularProfile = molecularDataRepository
+        MolecularProfileSamples commaSeparatedSampleIdsOfMolecularProfile = molecularDataRepository
             .getCommaSeparatedSampleIdsOfMolecularProfile(molecularProfileId);
-        List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfile.split(","))
+        List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfile.getSplitSampleIds())
             .mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
         Map<Integer, Integer> internalSampleIdToIndexMap = new HashMap<>();
         for (int lc = 0; lc < internalSampleIds.size(); lc++) {

--- a/service/src/main/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImpl.java
@@ -22,6 +22,7 @@ import org.cbioportal.model.MolecularAlteration;
 import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.MolecularProfile.MolecularAlterationType;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
+import org.cbioportal.model.MolecularProfileSamples;
 import org.cbioportal.model.Gene;
 import org.cbioportal.model.Sample;
 import org.cbioportal.persistence.MolecularDataRepository;
@@ -170,10 +171,10 @@ public class ExpressionEnrichmentServiceImpl implements ExpressionEnrichmentServ
             MolecularProfile molecularProfile) {
         
 
-        String commaSeparatedSampleIdsOfMolecularProfile = molecularDataRepository
+        MolecularProfileSamples commaSeparatedSampleIdsOfMolecularProfile = molecularDataRepository
                 .getCommaSeparatedSampleIdsOfMolecularProfile(molecularProfile.getStableId());
         
-        List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfile.split(","))
+        List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfile.getSplitSampleIds())
                 .mapToInt(Integer::parseInt)
                 .boxed()
                 .collect(Collectors.toList());

--- a/service/src/main/java/org/cbioportal/service/impl/GenericAssayServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenericAssayServiceImpl.java
@@ -16,6 +16,7 @@ import org.cbioportal.model.GenericAssayMolecularAlteration;
 import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.Sample;
 import org.cbioportal.model.MolecularProfile.MolecularAlterationType;
+import org.cbioportal.model.MolecularProfileSamples;
 import org.cbioportal.model.meta.GenericAssayMeta;
 import org.cbioportal.persistence.GenericAssayRepository;
 import org.cbioportal.persistence.MolecularDataRepository;
@@ -90,20 +91,22 @@ public class GenericAssayServiceImpl implements GenericAssayService {
 
         List<String> distinctMolecularProfileIds = molecularProfileIds.stream().distinct().sorted().collect(Collectors.toList());
 
-        List<String> commaSeparatedSampleIdsOfMolecularProfiles = molecularDataRepository
-            .getCommaSeparatedSampleIdsOfMolecularProfiles(distinctMolecularProfileIds);
-    
+        Map<String, MolecularProfileSamples> commaSeparatedSampleIdsOfMolecularProfilesMap = molecularDataRepository
+                .commaSeparatedSampleIdsOfMolecularProfilesMap(distinctMolecularProfileIds);
+
         Map<String, Map<Integer, Integer>> internalSampleIdsMap = new HashMap<>();
         List<Integer> allInternalSampleIds = new ArrayList<>();
-        
+
         for (int i = 0; i < distinctMolecularProfileIds.size(); i++) {
-            List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfiles.get(i).split(","))
-                .mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
+            String molecularProfileId = distinctMolecularProfileIds.get(i);
+            List<Integer> internalSampleIds = Arrays
+                    .stream(commaSeparatedSampleIdsOfMolecularProfilesMap.get(molecularProfileId).getSplitSampleIds())
+                    .mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
             HashMap<Integer, Integer> molecularProfileSampleMap = new HashMap<Integer, Integer>();
             for (int lc = 0; lc < internalSampleIds.size(); lc++) {
                 molecularProfileSampleMap.put(internalSampleIds.get(lc), lc);
             }
-            internalSampleIdsMap.put(distinctMolecularProfileIds.get(i), molecularProfileSampleMap);
+            internalSampleIdsMap.put(molecularProfileId, molecularProfileSampleMap);
             allInternalSampleIds.addAll(internalSampleIds);
         }
     

--- a/service/src/main/java/org/cbioportal/service/impl/GenesetDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenesetDataServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import org.cbioportal.model.GenesetMolecularAlteration;
 import org.cbioportal.model.GenesetMolecularData;
 import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.MolecularProfileSamples;
 import org.cbioportal.model.Sample;
 import org.cbioportal.persistence.MolecularDataRepository;
 import org.cbioportal.service.SampleListService;
@@ -62,13 +63,13 @@ public class GenesetDataServiceImpl implements GenesetDataService {
         
         List<GenesetMolecularData> genesetDataList = new ArrayList<>();
 
-        String commaSeparatedSampleIdsOfGeneticProfile = molecularDataRepository
+        MolecularProfileSamples commaSeparatedSampleIdsOfGeneticProfile = molecularDataRepository
             .getCommaSeparatedSampleIdsOfMolecularProfile(molecularProfileId);
         if (commaSeparatedSampleIdsOfGeneticProfile == null) {
         	//no data, return empty list:
             return genesetDataList;
         }
-        List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfGeneticProfile.split(","))
+        List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfGeneticProfile.getSplitSampleIds())
             .mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
 
         List<Sample> samples;

--- a/service/src/test/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImplTest.java
@@ -13,6 +13,7 @@ import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GroupStatistics;
 import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
+import org.cbioportal.model.MolecularProfileSamples;
 import org.cbioportal.model.ReferenceGenome;
 import org.cbioportal.model.Gene;
 import org.cbioportal.model.Sample;
@@ -61,9 +62,13 @@ public class ExpressionEnrichmentServiceImplTest extends BaseServiceImplTest {
 
         Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID))
                 .thenReturn(geneMolecularProfile);
+        
+        MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
+        molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
+        molecularProfileSamples.setCommaSeparatedSampleIds("1,2,3,4");
 
         Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
-                .thenReturn("1,2,3,4");
+                .thenReturn(molecularProfileSamples);
 
         List<Sample> samples = new ArrayList<>();
         Sample sample1 = new Sample();

--- a/service/src/test/java/org/cbioportal/service/impl/GenericAssayServiceImpTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenericAssayServiceImpTest.java
@@ -5,10 +5,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.cbioportal.model.GenericAssayData;
 import org.cbioportal.model.GenericAssayMolecularAlteration;
 import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.MolecularProfileSamples;
 import org.cbioportal.model.Sample;
 import org.cbioportal.model.MolecularProfile.MolecularAlterationType;
 import org.cbioportal.model.meta.GenericAssayMeta;
@@ -66,10 +68,29 @@ public class GenericAssayServiceImpTest extends BaseServiceImplTest {
      */
     @Before 
     public void setUp() throws Exception {
-        //stub for samples
-        Mockito.when(geneticDataRepository.getCommaSeparatedSampleIdsOfMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID_1))).thenReturn(Arrays.asList("1,2,"));
-        Mockito.when(geneticDataRepository.getCommaSeparatedSampleIdsOfMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_2))).thenReturn(
-                Arrays.asList("1,2,", "1,2,"));
+
+        MolecularProfileSamples molecularProfileSamples1 = new MolecularProfileSamples();
+        molecularProfileSamples1.setMolecularProfileId(MOLECULAR_PROFILE_ID_1);
+        molecularProfileSamples1.setCommaSeparatedSampleIds("1,2,");
+
+        MolecularProfileSamples molecularProfileSamples2 = new MolecularProfileSamples();
+        molecularProfileSamples2.setMolecularProfileId(MOLECULAR_PROFILE_ID_2);
+        molecularProfileSamples2.setCommaSeparatedSampleIds("1,2,");
+
+        Map<String, MolecularProfileSamples> commaSeparatedSampleIdsOfMolecularProfilesMap1 = new HashMap<>();
+        commaSeparatedSampleIdsOfMolecularProfilesMap1.put(MOLECULAR_PROFILE_ID_1, molecularProfileSamples1);
+
+        Map<String, MolecularProfileSamples> commaSeparatedSampleIdsOfMolecularProfilesMap2 = new HashMap<>();
+        commaSeparatedSampleIdsOfMolecularProfilesMap2.put(MOLECULAR_PROFILE_ID_1, molecularProfileSamples1);
+        commaSeparatedSampleIdsOfMolecularProfilesMap2.put(MOLECULAR_PROFILE_ID_2, molecularProfileSamples2);
+
+        // stub for samples
+        Mockito.when(geneticDataRepository
+                .commaSeparatedSampleIdsOfMolecularProfilesMap(Arrays.asList(MOLECULAR_PROFILE_ID_1)))
+                .thenReturn(commaSeparatedSampleIdsOfMolecularProfilesMap1);
+        Mockito.when(geneticDataRepository.commaSeparatedSampleIdsOfMolecularProfilesMap(
+                Arrays.asList(MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_2)))
+                .thenReturn(commaSeparatedSampleIdsOfMolecularProfilesMap2);
 
         List<Sample> sampleList1 = new ArrayList<>();
         Sample sample = new Sample();

--- a/service/src/test/java/org/cbioportal/service/impl/GenesetDataServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenesetDataServiceImplTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.cbioportal.model.GenesetMolecularAlteration;
 import org.cbioportal.model.GenesetMolecularData;
 import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.MolecularProfileSamples;
 import org.cbioportal.model.Sample;
 import org.cbioportal.persistence.MolecularDataRepository;
 import org.cbioportal.service.MolecularProfileService;
@@ -40,9 +41,13 @@ public class GenesetDataServiceImplTest extends BaseServiceImplTest {
      */
     @Before 
     public void setUp() throws Exception {
+        
+        MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
+        molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
+        molecularProfileSamples.setCommaSeparatedSampleIds("1,2,");
+        
         //stub for samples
-        Mockito.when(geneticDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(
-                "1,2,");
+        Mockito.when(geneticDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfileSamples);
 
         List<Sample> sampleList1 = new ArrayList<>();
         Sample sample = new Sample();

--- a/service/src/test/java/org/cbioportal/service/impl/MolecularDataServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MolecularDataServiceImplTest.java
@@ -3,6 +3,7 @@ package org.cbioportal.service.impl;
 import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GeneMolecularData;
 import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.MolecularProfileSamples;
 import org.cbioportal.model.Sample;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.MolecularDataRepository;
@@ -42,8 +43,12 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
         Mockito.when(sampleListRepository.getAllSampleIdsInSampleList(SAMPLE_LIST_ID))
             .thenReturn(Arrays.asList(SAMPLE_ID1));
         
+        MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
+        molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
+        molecularProfileSamples.setCommaSeparatedSampleIds("1,2,");
+        
         Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
-            .thenReturn("1,2,");
+            .thenReturn(molecularProfileSamples);
 
         MolecularProfile molecularProfile = new MolecularProfile();
         molecularProfile.setCancerStudyIdentifier(STUDY_ID);
@@ -86,8 +91,12 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
         Mockito.when(sampleListRepository.getAllSampleIdsInSampleList(SAMPLE_LIST_ID))
             .thenReturn(Arrays.asList(SAMPLE_ID1));
 
+        MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
+        molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
+        molecularProfileSamples.setCommaSeparatedSampleIds("1,2,");
+        
         Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
-            .thenReturn("1,2,");
+            .thenReturn(molecularProfileSamples);
 
         MolecularProfile molecularProfile = new MolecularProfile();
         molecularProfile.setCancerStudyIdentifier(STUDY_ID);
@@ -126,8 +135,12 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
         molecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.MRNA_EXPRESSION);
         Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
 
+        MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
+        molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
+        molecularProfileSamples.setCommaSeparatedSampleIds("1,2,");
+        
         Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
-            .thenReturn("1,2,");
+            .thenReturn(molecularProfileSamples);
 
         List<GeneMolecularAlteration> molecularAlterationList = new ArrayList<>();
         GeneMolecularAlteration molecularAlteration = new GeneMolecularAlteration();
@@ -178,8 +191,12 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
         molecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.MRNA_EXPRESSION);
         Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
 
+        MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
+        molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
+        molecularProfileSamples.setCommaSeparatedSampleIds("1,2,");
+        
         Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
-            .thenReturn("1,2,");
+            .thenReturn(molecularProfileSamples);
 
         List<GeneMolecularAlteration> molecularAlterationList = new ArrayList<>();
         GeneMolecularAlteration molecularAlteration = new GeneMolecularAlteration();
@@ -215,8 +232,12 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
     @Test
     public void getNumberOfSamplesInMolecularProfile() throws Exception {
 
+        MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
+        molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
+        molecularProfileSamples.setCommaSeparatedSampleIds("1,2,");
+        
         Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
-            .thenReturn("1,2,");
+            .thenReturn(molecularProfileSamples);
         
         Integer result = molecularDataService.getNumberOfSamplesInMolecularProfile(MOLECULAR_PROFILE_ID);
         


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/7299

sometimes the response from mysql is not in the expected order defined at https://github.com/cBioPortal/cbioportal/blob/2ffc5a01fd492db5befe2fc1af33834d2940c8d3/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml#L38

Instead of relying on response order its better to send molecular profile id in the response