### PR TITLE
Add generic assay enrichments api

### DIFF
--- a/model/src/main/java/org/cbioportal/model/ExpressionEnrichment.java
+++ b/model/src/main/java/org/cbioportal/model/ExpressionEnrichment.java
@@ -8,53 +8,24 @@ import javax.validation.constraints.NotNull;
 
 public class ExpressionEnrichment implements Serializable {
 
-    @NotNull
-    private Integer entrezGeneId;
-    @NotNull
-    private String hugoGeneSymbol;
-    private String cytoband;
-    @NotNull
-    private List<GroupStatistics> groupsStatistics;
-    @NotNull
-    private BigDecimal pValue;
+	@NotNull
+	private List<GroupStatistics> groupsStatistics;
+	@NotNull
+	private BigDecimal pValue;
 
-    public Integer getEntrezGeneId() {
-        return entrezGeneId;
-    }
+	public List<GroupStatistics> getGroupsStatistics() {
+		return groupsStatistics;
+	}
 
-    public void setEntrezGeneId(Integer entrezGeneId) {
-        this.entrezGeneId = entrezGeneId;
-    }
+	public void setGroupsStatistics(List<GroupStatistics> groupsStatistics) {
+		this.groupsStatistics = groupsStatistics;
+	}
 
-    public String getHugoGeneSymbol() {
-        return hugoGeneSymbol;
-    }
+	public BigDecimal getpValue() {
+		return pValue;
+	}
 
-    public void setHugoGeneSymbol(String hugoGeneSymbol) {
-        this.hugoGeneSymbol = hugoGeneSymbol;
-    }
-
-    public String getCytoband() {
-        return cytoband;
-    }
-
-    public void setCytoband(String cytoband) {
-        this.cytoband = cytoband;
-    }
-
-    public List<GroupStatistics> getGroupsStatistics() {
-        return groupsStatistics;
-    }
-
-    public void setGroupsStatistics(List<GroupStatistics> groupsStatistics) {
-        this.groupsStatistics = groupsStatistics;
-    }
-
-    public BigDecimal getpValue() {
-        return pValue;
-    }
-
-    public void setpValue(BigDecimal pValue) {
-        this.pValue = pValue;
-    }
+	public void setpValue(BigDecimal pValue) {
+		this.pValue = pValue;
+	}
 }

--- a/model/src/main/java/org/cbioportal/model/GenericAssayEnrichment.java
+++ b/model/src/main/java/org/cbioportal/model/GenericAssayEnrichment.java
@@ -1,0 +1,41 @@
+package org.cbioportal.model;
+
+import java.io.Serializable;
+import java.util.HashMap;
+
+import javax.validation.constraints.NotNull;
+
+public class GenericAssayEnrichment extends ExpressionEnrichment implements Serializable {
+
+	@NotNull
+	private String stableId;
+	@NotNull
+	private String name;
+	@NotNull
+	private HashMap<String, String> genericEntityMetaProperties;
+
+	public String getStableId() {
+		return stableId;
+	}
+
+	public void setStableId(String stableId) {
+		this.stableId = stableId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public HashMap<String, String> getGenericEntityMetaProperties() {
+		return genericEntityMetaProperties;
+	}
+
+	public void setGenericEntityMetaProperties(HashMap<String, String> genericEntityMetaProperties) {
+		this.genericEntityMetaProperties = genericEntityMetaProperties;
+	}
+
+}

--- a/model/src/main/java/org/cbioportal/model/GenomicEnrichment.java
+++ b/model/src/main/java/org/cbioportal/model/GenomicEnrichment.java
@@ -1,0 +1,38 @@
+package org.cbioportal.model;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+
+public class GenomicEnrichment extends ExpressionEnrichment implements Serializable {
+
+	@NotNull
+	private Integer entrezGeneId;
+	@NotNull
+	private String hugoGeneSymbol;
+	private String cytoband;
+
+	public Integer getEntrezGeneId() {
+		return entrezGeneId;
+	}
+
+	public void setEntrezGeneId(Integer entrezGeneId) {
+		this.entrezGeneId = entrezGeneId;
+	}
+
+	public String getHugoGeneSymbol() {
+		return hugoGeneSymbol;
+	}
+
+	public void setHugoGeneSymbol(String hugoGeneSymbol) {
+		this.hugoGeneSymbol = hugoGeneSymbol;
+	}
+
+	public String getCytoband() {
+		return cytoband;
+	}
+
+	public void setCytoband(String cytoband) {
+		this.cytoband = cytoband;
+	}
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
@@ -37,4 +37,8 @@ public interface MolecularDataRepository {
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<GenericAssayMolecularAlteration> getGenericAssayMolecularAlterations(String molecularProfileId, List<String> stableIds,
         String projection);
+
+	@Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+	Iterable<GenericAssayMolecularAlteration> getGenericAssayMolecularAlterationsIterable(String molecularProfileId,
+			List<String> stableIds, String projection);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
@@ -27,4 +27,7 @@ public interface MolecularDataMapper {
 
     List<GenericAssayMolecularAlteration> getGenericAssayMolecularAlterations(String molecularProfileId, List<String> stableIds,
                                                                     String projection);
+
+	Cursor<GenericAssayMolecularAlteration> getGenericAssayMolecularAlterationsIter(String molecularProfileId,
+			List<String> stableIds, String projection);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
@@ -73,4 +73,10 @@ public class MolecularDataMyBatisRepository implements MolecularDataRepository {
     public List<GenericAssayMolecularAlteration> getGenericAssayMolecularAlterations(String molecularProfileId, List<String> stableIds, String projection) {
         return molecularDataMapper.getGenericAssayMolecularAlterations(molecularProfileId, stableIds, projection);
     }
+
+	@Override
+	public Iterable<GenericAssayMolecularAlteration> getGenericAssayMolecularAlterationsIterable(
+			String molecularProfileId, List<String> stableIds, String projection) {
+		return molecularDataMapper.getGenericAssayMolecularAlterationsIter(molecularProfileId, stableIds, projection);
+	}
 }

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
@@ -132,7 +132,38 @@
         </where>
     </select>
 
+    <!-- Any changes to this routine should be kept in sync with getGenericAssayMolecularAlterationsIter below -->
     <select id="getGenericAssayMolecularAlterations" resultType="org.cbioportal.model.GenericAssayMolecularAlteration">
+        SELECT
+        genetic_entity.STABLE_ID AS genericAssayStableId,
+        genetic_profile.STABLE_ID AS molecularProfileId,
+        <if test="projection == 'ID'">
+            NULL AS "values"
+        </if>
+        <if test="projection != 'ID'">
+            genetic_alteration.VALUES AS "values"
+        </if>
+        FROM genetic_alteration
+        INNER JOIN genetic_profile ON genetic_alteration.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
+        INNER JOIN genetic_entity ON genetic_alteration.GENETIC_ENTITY_ID = genetic_entity.ID
+        <where>
+            genetic_profile.STABLE_ID = #{molecularProfileId}
+            <if test="stableIds != null and stableIds">
+                AND genetic_entity.STABLE_ID IN
+                <foreach item="item" collection="stableIds" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+            </if>
+        </where>
+    </select>
+
+    <!-- This routine is a copy of getGenericAssayMolecularAlterations above.  This copy is necessary because
+         it is backing a corresponding method in MolecularDataMapper.java which returns a Cursor as
+         opposed to a List. This method should be kept in sync with getGenericAssayMolecularAlterations above.
+         (Attempts where made to share getGenericAssayMolecularAlterations between methods in MolecularDataMapper.java
+         all of which have failed).
+    -->
+    <select id="getGenericAssayMolecularAlterationsIter" resultType="org.cbioportal.model.GenericAssayMolecularAlteration">
         SELECT
         genetic_entity.STABLE_ID AS genericAssayStableId,
         genetic_profile.STABLE_ID AS molecularProfileId,

--- a/service/src/main/java/org/cbioportal/service/ExpressionEnrichmentService.java
+++ b/service/src/main/java/org/cbioportal/service/ExpressionEnrichmentService.java
@@ -1,15 +1,21 @@
 package org.cbioportal.service;
 
-import org.cbioportal.model.ExpressionEnrichment;
-import org.cbioportal.model.MolecularProfileCaseIdentifier;
-import org.cbioportal.service.exception.MolecularProfileNotFoundException;
-
 import java.util.List;
 import java.util.Map;
 
+import org.cbioportal.model.GenericAssayEnrichment;
+import org.cbioportal.model.GenomicEnrichment;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
+import org.cbioportal.service.exception.MolecularProfileNotFoundException;
+
 public interface ExpressionEnrichmentService {
 
-    List<ExpressionEnrichment> getExpressionEnrichments(String molecularProfileId,
+    List<GenomicEnrichment> getGenomicEnrichments(String molecularProfileId,
             Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets, String enrichmentType)
             throws MolecularProfileNotFoundException;
+
+    List<GenericAssayEnrichment> getGenericAssayEnrichments(String molecularProfileId,
+            Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets, String enrichmentType)
+            throws MolecularProfileNotFoundException;
+
 }

--- a/service/src/main/java/org/cbioportal/service/GenericAssayService.java
+++ b/service/src/main/java/org/cbioportal/service/GenericAssayService.java
@@ -4,13 +4,11 @@ import java.util.List;
 
 import org.cbioportal.model.GenericAssayData;
 import org.cbioportal.model.meta.GenericAssayMeta;
-import org.cbioportal.service.exception.GenericAssayNotFoundException;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 
 public interface GenericAssayService {
     
-    List<GenericAssayMeta> getGenericAssayMetaByStableIdsAndMolecularIds(List<String> stableIds, List<String> molecularProfileIds, String projection)
-        throws GenericAssayNotFoundException;   
+    List<GenericAssayMeta> getGenericAssayMetaByStableIdsAndMolecularIds(List<String> stableIds, List<String> molecularProfileIds, String projection);   
 
     List<GenericAssayData> getGenericAssayData(String molecularProfileId, String sampleListId, 
                                             List<String> genericAssayStableIds, String projection) 

--- a/service/src/main/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImpl.java
@@ -1,37 +1,27 @@
 package org.cbioportal.service.impl;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
-import org.apache.commons.lang.math.NumberUtils;
-import org.apache.commons.math3.stat.StatUtils;
-import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
-import org.apache.commons.math3.stat.inference.OneWayAnova;
-import org.apache.commons.math3.stat.inference.TestUtils;
-import org.cbioportal.model.ExpressionEnrichment;
+import org.cbioportal.model.Gene;
 import org.cbioportal.model.GeneMolecularAlteration;
-import org.cbioportal.model.GroupStatistics;
-import org.cbioportal.model.MolecularAlteration;
+import org.cbioportal.model.GenericAssayEnrichment;
+import org.cbioportal.model.GenericAssayMolecularAlteration;
+import org.cbioportal.model.GenomicEnrichment;
 import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.MolecularProfile.MolecularAlterationType;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
-import org.cbioportal.model.MolecularProfileSamples;
-import org.cbioportal.model.Gene;
-import org.cbioportal.model.Sample;
+import org.cbioportal.model.meta.GenericAssayMeta;
 import org.cbioportal.persistence.MolecularDataRepository;
 import org.cbioportal.service.ExpressionEnrichmentService;
-import org.cbioportal.service.MolecularDataService;
-import org.cbioportal.service.MolecularProfileService;
 import org.cbioportal.service.GeneService;
-import org.cbioportal.service.SampleService;
+import org.cbioportal.service.GenericAssayService;
+import org.cbioportal.service.MolecularProfileService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
+import org.cbioportal.service.util.ExpressionEnrichmentUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,267 +29,104 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ExpressionEnrichmentServiceImpl implements ExpressionEnrichmentService {
 
-    private static final double LOG2 = Math.log(2);
-    private static final String RNA_SEQ = "rna_seq";
-
-    @Autowired
-    private SampleService sampleService;
     @Autowired
     private MolecularProfileService molecularProfileService;
     @Autowired
-    private MolecularDataService molecularDataService;
+    private MolecularDataRepository molecularDataRepository;
     @Autowired
     private GeneService geneService;
     @Autowired
-    private MolecularDataRepository molecularDataRepository;
+    private ExpressionEnrichmentUtil expressionEnrichmentUtil;
+    @Autowired
+    private GenericAssayService genericAssayService;
 
     @Override
     // transaction needs to be setup here in order to return Iterable from
     // molecularDataService in fetchCoExpressions
     @Transactional(readOnly = true)
-    public List<ExpressionEnrichment> getExpressionEnrichments(String molecularProfileId,
+    public List<GenomicEnrichment> getGenomicEnrichments(String molecularProfileId,
             Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets, String enrichmentType)
             throws MolecularProfileNotFoundException {
 
-        MolecularProfile molecularProfile = molecularProfileService
-                .getMolecularProfile(molecularProfileId);
+        MolecularProfile molecularProfile = molecularProfileService.getMolecularProfile(molecularProfileId);
 
-        validateMolecularProfile(molecularProfile);
-        
-        Map<String, List<Integer>> groupIndicesMap = getGroupIndicesMap(molecularProfileCaseSets, enrichmentType,
-                molecularProfile);
+        List<MolecularAlterationType> validGenomicMolecularAlterationTypes = Arrays.asList(
+                MolecularAlterationType.MICRO_RNA_EXPRESSION, MolecularAlterationType.MRNA_EXPRESSION,
+                MolecularAlterationType.MRNA_EXPRESSION_NORMALS, MolecularAlterationType.RNA_EXPRESSION,
+                MolecularAlterationType.METHYLATION, MolecularAlterationType.METHYLATION_BINARY,
+                MolecularAlterationType.PHOSPHORYLATION, MolecularAlterationType.PROTEIN_LEVEL,
+                MolecularAlterationType.PROTEIN_ARRAY_PROTEIN_LEVEL,
+                MolecularAlterationType.PROTEIN_ARRAY_PHOSPHORYLATION);
 
-        Iterable<GeneMolecularAlteration> maItr = molecularDataService
-                .getMolecularAlterations(molecularProfile.getStableId(), null, "SUMMARY");
+        validateMolecularProfile(molecularProfile, validGenomicMolecularAlterationTypes);
 
-        List<ExpressionEnrichment> expressionEnrichments = new ArrayList<ExpressionEnrichment>();
+        Iterable<GeneMolecularAlteration> maItr = molecularDataRepository
+                .getGeneMolecularAlterationsIterable(molecularProfile.getStableId(), null, "SUMMARY");
 
-        for (MolecularAlteration ma : maItr) {
-            List<GroupStatistics> groupsStatistics = new ArrayList<GroupStatistics>();
-            // used for p-value calculation
-            List<double[]> groupedValues = new ArrayList<double[]>();
+        List<GenomicEnrichment> expressionEnrichments = expressionEnrichmentUtil.getEnrichments(molecularProfile,
+                molecularProfileCaseSets, enrichmentType, maItr);
 
-            for (Entry<String, List<Integer>> group : groupIndicesMap.entrySet()) {
-                
-                //get expression values to all the indices in the group
-                List<String> molecularDataValues = group
-                        .getValue()
-                        .stream()
-                        .map(sampleIndex -> ma.getSplitValues()[sampleIndex])
-                        .collect(Collectors.toList());
-
-                // ignore group if there are less than 2 values or non numeric values
-                if (molecularDataValues.size() < 2
-                        || molecularDataValues.stream().filter(a -> !NumberUtils.isNumber(a)).count() > 0) {
-                    continue;
-                }
-
-                double[] values = getAlterationValues(molecularDataValues, molecularProfile.getStableId());
-
-                GroupStatistics groupStatistics = new GroupStatistics();
-                double alteredMean = calculateMean(values);
-                double alteredStandardDeviation = calculateStandardDeviation(values);
-
-                // ignore if mean or standard deviation are not numbers
-                if (Double.isNaN(alteredMean) || Double.isNaN(alteredStandardDeviation)) {
-                    continue;
-                }
-
-                groupedValues.add(values);
-                groupStatistics.setName(group.getKey());
-                groupStatistics.setMeanExpression(BigDecimal.valueOf(alteredMean));
-                groupStatistics.setStandardDeviation(BigDecimal.valueOf(alteredStandardDeviation));
-                groupsStatistics.add(groupStatistics);
-            }
-
-            // calculate p-value and add enrichment if atleast 2 groups have data
-            if (groupsStatistics.size() > 1) {
-                double pValue = calculatePValue(groupedValues);
-                if (Double.isNaN(pValue)) {
-                    continue;
-                }
-                ExpressionEnrichment expressionEnrichment = new ExpressionEnrichment();
-                expressionEnrichment.setEntrezGeneId(Integer.valueOf(ma.getStableId()));
-                expressionEnrichment.setpValue(BigDecimal.valueOf(pValue));
-                expressionEnrichment.setGroupsStatistics(groupsStatistics);
-                expressionEnrichments.add(expressionEnrichment);
-            }
-
-        }
-
-        List<Integer> entrezGeneIds = expressionEnrichments
-                .stream()
-                .map(ExpressionEnrichment::getEntrezGeneId)
+        List<Integer> entrezGeneIds = expressionEnrichments.stream().map(GenomicEnrichment::getEntrezGeneId)
                 .collect(Collectors.toList());
 
         Map<Integer, List<Gene>> geneMapByEntrezId = geneService
-                .fetchGenes(entrezGeneIds
-                    .stream()
-                    .map(Object::toString)
-                    .collect(Collectors.toList()),
-            "ENTREZ_GENE_ID",
-            "SUMMARY")
-                .stream()
-                .collect(Collectors.groupingBy(Gene::getEntrezGeneId));
-        
-        return expressionEnrichments
-                .stream()
-                // filter Enrichments having no gene reference object(this happens when multiple entrez ids map to same hugo gene symbol)
+                .fetchGenes(entrezGeneIds.stream().map(Object::toString).collect(Collectors.toList()), "ENTREZ_GENE_ID",
+                        "SUMMARY")
+                .stream().collect(Collectors.groupingBy(Gene::getEntrezGeneId));
+
+        return expressionEnrichments.stream()
+                // filter Enrichments having no gene reference object(this
+                // happens when multiple
+                // entrez ids map to same hugo gene symbol)
                 .filter(expressionEnrichment -> geneMapByEntrezId.containsKey(expressionEnrichment.getEntrezGeneId()))
                 .map(expressionEnrichment -> {
                     Gene gene = geneMapByEntrezId.get(expressionEnrichment.getEntrezGeneId()).get(0);
                     expressionEnrichment.setHugoGeneSymbol(gene.getHugoGeneSymbol());
                     return expressionEnrichment;
-                })
-                .collect(Collectors.toList());
+                }).collect(Collectors.toList());
     }
 
-    /**
-     * 
-     * This method maps valid samples in molecularProfileCaseSets to indices in genetic_alteration.VALUES column.
-     * Recall this column of the genetic_alteration table is a comma separated list of scalar values. Each
-     * value in this list is associated with a sample at the same position found in
-     * the genetic_profile_samples.ORDERED_SAMPLE_LIST column.
-     * 
-     * @param molecularProfileCaseSets
-     * @param enrichmentType
-     * @param molecularProfile
-     * @return
-     */
-    private Map<String, List<Integer>> getGroupIndicesMap(
-            Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets, String enrichmentType,
-            MolecularProfile molecularProfile) {
-        
+    @Override
+    // transaction needs to be setup here in order to return Iterable from
+    // molecularDataRepository in getGenericAssayMolecularAlterationsIterable
+    @Transactional(readOnly = true)
+    public List<GenericAssayEnrichment> getGenericAssayEnrichments(String molecularProfileId,
+            Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets, String enrichmentType)
+            throws MolecularProfileNotFoundException {
 
-        MolecularProfileSamples commaSeparatedSampleIdsOfMolecularProfile = molecularDataRepository
-                .getCommaSeparatedSampleIdsOfMolecularProfile(molecularProfile.getStableId());
-        
-        List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfile.getSplitSampleIds())
-                .mapToInt(Integer::parseInt)
-                .boxed()
-                .collect(Collectors.toList());
+        MolecularProfile molecularProfile = molecularProfileService.getMolecularProfile(molecularProfileId);
 
-        Map<Integer, Integer> internalSampleIdToIndexMap = IntStream
-                .range(0, internalSampleIds.size())
-                .boxed()
-                .collect(Collectors.toMap(internalSampleIds::get, Function.identity()));
+        validateMolecularProfile(molecularProfile, Arrays.asList(MolecularAlterationType.GENERIC_ASSAY));
 
-        Map<String, List<Integer>> selectedCaseIdToInternalIdsMap =
-                getCaseIdToInternalIdsMap(molecularProfileCaseSets, enrichmentType, molecularProfile);
+        Iterable<GenericAssayMolecularAlteration> maItr = molecularDataRepository
+                .getGenericAssayMolecularAlterationsIterable(molecularProfile.getStableId(), null, "SUMMARY");
 
-        // this block map caseIds(sampleIds or patientids) to sampleIndices which 
-        // represents the position fount in the genetic_profile_samples.ORDERED_SAMPLE_LIST column
-        Map<String, List<Integer>> groupIndicesMap = molecularProfileCaseSets
-                .entrySet()
-                .stream()
-                .collect(Collectors
-                        .toMap(
-                                entity -> entity.getKey(),
-                                entity -> {
-                                    List<Integer> sampleIndices = new ArrayList<>();
-                                    entity.getValue().forEach(molecularProfileCaseIdentifier -> {
-                                        // consider only valid samples
-                                        if (selectedCaseIdToInternalIdsMap.containsKey(molecularProfileCaseIdentifier.getCaseId())) {
-                                            List<Integer> sampleInternalIds = selectedCaseIdToInternalIdsMap
-                                                    .get(molecularProfileCaseIdentifier.getCaseId());
-                                            
-                                            // only consider samples which are profiled for the give molecular profile id
-                                            sampleInternalIds.forEach(sampleInternalId -> {
-                                                if (internalSampleIdToIndexMap.containsKey(sampleInternalId)) {
-                                                    sampleIndices.add(internalSampleIdToIndexMap.get(sampleInternalId));
-                                                }
-                                            });
-                                        }
-                                    });
-                                return sampleIndices;
-                            }));
-        return groupIndicesMap;
+        List<GenericAssayEnrichment> genericAssayEnrichments = expressionEnrichmentUtil.getEnrichments(molecularProfile,
+                molecularProfileCaseSets, enrichmentType, maItr);
+
+        List<String> getGenericAssayStableIds = genericAssayEnrichments.stream()
+                .map(GenericAssayEnrichment::getStableId).collect(Collectors.toList());
+
+        Map<String, GenericAssayMeta> genericAssayMetaByStableId = genericAssayService
+                .getGenericAssayMetaByStableIdsAndMolecularIds(getGenericAssayStableIds,
+                        getGenericAssayStableIds.stream().map(stableId -> molecularProfileId)
+                                .collect(Collectors.toList()),
+                        "SUMMARY")
+                .stream().collect(Collectors.toMap(GenericAssayMeta::getStableId, Function.identity()));
+
+        return genericAssayEnrichments.stream().map(enrichmentDatum -> {
+            enrichmentDatum.setGenericEntityMetaProperties(
+                    genericAssayMetaByStableId.get(enrichmentDatum.getStableId()).getGenericEntityMetaProperties());
+            return enrichmentDatum;
+        }).collect(Collectors.toList());
+
     }
 
-    private Map<String, List<Integer>> getCaseIdToInternalIdsMap(
-            Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets, String enrichmentType,
-            MolecularProfile molecularProfile) {
-        
-        if (enrichmentType.equals("PATIENT")) {
-            List<String> patientIds = molecularProfileCaseSets
-                    .values()
-                    .stream()
-                    .flatMap(molecularProfileCaseSet -> molecularProfileCaseSet.stream()
-                            .map(MolecularProfileCaseIdentifier::getCaseId))
-                    .collect(Collectors.toList());
-
-            List<Sample> samples = sampleService.getAllSamplesOfPatientsInStudy(molecularProfile.getCancerStudyIdentifier(),
-                    patientIds, "SUMMARY");
-
-            return samples
-                    .stream()
-                    .collect(Collectors
-                            .groupingBy(Sample::getPatientStableId, Collectors
-                                    .mapping(Sample::getInternalId, Collectors.toList())));
-        } else {
-            List<String> sampleIds = new ArrayList<>();
-            List<String> studyIds = new ArrayList<>();
-
-            molecularProfileCaseSets.values().forEach(molecularProfileCaseIdentifiers -> {
-                molecularProfileCaseIdentifiers.forEach(molecularProfileCaseIdentifier -> {
-                    sampleIds.add(molecularProfileCaseIdentifier.getCaseId());
-                    studyIds.add(molecularProfile.getCancerStudyIdentifier());
-                });
-            });
-            List<Sample> samples = sampleService.fetchSamples(studyIds, sampleIds, "ID");
-
-            return samples.stream()
-                    .collect(Collectors.toMap(Sample::getStableId, x -> Arrays.asList(x.getInternalId())));
-        }
-    }
-
-    private double[] getAlterationValues(List<String> molecularDataValues, String molecularProfileId) {
-
-        if (molecularProfileId.contains(RNA_SEQ)) {
-            return molecularDataValues
-                    .stream()
-                    .mapToDouble(d -> {
-                        double datum = Double.parseDouble(d);
-                        // reset to 0 if there are any negative values and then do log1p
-                        return Math.log1p(datum < 0 ? 0 : datum) / LOG2;
-                    })
-                    .toArray();
-        } else {
-            return molecularDataValues.stream().mapToDouble(g -> Double.parseDouble(g)).toArray();
-        }
-    }
-
-    private double calculatePValue(List<double[]> alteredValues) {
-
-        if (alteredValues.size() == 2) {
-            return TestUtils.tTest(alteredValues.get(0), alteredValues.get(1));
-        } else {
-            // calculate Anova statisitcs if there are more than 2 groups
-            OneWayAnova oneWayAnova = new OneWayAnova();
-            return oneWayAnova.anovaPValue(alteredValues);
-        }
-    }
-
-    private double calculateMean(double[] values) {
-
-        return StatUtils.mean(values);
-    }
-
-    private double calculateStandardDeviation(double[] values) {
-
-        DescriptiveStatistics descriptiveStatistics = new DescriptiveStatistics();
-        for (double value : values) {
-            descriptiveStatistics.addValue(value);
-        }
-        return descriptiveStatistics.getStandardDeviation();
-    }
-
-    private void validateMolecularProfile(MolecularProfile molecularProfile) throws MolecularProfileNotFoundException {
-        if (molecularProfile.getMolecularAlterationType().equals(MolecularAlterationType.MUTATION_EXTENDED)
-                || molecularProfile.getMolecularAlterationType().equals(MolecularAlterationType.MUTATION_UNCALLED)
-                || molecularProfile.getMolecularAlterationType().equals(MolecularAlterationType.FUSION)) {
-
+    private void validateMolecularProfile(MolecularProfile molecularProfile,
+            List<MolecularAlterationType> validMolecularAlterationTypes) throws MolecularProfileNotFoundException {
+        if (!validMolecularAlterationTypes.contains(molecularProfile.getMolecularAlterationType())) {
             throw new MolecularProfileNotFoundException(molecularProfile.getStableId());
         }
     }
+
 }

--- a/service/src/main/java/org/cbioportal/service/impl/GenericAssayServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenericAssayServiceImpl.java
@@ -8,27 +8,25 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import org.cbioportal.model.GenericAssayAdditionalProperty;
 import org.cbioportal.model.GenericAssayData;
 import org.cbioportal.model.GenericAssayMolecularAlteration;
 import org.cbioportal.model.MolecularProfile;
-import org.cbioportal.model.Sample;
 import org.cbioportal.model.MolecularProfile.MolecularAlterationType;
 import org.cbioportal.model.MolecularProfileSamples;
+import org.cbioportal.model.Sample;
 import org.cbioportal.model.meta.GenericAssayMeta;
-import org.cbioportal.model.GenericAssayAdditionalProperty;
 import org.cbioportal.persistence.GenericAssayRepository;
 import org.cbioportal.persistence.MolecularDataRepository;
 import org.cbioportal.persistence.SampleListRepository;
 import org.cbioportal.service.GenericAssayService;
 import org.cbioportal.service.MolecularProfileService;
 import org.cbioportal.service.SampleService;
-import org.cbioportal.service.exception.GenericAssayNotFoundException;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import org.springframework.stereotype.Service;
 
 
@@ -51,8 +49,7 @@ public class GenericAssayServiceImpl implements GenericAssayService {
     private SampleListRepository sampleListRepository;
 
     @Override
-    public List<GenericAssayMeta> getGenericAssayMetaByStableIdsAndMolecularIds(List<String> stableIds, List<String> molecularProfileIds, String projection)
-        throws GenericAssayNotFoundException {
+    public List<GenericAssayMeta> getGenericAssayMetaByStableIdsAndMolecularIds(List<String> stableIds, List<String> molecularProfileIds, String projection) {
         Set<String> allStableIds = new HashSet<String>();
         // extract genericAssayStableIds from the GENERIC_ASSAY profiles
         if (molecularProfileIds != null) {
@@ -63,10 +60,18 @@ public class GenericAssayServiceImpl implements GenericAssayService {
             }
         } 
         if (stableIds != null) {
-            allStableIds.addAll(stableIds);
+			Map<String, String> allStableIdMap = allStableIds
+					.stream()
+					.collect(Collectors.toMap(stableId -> stableId, stableId -> stableId));
+
+			allStableIds = stableIds
+					.stream()
+					.filter(stableId -> allStableIdMap.containsKey(stableId))
+					.collect(Collectors.toSet());
         }
         List<String> distinctStableIds = new ArrayList<String>(allStableIds);
         List<GenericAssayMeta> metaResults = new ArrayList<GenericAssayMeta>();
+        //TODO: move below logic to sql query
         if (distinctStableIds.size() > 0) {
             List<GenericAssayMeta> metaData = genericAssayRepository.getGenericAssayMeta(distinctStableIds);
             // just return stable_id if projection is ID

--- a/service/src/main/java/org/cbioportal/service/util/ExpressionEnrichmentUtil.java
+++ b/service/src/main/java/org/cbioportal/service/util/ExpressionEnrichmentUtil.java
@@ -1,0 +1,230 @@
+package org.cbioportal.service.util;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.math3.stat.StatUtils;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.apache.commons.math3.stat.inference.OneWayAnova;
+import org.apache.commons.math3.stat.inference.TestUtils;
+import org.cbioportal.model.ExpressionEnrichment;
+import org.cbioportal.model.GenericAssayEnrichment;
+import org.cbioportal.model.GenericAssayMolecularAlteration;
+import org.cbioportal.model.GenomicEnrichment;
+import org.cbioportal.model.GroupStatistics;
+import org.cbioportal.model.MolecularAlteration;
+import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
+import org.cbioportal.model.MolecularProfileSamples;
+import org.cbioportal.model.Sample;
+import org.cbioportal.persistence.MolecularDataRepository;
+import org.cbioportal.service.SampleService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExpressionEnrichmentUtil {
+
+	@Autowired
+	private SampleService sampleService;
+	@Autowired
+	private MolecularDataRepository molecularDataRepository;
+
+	private static final double LOG2 = Math.log(2);
+	private static final String RNA_SEQ = "rna_seq";
+
+	public <T extends MolecularAlteration, S extends ExpressionEnrichment> List<S> getEnrichments(
+			MolecularProfile molecularProfile,
+			Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets, String enrichmentType,
+			Iterable<T> maItr) {
+		List<S> expressionEnrichments = new ArrayList<>();
+
+		Map<String, List<Integer>> groupIndicesMap = getGroupIndicesMap(molecularProfileCaseSets, enrichmentType,
+				molecularProfile);
+		for (MolecularAlteration ma : maItr) {
+
+			List<GroupStatistics> groupsStatistics = new ArrayList<GroupStatistics>();
+			// used for p-value calculation
+			List<double[]> groupedValues = new ArrayList<double[]>();
+
+			for (Entry<String, List<Integer>> group : groupIndicesMap.entrySet()) {
+
+				// get expression values to all the indices in the group
+				List<String> molecularDataValues = group.getValue().stream()
+						.map(sampleIndex -> ma.getSplitValues()[sampleIndex]).collect(Collectors.toList());
+
+				// ignore group if there are less than 2 values or non numeric values
+				if (molecularDataValues.size() < 2
+						|| molecularDataValues.stream().filter(a -> !NumberUtils.isNumber(a)).count() > 0) {
+					continue;
+				}
+
+				double[] values = getAlterationValues(molecularDataValues, molecularProfile.getStableId());
+
+				GroupStatistics groupStatistics = new GroupStatistics();
+				double alteredMean = StatUtils.mean(values);
+				double alteredStandardDeviation = calculateStandardDeviation(values);
+
+				// ignore if mean or standard deviation are not numbers
+				if (Double.isNaN(alteredMean) || Double.isNaN(alteredStandardDeviation)) {
+					continue;
+				}
+
+				groupedValues.add(values);
+				groupStatistics.setName(group.getKey());
+				groupStatistics.setMeanExpression(BigDecimal.valueOf(alteredMean));
+				groupStatistics.setStandardDeviation(BigDecimal.valueOf(alteredStandardDeviation));
+				groupsStatistics.add(groupStatistics);
+			}
+
+			// calculate p-value and add enrichment if atleast 2 groups have data
+			if (groupsStatistics.size() > 1) {
+				double pValue = calculatePValue(groupedValues);
+				if (Double.isNaN(pValue)) {
+					continue;
+				}
+				S expressionEnrichment = null;
+				if (ma instanceof GenericAssayMolecularAlteration) {
+					GenericAssayEnrichment genericAssayEnrichment = new GenericAssayEnrichment();
+					genericAssayEnrichment.setStableId(ma.getStableId());
+					expressionEnrichment = (S) genericAssayEnrichment;
+				} else {
+					GenomicEnrichment genomicEnrichment = new GenomicEnrichment();
+					genomicEnrichment.setEntrezGeneId(Integer.valueOf(ma.getStableId()));
+					expressionEnrichment = (S) genomicEnrichment;
+				}
+				expressionEnrichment.setpValue(BigDecimal.valueOf(pValue));
+				expressionEnrichment.setGroupsStatistics(groupsStatistics);
+				expressionEnrichments.add(expressionEnrichment);
+			}
+		}
+		return expressionEnrichments;
+	}
+
+	private double[] getAlterationValues(List<String> molecularDataValues, String molecularProfileId) {
+
+		if (molecularProfileId.contains(RNA_SEQ)) {
+			return molecularDataValues.stream().mapToDouble(d -> {
+				double datum = Double.parseDouble(d);
+				// reset to 0 if there are any negative values and then do log1p
+				return Math.log1p(datum < 0 ? 0 : datum) / LOG2;
+			}).toArray();
+		} else {
+			return molecularDataValues.stream().mapToDouble(g -> Double.parseDouble(g)).toArray();
+		}
+	}
+
+	private double calculatePValue(List<double[]> alteredValues) {
+
+		if (alteredValues.size() == 2) {
+			return TestUtils.tTest(alteredValues.get(0), alteredValues.get(1));
+		} else {
+			// calculate Anova statisitcs if there are more than 2 groups
+			OneWayAnova oneWayAnova = new OneWayAnova();
+			return oneWayAnova.anovaPValue(alteredValues);
+		}
+	}
+
+	private double calculateStandardDeviation(double[] values) {
+
+		DescriptiveStatistics descriptiveStatistics = new DescriptiveStatistics();
+		for (double value : values) {
+			descriptiveStatistics.addValue(value);
+		}
+		return descriptiveStatistics.getStandardDeviation();
+	}
+
+	/**
+	 * 
+	 * This method maps valid samples in molecularProfileCaseSets to indices in
+	 * genetic_alteration.VALUES column. Recall this column of the
+	 * genetic_alteration table is a comma separated list of scalar values. Each
+	 * value in this list is associated with a sample at the same position found in
+	 * the genetic_profile_samples.ORDERED_SAMPLE_LIST column.
+	 * 
+	 * @param molecularProfileCaseSets
+	 * @param enrichmentType
+	 * @param molecularProfile
+	 * @return
+	 */
+	private Map<String, List<Integer>> getGroupIndicesMap(
+			Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets, String enrichmentType,
+			MolecularProfile molecularProfile) {
+
+		MolecularProfileSamples commaSeparatedSampleIdsOfMolecularProfile = molecularDataRepository
+				.getCommaSeparatedSampleIdsOfMolecularProfile(molecularProfile.getStableId());
+
+		List<Integer> internalSampleIds = Arrays.stream(commaSeparatedSampleIdsOfMolecularProfile.getSplitSampleIds())
+				.mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());
+
+		Map<Integer, Integer> internalSampleIdToIndexMap = IntStream.range(0, internalSampleIds.size()).boxed()
+				.collect(Collectors.toMap(internalSampleIds::get, Function.identity()));
+
+		Map<String, List<Integer>> selectedCaseIdToInternalIdsMap = getCaseIdToInternalIdsMap(molecularProfileCaseSets,
+				enrichmentType, molecularProfile);
+
+		// this block map caseIds(sampleIds or patientids) to sampleIndices which
+		// represents the position fount in the
+		// genetic_profile_samples.ORDERED_SAMPLE_LIST column
+		Map<String, List<Integer>> groupIndicesMap = molecularProfileCaseSets.entrySet().stream()
+				.collect(Collectors.toMap(entity -> entity.getKey(), entity -> {
+					List<Integer> sampleIndices = new ArrayList<>();
+					entity.getValue().forEach(molecularProfileCaseIdentifier -> {
+						// consider only valid samples
+						if (selectedCaseIdToInternalIdsMap.containsKey(molecularProfileCaseIdentifier.getCaseId())) {
+							List<Integer> sampleInternalIds = selectedCaseIdToInternalIdsMap
+									.get(molecularProfileCaseIdentifier.getCaseId());
+
+							// only consider samples which are profiled for the give molecular profile id
+							sampleInternalIds.forEach(sampleInternalId -> {
+								if (internalSampleIdToIndexMap.containsKey(sampleInternalId)) {
+									sampleIndices.add(internalSampleIdToIndexMap.get(sampleInternalId));
+								}
+							});
+						}
+					});
+					return sampleIndices;
+				}));
+		return groupIndicesMap;
+	}
+
+	private Map<String, List<Integer>> getCaseIdToInternalIdsMap(
+			Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets, String enrichmentType,
+			MolecularProfile molecularProfile) {
+
+		if (enrichmentType.equals("PATIENT")) {
+			List<String> patientIds = molecularProfileCaseSets.values().stream()
+					.flatMap(molecularProfileCaseSet -> molecularProfileCaseSet.stream()
+							.map(MolecularProfileCaseIdentifier::getCaseId))
+					.collect(Collectors.toList());
+
+			List<Sample> samples = sampleService
+					.getAllSamplesOfPatientsInStudy(molecularProfile.getCancerStudyIdentifier(), patientIds, "SUMMARY");
+
+			return samples.stream().collect(Collectors.groupingBy(Sample::getPatientStableId,
+					Collectors.mapping(Sample::getInternalId, Collectors.toList())));
+		} else {
+			List<String> sampleIds = new ArrayList<>();
+			List<String> studyIds = new ArrayList<>();
+
+			molecularProfileCaseSets.values().forEach(molecularProfileCaseIdentifiers -> {
+				molecularProfileCaseIdentifiers.forEach(molecularProfileCaseIdentifier -> {
+					sampleIds.add(molecularProfileCaseIdentifier.getCaseId());
+					studyIds.add(molecularProfile.getCancerStudyIdentifier());
+				});
+			});
+			List<Sample> samples = sampleService.fetchSamples(studyIds, sampleIds, "ID");
+
+			return samples.stream()
+					.collect(Collectors.toMap(Sample::getStableId, x -> Arrays.asList(x.getInternalId())));
+		}
+	}
+}

--- a/service/src/test/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImplTest.java
@@ -1,76 +1,65 @@
 package org.cbioportal.service.impl;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-import org.cbioportal.model.CancerStudy;
-import org.cbioportal.model.ExpressionEnrichment;
-import org.cbioportal.model.GeneMolecularAlteration;
-import org.cbioportal.model.GroupStatistics;
-import org.cbioportal.model.MolecularProfile;
-import org.cbioportal.model.MolecularProfileCaseIdentifier;
-import org.cbioportal.model.MolecularProfileSamples;
-import org.cbioportal.model.ReferenceGenome;
-import org.cbioportal.model.Gene;
-import org.cbioportal.model.Sample;
+import org.cbioportal.model.*;
+import org.cbioportal.model.meta.GenericAssayMeta;
 import org.cbioportal.persistence.MolecularDataRepository;
-import org.cbioportal.service.MolecularDataService;
-import org.cbioportal.service.MolecularProfileService;
 import org.cbioportal.service.GeneService;
+import org.cbioportal.service.GenericAssayService;
+import org.cbioportal.service.MolecularProfileService;
 import org.cbioportal.service.SampleService;
+import org.cbioportal.service.exception.MolecularProfileNotFoundException;
+import org.cbioportal.service.util.ExpressionEnrichmentUtil;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ExpressionEnrichmentServiceImplTest extends BaseServiceImplTest {
 
     @InjectMocks
-    private ExpressionEnrichmentServiceImpl expressionEnrichmentService;
-
+    private ExpressionEnrichmentServiceImpl enrichmentServiceImpl;
     @Mock
     private SampleService sampleService;
     @Mock
     private MolecularProfileService molecularProfileService;
     @Mock
-    private MolecularDataService molecularDataService;
-    @Mock
     private MolecularDataRepository molecularDataRepository;
     @Mock
     private GeneService geneService;
+    @Spy
+    @InjectMocks
+    private ExpressionEnrichmentUtil expressionEnrichmentUtil;
+    @Mock
+    private GenericAssayService genericAssayService;
 
-    @Test
-    public void getExpressionEnrichments() throws Exception {
-        
-        CancerStudy cancerStudy = new CancerStudy();
+    CancerStudy cancerStudy = new CancerStudy();
+    MolecularProfile geneMolecularProfile = new MolecularProfile();
+    MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
+    List<Sample> samples = new ArrayList<>();
+    Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets = new HashMap<>();
+
+    @Before
+    public void setup() throws MolecularProfileNotFoundException {
         cancerStudy.setReferenceGenome(ReferenceGenome.HOMO_SAPIENS_DEFAULT_GENOME_NAME);
         cancerStudy.setCancerStudyIdentifier(STUDY_ID);
 
-        MolecularProfile geneMolecularProfile = new MolecularProfile();
         geneMolecularProfile.setCancerStudyIdentifier(STUDY_ID);
         geneMolecularProfile.setStableId(MOLECULAR_PROFILE_ID);
-        geneMolecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.MRNA_EXPRESSION);
+
         geneMolecularProfile.setCancerStudy(cancerStudy);
 
-        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID))
-                .thenReturn(geneMolecularProfile);
-        
-        MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
         molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
         molecularProfileSamples.setCommaSeparatedSampleIds("1,2,3,4");
 
-        Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
-                .thenReturn(molecularProfileSamples);
-
-        List<Sample> samples = new ArrayList<>();
         Sample sample1 = new Sample();
         sample1.setStableId(SAMPLE_ID1);
         sample1.setInternalId(1);
@@ -92,36 +81,6 @@ public class ExpressionEnrichmentServiceImplTest extends BaseServiceImplTest {
         sample4.setCancerStudyIdentifier(STUDY_ID);
         samples.add(sample4);
 
-        Mockito.when(sampleService.fetchSamples(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID),
-                Arrays.asList(SAMPLE_ID3, SAMPLE_ID4, SAMPLE_ID1, SAMPLE_ID2), "ID")).thenReturn(samples);
-
-        List<GeneMolecularAlteration> molecularDataList = new ArrayList<GeneMolecularAlteration>();
-        GeneMolecularAlteration geneMolecularAlteration1 = new GeneMolecularAlteration();
-        geneMolecularAlteration1.setEntrezGeneId(ENTREZ_GENE_ID_2);
-        geneMolecularAlteration1.setValues("2,3,2.1,3");
-        molecularDataList.add(geneMolecularAlteration1);
-
-        GeneMolecularAlteration geneMolecularAlteration2 = new GeneMolecularAlteration();
-        geneMolecularAlteration2.setEntrezGeneId(ENTREZ_GENE_ID_3);
-        geneMolecularAlteration2.setValues("1.1,5,2.3,3");
-        molecularDataList.add(geneMolecularAlteration2);
-        Mockito.when(molecularDataService.getMolecularAlterations(MOLECULAR_PROFILE_ID, null, "SUMMARY"))
-                .thenReturn(molecularDataList);
-        
-        List<Gene> expectedGeneList = new ArrayList<>();
-        Gene gene1 = new Gene();
-        gene1.setEntrezGeneId(ENTREZ_GENE_ID_2);
-        gene1.setHugoGeneSymbol(HUGO_GENE_SYMBOL_2);
-        expectedGeneList.add(gene1);
-        Gene gene2 = new Gene();
-        gene2.setEntrezGeneId(ENTREZ_GENE_ID_3);
-        gene2.setHugoGeneSymbol(HUGO_GENE_SYMBOL_3);
-        expectedGeneList.add(gene2);
-
-        Mockito.when(geneService.fetchGenes(Arrays.asList("2", "3"),
-            "ENTREZ_GENE_ID","SUMMARY")).thenReturn(expectedGeneList);
-
-        Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets = new HashMap<>();
         List<MolecularProfileCaseIdentifier> alteredSampleIdentifieres = new ArrayList<>();
         List<MolecularProfileCaseIdentifier> unalteredSampleIdentifieres = new ArrayList<>();
 
@@ -148,11 +107,51 @@ public class ExpressionEnrichmentServiceImplTest extends BaseServiceImplTest {
         molecularProfileCaseSets.put("altered samples", alteredSampleIdentifieres);
         molecularProfileCaseSets.put("unaltered samples", unalteredSampleIdentifieres);
 
-        List<ExpressionEnrichment> result = expressionEnrichmentService
-                .getExpressionEnrichments(MOLECULAR_PROFILE_ID, molecularProfileCaseSets, "SAMPLE");
+        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID))
+                .thenReturn(geneMolecularProfile);
+
+        Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
+                .thenReturn(molecularProfileSamples);
+
+        Mockito.when(sampleService.fetchSamples(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID),
+                Arrays.asList(SAMPLE_ID3, SAMPLE_ID4, SAMPLE_ID1, SAMPLE_ID2), "ID")).thenReturn(samples);
+    }
+
+    @Test
+    public void getGenomicEnrichments() throws Exception {
+        geneMolecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.MRNA_EXPRESSION);
+
+        List<GeneMolecularAlteration> molecularDataList = new ArrayList<GeneMolecularAlteration>();
+        GeneMolecularAlteration geneMolecularAlteration1 = new GeneMolecularAlteration();
+        geneMolecularAlteration1.setEntrezGeneId(ENTREZ_GENE_ID_2);
+        geneMolecularAlteration1.setValues("2,3,2.1,3");
+        molecularDataList.add(geneMolecularAlteration1);
+
+        GeneMolecularAlteration geneMolecularAlteration2 = new GeneMolecularAlteration();
+        geneMolecularAlteration2.setEntrezGeneId(ENTREZ_GENE_ID_3);
+        geneMolecularAlteration2.setValues("1.1,5,2.3,3");
+        molecularDataList.add(geneMolecularAlteration2);
+        Mockito.when(molecularDataRepository.getGeneMolecularAlterationsIterable(MOLECULAR_PROFILE_ID, null, "SUMMARY"))
+                .thenReturn(molecularDataList);
+
+        List<Gene> expectedGeneList = new ArrayList<>();
+        Gene gene1 = new Gene();
+        gene1.setEntrezGeneId(ENTREZ_GENE_ID_2);
+        gene1.setHugoGeneSymbol(HUGO_GENE_SYMBOL_2);
+        expectedGeneList.add(gene1);
+        Gene gene2 = new Gene();
+        gene2.setEntrezGeneId(ENTREZ_GENE_ID_3);
+        gene2.setHugoGeneSymbol(HUGO_GENE_SYMBOL_3);
+        expectedGeneList.add(gene2);
+
+        Mockito.when(geneService.fetchGenes(Arrays.asList("2", "3"), "ENTREZ_GENE_ID", "SUMMARY"))
+                .thenReturn(expectedGeneList);
+
+        List<GenomicEnrichment> result = enrichmentServiceImpl.getGenomicEnrichments(MOLECULAR_PROFILE_ID,
+                molecularProfileCaseSets, "SAMPLE");
 
         Assert.assertEquals(2, result.size());
-        ExpressionEnrichment expressionEnrichment = result.get(0);
+        GenomicEnrichment expressionEnrichment = result.get(0);
         Assert.assertEquals(ENTREZ_GENE_ID_2, expressionEnrichment.getEntrezGeneId());
         Assert.assertEquals(HUGO_GENE_SYMBOL_2, expressionEnrichment.getHugoGeneSymbol());
         Assert.assertEquals(null, expressionEnrichment.getCytoband());
@@ -187,6 +186,67 @@ public class ExpressionEnrichmentServiceImplTest extends BaseServiceImplTest {
         Assert.assertEquals(new BigDecimal("2.7577164466275352"), alteredGroupStats.getStandardDeviation());
 
         Assert.assertEquals(new BigDecimal("0.8716148250471419"), expressionEnrichment.getpValue());
+
+    }
+
+    @Test
+    public void getGenericAssayEnrichments() throws Exception {
+        geneMolecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.GENERIC_ASSAY);
+
+        List<GenericAssayMolecularAlteration> molecularDataList = new ArrayList<GenericAssayMolecularAlteration>();
+        GenericAssayMolecularAlteration genericAssayMolecularAlteration1 = new GenericAssayMolecularAlteration();
+        genericAssayMolecularAlteration1.setGenericAssayStableId(HUGO_GENE_SYMBOL_1);
+        genericAssayMolecularAlteration1.setValues("2,3,2.1,3");
+        molecularDataList.add(genericAssayMolecularAlteration1);
+
+        GenericAssayMolecularAlteration geneMolecularAlteration2 = new GenericAssayMolecularAlteration();
+        geneMolecularAlteration2.setGenericAssayStableId(HUGO_GENE_SYMBOL_2);
+        geneMolecularAlteration2.setValues("1.1,5,2.3,3");
+        molecularDataList.add(geneMolecularAlteration2);
+        Mockito.when(molecularDataRepository.getGenericAssayMolecularAlterationsIterable(MOLECULAR_PROFILE_ID, null,
+                "SUMMARY")).thenReturn(molecularDataList);
+
+        Mockito.when(genericAssayService.getGenericAssayMetaByStableIdsAndMolecularIds(
+                Arrays.asList(HUGO_GENE_SYMBOL_1, HUGO_GENE_SYMBOL_2),
+                Arrays.asList(MOLECULAR_PROFILE_ID, MOLECULAR_PROFILE_ID), "SUMMARY"))
+                .thenReturn(Arrays.asList(new GenericAssayMeta(HUGO_GENE_SYMBOL_1),
+                        new GenericAssayMeta(HUGO_GENE_SYMBOL_2)));
+
+        List<GenericAssayEnrichment> result = enrichmentServiceImpl.getGenericAssayEnrichments(MOLECULAR_PROFILE_ID,
+                molecularProfileCaseSets, "SAMPLE");
+
+        Assert.assertEquals(2, result.size());
+        GenericAssayEnrichment genericAssayEnrichment = result.get(0);
+        Assert.assertEquals(HUGO_GENE_SYMBOL_1, genericAssayEnrichment.getStableId());
+        Assert.assertEquals(2, genericAssayEnrichment.getGroupsStatistics().size());
+
+        GroupStatistics unalteredGroupStats = genericAssayEnrichment.getGroupsStatistics().get(0);
+        Assert.assertEquals("unaltered samples", unalteredGroupStats.getName());
+        Assert.assertEquals(new BigDecimal("2.55"), unalteredGroupStats.getMeanExpression());
+        Assert.assertEquals(new BigDecimal("0.6363961030678927"), unalteredGroupStats.getStandardDeviation());
+
+        GroupStatistics alteredGroupStats = genericAssayEnrichment.getGroupsStatistics().get(1);
+        Assert.assertEquals("altered samples", alteredGroupStats.getName());
+        Assert.assertEquals(new BigDecimal("2.5"), alteredGroupStats.getMeanExpression());
+        Assert.assertEquals(new BigDecimal("0.7071067811865476"), alteredGroupStats.getStandardDeviation());
+
+        Assert.assertEquals(new BigDecimal("0.9475795430163914"), genericAssayEnrichment.getpValue());
+
+        genericAssayEnrichment = result.get(1);
+        Assert.assertEquals(HUGO_GENE_SYMBOL_2, genericAssayEnrichment.getStableId());
+        Assert.assertEquals(2, genericAssayEnrichment.getGroupsStatistics().size());
+
+        unalteredGroupStats = genericAssayEnrichment.getGroupsStatistics().get(0);
+        Assert.assertEquals("unaltered samples", unalteredGroupStats.getName());
+        Assert.assertEquals(new BigDecimal("2.65"), unalteredGroupStats.getMeanExpression());
+        Assert.assertEquals(new BigDecimal("0.4949747468305834"), unalteredGroupStats.getStandardDeviation());
+
+        alteredGroupStats = genericAssayEnrichment.getGroupsStatistics().get(1);
+        Assert.assertEquals("altered samples", alteredGroupStats.getName());
+        Assert.assertEquals(new BigDecimal("3.05"), alteredGroupStats.getMeanExpression());
+        Assert.assertEquals(new BigDecimal("2.7577164466275352"), alteredGroupStats.getStandardDeviation());
+
+        Assert.assertEquals(new BigDecimal("0.8716148250471419"), genericAssayEnrichment.getpValue());
 
     }
 }

--- a/web/src/main/java/org/cbioportal/web/ExpressionEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/ExpressionEnrichmentController.java
@@ -6,8 +6,11 @@ import java.util.stream.Collectors;
 import javax.validation.Valid;
 
 import org.cbioportal.model.ExpressionEnrichment;
+import org.cbioportal.model.GenericAssayEnrichment;
+import org.cbioportal.model.GenomicEnrichment;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.service.ExpressionEnrichmentService;
+import org.cbioportal.service.exception.GenericAssayNotFoundException;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.web.config.annotation.InternalApi;
 import org.cbioportal.web.parameter.EnrichmentType;
@@ -18,12 +21,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.RequestAttribute;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -33,18 +31,17 @@ import springfox.documentation.annotations.ApiIgnore;
 @InternalApi
 @RestController
 @Validated
-@Api(tags = "Expression Enrichments", description = " ")
+@Api(tags = "Enrichments", description = " ")
 public class ExpressionEnrichmentController {
-
     @Autowired
     private ExpressionEnrichmentService expressionEnrichmentService;
-
+    
     @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
     @RequestMapping(value = "/expression-enrichments/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation("Fetch expression enrichments in a molecular profile")
-    public ResponseEntity<List<ExpressionEnrichment>> fetchExpressionEnrichments(
+    @ApiOperation("Fetch genomic enrichments in a molecular profile")
+    public ResponseEntity<List<GenomicEnrichment>> fetchGenomicEnrichments(
         @ApiIgnore // prevent reference to this attribute in the swagger-ui interface
         @RequestAttribute(required = false, value = "involvedCancerStudies") Collection<String> involvedCancerStudies,
         @ApiParam("Type of the enrichment e.g. SAMPLE or PATIENT")
@@ -54,22 +51,55 @@ public class ExpressionEnrichmentController {
         @ApiIgnore // prevent reference to this attribute in the swagger-ui interface. this attribute is needed for the @PreAuthorize tag above.
         @Valid @RequestAttribute(required = false, value = "interceptedMolecularProfileCasesGroupFilters") List<MolecularProfileCasesGroupFilter> interceptedMolecularProfileCasesGroupFilters) throws MolecularProfileNotFoundException {
 
-        Map<String, List<MolecularProfileCaseIdentifier>> groupCaseIdentifierSet = interceptedMolecularProfileCasesGroupFilters.stream()
-                .collect(Collectors.toMap(MolecularProfileCasesGroupFilter::getName,
+        return new ResponseEntity<>(
+                fetchExpressionEnrichments(enrichmentType, interceptedMolecularProfileCasesGroupFilters, false),
+                HttpStatus.OK);
+    }
+
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @RequestMapping(value = "/generic-assay-enrichments/fetch",
+        method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Fetch generic assay enrichments in a molecular profile")
+    public ResponseEntity<List<GenericAssayEnrichment>> fetchGenericAssayEnrichments(
+        @ApiIgnore // prevent reference to this attribute in the swagger-ui interface
+        @RequestAttribute(required = false, value = "involvedCancerStudies") Collection<String> involvedCancerStudies,
+        @ApiParam("Type of the enrichment e.g. SAMPLE or PATIENT")
+        @RequestParam(defaultValue = "SAMPLE") EnrichmentType enrichmentType,
+        @ApiParam(required = true, value = "List of groups containing sample and molecular profile identifiers")
+        @Valid @RequestBody(required = false) List<MolecularProfileCasesGroupFilter> groups,
+        @ApiIgnore // prevent reference to this attribute in the swagger-ui interface. this attribute is needed for the @PreAuthorize tag above.
+        @Valid @RequestAttribute(required = false, value = "interceptedMolecularProfileCasesGroupFilters") List<MolecularProfileCasesGroupFilter> interceptedMolecularProfileCasesGroupFilters)
+                throws MolecularProfileNotFoundException, UnsupportedOperationException, GenericAssayNotFoundException {
+
+        return new ResponseEntity<>(
+                fetchExpressionEnrichments(enrichmentType, interceptedMolecularProfileCasesGroupFilters, true),
+                HttpStatus.OK);
+    }
+
+    private <S extends ExpressionEnrichment> List<S> fetchExpressionEnrichments(EnrichmentType enrichmentType,
+            List<MolecularProfileCasesGroupFilter> interceptedMolecularProfileCasesGroupFilters,
+            Boolean isRequestForGenericAssayEnrichments) throws MolecularProfileNotFoundException {
+
+        Map<String, List<MolecularProfileCaseIdentifier>> groupCaseIdentifierSet = interceptedMolecularProfileCasesGroupFilters
+                .stream().collect(Collectors.toMap(MolecularProfileCasesGroupFilter::getName,
                         MolecularProfileCasesGroupFilter::getMolecularProfileCaseIdentifiers));
 
-        Set<String> molecularProfileIds = groupCaseIdentifierSet
-                .values()
-                .stream()
+        Set<String> molecularProfileIds = groupCaseIdentifierSet.values().stream()
                 .flatMap(molecularProfileCaseSet -> molecularProfileCaseSet.stream()
                         .map(MolecularProfileCaseIdentifier::getMolecularProfileId))
                 .collect(Collectors.toSet());
 
-        if(molecularProfileIds.size()> 1) {
+        if (molecularProfileIds.size() > 1) {
             throw new UnsupportedOperationException("Multi-study expression enrichments is not yet implemented");
         }
 
+        if (isRequestForGenericAssayEnrichments) {
+            return (List<S>) expressionEnrichmentService.getGenericAssayEnrichments(
+                    molecularProfileIds.iterator().next(), groupCaseIdentifierSet, enrichmentType.name());
+        }
 
-        return new ResponseEntity<>(expressionEnrichmentService.getExpressionEnrichments(molecularProfileIds.iterator().next(), groupCaseIdentifierSet, enrichmentType.name()), HttpStatus.OK);
+        return (List<S>) expressionEnrichmentService.getGenomicEnrichments(molecularProfileIds.iterator().next(),
+                groupCaseIdentifierSet, enrichmentType.name());
     }
 }

--- a/web/src/main/java/org/cbioportal/web/GenericAssayController.java
+++ b/web/src/main/java/org/cbioportal/web/GenericAssayController.java
@@ -6,7 +6,6 @@ import io.swagger.annotations.ApiParam;
 import springfox.documentation.annotations.ApiIgnore;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 

--- a/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
+++ b/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
@@ -112,6 +112,7 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
     public static final String TREATMENTS_PATIENT_PATH = "/treatments/patient";
     public static final String TREATMENTS_PATIENT_EXISTS_PATH = "/treatments/display";
     public static final String TREATMENTS_SAMPLE_PATH = "/treatments/sample";
+    public static final String GENERIC_ASSAY_ENRICHMENT_FETCH_PATH = "/generic-assay-enrichments/fetch";
 
     @Override public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         if (!request.getMethod().equals("POST")) {
@@ -153,7 +154,10 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
             return extractAttributesFromStudyViewFilter(request);
         } else if (requestPathInfo.equals(CLINICAL_DATA_ENRICHMENT_FETCH_PATH)) {
             return extractAttributesFromGroupFilter(request);
-        } else if (requestPathInfo.equals(MUTATION_ENRICHMENT_FETCH_PATH) || requestPathInfo.equals(COPY_NUMBER_ENRICHMENT_FETCH_PATH) || requestPathInfo.equals(EXPRESSION_ENRICHMENT_FETCH_PATH)) {
+        } else if (requestPathInfo.equals(MUTATION_ENRICHMENT_FETCH_PATH) ||
+        		requestPathInfo.equals(COPY_NUMBER_ENRICHMENT_FETCH_PATH) ||
+        		requestPathInfo.equals(EXPRESSION_ENRICHMENT_FETCH_PATH) ||
+        		requestPathInfo.equals(GENERIC_ASSAY_ENRICHMENT_FETCH_PATH)) {
             return extractAttributesFromMolecularProfileCasesGroups(request);
         } else if (requestPathInfo.equals(STRUCTURAL_VARIANT_FETCH_PATH)) {
             return extractAttributesFromStructuralVariantFilter(request);

--- a/web/src/test/java/org/cbioportal/web/ExpressionEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/ExpressionEnrichmentControllerTest.java
@@ -1,6 +1,11 @@
 package org.cbioportal.web;
 
-import org.cbioportal.model.ExpressionEnrichment;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.cbioportal.model.GenericAssayEnrichment;
+import org.cbioportal.model.GenomicEnrichment;
 import org.cbioportal.model.GroupStatistics;
 import org.cbioportal.service.ExpressionEnrichmentService;
 import org.hamcrest.Matchers;
@@ -20,10 +25,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
@@ -69,10 +70,10 @@ public class ExpressionEnrichmentControllerTest {
     }
 
     @Test
-    public void fetchExpressionEnrichments() throws Exception {
+    public void fetchGenomicEnrichments() throws Exception {
 
-        List<ExpressionEnrichment> expressionEnrichments = new ArrayList<>();
-        ExpressionEnrichment expressionEnrichment1 = new ExpressionEnrichment();
+        List<GenomicEnrichment> expressionEnrichments = new ArrayList<>();
+        GenomicEnrichment expressionEnrichment1 = new GenomicEnrichment();
         expressionEnrichment1.setEntrezGeneId(TEST_ENTREZ_GENE_ID_1);
         expressionEnrichment1.setHugoGeneSymbol(TEST_HUGO_GENE_SYMBOL_1);
         expressionEnrichment1.setCytoband(TEST_CYTOBAND_1);
@@ -91,8 +92,7 @@ public class ExpressionEnrichmentControllerTest {
         expressionEnrichments.add(expressionEnrichment1);
         expressionEnrichment1.setGroupsStatistics(groupStatistics1);
 
-
-        ExpressionEnrichment expressionEnrichment2 = new ExpressionEnrichment();
+        GenomicEnrichment expressionEnrichment2 = new GenomicEnrichment();
         expressionEnrichment2.setEntrezGeneId(TEST_ENTREZ_GENE_ID_2);
         expressionEnrichment2.setHugoGeneSymbol(TEST_HUGO_GENE_SYMBOL_2);
         expressionEnrichment2.setCytoband(TEST_CYTOBAND_2);
@@ -111,41 +111,109 @@ public class ExpressionEnrichmentControllerTest {
         expressionEnrichment2.setpValue(TEST_P_VALUE_2);
         expressionEnrichments.add(expressionEnrichment2);
 
-        Mockito.when(expressionEnrichmentService.getExpressionEnrichments( Mockito.anyString(), Mockito.anyMap(), Mockito.anyString()))
-            .thenReturn(expressionEnrichments);
+        Mockito.when(expressionEnrichmentService.getGenomicEnrichments(Mockito.anyString(), Mockito.anyMap(),
+                Mockito.anyString())).thenReturn(expressionEnrichments);
 
-        mockMvc.perform(MockMvcRequestBuilders.post(
-            "/expression-enrichments/fetch")
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content("[{\"molecularProfileCaseIdentifiers\":[{\"caseId\":\"TCGA-OR-A5JH-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"},{\"caseId\":\"TCGA-OR-A5K2-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"}],\"name\":\"altered\"},"
-                    + "{\"molecularProfileCaseIdentifiers\":[{\"caseId\":\"TCGA-OR-A5LN-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"},{\"caseId\":\"TCGA-OR-A5LS-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"}],\"name\":\"unaltered\"}]"))
-            .andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneId").value(TEST_ENTREZ_GENE_ID_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].hugoGeneSymbol").value(TEST_HUGO_GENE_SYMBOL_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].cytoband").value(TEST_CYTOBAND_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].groupsStatistics[0].meanExpression").value(
-                    TEST_MEAN_EXPRESSION_IN_ALTERED_GROUP_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].groupsStatistics[0].standardDeviation").value(
-                    TEST_STANDARD_DEVIATION_IN_ALTERED_GROUP_1 ))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].groupsStatistics[1].meanExpression").value(
-                    TEST_MEAN_EXPRESSION_IN_UNALTERED_GROUP_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].groupsStatistics[1].standardDeviation").value(
-                    TEST_STANDARD_DEVIATION_IN_UNALTERED_GROUP_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].pValue").value(TEST_P_VALUE_1))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneId").value(TEST_ENTREZ_GENE_ID_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].hugoGeneSymbol").value(TEST_HUGO_GENE_SYMBOL_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].cytoband").value(TEST_CYTOBAND_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].groupsStatistics[0].meanExpression").value(
-                    TEST_MEAN_EXPRESSION_IN_ALTERED_GROUP_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].groupsStatistics[0].standardDeviation").value(
-                    TEST_STANDARD_DEVIATION_IN_ALTERED_GROUP_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].groupsStatistics[1].meanExpression").value(
-                    TEST_MEAN_EXPRESSION_IN_UNALTERED_GROUP_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].groupsStatistics[1].standardDeviation").value(
-                    TEST_STANDARD_DEVIATION_IN_UNALTERED_GROUP_2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[1].pValue").value(TEST_P_VALUE_2));
+        mockMvc.perform(MockMvcRequestBuilders.post("/expression-enrichments/fetch").accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON).content(
+                        "[{\"molecularProfileCaseIdentifiers\":[{\"caseId\":\"TCGA-OR-A5JH-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"},{\"caseId\":\"TCGA-OR-A5K2-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"}],\"name\":\"altered\"},"
+                                + "{\"molecularProfileCaseIdentifiers\":[{\"caseId\":\"TCGA-OR-A5LN-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"},{\"caseId\":\"TCGA-OR-A5LS-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"}],\"name\":\"unaltered\"}]"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneId").value(TEST_ENTREZ_GENE_ID_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].hugoGeneSymbol").value(TEST_HUGO_GENE_SYMBOL_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].cytoband").value(TEST_CYTOBAND_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].groupsStatistics[0].meanExpression")
+                        .value(TEST_MEAN_EXPRESSION_IN_ALTERED_GROUP_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].groupsStatistics[0].standardDeviation")
+                        .value(TEST_STANDARD_DEVIATION_IN_ALTERED_GROUP_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].groupsStatistics[1].meanExpression")
+                        .value(TEST_MEAN_EXPRESSION_IN_UNALTERED_GROUP_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].groupsStatistics[1].standardDeviation")
+                        .value(TEST_STANDARD_DEVIATION_IN_UNALTERED_GROUP_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].pValue").value(TEST_P_VALUE_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneId").value(TEST_ENTREZ_GENE_ID_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].hugoGeneSymbol").value(TEST_HUGO_GENE_SYMBOL_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].cytoband").value(TEST_CYTOBAND_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].groupsStatistics[0].meanExpression")
+                        .value(TEST_MEAN_EXPRESSION_IN_ALTERED_GROUP_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].groupsStatistics[0].standardDeviation")
+                        .value(TEST_STANDARD_DEVIATION_IN_ALTERED_GROUP_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].groupsStatistics[1].meanExpression")
+                        .value(TEST_MEAN_EXPRESSION_IN_UNALTERED_GROUP_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].groupsStatistics[1].standardDeviation")
+                        .value(TEST_STANDARD_DEVIATION_IN_UNALTERED_GROUP_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].pValue").value(TEST_P_VALUE_2));
+    }
+
+    @Test
+    public void fetchGenericAssayEnrichments() throws Exception {
+
+        List<GenericAssayEnrichment> genericAssayEnrichments = new ArrayList<>();
+        GenericAssayEnrichment genericAssayEnrichment1 = new GenericAssayEnrichment();
+        genericAssayEnrichment1.setStableId(TEST_HUGO_GENE_SYMBOL_1);
+        List<GroupStatistics> groupStatistics1 = new ArrayList<>();
+        GroupStatistics alteredGroupStats1 = new GroupStatistics();
+        alteredGroupStats1.setName("altered samples");
+        alteredGroupStats1.setMeanExpression(TEST_MEAN_EXPRESSION_IN_ALTERED_GROUP_1);
+        alteredGroupStats1.setStandardDeviation(TEST_STANDARD_DEVIATION_IN_ALTERED_GROUP_1);
+        groupStatistics1.add(alteredGroupStats1);
+        GroupStatistics unalteredGroupStats1 = new GroupStatistics();
+        unalteredGroupStats1.setName("unaltered samples");
+        unalteredGroupStats1.setMeanExpression(TEST_MEAN_EXPRESSION_IN_UNALTERED_GROUP_1);
+        unalteredGroupStats1.setStandardDeviation(TEST_STANDARD_DEVIATION_IN_UNALTERED_GROUP_1);
+        groupStatistics1.add(unalteredGroupStats1);
+        genericAssayEnrichment1.setpValue(TEST_P_VALUE_1);
+        genericAssayEnrichments.add(genericAssayEnrichment1);
+        genericAssayEnrichment1.setGroupsStatistics(groupStatistics1);
+
+        GenericAssayEnrichment genericAssayEnrichment2 = new GenericAssayEnrichment();
+        genericAssayEnrichment2.setStableId(TEST_HUGO_GENE_SYMBOL_2);
+        List<GroupStatistics> groupStatistics2 = new ArrayList<>();
+        GroupStatistics alteredGroupStats2 = new GroupStatistics();
+        alteredGroupStats2.setName("altered samples");
+        alteredGroupStats2.setMeanExpression(TEST_MEAN_EXPRESSION_IN_ALTERED_GROUP_2);
+        alteredGroupStats2.setStandardDeviation(TEST_STANDARD_DEVIATION_IN_ALTERED_GROUP_2);
+        groupStatistics2.add(alteredGroupStats2);
+        GroupStatistics unalteredGroupStats2 = new GroupStatistics();
+        unalteredGroupStats2.setName("unaltered samples");
+        unalteredGroupStats2.setMeanExpression(TEST_MEAN_EXPRESSION_IN_UNALTERED_GROUP_2);
+        unalteredGroupStats2.setStandardDeviation(TEST_STANDARD_DEVIATION_IN_UNALTERED_GROUP_2);
+        groupStatistics2.add(unalteredGroupStats2);
+        genericAssayEnrichment2.setGroupsStatistics(groupStatistics2);
+        genericAssayEnrichment2.setpValue(TEST_P_VALUE_2);
+        genericAssayEnrichments.add(genericAssayEnrichment2);
+
+        Mockito.when(expressionEnrichmentService.getGenericAssayEnrichments(Mockito.anyString(), Mockito.anyMap(),
+                Mockito.anyString())).thenReturn(genericAssayEnrichments);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/generic-assay-enrichments/fetch")
+                .accept(MediaType.APPLICATION_JSON).contentType(MediaType.APPLICATION_JSON).content(
+                        "[{\"molecularProfileCaseIdentifiers\":[{\"caseId\":\"TCGA-OR-A5JH-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"},{\"caseId\":\"TCGA-OR-A5K2-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"}],\"name\":\"altered\"},"
+                                + "{\"molecularProfileCaseIdentifiers\":[{\"caseId\":\"TCGA-OR-A5LN-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"},{\"caseId\":\"TCGA-OR-A5LS-01\",\"molecularProfileId\":\"acc_tcga_pan_can_atlas_2018_rna_seq_v2_mrna\"}],\"name\":\"unaltered\"}]"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].stableId").value(TEST_HUGO_GENE_SYMBOL_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].groupsStatistics[0].meanExpression")
+                        .value(TEST_MEAN_EXPRESSION_IN_ALTERED_GROUP_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].groupsStatistics[0].standardDeviation")
+                        .value(TEST_STANDARD_DEVIATION_IN_ALTERED_GROUP_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].groupsStatistics[1].meanExpression")
+                        .value(TEST_MEAN_EXPRESSION_IN_UNALTERED_GROUP_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].groupsStatistics[1].standardDeviation")
+                        .value(TEST_STANDARD_DEVIATION_IN_UNALTERED_GROUP_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].pValue").value(TEST_P_VALUE_1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].stableId").value(TEST_HUGO_GENE_SYMBOL_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].groupsStatistics[0].meanExpression")
+                        .value(TEST_MEAN_EXPRESSION_IN_ALTERED_GROUP_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].groupsStatistics[0].standardDeviation")
+                        .value(TEST_STANDARD_DEVIATION_IN_ALTERED_GROUP_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].groupsStatistics[1].meanExpression")
+                        .value(TEST_MEAN_EXPRESSION_IN_UNALTERED_GROUP_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].groupsStatistics[1].standardDeviation")
+                        .value(TEST_STANDARD_DEVIATION_IN_UNALTERED_GROUP_2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[1].pValue").value(TEST_P_VALUE_2));
     }
 }


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/7701

Adds new api(path `/generic-assay-enrichments/fetch`) to fetch generic assay enrichments.

Note: Currently support only for single study

**Request**: similar to other enrichments api's

Request body
```
[
  {
    "molecularProfileCaseIdentifiers": [
      {
        "caseId": "string",
        "molecularProfileId": "string"
      }
    ],
    "name": "string"
  }
]
```

**Response model**

```
[
  {
    "genericAssayStableId": "string",
    "genericEntityMetaProperties": {
      "additionalProp1": "string",
      "additionalProp2": "string",
      "additionalProp3": "string"
    },
    "groupsStatistics": [
      {
        "meanExpression": 0,
        "name": "string",
        "standardDeviation": 0
      }
    ],
    "pValue": 0
  }
]
```
