### PR TITLE
Set order of API Tags without alphabet prefix

### DIFF
--- a/web/src/main/java/org/cbioportal/web/CancerTypeController.java
+++ b/web/src/main/java/org/cbioportal/web/CancerTypeController.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.TypeOfCancer;
 import org.cbioportal.service.CancerTypeService;
 import org.cbioportal.service.exception.CancerTypeNotFoundException;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -31,7 +32,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "A. Cancer Types", description = " ")
+@Api(tags = PublicApiTags.CANCER_TYPES, description = " ")
 public class CancerTypeController {
 
     @Autowired
@@ -41,21 +42,21 @@ public class CancerTypeController {
     @ApiOperation("Get all cancer types")
     public ResponseEntity<List<TypeOfCancer>> getAllCancerTypes(
         @ApiParam("Level of detail of the response")
-        @RequestParam(defaultValue = "SUMMARY") Projection projection,
+        @RequestParam(defaultValue = "SUMMARY") final Projection projection,
         @ApiParam("Page size of the result list")
         @Max(PagingConstants.MAX_PAGE_SIZE)
         @Min(PagingConstants.MIN_PAGE_SIZE)
-        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
+        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) final Integer pageSize,
         @ApiParam("Page number of the result list")
         @Min(PagingConstants.MIN_PAGE_NUMBER)
-        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber,
+        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) final Integer pageNumber,
         @ApiParam("Name of the property that the result list is sorted by")
-        @RequestParam(required = false) CancerTypeSortBy sortBy,
+        @RequestParam(required = false) final CancerTypeSortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") final Direction direction) {
 
         if (projection == Projection.META) {
-            HttpHeaders responseHeaders = new HttpHeaders();
+            final HttpHeaders responseHeaders = new HttpHeaders();
             responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, cancerTypeService.getMetaCancerTypes().getTotalCount()
                 .toString());
             return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
@@ -71,7 +72,7 @@ public class CancerTypeController {
     @ApiOperation("Get a cancer type")
     public ResponseEntity<TypeOfCancer> getCancerType(
         @ApiParam(required = true, value = "Cancer Type ID e.g. acc")
-        @PathVariable String cancerTypeId) throws CancerTypeNotFoundException {
+        @PathVariable final String cancerTypeId) throws CancerTypeNotFoundException {
 
         return new ResponseEntity<>(cancerTypeService.getCancerType(cancerTypeId), HttpStatus.OK);
     }

--- a/web/src/main/java/org/cbioportal/web/ClinicalAttributeController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalAttributeController.java
@@ -13,6 +13,7 @@ import org.cbioportal.model.ClinicalAttributeCount;
 import org.cbioportal.service.ClinicalAttributeService;
 import org.cbioportal.service.exception.ClinicalAttributeNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.ClinicalAttributeCountFilter;
 import org.cbioportal.web.parameter.Direction;
@@ -40,7 +41,7 @@ import springfox.documentation.annotations.ApiIgnore;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "F. Clinical Attributes", description = " ")
+@Api(tags = PublicApiTags.CLINICAL_ATTRIBUTES, description = " ")
 public class ClinicalAttributeController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/ClinicalDataController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalDataController.java
@@ -12,6 +12,7 @@ import org.cbioportal.service.ClinicalDataService;
 import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.ClinicalDataIdentifier;
 import org.cbioportal.web.parameter.ClinicalDataMultiStudyFilter;
@@ -41,7 +42,7 @@ import springfox.documentation.annotations.ApiIgnore;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "G. Clinical Data", description = " ")
+@Api(tags = PublicApiTags.CLINICAL_DATA, description = " ")
 public class ClinicalDataController {
 
     public static final int CLINICAL_DATA_MAX_PAGE_SIZE = 10000000;

--- a/web/src/main/java/org/cbioportal/web/ClinicalEventController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalEventController.java
@@ -7,6 +7,7 @@ import org.cbioportal.model.ClinicalEvent;
 import org.cbioportal.service.ClinicalEventService;
 import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -33,7 +34,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "H. Clinical Events", description = " ")
+@Api(tags = PublicApiTags.CLINICAL_EVENTS, description = " ")
 public class ClinicalEventController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/CopyNumberSegmentController.java
+++ b/web/src/main/java/org/cbioportal/web/CopyNumberSegmentController.java
@@ -7,6 +7,7 @@ import org.cbioportal.model.CopyNumberSeg;
 import org.cbioportal.service.CopyNumberSegmentService;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -38,7 +39,7 @@ import java.util.*;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "M. Copy Number Segments", description = " ")
+@Api(tags = PublicApiTags.COPY_NUMBER_SEGMENTS, description = " ")
 public class CopyNumberSegmentController {
 
     private static final int COPY_NUMBER_SEGMENT_MAX_PAGE_SIZE = 20000;

--- a/web/src/main/java/org/cbioportal/web/DiscreteCopyNumberController.java
+++ b/web/src/main/java/org/cbioportal/web/DiscreteCopyNumberController.java
@@ -8,6 +8,7 @@ import org.cbioportal.model.DiscreteCopyNumberData;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.service.DiscreteCopyNumberService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.CopyNumberCountIdentifier;
 import org.cbioportal.web.parameter.DiscreteCopyNumberEventType;
@@ -36,7 +37,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "L. Discrete Copy Number Alterations", description = " ")
+@Api(tags = PublicApiTags.DISCRETE_COPY_NUMBER_ALTERATIONS, description = " ")
 public class DiscreteCopyNumberController {
 
     private static final int COPY_NUMBER_COUNT_MAX_PAGE_SIZE = 50000;

--- a/web/src/main/java/org/cbioportal/web/GeneController.java
+++ b/web/src/main/java/org/cbioportal/web/GeneController.java
@@ -8,6 +8,7 @@ import org.cbioportal.service.GeneService;
 import org.cbioportal.service.exception.GeneNotFoundException;
 import org.cbioportal.service.exception.GeneWithMultipleEntrezIdsException;
 import org.cbioportal.web.config.annotation.PublicApi;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.GeneIdType;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -35,7 +36,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "N. Genes", description = " ")
+@Api(tags = PublicApiTags.GENES, description = " ")
 public class GeneController {
 
     private static final int GENE_MAX_PAGE_SIZE = 100000;

--- a/web/src/main/java/org/cbioportal/web/GenePanelController.java
+++ b/web/src/main/java/org/cbioportal/web/GenePanelController.java
@@ -8,6 +8,7 @@ import org.cbioportal.model.GenePanelData;
 import org.cbioportal.service.exception.GenePanelNotFoundException;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.GenePanelService;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.GenePanelDataFilter;
@@ -41,7 +42,7 @@ import java.util.*;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "O. Gene Panels", description = " ")
+@Api(tags = PublicApiTags.GENE_PANELS, description = " ")
 public class GenePanelController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/GenericAssayController.java
+++ b/web/src/main/java/org/cbioportal/web/GenericAssayController.java
@@ -17,6 +17,7 @@ import org.cbioportal.model.meta.GenericAssayMeta;
 import org.cbioportal.service.GenericAssayService;
 import org.cbioportal.service.exception.GenericAssayNotFoundException;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.GenericAssayDataFilter;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -42,7 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "P. Generic Assay", description = " ")
+@Api(tags = PublicApiTags.GENERIC_ASSAYS, description = " ")
 public class GenericAssayController {
     
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/MolecularDataController.java
+++ b/web/src/main/java/org/cbioportal/web/MolecularDataController.java
@@ -8,6 +8,7 @@ import org.cbioportal.model.GeneMolecularData;
 import org.cbioportal.model.NumericGeneMolecularData;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.MolecularDataService;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
 import org.cbioportal.web.parameter.MolecularDataFilter;
@@ -37,7 +38,7 @@ import java.util.*;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "I. Molecular Data", description = " ")
+@Api(tags = PublicApiTags.MOLECULAR_DATA, description = " ")
 public class MolecularDataController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/MolecularProfileController.java
+++ b/web/src/main/java/org/cbioportal/web/MolecularProfileController.java
@@ -8,6 +8,7 @@ import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.service.MolecularProfileService;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -39,7 +40,7 @@ import java.util.*;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "J. Molecular Profiles", description = " ")
+@Api(tags = PublicApiTags.MOLECULAR_PROFILES, description = " ")
 public class MolecularProfileController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/MutationController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationController.java
@@ -9,6 +9,7 @@ import org.cbioportal.model.MutationCountByPosition;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.MolecularProfileService;
 import org.cbioportal.service.MutationService;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -44,7 +45,7 @@ import java.util.*;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "K. Mutations", description = " ")
+@Api(tags = PublicApiTags.MUTATIONS, description = " ")
 public class MutationController {
 
     public static final int MUTATION_MAX_PAGE_SIZE = 10000000;

--- a/web/src/main/java/org/cbioportal/web/PatientController.java
+++ b/web/src/main/java/org/cbioportal/web/PatientController.java
@@ -7,6 +7,7 @@ import org.cbioportal.model.Patient;
 import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.service.PatientService;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.*;
 import org.cbioportal.web.parameter.sort.PatientSortBy;
@@ -35,7 +36,7 @@ import java.util.*;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "C. Patients", description = " ")
+@Api(tags = PublicApiTags.PATIENTS, description = " ")
 public class PatientController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/ReferenceGenomeGeneController.java
+++ b/web/src/main/java/org/cbioportal/web/ReferenceGenomeGeneController.java
@@ -8,6 +8,7 @@ import org.cbioportal.service.GeneMemoizerService;
 import org.cbioportal.service.ReferenceGenomeGeneService;
 import org.cbioportal.service.StaticDataTimestampService;
 import org.cbioportal.service.exception.GeneNotFoundException;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,7 +31,7 @@ import java.util.stream.Collectors;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "R. Reference Genome Genes", description = " ")
+@Api(tags = PublicApiTags.REFERENCE_GENOME_GENES, description = " ")
 public class ReferenceGenomeGeneController {
     private static final int GENE_MAX_PAGE_SIZE = 100000;
     private static final String GENE_DEFAULT_PAGE_SIZE = "100000";

--- a/web/src/main/java/org/cbioportal/web/ResourceDataController.java
+++ b/web/src/main/java/org/cbioportal/web/ResourceDataController.java
@@ -10,6 +10,7 @@ import org.cbioportal.service.ResourceDataService;
 import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.PagingConstants;
@@ -28,7 +29,7 @@ import io.swagger.annotations.ApiParam;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "T. Resource Data", description = " ")
+@Api(tags = PublicApiTags.RESOURCE_DATA, description = " ")
 public class ResourceDataController {
 
     public static final int RESOURCE_DATA_MAX_PAGE_SIZE = 10000000;

--- a/web/src/main/java/org/cbioportal/web/ResourceDefinitionController.java
+++ b/web/src/main/java/org/cbioportal/web/ResourceDefinitionController.java
@@ -9,6 +9,7 @@ import org.cbioportal.model.ResourceDefinition;
 import org.cbioportal.service.ResourceDefinitionService;
 import org.cbioportal.service.exception.ResourceDefinitionNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.*;
 import org.cbioportal.web.parameter.sort.ResourceDefinitionSortBy;
@@ -25,7 +26,7 @@ import io.swagger.annotations.ApiParam;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "S. Resource Definitions", description = " ")
+@Api(tags = PublicApiTags.RESOURCE_DEFINITIONS, description = " ")
 public class ResourceDefinitionController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/SampleController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleController.java
@@ -11,6 +11,7 @@ import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.service.SampleService;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.*;
 import org.cbioportal.web.parameter.sort.SampleSortBy;
@@ -41,7 +42,7 @@ import java.util.stream.Collectors;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "D. Samples", description = " ")
+@Api(tags = PublicApiTags.SAMPLES, description = " ")
 public class SampleController {
 
     public static final int SAMPLE_MAX_PAGE_SIZE = 10000000;

--- a/web/src/main/java/org/cbioportal/web/SampleListController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleListController.java
@@ -7,6 +7,7 @@ import org.cbioportal.model.SampleList;
 import org.cbioportal.service.SampleListService;
 import org.cbioportal.service.exception.SampleListNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -35,7 +36,7 @@ import java.util.List;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "E. Sample Lists", description = " ")
+@Api(tags = PublicApiTags.SAMPLE_LISTS, description = " ")
 public class SampleListController {
 
     @Autowired

--- a/web/src/main/java/org/cbioportal/web/StructuralVariantController.java
+++ b/web/src/main/java/org/cbioportal/web/StructuralVariantController.java
@@ -30,6 +30,8 @@ import org.cbioportal.web.parameter.StructuralVariantFilter;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.SampleMolecularIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,7 +53,7 @@ import java.util.*;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "Q. Structural Variants", description = " ")
+@Api(tags = PublicApiTags.STRUCTURAL_VARIANTS, description = " ")
 public class StructuralVariantController {
     @Autowired
     private StructuralVariantService structuralVariantService;

--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -7,6 +7,7 @@ import org.cbioportal.model.CancerStudy;
 import org.cbioportal.model.CancerStudyTags;
 import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.Direction;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
@@ -46,7 +47,7 @@ import java.util.Map;
 @PublicApi
 @RestController
 @Validated
-@Api(tags = "B. Studies", description = " ")
+@Api(tags = PublicApiTags.STUDIES, description = " ")
 public class StudyController {
     @Value("${authenticate:false}")
     private String authenticate;

--- a/web/src/main/java/org/cbioportal/web/config/PublicApiTags.java
+++ b/web/src/main/java/org/cbioportal/web/config/PublicApiTags.java
@@ -1,0 +1,24 @@
+package org.cbioportal.web.config;
+
+public class PublicApiTags {
+    public static final String CANCER_TYPES = "Cancer Types";
+    public static final String STUDIES = "Studies";
+    public static final String PATIENTS = "Patients";
+    public static final String SAMPLES = "Samples";
+    public static final String SAMPLE_LISTS = "Sample Lists";
+    public static final String CLINICAL_ATTRIBUTES = "Clinical Attributes";
+    public static final String CLINICAL_DATA = "Clinical Data";
+    public static final String CLINICAL_EVENTS = "Clinical Events";
+    public static final String MOLECULAR_DATA = "Molecular Data";
+    public static final String MOLECULAR_PROFILES = "Molecular Profiles";
+    public static final String MUTATIONS = "Mutations";
+    public static final String DISCRETE_COPY_NUMBER_ALTERATIONS = "Discrete Copy Number Alterations";
+    public static final String COPY_NUMBER_SEGMENTS = "Copy Number Segments";
+    public static final String GENES = "Genes";
+    public static final String GENE_PANELS = "Gene Panels";
+    public static final String GENERIC_ASSAYS = "Generic Assays";
+    public static final String STRUCTURAL_VARIANTS = "Structural Variants";
+    public static final String REFERENCE_GENOME_GENES = "Reference Genome Genes";
+    public static final String RESOURCE_DEFINITIONS = "Resource Definitions";
+    public static final String RESOURCE_DATA = "Resource Data";
+}

--- a/web/src/main/java/org/cbioportal/web/config/SwaggerConfig.java
+++ b/web/src/main/java/org/cbioportal/web/config/SwaggerConfig.java
@@ -1,36 +1,60 @@
 package org.cbioportal.web.config;
 
+import java.util.Collections;
+
 import org.cbioportal.web.config.annotation.InternalApi;
 import org.cbioportal.web.config.annotation.PublicApi;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.Contact;
+import springfox.documentation.service.Tag;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
+
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 import springfox.documentation.swagger.web.UiConfiguration;
 import springfox.documentation.swagger.web.UiConfigurationBuilder;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 
 @Configuration
 @EnableSwagger2
 @PropertySource("classpath:springfox.properties")
 public class SwaggerConfig {
-
     @Bean
     public Docket publicApi() {
-        return new Docket(DocumentationType.SWAGGER_2)
+        Docket d = new Docket(DocumentationType.SWAGGER_2)
             .select()
             .apis(RequestHandlerSelectors.withClassAnnotation(PublicApi.class))
             .build()
             .useDefaultResponseMessages(false)
             .apiInfo(apiInfo());
+
+        d.tags(
+            new Tag(PublicApiTags.CANCER_TYPES, "", 0),
+            new Tag(PublicApiTags.STUDIES, "", 1),
+            new Tag(PublicApiTags.PATIENTS, "", 2),
+            new Tag(PublicApiTags.SAMPLES, "", 3),
+            new Tag(PublicApiTags.SAMPLE_LISTS, "", 4),
+            new Tag(PublicApiTags.CLINICAL_ATTRIBUTES, "", 5),
+            new Tag(PublicApiTags.CLINICAL_DATA, "", 6),
+            new Tag(PublicApiTags.CLINICAL_EVENTS, "", 7),
+            new Tag(PublicApiTags.MOLECULAR_DATA, "", 8),
+            new Tag(PublicApiTags.MOLECULAR_PROFILES, "", 9),
+            new Tag(PublicApiTags.MUTATIONS, "", 10),
+            new Tag(PublicApiTags.DISCRETE_COPY_NUMBER_ALTERATIONS, "", 11),
+            new Tag(PublicApiTags.COPY_NUMBER_SEGMENTS, "", 12),
+            new Tag(PublicApiTags.GENES, "", 13),
+            new Tag(PublicApiTags.GENE_PANELS, "", 14),
+            new Tag(PublicApiTags.GENERIC_ASSAYS, "", 15),
+            new Tag(PublicApiTags.STRUCTURAL_VARIANTS, "", 16),
+            new Tag(PublicApiTags.REFERENCE_GENOME_GENES, "", 17),
+            new Tag(PublicApiTags.RESOURCE_DEFINITIONS, "", 18),
+            new Tag(PublicApiTags.RESOURCE_DATA, "", 19)
+        );
+
+        return d;
     }
 
     @Bean


### PR DESCRIPTION
Fix #7516

Remove the prefix from the tags:

<img width="323" alt="Screen Shot 2020-06-01 at 9 18 02 PM" src="https://user-images.githubusercontent.com/1334004/83469350-745e5e00-a44d-11ea-9351-0fd692b77eb5.png">