### PR TITLE
Disconnect DumpPortalInfo (used by validator) from business module.

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/model/CanonicalGene.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/model/CanonicalGene.java
@@ -35,20 +35,24 @@ package org.mskcc.cbio.portal.model;
 import org.mskcc.cbio.portal.dao.DaoException;
 import org.mskcc.cbio.portal.dao.DaoSangerCensus;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Class to wrap Entrez Gene ID, HUGO Gene Symbols,etc.
  */
-public class CanonicalGene extends Gene {
+public class CanonicalGene extends Gene implements Serializable {
     public static final String MIRNA_TYPE = "miRNA";
     public static final String PHOSPHOPROTEIN_TYPE = "phosphoprotein";
     private int geneticEntityId;
+    @JsonProperty("entrez_gene_id")
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     private long entrezGeneId;
+    @JsonProperty("hugo_gene_symbol")
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     private String hugoGeneSymbol;
     private Set<String> aliases;
     private double somaticMutationFrequency;
@@ -78,7 +82,7 @@ public class CanonicalGene extends Gene {
     public CanonicalGene(String hugoGeneSymbol, Set<String> aliases) {
         this(-1, -1, hugoGeneSymbol, aliases);
     }
-    
+
     /** 
      * This constructor can be used when geneticEntityId is not yet known, 
      * e.g. in case of a new gene (like when adding new genes in ImportGeneData), or is
@@ -103,7 +107,7 @@ public class CanonicalGene extends Gene {
     public CanonicalGene(long entrezGeneId, String hugoGeneSymbol, Set<String> aliases) {
     	this(-1, entrezGeneId, hugoGeneSymbol, aliases);
     }
-    
+
     public CanonicalGene(int geneticEntityId, long entrezGeneId, String hugoGeneSymbol, Set<String> aliases) {
    		this.geneticEntityId = geneticEntityId;
     	this.entrezGeneId = entrezGeneId;
@@ -111,6 +115,8 @@ public class CanonicalGene extends Gene {
         setAliases(aliases);
     }
 
+    @JsonIgnore
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     public String getType() {
         return type;
     }
@@ -119,6 +125,8 @@ public class CanonicalGene extends Gene {
         this.type = type;
     }
 
+    @JsonIgnore
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     public Set<String> getAliases() {
         if (aliases==null) {
             return Collections.emptySet();
@@ -131,19 +139,21 @@ public class CanonicalGene extends Gene {
             this.aliases = null;
             return;
         }
-        
+
         Map<String,String> map = new HashMap<String,String>(aliases.size());
         for (String alias : aliases) {
             map.put(alias.toUpperCase(), alias);
         }
-        
+
         this.aliases = new HashSet<String>(map.values());
     }
-    
+
+    @JsonIgnore
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     public int getGeneticEntityId() {
     	return geneticEntityId;
     }
-    
+
     public void setGeneticEntityId(int geneticEntityId) {
         this.geneticEntityId = geneticEntityId;
     }
@@ -156,10 +166,14 @@ public class CanonicalGene extends Gene {
         this.entrezGeneId = entrezGeneId;
     }
 
+    @JsonIgnore
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     public String getHugoGeneSymbolAllCaps() {
         return hugoGeneSymbol.toUpperCase();
     }
 
+    @JsonIgnore
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     public String getStandardSymbol() {
         return getHugoGeneSymbolAllCaps();
     }
@@ -167,11 +181,15 @@ public class CanonicalGene extends Gene {
     public void setHugoGeneSymbol(String hugoGeneSymbol) {
         this.hugoGeneSymbol = hugoGeneSymbol;
     }
-    
+
+    @JsonIgnore
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     public boolean isMicroRNA() {
         return MIRNA_TYPE.equals(type);
     }
-    
+
+    @JsonIgnore
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     public boolean isPhosphoProtein() {
         return PHOSPHOPROTEIN_TYPE.equals(type);
     }
@@ -186,7 +204,7 @@ public class CanonicalGene extends Gene {
         if (!(obj0 instanceof CanonicalGene)) {
             return false;
         }
-        
+
         CanonicalGene gene0 = (CanonicalGene) obj0;
         if (gene0.getEntrezGeneId() == entrezGeneId) {
             return true;
@@ -194,6 +212,8 @@ public class CanonicalGene extends Gene {
         return false;
     }
 
+    @JsonIgnore
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     public double getSomaticMutationFrequency() {
         return somaticMutationFrequency;
     }
@@ -202,6 +222,9 @@ public class CanonicalGene extends Gene {
         this.somaticMutationFrequency = somaticMutationFrequency;
     }
 
+    @JsonIgnore
+    // significant speedup to jackson json writing in
+    // DumpPortalInfo.java with this field ignored (not needed)
     public boolean isSangerGene() throws DaoException {
         DaoSangerCensus daoSangerCensus = DaoSangerCensus.getInstance();
 

--- a/core/src/main/java/org/mskcc/cbio/portal/model/TypeOfCancer.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/model/TypeOfCancer.java
@@ -32,6 +32,10 @@
 
 package org.mskcc.cbio.portal.model;
 
+import java.io.Serializable;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * A TypeOfCancer is a clinical cancer type, such as Glioblastoma, Ovarian, etc.
  * Eventually, we'll have ontology problems with this, but initially the dbms
@@ -40,13 +44,23 @@ package org.mskcc.cbio.portal.model;
  * @author Arthur Goldberg goldberg@cbio.mskcc.org
  * @author Arman Aksoy
  */
-public class TypeOfCancer {
+public class TypeOfCancer implements Serializable {
 
     private String name;
+    @JsonProperty("id")
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     private String typeOfCancerId;
+    @JsonIgnore
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     private String clinicalTrialKeywords = ""; // Separated by commas
+    @JsonProperty("color")
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     private String dedicatedColor = "white";
+    @JsonIgnore
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     private String shortName = "";
+    @JsonIgnore
+    // to preserve json output in DumpPortalInfo.java after migrating from ApiService
     private String parentTypeOfCancerId;
 
     public String getName() {

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/DumpPortalInfo.java
@@ -22,21 +22,20 @@
 
 package org.mskcc.cbio.portal.scripts;
 
-import java.util.List;
-import java.util.Arrays;
-import java.io.Serializable;
-import java.io.File;
-import java.io.IOException;
+import org.mskcc.cbio.portal.util.SpringUtil;
+import org.mskcc.cbio.portal.util.ProgressMonitor;
+import org.cbioportal.service.GenesetService;
+import org.cbioportal.service.GenePanelService;
+import org.cbioportal.web.config.CustomObjectMapper;
+
+import org.mskcc.cbio.portal.dao.*;
+import org.mskcc.cbio.portal.model.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.cbioportal.web.config.CustomObjectMapper;
 
-import org.mskcc.cbio.portal.util.SpringUtil;
-import org.mskcc.cbio.portal.util.ProgressMonitor;
-import org.mskcc.cbio.portal.service.ApiService;
-import org.cbioportal.service.GenesetService;
-import org.cbioportal.service.GenePanelService;
+import java.io.*;
+import java.util.*;
 
 /**
  * Command line tool to generate JSON files used by the validation script.
@@ -53,6 +52,25 @@ public class DumpPortalInfo extends ConsoleRunnable {
     private static final String API_GENE_PANELS = "/gene-panels";
     private static final int MAX_PAGE_SIZE = 10000000;
     private static final int MIN_PAGE_NUMBER = 0;
+
+    static class GeneAlias implements Serializable {
+        public String gene_alias;
+        public String entrez_gene_id;
+    }
+
+    private static List<GeneAlias> extractGeneAliases(List<CanonicalGene> canonicalGenes) {
+        List<GeneAlias> toReturn = new ArrayList<GeneAlias>();
+        for (CanonicalGene canonicalGene : canonicalGenes) {
+            String entrezGeneId = String.valueOf(canonicalGene.getEntrezGeneId()); 
+            for (String alias : canonicalGene.getAliases()) {
+                GeneAlias geneAlias = new GeneAlias();
+                geneAlias.gene_alias = alias;
+                geneAlias.entrez_gene_id = entrezGeneId;
+                toReturn.add(geneAlias);
+            }
+        }
+        return toReturn;
+    }
 
     private static File nameJsonFile(File dirName, String apiName) {
         // Determine the first alphabetic character
@@ -103,8 +121,6 @@ public class DumpPortalInfo extends ConsoleRunnable {
 
             // initialize application context, including database connection
             SpringUtil.initDataSource();
-            ApiService apiService = SpringUtil.getApplicationContext().getBean(
-                    ApiService.class);
             GenesetService genesetService = SpringUtil.getApplicationContext().getBean(
                 GenesetService.class);
             GenePanelService genePanelService = SpringUtil.getApplicationContext().getBean(
@@ -122,13 +138,15 @@ public class DumpPortalInfo extends ConsoleRunnable {
 
             try {
                 writeJsonFile(
-                        apiService.getCancerTypes(),
+                        DaoTypeOfCancer.getAllTypesOfCancer(),
                         nameJsonFile(outputDir, API_CANCER_TYPES));
+                DaoGeneOptimized daoGeneOptimized = DaoGeneOptimized.getInstance();
+                List<CanonicalGene> allGenes = daoGeneOptimized.getAllGenes();
                 writeJsonFile(
-                        apiService.getGenes(),
+                        allGenes,
                         nameJsonFile(outputDir, API_GENES));
                 writeJsonFile(
-                        apiService.getGenesAliases(),
+                        extractGeneAliases(allGenes),
                         nameJsonFile(outputDir, API_GENE_ALIASES));
                 writeJsonFile(
                     genesetService.getAllGenesets("SUMMARY", MAX_PAGE_SIZE, MIN_PAGE_NUMBER),
@@ -139,6 +157,8 @@ public class DumpPortalInfo extends ConsoleRunnable {
                 writeJsonFile(
                     genePanelService.getAllGenePanels("SUMMARY", MAX_PAGE_SIZE, MIN_PAGE_NUMBER, null, "ASC"),
                     nameJsonFile(outputDir, API_GENE_PANELS));
+            } catch (DaoException e) {
+                throw new RuntimeException(e);
             } catch (IOException e) {
                 throw new IOException(
                         "Error writing portal info file: " + e.toString(),


### PR DESCRIPTION
The forth of a few PRs to disconnect and ultimately remove the business module. This PR focuses on disconnecting the DumpPortalInfo script from its use of ApiService in the business module.

I have checked that the outputs are consistent against the public_test database on devdb.cbioportal.org.