### PR TITLE
Add show.transcript_dropdown to properties

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -267,6 +267,10 @@ public class GlobalProperties {
     @Value("${sitemaps:false}") // default is false
     public void setSitemaps(String property) { sitemaps = Boolean.parseBoolean(property); }
 
+    private static boolean showTranscriptDropdown;
+    @Value("${show.transcript_dropdown:false}") // default is false
+    public void setShowTranscriptDropdown(String property) { showTranscriptDropdown = Boolean.parseBoolean(property); }
+
     private static boolean showGenomeNexus;
     @Value("${show.genomenexus:true}") // default is true
     public void setShowGenomeNexus(String property) { showGenomeNexus = Boolean.parseBoolean(property); }
@@ -907,6 +911,10 @@ public class GlobalProperties {
 
     public static boolean showCivic() {
         return showCivic;
+    }
+
+    public static boolean showTranscriptDropdown() {
+        return showTranscriptDropdown;
     }
 
     public static boolean showGenomeNexus() {

--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -14,6 +14,7 @@ window.legacySupportFrontendConfig = {
     showCivic : <%=GlobalProperties.showCivic()%>,
     showHotspot : <%=GlobalProperties.showHotspot()%>,
     showMyCancerGenome : <%=GlobalProperties.showMyCancerGenomeUrl()%>,
+    showTranscriptDropdown : <%=GlobalProperties.showTranscriptDropdown()%>,
     showGenomeNexus : <%=GlobalProperties.showGenomeNexus()%>,
     showMutationMapperToolGrch38 : <%=GlobalProperties.showMutationMapperToolGrch38()%>,
     querySetsOfGenes : JSON.parse('<%=GlobalProperties.getQuerySetsOfGenes()%>'),

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -60,6 +60,7 @@
             "show.civic",
             "show.genomenexus",
             "show.mutation_mappert_tool.grch38",
+            "show.transcript_dropdown",
             "skin.documentation.about",
             "skin.documentation.baseurl",
             "skin.example_study_queries",

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -187,6 +187,9 @@ show.civic=false
 # Link to My Cancer Genome. Please disable (set to false) when using cBioPortal with patient identifiable data due My Cancer Genome license restrictions.
 mycancergenome.show=true
 
+# Enable transcript switch dropdown (true, false)
+# show.transcript_dropdown=false
+
 # igv bam linking
 igv.bam.linking=
 # colon delimited


### PR DESCRIPTION
Fix #7479 
Part of the epic, setting `show.transcript_dropdown` to true will add transcript switch dropdown on results view page.

Describe changes proposed in this pull request:
- Add `show.transcript_dropdown` to properties, default is false
