### PR TITLE
Fix for issue #7386 - forward page wrong

### DIFF
--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -122,8 +122,8 @@
 
     <!-- Handler deciding where to redirect user after successful login -->
     <b:bean id="successRedirectHandler" class="org.cbioportal.security.spring.PortalSavedRequestAwareAuthenticationSuccessHandler">
-        <b:property name="defaultTargetUrl" value="/index.do"/>
-        <b:property name="alwaysUseDefaultTargetUrl" value="false"/>
+        <b:property name="defaultTargetUrl" value="/restore?key=login-redirect"/>
+        <b:property name="alwaysUseDefaultTargetUrl" value="true"/>
         <b:property name="targetUrlParameter" value="spring-security-redirect"/>
     </b:bean>
 
@@ -138,7 +138,9 @@
         <intercept-url pattern="/favicon.ico" access="permitAll"/>
         <intercept-url pattern="/login.jsp*" access="permitAll"/>
         <intercept-url pattern="/case.do*" access="permitAll"/>
-        <intercept-url pattern="/patient*" access="permitAll"/>
+        <intercept-url pattern="/patient/**" access="permitAll"/>
+        <intercept-url pattern="/study/**" access="permitAll"/>
+        <intercept-url pattern="/results/**" access="permitAll"/>
         <intercept-url pattern="/network.do*" access="permitAll"/>
         <intercept-url pattern="/webservice.do*" access="isAuthenticated() or hasIpAddress('127.0.0.1')"/>
         <intercept-url pattern="/**" access="isAuthenticated()"/>
@@ -270,7 +272,9 @@
         <intercept-url pattern="/favicon.ico" access="permitAll"/>
         <intercept-url pattern="/login.jsp*" access="permitAll"/>
         <intercept-url pattern="/case.do*" access="permitAll"/>
-        <intercept-url pattern="/patient*" access="permitAll"/>
+        <intercept-url pattern="/patient/**" access="permitAll"/>
+        <intercept-url pattern="/study/**" access="permitAll"/>
+        <intercept-url pattern="/results/**" access="permitAll"/>
         <intercept-url pattern="/network.do*" access="permitAll"/>
         <intercept-url pattern="/webservice.do*" access="isAuthenticated() or hasIpAddress('127.0.0.1')"/>
         <intercept-url pattern="/**" access="isAuthenticated()"/>
@@ -535,7 +539,9 @@
             <intercept-url pattern="/favicon.ico" access="permitAll"/>
             <intercept-url pattern="/login.jsp*" access="permitAll"/>
             <intercept-url pattern="/case.do*" access="permitAll"/>
-            <intercept-url pattern="/patient*" access="permitAll"/>
+            <intercept-url pattern="/patient/**" access="permitAll"/>
+            <intercept-url pattern="/study/**" access="permitAll"/>
+            <intercept-url pattern="/results/**" access="permitAll"/>
             <intercept-url pattern="/network.do*" access="permitAll"/>
             <intercept-url pattern="/webservice.do*" access="isAuthenticated() or hasIpAddress('127.0.0.1')"/>
             <intercept-url pattern="/**" access="isAuthenticated()"/>
@@ -570,7 +576,9 @@
             <intercept-url pattern="/favicon.ico" access="permitAll"/>
             <intercept-url pattern="/login.jsp*" access="permitAll"/>
             <intercept-url pattern="/case.do*" access="permitAll"/>
-            <intercept-url pattern="/patient*" access="permitAll"/>
+            <intercept-url pattern="/patient/**" access="permitAll"/>
+            <intercept-url pattern="/study/**" access="permitAll"/>
+            <intercept-url pattern="/results/**" access="permitAll"/>
             <intercept-url pattern="/network.do*" access="permitAll"/>
             <intercept-url pattern="/webservice.do*" access="isAuthenticated() or hasIpAddress('127.0.0.1')"/>
             <intercept-url pattern="/**" access="isAuthenticated()"/>
@@ -651,8 +659,8 @@
 
 	    <!-- Handler deciding where to redirect user after successful login -->
 	    <b:bean id="successRedirectHandler" class="org.cbioportal.security.spring.PortalSavedRequestAwareAuthenticationSuccessHandler">
-	        <b:property name="defaultTargetUrl" value="/index.do"/>
-	        <b:property name="alwaysUseDefaultTargetUrl" value="false"/>
+            <b:property name="defaultTargetUrl" value="/restore?key=login-redirect"/>
+            <b:property name="alwaysUseDefaultTargetUrl" value="true"/>
 	        <b:property name="targetUrlParameter" value="spring-security-redirect"/>
 	    </b:bean>
 


### PR DESCRIPTION
All redirects (results, study, patient) after successful authentication are now handled by frontend.