### PR TITLE
Use environment perl instead of hard-coded system perl 

### DIFF
--- a/core/src/main/scripts/addCaseList.pl
+++ b/core/src/main/scripts/addCaseList.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/envSimple.pl";
 
 exec("$JAVA_HOME/bin/java -Xmx1524M -Dspring.profiles.active=dbcp -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.AddCaseList @ARGV");

--- a/core/src/main/scripts/calculateCoExpression.pl
+++ b/core/src/main/scripts/calculateCoExpression.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx2048M -XX:-UseGCOverheadLimit -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.CalculateCoexpression @ARGV");

--- a/core/src/main/scripts/convertCosmicVcfToMaf.pl
+++ b/core/src/main/scripts/convertCosmicVcfToMaf.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ConvertCosmicVcfToMaf @ARGV");

--- a/core/src/main/scripts/convertExpressionZscores.pl
+++ b/core/src/main/scripts/convertExpressionZscores.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/envSimple.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -Dspring.profiles.active=dbcp -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.NormalizeExpressionLevels @ARGV");

--- a/core/src/main/scripts/convertGeneSymbols.pl
+++ b/core/src/main/scripts/convertGeneSymbols.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ConvertGeneSymbols @ARGV");

--- a/core/src/main/scripts/convertSvsImages.pl
+++ b/core/src/main/scripts/convertSvsImages.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx4g -cp $cp org.mskcc.cbio.portal.scripts.ConvertSvsImages @ARGV");

--- a/core/src/main/scripts/cutInvalidCases.pl
+++ b/core/src/main/scripts/cutInvalidCases.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.CutInvalidCases @ARGV");

--- a/core/src/main/scripts/deleteAllCaseLists.pl
+++ b/core/src/main/scripts/deleteAllCaseLists.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.DeleteAllSampleLists @ARGV");

--- a/core/src/main/scripts/dumpPortalInfo.pl
+++ b/core/src/main/scripts/dumpPortalInfo.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/envSimple.pl";
 
 exec("$JAVA_HOME/bin/java -Xmx1524M -Dspring.profiles.active=dbcp -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.DumpPortalInfo @ARGV");

--- a/core/src/main/scripts/exportProfile.pl
+++ b/core/src/main/scripts/exportProfile.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ExportProfileData @ARGV");

--- a/core/src/main/scripts/filterCases.pl
+++ b/core/src/main/scripts/filterCases.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.FilterCases @ARGV");

--- a/core/src/main/scripts/generateMutationData.pl
+++ b/core/src/main/scripts/generateMutationData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1192M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.GenerateMutationData @ARGV");

--- a/core/src/main/scripts/importAccessRights.pl
+++ b/core/src/main/scripts/importAccessRights.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportUserAccessRights @ARGV");

--- a/core/src/main/scripts/importCancerStudy.pl
+++ b/core/src/main/scripts/importCancerStudy.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 exec("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportCancerStudy @ARGV");

--- a/core/src/main/scripts/importCaseList.pl
+++ b/core/src/main/scripts/importCaseList.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportCaisesClinicalXML @ARGV");

--- a/core/src/main/scripts/importCaseListData.pl
+++ b/core/src/main/scripts/importCaseListData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 exec("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportSampleList @ARGV");

--- a/core/src/main/scripts/importClinicalData.pl
+++ b/core/src/main/scripts/importClinicalData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 exec("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportClinicalData @ARGV");

--- a/core/src/main/scripts/importCosmicData.pl
+++ b/core/src/main/scripts/importCosmicData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportCosmicData @ARGV");

--- a/core/src/main/scripts/importDrugData.pl
+++ b/core/src/main/scripts/importDrugData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.drug.ImportDrugBank $portalDataHome/reference-data/drugbank/drugbank.xml $portalDataHome/reference-data/drugbank/target_links.csv");

--- a/core/src/main/scripts/importGenePanel.pl
+++ b/core/src/main/scripts/importGenePanel.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/envSimple.pl";
 
 exec("$JAVA_HOME/bin/java -Xmx1524M -Dspring.profiles.active=dbcp -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportGenePanel @ARGV");

--- a/core/src/main/scripts/importGenes.pl
+++ b/core/src/main/scripts/importGenes.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/envSimple.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -Dspring.profiles.active=dbcp -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportGeneData @ARGV");

--- a/core/src/main/scripts/importGenesetData.pl
+++ b/core/src/main/scripts/importGenesetData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/envSimple.pl";
 
 exec("$JAVA_HOME/bin/java -Xmx1524M -Dspring.profiles.active=dbcp -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportGenesetData @ARGV");

--- a/core/src/main/scripts/importGenesetHierarchy.pl
+++ b/core/src/main/scripts/importGenesetHierarchy.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/envSimple.pl";
 
 exec("$JAVA_HOME/bin/java -Xmx1524M -Dspring.profiles.active=dbcp -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportGenesetHierarchy @ARGV");

--- a/core/src/main/scripts/importGistic.pl
+++ b/core/src/main/scripts/importGistic.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 exec("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportGisticData @ARGV");

--- a/core/src/main/scripts/importHprd.pl
+++ b/core/src/main/scripts/importHprd.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportHprd @ARGV");

--- a/core/src/main/scripts/importMicroRNAIDs.pl
+++ b/core/src/main/scripts/importMicroRNAIDs.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportMicroRNAIDs @ARGV");

--- a/core/src/main/scripts/importMicroRna.pl
+++ b/core/src/main/scripts/importMicroRna.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportMicroRnaData @ARGV");

--- a/core/src/main/scripts/importMutSig.pl
+++ b/core/src/main/scripts/importMutSig.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportMutSigData @ARGV");

--- a/core/src/main/scripts/importPfamGraphicsData.pl
+++ b/core/src/main/scripts/importPfamGraphicsData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportPfamGraphicsData @ARGV");

--- a/core/src/main/scripts/importPiHelperData.pl
+++ b/core/src/main/scripts/importPiHelperData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.drug.ImportPiHelperData $portalDataHome/reference-data/pihelper/drugs.tsv $portalDataHome/reference-data/pihelper/drugtargets.tsv");

--- a/core/src/main/scripts/importProfileData.pl
+++ b/core/src/main/scripts/importProfileData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 $startTime = time;

--- a/core/src/main/scripts/importProteinArrayData.pl
+++ b/core/src/main/scripts/importProteinArrayData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportProteinArrayData @ARGV");

--- a/core/src/main/scripts/importSangerCensus.pl
+++ b/core/src/main/scripts/importSangerCensus.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportSangerCensusData @ARGV");

--- a/core/src/main/scripts/importSif.pl
+++ b/core/src/main/scripts/importSif.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportSif @ARGV");

--- a/core/src/main/scripts/importTimelineData.pl
+++ b/core/src/main/scripts/importTimelineData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 exec("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportTimelineData @ARGV");

--- a/core/src/main/scripts/importTypesOfCancer.pl
+++ b/core/src/main/scripts/importTypesOfCancer.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # author: Arthur Goldberg, goldberg@cbio.mskcc.org
 require "../scripts/env.pl";
 

--- a/core/src/main/scripts/importUniProtIdMapping.pl
+++ b/core/src/main/scripts/importUniProtIdMapping.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ImportUniProtIdMapping @ARGV");

--- a/core/src/main/scripts/resetDb.pl
+++ b/core/src/main/scripts/resetDb.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.ResetDatabase @ARGV");

--- a/core/src/main/scripts/showAllCaseLists.pl
+++ b/core/src/main/scripts/showAllCaseLists.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.GetAllCaseLists @ARGV");

--- a/core/src/main/scripts/statDb.pl
+++ b/core/src/main/scripts/statDb.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.StatDatabase @ARGV");

--- a/core/src/main/scripts/updateMetaData.pl
+++ b/core/src/main/scripts/updateMetaData.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.UpdateMetaData @ARGV");

--- a/core/src/main/scripts/verifyGeneSets.pl
+++ b/core/src/main/scripts/verifyGeneSets.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 require "../scripts/env.pl";
 
 system ("$JAVA_HOME/bin/java -Xmx1524M -cp $cp -DPORTAL_HOME='$portalHome' org.mskcc.cbio.portal.scripts.GeneSetsVerification @ARGV");


### PR DESCRIPTION
Hi there, 

the hardcoded /usr/bin/perl is challenging if you don't have a perl in the location specified. it's better to use /usr/bin/env <prg> 

seee

https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my