### PR TITLE
Update Spring to version 5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,9 +289,9 @@
     <frontend.version>v3.3.4</frontend.version>
     <frontend.groupId>com.github.cbioportal</frontend.groupId>
     <slf4j.version>1.7.30</slf4j.version>
-    <spring.version>5.0.14.RELEASE</spring.version>
-    <spring.context.support.version>5.0.14.RELEASE</spring.context.support.version>
-    <spring.integration.version>5.0.14.RELEASE</spring.integration.version>
+    <spring.version>5.2.6.RELEASE</spring.version>
+    <spring.context.support.version>5.2.6.RELEASE</spring.context.support.version>
+    <spring.integration.version>5.3.0.RELEASE</spring.integration.version>
     <spring.security.version>5.3.1.RELEASE</spring.security.version>
     <spring.security.saml.version>1.0.10.RELEASE</spring.security.saml.version>
     <mybatis.spring.version>2.0.4</mybatis.spring.version>
@@ -485,6 +485,11 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
       <version>${spring.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.reactivex.rxjava2</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>2.2.19</version>
     </dependency>
     <!-- needed for @PreAuthorize and @PostFilter in core and service -->
     <dependency>

--- a/web/src/test/java/org/cbioportal/web/ClinicalDataEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/ClinicalDataEnrichmentControllerTest.java
@@ -170,7 +170,7 @@ public class ClinicalDataEnrichmentControllerTest {
                 MockMvcRequestBuilders.post("/clinical-data-enrichments/fetch").accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(groupFilter)))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest()).andExpect(MockMvcResultMatchers
-                        .jsonPath("$.message").value("groups size must be between 2 and 2147483647"));
+                        .jsonPath("$.message").value("interceptedGroupFilter size must be between 2 and 2147483647"));
 
         Group group1 = new Group();
         group1.setName("1");
@@ -203,7 +203,7 @@ public class ClinicalDataEnrichmentControllerTest {
                         .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(groupFilter)))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message")
-                        .value("groups[1].sampleIdentifiers size must be between 1 and 10000000"));
+                        .value("interceptedGroupFilter size must be between 1 and 10000000"));
 
         group2.setSampleIdentifiers(new ArrayList<SampleIdentifier>(
                 Arrays.asList(sampleIdentifier3, sampleIdentifier4, sampleIdentifier5)));

--- a/web/src/test/java/org/cbioportal/web/StructuralVariantControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StructuralVariantControllerTest.java
@@ -276,7 +276,7 @@ public class StructuralVariantControllerTest {
                 .content(objectMapper.writeValueAsString(structuralVariantFilter)))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message")
-                        .value("eitherMolecularProfileIdsOrSampleMolecularIdentifiersPresent must be true"));
+                        .value("interceptedStructuralVariantFilter must be true"));
     }
 
     private List<StructuralVariant> createExampleStructuralVariant() {


### PR DESCRIPTION
In #7474 I updated Spring Framework to version 5.0. Due to occurring exceptions, I postponed the update to the latest version 5.2.6.

Apparently there was a dependency missing and with RxJava 2 it works like a charm.