### PR TITLE
remove leftover api-legacy references

### DIFF
--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -221,20 +221,6 @@
     </servlet-mapping>
     
     <servlet>
-        <servlet-name>api-legacy</servlet-name>
-        <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
-        <init-param>
-            <param-name>contextConfigLocation</param-name>
-            <param-value>classpath:applicationContext-weblegacy.xml</param-value>
-        </init-param>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
-    <servlet-mapping>
-        <servlet-name>api-legacy</servlet-name>
-        <url-pattern>/api-legacy/*</url-pattern>
-    </servlet-mapping>
-
-    <servlet>
         <servlet-name>url_shortener</servlet-name>
         <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
         <init-param>

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -107,11 +107,6 @@
         <csrf disabled="true"/>
         <custom-filter ref="tokenAuthenticationFilter" before="FORM_LOGIN_FILTER"/>
     </http>
-    <http use-expressions="true" pattern="/api-legacy/**" entry-point-ref="restAuthenticationEntryPoint" create-session="never">
-        <intercept-url pattern="/**" access="isAuthenticated()"/>
-        <csrf disabled="true"/>
-        <custom-filter ref="tokenAuthenticationFilter" before="FORM_LOGIN_FILTER"/>
-    </http>
     <http use-expressions="true" pattern="/webservice.do" entry-point-ref="restAuthenticationEntryPoint" create-session="never">
         <intercept-url pattern="/**" access="isAuthenticated()"/>
         <csrf disabled="true"/>
@@ -629,7 +624,7 @@
         <!-- create-session is never so spring security will not create the session,
             this relies on the app creating the session -->
         <http use-expressions="true" entry-point-ref="restAuthenticationEntryPoint" create-session="never">
-            <intercept-url pattern="/api-legacy/proxy/session-service/**" access="@sessionSecurity.checkWrite(request)"/>
+            <intercept-url pattern="/api/proxy/session-service/**" access="@sessionSecurity.checkWrite(request)"/>
             <intercept-url pattern="/**" access="permitAll"/>
             <csrf disabled="true"/>
         </http>

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -624,7 +624,7 @@
         <!-- create-session is never so spring security will not create the session,
             this relies on the app creating the session -->
         <http use-expressions="true" entry-point-ref="restAuthenticationEntryPoint" create-session="never">
-            <intercept-url pattern="/api/proxy/session-service/**" access="@sessionSecurity.checkWrite(request)"/>
+            <intercept-url pattern="/api/session-service/**" access="@sessionSecurity.checkWrite(request)"/>
             <intercept-url pattern="/**" access="permitAll"/>
             <csrf disabled="true"/>
         </http>


### PR DESCRIPTION
Current v3.4.4 gives some error stack trace b/c of leftover api-legacy references I believe:

```
13:49:52 [localhost-startStop-1] ERROR org.springframework.web.servlet.DispatcherServlet - Context initialization failed                                       
org.springframework.beans.factory.BeanDefinitionStoreException: IOException parsing XML document from class path resource [applicationContext-weblegacy.xml]; n
ested exception is java.io.FileNotFoundException: class path resource [applicationContext-weblegacy.xml] cannot be opened because it does not exist 
```