### PR TITLE
cleanup of redis-cache-dev

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CacheEnabledConfig.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/CacheEnabledConfig.java
@@ -16,11 +16,9 @@ public class CacheEnabledConfig {
 
     public CacheEnabledConfig(String cacheType) {
         this.enabled = enableCache(cacheType);
-        this.enabled = true;
     }
 
     public static boolean enableCache(String cacheType) {
-        if (1 > 0) return true;
         for (String validCacheType : validCacheTypes) {
             if (validCacheType.equalsIgnoreCase(cacheType)) {
                 return true;
@@ -30,21 +28,15 @@ public class CacheEnabledConfig {
     }
 
     public String getEnabled() {
-        return "true";
-/*
         if (enabled) {
             return "true";
         } else {
             return "false";
         }
-*/
     }
 
     public boolean isEnabled() {
-        return true;
-/*
         return enabled;
-*/
     }
 
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/EhCacheStatistics.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/EhCacheStatistics.java
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 import javax.annotation.PostConstruct;
 
-//@Component
+@Component
 public class EhCacheStatistics {
 
     private static String TIER_NOT_IN_USE = "Tier not in use";
@@ -59,7 +59,7 @@ public class EhCacheStatistics {
         this.cacheManager = cacheManager;
     }
 
-    //@PostConstruct
+    @PostConstruct
     public void initializeStatisticsService () {
         try {
             statisticsService = new DefaultStatisticsService();
@@ -77,7 +77,6 @@ public class EhCacheStatistics {
     public String getCacheStatistics() {
         StringBuilder builder = new StringBuilder();
         builder.append("\n\nCACHE_STATISTICS START\n\n");
-        /*
         for (String cacheName : cacheManager.getCacheNames()) {
             builder.append("Cache: " + cacheName + "\n");
             builder.append("Allocated (heap): " + getAllocatedBytes(cacheName, ResourceType.Core.HEAP) + "\n");
@@ -86,7 +85,6 @@ public class EhCacheStatistics {
             builder.append("Occupied (disk): " + getOccupiedBytes(cacheName, "Disk", ResourceType.Core.DISK) + "\n");
             builder.append("\n");
         }
-        */
         builder.append("CACHE_STATISTICS END\n");
         return builder.toString();
     }

--- a/persistence/persistence-api/src/main/resources/applicationContext-ehcache.xml
+++ b/persistence/persistence-api/src/main/resources/applicationContext-ehcache.xml
@@ -10,34 +10,33 @@
     http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
 
 <!--
-    <cache:annotation-driven cache-manager="cacheManager" key-generator="customKeyGenerator"/>
-
+    <cache:annotation-driven cache-manager="ehcacheCacheManager" key-generator="customKeyGenerator"/>
+-->
     <bean id="cacheEnabledConfig" class="org.cbioportal.persistence.CacheEnabledConfig">
         <constructor-arg value="${ehcache.cache_type:none}"/>
     </bean>
 
     <bean id="customEhCacheProvider" class="org.cbioportal.persistence.util.CustomEhCachingProvider"/>
 
-    <bean id="getCacheManager" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+    <bean id="getEhcacheCacheManager" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
         <property name="targetObject" ref="customEhCacheProvider" />
         <property name="targetMethod" value="getCacheManager" />
     </bean>
 
-    <bean id="cacheManager" class="org.springframework.cache.jcache.JCacheCacheManager">
-        <property name="cacheManager" ref="getCacheManager"/>
+    <bean id="ehcacheCacheManager" class="org.springframework.cache.jcache.JCacheCacheManager">
+        <property name="cacheManager" ref="getEhcacheCacheManager"/>
     </bean>
 
     <bean id="customKeyGenerator" class="org.cbioportal.persistence.util.CustomKeyGenerator"/>
 
-    <bean id="ehCacheStatistics" class="org.cbioportal.persistence.util.EhCacheStatistics">
-        <constructor-arg ref="getCacheManager"/>
+    <bean id="ehcacheStatistics" class="org.cbioportal.persistence.util.EhCacheStatistics">
+        <constructor-arg ref="getEhcacheCacheManager"/>
     </bean>
 
     <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
         <property name="staticMethod" value="org.cbioportal.persistence.util.CacheEventLogger.setCacheStatistics" />
         <property name="arguments">
-            <list><ref bean="ehCacheStatistics"/></list>
+            <list><ref bean="ehcacheStatistics"/></list>
         </property>
     </bean>
--->
 </beans>

--- a/persistence/persistence-api/src/main/resources/applicationContext-rediscache.xml
+++ b/persistence/persistence-api/src/main/resources/applicationContext-rediscache.xml
@@ -9,7 +9,7 @@
     http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd
     http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
 
-    <cache:annotation-driven cache-manager="cacheManager" key-generator="customKeyGenerator"/>
+    <cache:annotation-driven cache-manager="redisCacheManager" key-generator="customKeyGenerator"/>
 
     <bean id="cacheEnabledConfig" class="org.cbioportal.persistence.CacheEnabledConfig">
         <constructor-arg value="${ehcache.cache_type:none}"/>
@@ -22,7 +22,7 @@
         <property name="targetMethod" value="getRedissionClient" />
     </bean>
 
-    <bean id="cacheManager" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+    <bean id="redisCacheManager" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
         <property name="targetObject" ref="customRedisCacheProvider" />
         <property name="targetMethod" value="getCacheManager" />
         <property name="arguments">

--- a/service/src/main/java/org/cbioportal/service/impl/CacheStatisticsServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CacheStatisticsServiceImpl.java
@@ -15,10 +15,10 @@ import org.springframework.stereotype.Service;
 @Service
 public class CacheStatisticsServiceImpl implements CacheStatisticsService {
 
-    //@Autowired
+    @Autowired
     public CacheManager cacheManager;
 
-    //@Autowired
+    @Autowired
     public EhCacheStatistics ehCacheStatistics;
 
     @Value("${cache.statistics_endpoint_enabled:false}")
@@ -32,7 +32,6 @@ public class CacheStatisticsServiceImpl implements CacheStatisticsService {
 
     @Override
     public List<String> getKeyCountsPerClass(String cacheName) throws CacheNotFoundException {
-/*
         checkIfCacheStatisticsEndpointEnabled();
         Cache<String, Object> cache = cacheManager.getCache(cacheName);
         if (cache == null) {
@@ -52,13 +51,10 @@ public class CacheStatisticsServiceImpl implements CacheStatisticsService {
             keyCountsPerClass.add(entry.getKey().toString() + ": " + entry.getValue().toString() + " keys");
         }
         return keyCountsPerClass;
-*/
-        return new ArrayList<String>();
     }
 
     @Override
     public List<String> getKeysInCache(String cacheName) throws CacheNotFoundException {
-/*
         checkIfCacheStatisticsEndpointEnabled();
         Cache<String, Object> cache = cacheManager.getCache(cacheName);
         if (cache == null) {
@@ -74,16 +70,11 @@ public class CacheStatisticsServiceImpl implements CacheStatisticsService {
         }
         keysInCache.add("Total Number of Keys: " + numberOfKeys.toString());
         return keysInCache;
-*/
-        return new ArrayList<String>();
     }
 
     @Override
     public String getCacheStatistics() {
-/*
         checkIfCacheStatisticsEndpointEnabled();
         return ehCacheStatistics.getCacheStatistics();
-*/
-        return "currently disabled";
     }
 }

--- a/web/src/main/java/org/cbioportal/web/CancerTypeController.java
+++ b/web/src/main/java/org/cbioportal/web/CancerTypeController.java
@@ -24,8 +24,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -36,8 +34,6 @@ import java.util.List;
 @Validated
 @Api(tags = PublicApiTags.CANCER_TYPES, description = " ")
 public class CancerTypeController {
-
-    private static final Logger LOG = LoggerFactory.getLogger(CancerTypeController.class);
 
     @Autowired
     private CancerTypeService cancerTypeService;
@@ -59,10 +55,6 @@ public class CancerTypeController {
         @ApiParam("Direction of the sort")
         @RequestParam(defaultValue = "ASC") final Direction direction) {
 
-        LOG.error("test log error");
-        LOG.warn("test log warn");
-        LOG.info("test log info");
-        LOG.debug("test log debug");
         if (projection == Projection.META) {
             final HttpHeaders responseHeaders = new HttpHeaders();
             responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, cancerTypeService.getMetaCancerTypes().getTotalCount()
@@ -81,10 +73,6 @@ public class CancerTypeController {
     public ResponseEntity<TypeOfCancer> getCancerType(
         @ApiParam(required = true, value = "Cancer Type ID e.g. acc")
         @PathVariable final String cancerTypeId) throws CancerTypeNotFoundException {
-        LOG.error("test log error");
-        LOG.warn("test log warn");
-        LOG.info("test log info");
-        LOG.debug("test log debug");
         return new ResponseEntity<>(cancerTypeService.getCancerType(cancerTypeId), HttpStatus.OK);
     }
 }


### PR DESCRIPTION
- remove the hardcoding of the CacheEnabled ... property cache_type now can be set to "heap" "disk" or "hybrid" to enable persistence caching
- remove the hardcoded testing of logging in the CancerTypeController class
- restore full EhCacheStatistics class component
- restore beans in applicationContext-ehcache.xml with adjustments
    - bean name clashes with applicationContext-rediscache.xml handled by renaming beans
- restore CacheStatisticsServiceImpl
    - service only reports Ehcache usage, which will show non-use during redis cache operation