### PR TITLE
Revert spring saml version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
     <spring.context.support.version>5.2.6.RELEASE</spring.context.support.version>
     <spring.integration.version>5.3.0.RELEASE</spring.integration.version>
     <spring.security.version>5.3.1.RELEASE</spring.security.version>
-    <spring.security.saml.version>1.0.10.RELEASE</spring.security.saml.version>
+    <spring.security.saml.version>1.0.3.RELEASE</spring.security.saml.version>
     <mybatis.spring.version>2.0.4</mybatis.spring.version>
     <mybatis.version>3.5.4</mybatis.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Having problems deploying to internal portals. Might work to revert back the spring security saml version