### PR TITLE
Accelerate generic assay endpoint response speed

### DIFF
--- a/model/src/main/java/org/cbioportal/model/GenericAssayAdditionalProperty.java
+++ b/model/src/main/java/org/cbioportal/model/GenericAssayAdditionalProperty.java
@@ -1,0 +1,37 @@
+package org.cbioportal.model;
+
+public class GenericAssayAdditionalProperty {
+    private String name;
+    private String value;
+    private String stableId;
+
+    public GenericAssayAdditionalProperty(String name, String value, String stableId) {
+        this.name = name;
+        this.value = value;
+        this.stableId = stableId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getStableId() {
+        return stableId;
+    }
+
+    public void setStableId(String stableId) {
+        this.stableId = stableId;
+    }
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenericAssayRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenericAssayRepository.java
@@ -1,9 +1,9 @@
 package org.cbioportal.persistence;
 
-import java.util.HashMap;
 import java.util.List;
 
 import org.cbioportal.model.meta.GenericAssayMeta;
+import org.cbioportal.model.GenericAssayAdditionalProperty;
 import org.springframework.cache.annotation.Cacheable;
 
 public interface GenericAssayRepository {
@@ -12,11 +12,8 @@ public interface GenericAssayRepository {
     List<GenericAssayMeta> getGenericAssayMeta(List<String> stableIds);
 
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    List<GenericAssayAdditionalProperty> getGenericAssayAdditionalproperties(List<String> stableIds);
+
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<String> getGenericAssayStableIdsByMolecularIds(List<String> molecularProfileIds);
-
-    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
-    int getGeneticEntityIdByStableId(String stableId);
-
-    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
-    List<HashMap<String, String>> getGenericAssayMetaPropertiesMap(int geneticEntityId);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenericAssayMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenericAssayMapper.java
@@ -4,19 +4,18 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.cbioportal.model.meta.GenericAssayMeta;
+import org.cbioportal.model.GenericAssayAdditionalProperty;
 
 public interface GenericAssayMapper {
 
     List<GenericAssayMeta> getGenericAssayMeta(List<String> stableIds);
+
+    List<GenericAssayAdditionalProperty> getGenericAssayAdditionalproperties(List<String> stableIds);
 
     List<Integer> getMolecularProfileInternalIdsByMolecularProfileIds(List<String> molecularProfileIds);
 
     List<Integer> getGeneticEntityIdsByMolecularProfileInternalIds(List<Integer> molecularProfileInternalIds);
     
     List<String> getGenericAssayStableIdsByGeneticEntityIds(List<Integer> geneticEntityIds);
-
-    int getGeneticEntityIdByStableId(String stableId);
-
-    List<HashMap<String, String>> getGenericAssayMetaPropertiesMap(int geneticEntityId);
 
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenericAssayMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenericAssayMyBatisRepository.java
@@ -1,15 +1,11 @@
 package org.cbioportal.persistence.mybatis;
 
-import org.cbioportal.model.GeneMolecularAlteration;
-import org.cbioportal.model.GenesetMolecularAlteration;
 import org.cbioportal.model.meta.GenericAssayMeta;
+import org.cbioportal.model.GenericAssayAdditionalProperty;
 import org.cbioportal.persistence.GenericAssayRepository;
-import org.cbioportal.persistence.MolecularDataRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +25,11 @@ public class GenericAssayMyBatisRepository implements GenericAssayRepository {
     }
 
     @Override
+    public List<GenericAssayAdditionalProperty> getGenericAssayAdditionalproperties(List<String> stableIds) {
+        return genericAssayMapper.getGenericAssayAdditionalproperties(stableIds);
+    }
+
+    @Override
     public List<String> getGenericAssayStableIdsByMolecularIds(List<String> molecularProfileIds) {
         
         List<Integer> molecularProfileInternalIds = genericAssayMapper.getMolecularProfileInternalIdsByMolecularProfileIds(molecularProfileIds);
@@ -45,17 +46,5 @@ public class GenericAssayMyBatisRepository implements GenericAssayRepository {
         }
         // log error and return empty list if something went wrong
         return new ArrayList<String>();
-    }
-
-    @Override
-    public int getGeneticEntityIdByStableId(String stableId) {
-
-        return genericAssayMapper.getGeneticEntityIdByStableId(stableId);
-    }
-
-    @Override
-    public List<HashMap<String, String>> getGenericAssayMetaPropertiesMap(int geneticEntityId) {
-
-        return genericAssayMapper.getGenericAssayMetaPropertiesMap(geneticEntityId);
     }
 }

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenericAssayMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenericAssayMapper.xml
@@ -4,10 +4,6 @@
 <mapper namespace="org.cbioportal.persistence.mybatis.GenericAssayMapper">
     <cache readOnly="true"/>
 
-    <resultMap id="typeForGenericAssayMetaProperties" type="java.util.HashMap">
-                <result property="key" column="NAME"/> 
-                <result property="value" column="VALUE"/> 
-    </resultMap>
 
     <select id="getGenericAssayMeta" resultType="org.cbioportal.model.meta.GenericAssayMeta">
         SELECT genetic_entity.STABLE_ID as stableId,
@@ -21,21 +17,24 @@
         </where>
     </select>
 
-    <select id="getGeneticEntityIdByStableId" parameterType="string" resultType="int">
-        SELECT genetic_entity.ID
-        FROM genetic_entity
-        <where>
-            genetic_entity.STABLE_ID = #{stableId}
-        </where>
-    </select>
-
-    <select id="getGenericAssayMetaPropertiesMap" resultMap="typeForGenericAssayMetaProperties">
-        SELECT generic_entity_properties.NAME,
-        generic_entity_properties.VALUE
+    <select id="getGenericAssayAdditionalproperties" resultType="org.cbioportal.model.GenericAssayAdditionalProperty">
+        SELECT generic_entity_properties.NAME as name,
+        generic_entity_properties.VALUE as value,
+        genetic_entity.STABLE_ID as stableId
         FROM generic_entity_properties
-        <where>
-            generic_entity_properties.GENETIC_ENTITY_ID = #{geneticEntityId}
-        </where>
+        INNER JOIN genetic_entity ON genetic_entity.ID = generic_entity_properties.GENETIC_ENTITY_ID
+        WHERE
+            generic_entity_properties.GENETIC_ENTITY_ID IN 
+            (
+                SELECT genetic_entity.ID
+                FROM genetic_entity
+                    <where>
+                        genetic_entity.STABLE_ID IN
+                            <foreach item="item" collection="list" open="(" separator="," close=")">
+                                #{item}
+                            </foreach>
+                    </where>
+            )
     </select>
 
     <select id="getMolecularProfileInternalIdsByMolecularProfileIds" resultType="int">

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/GenericAssayMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/GenericAssayMyBatisRepositoryTest.java
@@ -2,9 +2,9 @@
 package org.cbioportal.persistence.mybatis;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 
+import org.cbioportal.model.GenericAssayAdditionalProperty;
 import org.cbioportal.model.meta.GenericAssayMeta;
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,35 +30,26 @@ public class GenericAssayMyBatisRepositoryTest {
     }
 
     @Test
-    public void getGeneticEntityIdByStableId() {
-        int result = genericAssayMyBatisRepository.getGeneticEntityIdByStableId("Nmut");
+    public void getGenericAssayAdditionalproperties() {
+        List<String> stableIds = Arrays.asList("Nmut", "mean_1");
+        List<GenericAssayAdditionalProperty> result = genericAssayMyBatisRepository.getGenericAssayAdditionalproperties(stableIds);
         Assert.assertNotNull(result);
-        Assert.assertEquals(28, result);
-    }
+        Assert.assertEquals(4, result.size());
 
-    @Test
-    public void getGenericAssayMetaPropertiesMap() {
-        List<HashMap<String, String>> result = genericAssayMyBatisRepository.getGenericAssayMetaPropertiesMap(28);
-        Assert.assertNotNull(result);
-        Assert.assertEquals(2, result.size());
-        HashMap<String, String> map1 = result.get(0);
-        HashMap<String, String> map2 = result.get(1);
-
-        for (String key : map1.keySet()) {
-            if (key.equals("key")) {
-                Assert.assertEquals("description",map1.get(key));
+        for (GenericAssayAdditionalProperty additionalProperty : result) {
+            if (additionalProperty.getStableId().equals("Nmut")) {
+                if (additionalProperty.getName().equals("name")) {
+                    Assert.assertEquals("Nmut",additionalProperty.getValue());
+                } else {
+                    Assert.assertEquals("number of mutations",additionalProperty.getValue());
+                }
             }
-            if (key.equals("value")) {
-                Assert.assertEquals("number of mutations",map1.get(key));
-            }
-        }
-
-        for (String key : map2.keySet()) {
-            if (key.equals("key")) {
-                Assert.assertEquals("name",map2.get(key));
-            }
-            if (key.equals("value")) {
-                Assert.assertEquals("Nmut",map2.get(key));
+            else if (additionalProperty.getStableId().equals("mean_1")) {
+                if (additionalProperty.getName().equals("name")) {
+                    Assert.assertEquals("mean_1",additionalProperty.getValue());
+                } else {
+                    Assert.assertEquals("description of mean_1",additionalProperty.getValue());
+                }
             }
         }
     }

--- a/service/src/main/java/org/cbioportal/service/impl/GenericAssayServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenericAssayServiceImpl.java
@@ -18,6 +18,7 @@ import org.cbioportal.model.Sample;
 import org.cbioportal.model.MolecularProfile.MolecularAlterationType;
 import org.cbioportal.model.MolecularProfileSamples;
 import org.cbioportal.model.meta.GenericAssayMeta;
+import org.cbioportal.model.GenericAssayAdditionalProperty;
 import org.cbioportal.persistence.GenericAssayRepository;
 import org.cbioportal.persistence.MolecularDataRepository;
 import org.cbioportal.persistence.SampleListRepository;
@@ -74,14 +75,19 @@ public class GenericAssayServiceImpl implements GenericAssayService {
                     metaResults.add(new GenericAssayMeta(meta.getStableId()));
                 }
             } else {
-                // get additional properties for each meta data
+                List<GenericAssayAdditionalProperty> additionalProperties = genericAssayRepository.getGenericAssayAdditionalproperties(distinctStableIds);
                 for (GenericAssayMeta meta : metaData) {
-                    int geneticEntityId = genericAssayRepository.getGeneticEntityIdByStableId(meta.getStableId());
+                    String stableId = meta.getStableId();
                     HashMap<String, String> map = new HashMap<>();
-                    for (HashMap<String, String> data : genericAssayRepository.getGenericAssayMetaPropertiesMap(geneticEntityId)) {
-                        map.put(data.get("key"), data.get("value"));
+                    List<GenericAssayAdditionalProperty> filteredAdditionalProperties = additionalProperties
+                            .stream()
+                            .filter(additionalProperty -> additionalProperty.getStableId().equals(stableId))
+                            .collect(Collectors.toList());
+                    for (GenericAssayAdditionalProperty additionalProperty : filteredAdditionalProperties) {
+                        map.put(additionalProperty.getName(), additionalProperty.getValue());
                     }
-                    metaResults.add(new GenericAssayMeta(meta.getEntityType(), meta.getStableId(), map));
+                    meta.setGenericEntityMetaProperties(map);
+                    metaResults.add(meta);
                 }
             }
         }

--- a/service/src/test/java/org/cbioportal/service/impl/GenericAssayServiceImpTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenericAssayServiceImpTest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.cbioportal.model.GenericAssayAdditionalProperty;
 import org.cbioportal.model.GenericAssayData;
 import org.cbioportal.model.GenericAssayMolecularAlteration;
 import org.cbioportal.model.MolecularProfile;
@@ -42,12 +43,18 @@ public class GenericAssayServiceImpTest extends BaseServiceImplTest {
 
     private static final String PROFILE_ID = "test_profile_id";
     private static final List<String> PROFILE_ID_LIST = Arrays.asList(PROFILE_ID);
-    private static final List<String> idList = Arrays.asList(GENERIC_ASSAY_ID_1);
+    private static final List<String> idList = Arrays.asList(GENERIC_ASSAY_ID_1, GENERIC_ASSAY_ID_2);
     private static final List<GenericAssayMeta> mockGenericAssayMetaList = createGenericAssayMetaList();
+    private static final List<GenericAssayAdditionalProperty> mockGenericAssayAdditionalPropertyList = createGenericAssayAdditionalPropertyList();
     private static final String MOLECULAR_PROFILE_ID_1 = "molecular_profile_id_1";
     private static final String MOLECULAR_PROFILE_ID_2 = "molecular_profile_id_2";
     private static final String STABLE_ID_1 = "stable_id_1";
     private static final String STABLE_ID_2 = "stable_id_2";   
+
+    private static final String PROPERTY_NAME_1 = "property_name_1";
+    private static final String PROPERTY_NAME_2 = "property_name_2";
+    private static final String PROPERTY_VALUE_1 = "property_value_1";
+    private static final String PROPERTY_VALUE_2 = "property_value_2";
 
     @InjectMocks
     private GenericAssayServiceImpl genericAssayService;
@@ -260,15 +267,8 @@ public class GenericAssayServiceImpTest extends BaseServiceImplTest {
         Mockito.when(genericAssayRepository.getGenericAssayStableIdsByMolecularIds(PROFILE_ID_LIST))
         .thenReturn(idList);
 
-        Mockito.when(genericAssayRepository.getGeneticEntityIdByStableId(GENERIC_ASSAY_ID_1))
-        .thenReturn(INTERNAL_ID_1);
-        Mockito.when(genericAssayRepository.getGeneticEntityIdByStableId(GENERIC_ASSAY_ID_2))
-        .thenReturn(INTERNAL_ID_2);
-
-        Mockito.when(genericAssayRepository.getGenericAssayMetaPropertiesMap(INTERNAL_ID_1))
-        .thenReturn(new ArrayList<HashMap<String,String>>());
-        Mockito.when(genericAssayRepository.getGenericAssayMetaPropertiesMap(INTERNAL_ID_2))
-        .thenReturn(new ArrayList<HashMap<String,String>>());
+        Mockito.when(genericAssayRepository.getGenericAssayAdditionalproperties(idList))
+        .thenReturn(mockGenericAssayAdditionalPropertyList);
 
         List<GenericAssayMeta> result = genericAssayService.getGenericAssayMetaByStableIdsAndMolecularIds(idList, PROFILE_ID_LIST, PersistenceConstants.SUMMARY_PROJECTION);
         GenericAssayMeta meta1 = result.get(0);
@@ -288,11 +288,29 @@ public class GenericAssayServiceImpTest extends BaseServiceImplTest {
 
 
         GenericAssayMeta meta1 = new GenericAssayMeta(GENERIC_ASSAY_ID_1,ENTITY_TYPE);
+        HashMap<String, String> map1 = new HashMap<String, String>();
+        map1.put(PROPERTY_NAME_1, PROPERTY_VALUE_1);
+        meta1.setGenericEntityMetaProperties(map1);
         genericAssayMetaList.add(meta1);
 
         GenericAssayMeta meta2 = new GenericAssayMeta(GENERIC_ASSAY_ID_2,ENTITY_TYPE);
+        HashMap<String, String> map2 = new HashMap<String, String>();
+        map2.put(PROPERTY_NAME_2, PROPERTY_VALUE_2);
+        meta2.setGenericEntityMetaProperties(map2);
         genericAssayMetaList.add(meta2);
         return genericAssayMetaList;
+    }
+
+    private static List<GenericAssayAdditionalProperty> createGenericAssayAdditionalPropertyList() {
+
+        List<GenericAssayAdditionalProperty> genericAssayAdditionalPropertyList = new ArrayList<>();
+
+        GenericAssayAdditionalProperty property1 = new GenericAssayAdditionalProperty(PROPERTY_NAME_1, PROPERTY_VALUE_1, GENERIC_ASSAY_ID_1);
+        genericAssayAdditionalPropertyList.add(property1);
+
+        GenericAssayAdditionalProperty property2 = new GenericAssayAdditionalProperty(PROPERTY_NAME_2, PROPERTY_VALUE_2, GENERIC_ASSAY_ID_2);
+        genericAssayAdditionalPropertyList.add(property2);
+        return genericAssayAdditionalPropertyList;
     }
 
 }


### PR DESCRIPTION
Fix #7448  
Result: take `ccle_broad_2019` as an example, response time dropped from `9s-10s` to `0.3-0.5s`.

This pr will address the issue that causes the slowness of generic assay endpoint.
The issue is: the mybatis mapper will be called (2 * number of stable ids) times. So the response speed is very slow.

Describe changes proposed in this pull request:
- call mapper just one time
- update related unit tests