### PR TITLE
semi-manually set recommended docker version

### DIFF
--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -92,7 +92,7 @@ database irreversibly incompatible with older versions of the portal code.
 ```
 docker run --rm -it --net cbio-net \
     -v /<path_to_config_file>/portal.properties:/cbioportal/portal.properties:ro \
-    cbioportal/cbioportal:latest \
+    cbioportal/cbioportal:3.4.2 \
     migrate_db.py -p /cbioportal/portal.properties -s /cbioportal/db-scripts/src/main/resources/migration.sql
 ```
 
@@ -135,7 +135,7 @@ docker run -d --restart=always \
         -Dsession.service.url=http://cbio-session-service:5000/api/sessions/my_portal/
     ' \
     -p 8081:8080 \
-    cbioportal/cbioportal:latest \
+    cbioportal/cbioportal:3.4.2 \
     /bin/sh -c 'java ${JAVA_OPTS} -jar webapp-runner.jar /cbioportal-webapp'
 ```
 
@@ -156,22 +156,6 @@ Activity of Docker containers can be seen with:
 
 ```
 docker ps -a
-```
-
-## A note on versioning ##
-
-For production you might want to deploy a specific docker image tag, instead of
-the `latest` image. The version can be seen in the footer of the home page. The
-various image versions can be found here:
-https://hub.docker.com/r/cbioportal/cbioportal/tags. You can also get the
-latest version programmatically like this:
-
-```
-LATEST_VERSION=$(curl --silent "https://api.github.com/repos/cBioPortal/cbioportal/releases/latest" \
-    | grep "tag_name" \
-    | cut -d'"' -f4 \
-    | cut -dv -f2)
-echo $LATEST_VERSION
 ```
 
 ## Data loading & more commands ##
@@ -207,5 +191,5 @@ Finally we remove the cached Docker images.
 ```
 docker rmi mysql:5.7
 docker rmi mongo:3.6.6
-docker rmi cbioportal/cbioportal:latest
+docker rmi cbioportal/cbioportal:3.4.2
 ```

--- a/docs/docker/example_commands.md
+++ b/docs/docker/example_commands.md
@@ -8,7 +8,7 @@ docker run -it --rm \
     --net cbio-net \
     -v /<path_to_config_file>/portal.properties:/cbioportal/portal.properties:ro \
     -v <path_to_genepanel_file>:/gene_panels/gene_panel.txt:ro \
-    cbioportal/cbioportal:latest \
+    cbioportal/cbioportal:3.4.2 \
     bash -c 'cd /cbioportal/core/src/main/scripts/ && ./importGenePanel.pl --data /gene_panels/gene_panel.txt'
 ```
 
@@ -25,7 +25,7 @@ docker run -it --rm --net cbio-net \
     -v /<path_to_config_file>/portal.properties:/cbioportal/portal.properties:ro \
     -v "<path_to_study_directory>:/study:ro" \
     -v "<path_to_report_folder>:/report" \
-    cbioportal/cbioportal:latest \
+    cbioportal/cbioportal:3.4.2 \
     metaImport.py -u http://cbioportal-container:8080 -s /study --html=/report/report.html
 ```
 :warning: after importing a study, remember to restart `cbioportal-container`
@@ -40,7 +40,7 @@ docker run --rm --net cbio-net \
     -v /<path_to_config_file>/portal.properties:/cbioportal/portal.properties:ro \
     -v "<path_to_portalinfo>/portalinfo:/portalinfo" \
     -w /cbioportal/core/src/main/scripts \
-    cbioportal/cbioportal:latest \
+    cbioportal/cbioportal:3.4.2 \
     ./dumpPortalInfo.pl /portalinfo
 ```
 
@@ -52,7 +52,7 @@ docker run -it --rm --net cbio-net \
     -v "<path_to_study_directory>:/study:ro" \
     -v "<path_to_report_folder>:/report" \
     -v "<path_to_portalinfo>/portalinfo:/portalinfo:ro" \
-    cbioportal/cbioportal:latest \
+    cbioportal/cbioportal:3.4.2 \
     metaImport.py -p /portalinfo -s /study --html=/report/report.html
 ```
 
@@ -88,7 +88,7 @@ To remove a study, run:
 ```shell
 docker run -it --rm --net cbio-net \
     -v /<path_to_config_file>/portal.properties:/cbioportal/portal.properties:ro \
-    cbioportal/cbioportal:latest \
+    cbioportal/cbioportal:3.4.2 \
     cbioportalImporter.py -c remove-study -id study_id
 ```
 

--- a/docs/docker/import_data.md
+++ b/docs/docker/import_data.md
@@ -13,7 +13,7 @@ These are the commands for importing `study_es_0` gene panels (`data_gene_panel_
 docker run -it --rm \
     --net cbio-net \
     -v /<path_to_config_file>/portal.properties:/cbioportal/portal.properties:ro \
-    cbioportal/cbioportal:latest \
+    cbioportal/cbioportal:3.4.2 \
     bash -c 'cd /cbioportal/core/src/main/scripts/ && ./importGenePanel.pl --data /cbioportal/core/src/test/scripts/test_data/study_es_0/data_gene_panel_testpanel1.txt'
 ```
 
@@ -21,7 +21,7 @@ docker run -it --rm \
 docker run -it --rm \
     --net cbio-net \
     -v /<path_to_config_file>/portal.properties:/cbioportal/portal.properties:ro \
-    cbioportal/cbioportal:latest \
+    cbioportal/cbioportal:3.4.2 \
     bash -c 'cd /cbioportal/core/src/main/scripts/ && ./importGenePanel.pl --data /cbioportal/core/src/test/scripts/test_data/study_es_0/data_gene_panel_testpanel2.txt'
 ```
 
@@ -34,7 +34,7 @@ Command for importing `study_es_0` data:
 ```shell
 docker run -it --rm --net cbio-net \
     -v /<path_to_config_file>/portal.properties:/cbioportal/portal.properties:ro \
-    cbioportal/cbioportal:latest \
+    cbioportal/cbioportal:3.4.2 \
     metaImport.py -u http://cbioportal-container:8080 -s /cbioportal/core/src/test/scripts/test_data/study_es_0
 ```
 
@@ -77,7 +77,7 @@ Specify the study directory by replacing
 docker run -it --rm --net cbio-net \
     -v /<path_to_config_file>/portal.properties:/cbioportal/portal.properties:ro \
     -v "<path_to_study_directory>:/study:ro" \
-    cbioportal/cbioportal:latest \
+    cbioportal/cbioportal:3.4.2 \
     metaImport.py -u http://cbioportal-container:8080 -s /study -o --html=/report/report.html
 ```
 after data imported successfully:

--- a/docs/docker/using-keycloak.md
+++ b/docs/docker/using-keycloak.md
@@ -71,6 +71,6 @@ docker run -d --restart=always \
         -Dsession.service.url=http://cbio-session-service:5000/api/sessions/my_portal/
     ' \
     -p 8081:8080 \
-    cbioportal/cbioportal:latest \
+    cbioportal/cbioportal:3.4.2 \
     /bin/sh -c 'java ${JAVA_OPTS} -jar webapp-runner.jar /cbioportal-webapp'
 </pre>

--- a/docs/scripts/update_recommended_docker_version.sh
+++ b/docs/scripts/update_recommended_docker_version.sh
@@ -1,0 +1,55 @@
+#/bin/bash
+# update the recommended docker version to install
+# use like e.g. ./update_recommended_docker_version.sh 3.4.2
+set -e
+HELPDOC=$( cat <<EOF
+Update the recommended docker version to install
+
+Usage:
+
+    ./update_recommended_docker_version.sh version
+
+    e.g. ./update_recommended_docker_version.sh 3.4.2
+
+Options:
+    -h      This help documentation.
+EOF
+) 
+ 
+# Halt on error
+set -e
+
+# Parse options
+while getopts ":h" opt; do
+    case $opt in
+        h)
+            echo "$HELPDOC"
+            exit 0
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            echo "$HELPDOC"
+            exit 1
+            ;;
+    esac
+done
+
+# Parse arguments
+if [ "$#" -ne "1" ]
+then
+    echo "Invalid number of arguments: 1 needed but $# supplied" >&2
+    echo "$HELPDOC"
+    exit 1
+fi
+
+NEW_VERSION=$1
+# strip off "v"
+NEW_VERSION=${NEW_VERSION#v}
+echo "Setting docs to use docker image cbioportal/cbioportal:$NEW_VERSION"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $SCRIPT_DIR/../docker
+
+for f in $(git grep 'cbioportal/cbioportal:' | gcut -f1 -d: | uniq);
+	do gsed -i "s|cbioportal/cbioportal:[a-z0-9.]*|cbioportal/cbioportal:${NEW_VERSION}|g" $f;
+done


### PR DESCRIPTION
We were using "latest" docker tag as the image to indicate the latest stable version. We found that we occasionally roll out non-stable releases on that tag, so we want some more manual control. This PR contains a script to update the version:

```
./update_recommended_docker_version.sh 3.4.2
``` 

will set the docs to point to use 3.4.2

An alternative to this approach would be to manually push the latest tag to docker hub instead of auto pushing that on each tag with github actions as we do now. Would be this sequence of commands (just retagging an existing image, so not rebuilding the whole thing):

```
docker pull cbioportal/cbioportal:3.4.2
docker tag cbioportal/cbioportal:3.4.2 cbioportal/cbioportal:latest
docker push cbioportal/cbioportal:latest
```