### PR TITLE
Update Docker Images to use Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: required
 language: java
-jdk: openjdk8
+jdk:
+- openjdk8
+- openjdk11
 services:
 - docker
 - mysql

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -301,7 +301,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.16</version>
+        <version>2.22.2</version>
         <configuration>
           <forkMode>always</forkMode>
           <filtering>true</filtering>

--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -11,7 +11,7 @@
 # NOTE: the .git folder is included in the build stage, but excluded 
 # from the final image. No confidential information is exposed.
 # (see: stackoverflow.com/questions/56278325)
-FROM maven:3.5.4 as build
+FROM maven:3-openjdk-11 as build
 
 # download maven dependencies first to take advantage of docker caching
 COPY pom.xml                                     /cbioportal/
@@ -37,7 +37,7 @@ RUN mvn dependency:go-offline --fail-never
 COPY $PWD /cbioportal
 RUN mvn -DskipTests clean install
 
-FROM openjdk:8-jre
+FROM openjdk:11-jre-slim
 
 # download system dependencies first to take advantage of docker caching
 RUN apt-get update; apt-get install -y --no-install-recommends \
@@ -48,6 +48,7 @@ RUN apt-get update; apt-get install -y --no-install-recommends \
         python3-setuptools \
         python3-dev \
         python3-pip \
+        unzip \
 	&& rm -rf /var/lib/apt/lists/* \
     && pip3 install wheel
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -17,12 +17,12 @@
 # WARNING: Be careful about publishing images generated like this publicly
 # because your .git folder is exposed in the build step. We are not sure if
 # this is a security risk: stackoverflow.com/questions/56278325
-FROM maven:3.5.4 as build
+FROM maven:3-openjdk-11 as build
 COPY $PWD /cbioportal
 WORKDIR /cbioportal
 RUN mvn -DskipTests clean install
 
-FROM shipilev/openjdk-shenandoah:8
+FROM shipilev/openjdk-shenandoah:11
 
 ENV PORTAL_WEB_HOME=/cbioportal-webapp
 

--- a/pom.xml
+++ b/pom.xml
@@ -538,6 +538,16 @@
         <artifactId>javax.el</artifactId>
         <version>2.2.4</version>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>2.3.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
   </profiles>
 
   <properties>
-    <frontend.version>d3a2268c594d2cb12eaa78b13359cf2a395b740b</frontend.version>
+    <frontend.version>fb7029b3be8758f80255d15875c0df0cee72fa30</frontend.version>
     <frontend.groupId>com.github.cbioportal</frontend.groupId>
     <slf4j.version>1.6.6</slf4j.version>
     <spring.version>4.3.14.RELEASE</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.47</version>
+      <version>5.1.48</version>
     </dependency>
     <!-- slf4j -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
     <bundle.namespace>org.mskcc.mondrian</bundle.namespace>
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
-    <jacoco-maven-plugin.version>0.7.6.201602180812</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
     <mockito.version>1.10.19</mockito.version>
 
     <final.war.name>cbioportal</final.war.name>

--- a/test/end-to-end/docker-compose.yml
+++ b/test/end-to-end/docker-compose.yml
@@ -1,5 +1,5 @@
 cbioportal:
-  image: maven:3.3.9-jdk-8
+  image: openjdk:11-jre-slim
   ports:
     - "8080:8080"
   volumes:


### PR DESCRIPTION
Fix #7412

Describe changes proposed in this pull request:

- Update pom.xml for building with JDK11
- Update dockerfiles to use JDK11 / JRE11
- Ensure Java 8 backwards compatibility by running Travis build for both java 8 and 11