### PR TITLE
Update session and matchminer endpoints

### DIFF
--- a/web/src/main/java/org/cbioportal/web/MatchMinerController.java
+++ b/web/src/main/java/org/cbioportal/web/MatchMinerController.java
@@ -1,4 +1,4 @@
-package org.cbioportal.proxy;
+package org.cbioportal.web;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.logging.Log;
@@ -21,7 +21,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 @RestController
-@RequestMapping("/proxy/matchminer")
+@RequestMapping("/matchminer")
 public class MatchMinerController {
 
     private static final Log LOG = LogFactory.getLog( MatchMinerController.class);
@@ -35,7 +35,7 @@ public class MatchMinerController {
     @RequestMapping(value = "/**", produces = "application/json")
     public ResponseEntity<Object> proxy(@RequestBody(required = false) JSONObject body, HttpMethod method, HttpServletRequest request) {
         try {
-            String path = request.getPathInfo().replace("/proxy/matchminer", "");
+            String path = request.getPathInfo().replace("/matchminer", "");
             URI uri = new URI(this.url + path);
 
             HttpHeaders httpHeaders = new HttpHeaders();

--- a/web/src/main/java/org/cbioportal/web/SessionServiceController.java
+++ b/web/src/main/java/org/cbioportal/web/SessionServiceController.java
@@ -1,4 +1,4 @@
-package org.cbioportal.proxy;
+package org.cbioportal.web;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -52,10 +52,10 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Controller
-@RequestMapping("/proxy/session")
-public class ProxySessionServiceController {
+@RequestMapping("/session")
+public class SessionServiceController {
 
-    private static final Log LOG = LogFactory.getLog(ProxySessionServiceController.class);
+    private static final Log LOG = LogFactory.getLog(SessionServiceController.class);
 
     @Value("${session.service.url:}")
     private String sessionServiceURL;


### PR DESCRIPTION
This pr is continuation to https://github.com/cBioPortal/cbioportal/pull/7653

Changes:
1. path for session api's are changed from `/proxy/session` to `/session`
2. path for matchminer  api's are changed from `/proxy/matchminer` to `/matchminer`