### PR TITLE
Make metaImport.py use subcommands instead of -c

### DIFF
--- a/core/src/main/scripts/importer/cbioportalImporter.py
+++ b/core/src/main/scripts/importer/cbioportalImporter.py
@@ -403,26 +403,30 @@ def add_parser_args(parser):
                         help='Path to meta file')
     parser.add_argument('-data', '--data_filename', type=str, required=False,
                         help='Path to Data file')
-    parser.add_argument('-id', '--study_ids', type=str, required=False,
-                        help='Cancer Study IDs for `remove-study` command, comma separated')
 
 def interface():
-    parser = argparse.ArgumentParser(description='cBioPortal meta Importer')
-    subparsers = parser.add_subparsers(title='commands', dest='command',
+    parent_parser = argparse.ArgumentParser(description='cBioPortal meta Importer')
+    add_parser_args(parent_parser)
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(title='subcommands', dest='command',
                           help='Command for import. Allowed commands: import-cancer-type, '
                           'import-study, import-study-data, import-case-list or '
                           'remove-study')
-    import_cancer_type = subparsers.add_parser('import-cancer-type')
-    import_study = subparsers.add_parser('import-study')
-    import_study_data = subparsers.add_parser('import-study-data')
-    import_case_list = subparsers.add_parser('import-case-list')
-    remove_study = subparsers.add_parser('remove-study')
-
-    add_parser_args(import_cancer_type)
-    add_parser_args(import_study)
-    add_parser_args(import_study_data)
-    add_parser_args(import_case_list)
-    add_parser_args(remove_study)
+    import_cancer_type = subparsers.add_parser('import-cancer-type', parents=[parent_parser], add_help=False)
+    import_study = subparsers.add_parser('import-study', parents=[parent_parser], add_help=False)
+    import_study_data = subparsers.add_parser('import-study-data', parents=[parent_parser], add_help=False)
+    import_case_list = subparsers.add_parser('import-case-list', parents=[parent_parser], add_help=False)
+    remove_study = subparsers.add_parser('remove-study', parents=[parent_parser], add_help=False)
+    
+    remove_study.add_argument('-id', '--study_ids', type=str, required=False,
+                        help='Cancer Study IDs for `remove-study` command, comma separated')
+    parser.add_argument('-c', '--command', type=str, required=False, 
+                        help='Command for import. Allowed commands: import-cancer-type, '
+                        'import-study, import-study-data, import-case-list or '
+                        'remove-study')
+    add_parser_args(parser)
+    parser.add_argument('-id', '--study_ids', type=str, required=False,
+                        help='Cancer Study IDs for `remove-study` command, comma separated')
     
     # TODO - add same argument to metaimporter
     # TODO - harmonize on - and _

--- a/core/src/main/scripts/importer/cbioportalImporter.py
+++ b/core/src/main/scripts/importer/cbioportalImporter.py
@@ -408,7 +408,7 @@ def interface():
     parent_parser = argparse.ArgumentParser(description='cBioPortal meta Importer')
     add_parser_args(parent_parser)
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(title='subcommands', dest='command',
+    subparsers = parser.add_subparsers(title='subcommands', dest='subcommand',
                           help='Command for import. Allowed commands: import-cancer-type, '
                           'import-study, import-study-data, import-case-list or '
                           'remove-study')
@@ -433,6 +433,11 @@ def interface():
     # TODO - harmonize on - and _
 
     parser = parser.parse_args()
+    if parser.command is not None and parser.subcommand is not None:
+        print('Cannot call multiple commands')
+        sys.exit(2)
+    elif parser.subcommand is not None:
+        parser.command = parser.subcommand
     return parser
 
 

--- a/core/src/main/scripts/importer/cbioportalImporter.py
+++ b/core/src/main/scripts/importer/cbioportalImporter.py
@@ -421,7 +421,8 @@ def interface():
     remove_study.add_argument('-id', '--study_ids', type=str, required=False,
                         help='Cancer Study IDs for `remove-study` command, comma separated')
     parser.add_argument('-c', '--command', type=str, required=False, 
-                        help='Command for import. Allowed commands: import-cancer-type, '
+                        help='This argument is outdated. Please use the listed subcommands, without the -c flag. '
+                        'Command for import. Allowed commands: import-cancer-type, '
                         'import-study, import-study-data, import-case-list or '
                         'remove-study')
     add_parser_args(parser)

--- a/core/src/main/scripts/importer/cbioportalImporter.py
+++ b/core/src/main/scripts/importer/cbioportalImporter.py
@@ -394,12 +394,7 @@ def check_dir(study_directory):
         print('Study cannot be found: ' + study_directory, file=ERROR_FILE)
         sys.exit(2)
 
-def interface():
-    parser = argparse.ArgumentParser(description='cBioPortal meta Importer')
-    parser.add_argument('-c', '--command', type=str, required=False,
-                        help='Command for import. Allowed commands: import-cancer-type, '
-                             'import-study, import-study-data, import-case-list or '
-                             'remove-study')
+def add_parser_args(parser):
     parser.add_argument('-s', '--study_directory', type=str, required=False,
                         help='Path to Study Directory')
     parser.add_argument('-jar', '--jar_path', type=str, required=False,
@@ -410,6 +405,25 @@ def interface():
                         help='Path to Data file')
     parser.add_argument('-id', '--study_ids', type=str, required=False,
                         help='Cancer Study IDs for `remove-study` command, comma separated')
+
+def interface():
+    parser = argparse.ArgumentParser(description='cBioPortal meta Importer')
+    subparsers = parser.add_subparsers(title='commands', dest='command',
+                          help='Command for import. Allowed commands: import-cancer-type, '
+                          'import-study, import-study-data, import-case-list or '
+                          'remove-study')
+    import_cancer_type = subparsers.add_parser('import-cancer-type')
+    import_study = subparsers.add_parser('import-study')
+    import_study_data = subparsers.add_parser('import-study-data')
+    import_case_list = subparsers.add_parser('import-case-list')
+    remove_study = subparsers.add_parser('remove-study')
+
+    add_parser_args(import_cancer_type)
+    add_parser_args(import_study)
+    add_parser_args(import_study_data)
+    add_parser_args(import_case_list)
+    add_parser_args(remove_study)
+    
     # TODO - add same argument to metaimporter
     # TODO - harmonize on - and _
 


### PR DESCRIPTION
Close #7201 

The cbioportalImporter.py script no longer requires a -c flag to run a command. Each command is now a subcommand that can be run with its own flags.

# Checks
- [ ] Runs on heroku
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
