### PR TITLE
add genome nexus annotation sources to portal.properties

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -273,6 +273,11 @@ public class GlobalProperties {
     @Value("${show.genomenexus:true}") // default is true
     public void setShowGenomeNexus(String property) { showGenomeNexus = Boolean.parseBoolean(property); }
 
+    // TODO should support more sources such as clinvar,gnomad,sift
+    private static String showGenomeNexusAnnotationSources;
+    @Value("${show.genomenexus.annotation_sources:mutation_assessor}") // Available sources: mutation_assessor
+    public void setShowGenomeNexusAnnotationSources(String property) { showGenomeNexusAnnotationSources = property; }
+
     private static boolean showMutationMapperToolGrch38;
     @Value("${show.mutation_mappert_tool.grch38:true}") // default is true
     public void setShowMutationMapperToolGrch38(String property) { showMutationMapperToolGrch38 = Boolean.parseBoolean(property); }
@@ -917,6 +922,10 @@ public class GlobalProperties {
 
     public static boolean showGenomeNexus() {
         return showGenomeNexus;
+    }
+
+    public static String setShowGenomeNexusAnnotationSources() {
+        return showGenomeNexusAnnotationSources;
     }
 
     public static boolean showMutationMapperToolGrch38() {

--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -16,6 +16,7 @@ window.legacySupportFrontendConfig = {
     showMyCancerGenome : <%=GlobalProperties.showMyCancerGenomeUrl()%>,
     showTranscriptDropdown : <%=GlobalProperties.showTranscriptDropdown()%>,
     showGenomeNexus : <%=GlobalProperties.showGenomeNexus()%>,
+    showGenomeNexusAnnotationSources : <%=GlobalProperties.showGenomeNexusAnnotationSources()%>,
     showMutationMapperToolGrch38 : <%=GlobalProperties.showMutationMapperToolGrch38()%>,
     querySetsOfGenes : JSON.parse('<%=GlobalProperties.getQuerySetsOfGenes()%>'),
     skinBlurb : '<%=GlobalProperties.getBlurb()%>',

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -59,6 +59,7 @@
             "show.oncokb",
             "show.civic",
             "show.genomenexus",
+            "show.genomenexus.annotation_sources",
             "show.mutation_mappert_tool.grch38",
             "show.transcript_dropdown",
             "skin.documentation.about",

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -190,6 +190,10 @@ mycancergenome.show=true
 # Enable transcript switch dropdown (true, false)
 # show.transcript_dropdown=false
 
+# Set Genome Nexus annotation sources, please list all sources name with comma-separated.
+# Available sources: mutation_assessor
+# show.genomenexus.annotation_sources=mutation_assessor
+
 # igv bam linking
 igv.bam.linking=
 # colon delimited


### PR DESCRIPTION
Partial Fix https://github.com/cBioPortal/cbioportal/issues/7756

`show.genome_nexus.annotation_sources` will set which sources to show on the frontend, list all sources name with comma-separated.

For now we only support `mutation_assessor`.

By default;
```
show.genome_nexus.annotation_sources=mutation_assessor
```
TODO: support more sources like clinvar and gnomad
