### PR TITLE
Unit test failure fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,6 @@ script:
           -Ppublic \
           -Dauthenticate=false \
           -Dfinal.war.name=cbioportal \
-          -Ddb.test.username=cbio_user \
-          -Ddb.test.password=somepassword \
           clean \
           install \
           integration-test

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoTextCache.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoTextCache.java
@@ -42,10 +42,10 @@ import java.util.Date;
 import org.mskcc.cbio.portal.util.CacheUtil;
 
 public class DaoTextCache
-{	
+{
 	/**
 	 * Generates an MD5 key for the given text.
-	 * 
+	 *
 	 * @param text	text to hashed
 	 * @return		an MD5 key corresponding to the given text
 	 */
@@ -53,21 +53,21 @@ public class DaoTextCache
 	{
 		return CacheUtil.md5sum(text);
 	}
-	
+
 	/**
 	 * Inserts the given key and text pair to the database.
-	 *  
+	 *
 	 * @param key			key value
 	 * @param text			text value
 	 * @return
-	 * @throws DaoException	if an entity already exists with the same key 
+	 * @throws DaoException	if an entity already exists with the same key
 	 */
 	public int cacheText(String key, String text) throws DaoException
 	{
 		Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
-        
+
         try
         {
 			con = JdbcUtil.getDbConnection(DaoTextCache.class);
@@ -76,7 +76,6 @@ public class DaoTextCache
 			        		+ "VALUES (?,?,NOW())");
 			pstmt.setString(1, key);
 			pstmt.setString(2, text);
-			
 			return pstmt.executeUpdate();
         }
         catch (SQLException e)
@@ -88,10 +87,10 @@ public class DaoTextCache
             JdbcUtil.closeAll(DaoTextCache.class, con, pstmt, rs);
         }
 	}
-	
+
 	/**
 	 * Retrieves the text corresponding to the given key form the DB.
-	 * 
+	 *
 	 * @param key	cache key
 	 * @return
 	 * @throws DaoException
@@ -101,7 +100,7 @@ public class DaoTextCache
     	Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
-        
+
         try
         {
             con = JdbcUtil.getDbConnection(DaoTextCache.class);
@@ -109,12 +108,10 @@ public class DaoTextCache
                     "WHERE HASH_KEY=?");
             pstmt.setString(1, key);
             rs = pstmt.executeQuery();
-            
             if (rs.next())
             {
                 return rs.getString("TEXT");
             }
-            
             return null;
         }
         catch (SQLException e)
@@ -126,10 +123,10 @@ public class DaoTextCache
             JdbcUtil.closeAll(DaoTextCache.class, con, pstmt, rs);
         }
     }
-    
+
     /**
      * Deletes all records in the table.
-     * 
+     *
      * @throws DaoException
      */
     public void deleteAllKeys() throws DaoException
@@ -137,7 +134,7 @@ public class DaoTextCache
     	Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
-        
+
         try
         {
             con = JdbcUtil.getDbConnection(DaoTextCache.class);
@@ -147,42 +144,41 @@ public class DaoTextCache
         catch (SQLException e)
         {
             throw new DaoException(e);
-        } 
+        }
         finally
         {
             JdbcUtil.closeAll(DaoTextCache.class, con, pstmt, rs);
         }
     }
-    
+
     /**
      * Remove records older than the specified date.
-     * 
+     *
      * @param date	threshold date
-     * @throws DaoException 
+     * @throws DaoException
      */
     public void purgeOldKeys(Date date) throws DaoException
     {
     	Connection con = null;
         PreparedStatement pstmt = null;
         ResultSet rs = null;
-        
+
         try
         {
             con = JdbcUtil.getDbConnection(DaoTextCache.class);
             pstmt = con.prepareStatement("DELETE FROM text_cache " +
             		"WHERE `DATE_TIME_STAMP` <= ?");
-            
             // create date_time_stamp string using the given date
             // (java.sql package does not have a proper "datetime" type support)
             SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMddHHmmss");
-            
+            formatter.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
             pstmt.setString(1, formatter.format(date));
             pstmt.executeUpdate();
         }
         catch (SQLException e)
         {
             throw new DaoException(e);
-        } 
+        }
         finally
         {
             JdbcUtil.closeAll(DaoTextCache.class, con, pstmt, rs);

--- a/core/src/test/resources/applicationContext-dao.xml
+++ b/core/src/test/resources/applicationContext-dao.xml
@@ -56,8 +56,9 @@
 	<bean id="dbcpDataSource" destroy-method="close" class="org.apache.commons.dbcp2.BasicDataSource">
 		<property name="driverClassName" value="com.mysql.jdbc.Driver" />
 		<property name="url" value="jdbc:mysql://localhost:3306/cgds_test" />
-		<property name="username" value="${db.test.username}" />
-		<property name="password" value="${db.test.password}" />
+        <!-- - test db credentials should be keep in sync with parent pom.xml -->
+		<property name="username" value="${db.test.username:cbio_user}" />
+		<property name="password" value="${db.test.password:somepassword}" />
 		<property name="minIdle" value="0" />
 		<property name="maxIdle" value="10" />
 		<property name="maxTotal" value="100" />
@@ -69,6 +70,9 @@
         <property name="dataSource" ref="businessDataSource" />
         <property name="typeAliasesPackage" value="org.mskcc.cbio.portal.model" />
         <property name="typeHandlersPackage" value="org.cbioportal.persistence.mybatis.typehandler" /><!-- this can prob. be multiple , separated items like other package config below -->
+        <!-- mapper locations is set here to support interdependency between mappers without -->
+        <!-- having to autowire repositories into java classes that do not make direct uses of them -->
+        <property name="mapperLocations" value="classpath*:org/cbioportal/persistence/mybatis/**/*.xml"/>
     </bean>
     
     <!-- scan for mappers and let them be autowired -->


### PR DESCRIPTION
Fixes one exception and a test failure while running unit tests in core:

* Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'cacheMapUtil': Invocation of init method failed; nested exception is org.apache.ibatis.builder.IncompleteElementException: Could not find SQL statement to include with refid 'org.cbioportal.persistence.mybatis.GeneMapper.select'

This one is solved by setting mapperLocations in dao context file.

* TestDaoTextCache.testDaoCaseList:82 expected:<null> but was:<even a single character change should make a big difference>

I fixed this by setting the time zone of the java code to UTC which seems to be the default time zone of MySQL installations.  This could be problematic if local installations change the default timezone.

Per @pvannierop good suggestion - set default values for db test database inside applicationContext-dao.xml.  This also allows travis command to be shortened.