### PR TITLE
Add duplicate event check after import of Fusions into 'mutation_event' table

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportFusionData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportFusionData.java
@@ -168,6 +168,11 @@ public class ImportFusionData {
                 }
             }
         }
+        // run sanity check on `mutation_event` to determine whether duplicate
+        // events were introduced during current import
+        if (DaoMutation.hasDuplicateMutationEvents()) {
+            throw new DaoException("Duplicate mutation events were detected during the FUSIONS import. Aborting...");
+        }
         buf.close();
         if( MySQLbulkLoader.isBulkLoad()) {
             MySQLbulkLoader.flushAll();


### PR DESCRIPTION
Resolves issue where duplicate records were being imported into the 'mutation_event' table via the Fusions import. We have a check that runs after `ImportExtendedMutationData` to prevent this from  happening during the import of Mutations data. This PR adds the same check after `ImportFusionData` runs. 

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
