### PR TITLE
Update to getter method call to match what is in frontend_config.jsp

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -930,7 +930,7 @@ public class GlobalProperties {
         return showGenomeNexus;
     }
 
-    public static String setShowGenomeNexusAnnotationSources() {
+    public static String showGenomeNexusAnnotationSources() {
         return showGenomeNexusAnnotationSources;
     }
 


### PR DESCRIPTION
restful_login.jsp (used by MSK-CIS system), was failing to load, the cause was tracked down to the following jsp compilation issue in [frontend_config.jsp](https://github.com/cBioPortal/cbioportal/blob/master/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp#L19) Seems the call to GlobalProperties.showGenomeNexusAnnotationSources() was failing due to copy/paste error - method was called setShowGenomeNexusAnnotationSources() in GlobalProperties.java.

```
24-Aug-2020 11:56:48.079 SEVERE [ajp-nio-58009-exec-3] org.apache.catalina.core.StandardWrapperValve.invoke Servlet.service() for servlet [RestfulLoginJSP] in context with path [] threw exception [Unable to compile class for JSP:

An error occurred at line: [19] in the jsp file: [/WEB-INF/jsp/global/frontend_config.jsp]
The method showGenomeNexusAnnotationSources() is undefined for the type GlobalProperties
16:     showMyCancerGenome : <%=GlobalProperties.showMyCancerGenomeUrl()%>,
17:     showTranscriptDropdown : <%=GlobalProperties.showTranscriptDropdown()%>,
18:     showGenomeNexus : <%=GlobalProperties.showGenomeNexus()%>,
19:     showGenomeNexusAnnotationSources : <%=GlobalProperties.showGenomeNexusAnnotationSources()%>,
20:     showMutationMapperToolGrch38 : <%=GlobalProperties.showMutationMapperToolGrch38()%>,
21:     querySetsOfGenes : JSON.parse('<%=GlobalProperties.getQuerySetsOfGenes()%>'),
22:     skinBlurb : '<%=GlobalProperties.getBlurb()%>',
```