### PR TITLE
increase genes endpoint page size

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -4885,11 +4885,8 @@ def validate_data_relations(validators_by_meta_type, logger):
 def request_from_portal_api(server_url, api_name, logger):
     """Send a request to the portal API and return the decoded JSON object."""
 
-    if api_name in ['info', 'cancer-types', 'genesets', 'gene-panels']:
+    if api_name in ['info', 'cancer-types', 'genes', 'genesets', 'gene-panels']:
         service_url = server_url + '/api/' + api_name + "?pageSize=9999999"
-    # TODO: make subsequent calls to /genes/{geneId}/aliases
-    elif api_name in ['genes']:
-        service_url = server_url + '/api/' + api_name + '?pageSize=100000'
     elif api_name in ['genesets_version']:
         service_url = server_url + '/api/genesets/version'
 

--- a/web/src/main/java/org/cbioportal/web/GeneController.java
+++ b/web/src/main/java/org/cbioportal/web/GeneController.java
@@ -39,8 +39,8 @@ import java.util.List;
 @Api(tags = PublicApiTags.GENES, description = " ")
 public class GeneController {
 
-    private static final int GENE_MAX_PAGE_SIZE = 100000;
-    private static final String GENE_DEFAULT_PAGE_SIZE = "100000";
+    private static final int GENE_MAX_PAGE_SIZE = 9999999;
+    private static final String GENE_DEFAULT_PAGE_SIZE = "9999999";
 
     @Autowired
     private GeneService geneService;

--- a/web/src/main/java/org/cbioportal/web/GeneController.java
+++ b/web/src/main/java/org/cbioportal/web/GeneController.java
@@ -39,9 +39,6 @@ import java.util.List;
 @Api(tags = PublicApiTags.GENES, description = " ")
 public class GeneController {
 
-    private static final int GENE_MAX_PAGE_SIZE = 9999999;
-    private static final String GENE_DEFAULT_PAGE_SIZE = "9999999";
-
     @Autowired
     private GeneService geneService;
 
@@ -55,9 +52,9 @@ public class GeneController {
         @ApiParam("Level of detail of the response")
         @RequestParam(defaultValue = "SUMMARY") Projection projection,
         @ApiParam("Page size of the result list")
-        @Max(GENE_MAX_PAGE_SIZE)
+        @Max(PagingConstants.MAX_PAGE_SIZE)
         @Min(PagingConstants.MIN_PAGE_SIZE)
-        @RequestParam(defaultValue = GENE_DEFAULT_PAGE_SIZE) Integer pageSize,
+        @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE) Integer pageSize,
         @ApiParam("Page number of the result list")
         @Min(PagingConstants.MIN_PAGE_NUMBER)
         @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_NUMBER) Integer pageNumber,
@@ -104,7 +101,7 @@ public class GeneController {
         @ApiParam("Type of gene ID")
         @RequestParam(defaultValue = "ENTREZ_GENE_ID") GeneIdType geneIdType,
         @ApiParam(required = true, value = "List of Entrez Gene IDs or Hugo Gene Symbols")
-        @Size(min = 1, max = GENE_MAX_PAGE_SIZE)
+        @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
         @RequestBody List<String> geneIds,
         @ApiParam("Level of detail of the response")
         @RequestParam(defaultValue = "SUMMARY") Projection projection) {


### PR DESCRIPTION
The genes API endpoint pageSize was restricted to 100K entries, while there are seemingly more genes in the DB (many many phosphoproteins).

The page size in the gene controller is increased and the validator is adjusted as appropriate