### PR TITLE
CoExpression: fix error while querying for geneset molecular profile

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CoExpressionServiceImpl.java
@@ -196,8 +196,8 @@ public class CoExpressionServiceImpl implements CoExpressionService {
     // transaction needs to be setup here in order to return Iterable from molecularDataService in fetchCoExpressions
     @Transactional(readOnly=true)
     public List<CoExpression> fetchCoExpressions(String geneticEntityId,
-            EntityType geneticEntityType, List<String> sampleIds, String molecularProfileIdB,
-            String molecularProfileIdA, Double threshold) throws MolecularProfileNotFoundException, GenesetNotFoundException, GeneNotFoundException {
+            EntityType geneticEntityType, List<String> sampleIds, String molecularProfileIdA,
+            String molecularProfileIdB, Double threshold) throws MolecularProfileNotFoundException, GenesetNotFoundException, GeneNotFoundException {
 
         if (molecularProfileIdA.equals(molecularProfileIdB)) {
             return fetchCoExpressions(molecularProfileIdA, sampleIds, geneticEntityId, geneticEntityType, threshold);
@@ -210,7 +210,7 @@ public class CoExpressionServiceImpl implements CoExpressionService {
             molecularDataListA = molecularDataService.fetchMolecularData(molecularProfileIdA, sampleIds, null,
                     "SUMMARY");
         } else if (geneticEntityType.equals(EntityType.GENESET)) {
-            molecularDataListA = genesetDataService.fetchGenesetData(molecularProfileIdB, sampleIds, null);
+            molecularDataListA = genesetDataService.fetchGenesetData(molecularProfileIdA, sampleIds, null);
         }
         MolecularProfile molecularProfileB = molecularProfileService.getMolecularProfile(molecularProfileIdB);
         Boolean isMolecularProfileBOfGenesetType = molecularProfileB.getMolecularAlterationType()

--- a/service/src/test/java/org/cbioportal/service/impl/CoExpressionServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/CoExpressionServiceImplTest.java
@@ -195,7 +195,7 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
         
         MolecularProfile genesetMolecularProfile = createGenesetMolecularProfile();
 
-        Mockito.when(molecularProfileService.getMolecularProfile("profile_id_gsva_scores_a"))
+        Mockito.when(molecularProfileService.getMolecularProfile("profile_id_gsva_scores_b"))
             .thenReturn(genesetMolecularProfile);
         Mockito.when(genesetDataService.fetchGenesetData("profile_id_gsva_scores_b", Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), 
             null)).thenReturn(molecularDataList);


### PR DESCRIPTION
Found this error while fixing https://github.com/cBioPortal/cbioportal/issues/7403
Moelcualar Profile Ids misplaced in `fetchCoExpressions` implementation method