### PR TITLE
prevent deprecation for embedding of netlify PRs

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -97,7 +97,7 @@ window.localdist = localStorage.getItem("localdist") === "true";
 if (window.localdist || window.localdev) {
 	window.frontendConfig.frontendUrl = '//localhost:3000/'
 } else if (localStorage.netlify) {
-	var netlifyInstance = '//' + localStorage.getItem('netlify') + '.netlify.com/';
+	var netlifyInstance = '//' + localStorage.getItem('netlify') + '.netlify.app/';
 	window.frontendConfig.frontendUrl = netlifyInstance;
 }
 // clean userEmailAddress config


### PR DESCRIPTION
The domain changed from .com to .app. Although it still works, might be good to update before they deprecate it