### PR TITLE
Treatment endpoints no longer called with sample + study id lists that aren't 1-1

### DIFF
--- a/web/src/main/java/org/cbioportal/web/TreatmentController.java
+++ b/web/src/main/java/org/cbioportal/web/TreatmentController.java
@@ -56,11 +56,9 @@ public class TreatmentController {
         List<SampleIdentifier> sampleIdentifiers = studyViewFilterApplier.apply(interceptedStudyViewFilter);
         List<String> sampleIds = sampleIdentifiers.stream()
             .map(SampleIdentifier::getSampleId)
-            .distinct()
             .collect(Collectors.toList());
         List<String> studyIds = sampleIdentifiers.stream()
             .map(SampleIdentifier::getStudyId)
-            .distinct()
             .collect(Collectors.toList());
         List<PatientTreatmentRow> treatments = treatmentService.getAllPatientTreatmentRows(sampleIds, studyIds);
         return new ResponseEntity<>(treatments, HttpStatus.OK);
@@ -88,11 +86,9 @@ public class TreatmentController {
         List<SampleIdentifier> sampleIdentifiers = studyViewFilterApplier.apply(interceptedStudyViewFilter);
         List<String> sampleIds = sampleIdentifiers.stream()
             .map(SampleIdentifier::getSampleId)
-            .distinct()
             .collect(Collectors.toList());
         List<String> studyIds = sampleIdentifiers.stream()
             .map(SampleIdentifier::getStudyId)
-            .distinct()
             .collect(Collectors.toList());
         List<SampleTreatmentRow> treatments = treatmentService.getAllSampleTreatmentRows(sampleIds, studyIds);
         return new ResponseEntity<>(treatments, HttpStatus.OK);
@@ -119,11 +115,9 @@ public class TreatmentController {
         List<SampleIdentifier> sampleIdentifiers = studyViewFilterApplier.apply(interceptedStudyViewFilter);
         List<String> sampleIds = sampleIdentifiers.stream()
             .map(SampleIdentifier::getSampleId)
-            .distinct()
             .collect(Collectors.toList());
         List<String> studyIds = sampleIdentifiers.stream()
             .map(SampleIdentifier::getStudyId)
-            .distinct()
             .collect(Collectors.toList());
         Boolean containsTreatmentData = treatmentService.containsTreatmentData(sampleIds, studyIds);
         return new ResponseEntity<>(containsTreatmentData, HttpStatus.OK);

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -243,16 +243,14 @@ public class StudyViewFilterApplier {
         if (studyViewFilter.getSampleTreatmentFilters() != null) {
             sampleIdentifiers = sampleTreatmentFilterApplier.filter(
                 studyViewFilter.getSampleTreatmentFilters(),
-                sampleIdentifiers,
-                studyIds
+                sampleIdentifiers
             );
         }
 
         if (studyViewFilter.getPatientTreatmentFilters() != null) {
             sampleIdentifiers = patientTreatmentFilterApplier.filter(
                 sampleIdentifiers,
-                studyViewFilter.getPatientTreatmentFilters(),
-                studyIds
+                studyViewFilter.getPatientTreatmentFilters()
             );
         }
 

--- a/web/src/main/java/org/cbioportal/web/util/appliers/PatientTreatmentFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/appliers/PatientTreatmentFilterApplier.java
@@ -19,11 +19,14 @@ public class PatientTreatmentFilterApplier {
     
     public List<SampleIdentifier> filter(
         List<SampleIdentifier> identifiers,
-        AndedPatientTreatmentFilters filters,
-        List<String> studyIds
+        AndedPatientTreatmentFilters filters
     ) {
         List<String> sampleIds = identifiers.stream()
             .map(SampleIdentifier::getSampleId)
+            .collect(Collectors.toList());
+
+        List<String> studyIds = identifiers.stream()
+            .map(SampleIdentifier::getStudyId)
             .collect(Collectors.toList());
 
         Map<String, Map<String, Boolean>> rows = treatmentService.getAllPatientTreatmentRows(sampleIds, studyIds)

--- a/web/src/main/java/org/cbioportal/web/util/appliers/SampleTreatmentFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/appliers/SampleTreatmentFilterApplier.java
@@ -19,11 +19,13 @@ public class SampleTreatmentFilterApplier {
     
     public List<SampleIdentifier> filter (
         AndedSampleTreatmentFilters filters,
-        List<SampleIdentifier> identifiers,
-        List<String> studyIds
+        List<SampleIdentifier> identifiers
     ) {
         List<String> sampleIds = identifiers.stream()
             .map(SampleIdentifier::getSampleId)
+            .collect(Collectors.toList());
+        List<String> studyIds = identifiers.stream()
+            .map(SampleIdentifier::getStudyId)
             .collect(Collectors.toList());
 
         Map<String, Map<String, Boolean>> rows = treatmentService.getAllSampleTreatmentRows(sampleIds, studyIds)

--- a/web/src/test/java/org/cbioportal/web/util/appliers/PatientTreatmentFilterApplierTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/appliers/PatientTreatmentFilterApplierTest.java
@@ -40,7 +40,6 @@ public class PatientTreatmentFilterApplierTest {
     @Test
     public void filterEmptyList() {
         List<SampleIdentifier> samples = new ArrayList<>();
-        List<String> studies = new ArrayList<>();
         AndedPatientTreatmentFilters andedFilters = createAndedFilters(
             Arrays.asList("Fakeazil", "Madeupanib"),
             Arrays.asList("Fabricada", "Fakeamab")
@@ -49,7 +48,7 @@ public class PatientTreatmentFilterApplierTest {
             .when(treatmentService.getAllPatientTreatmentRows(Mockito.anyList(), Mockito.anyList()))
             .thenReturn(new ArrayList<>());
 
-        List<SampleIdentifier> actual = subject.filter(samples, andedFilters, studies);
+        List<SampleIdentifier> actual = subject.filter(samples, andedFilters);
         List<SampleIdentifier> expected = new ArrayList<>();
         
         Assert.assertEquals(expected, actual);
@@ -63,10 +62,6 @@ public class PatientTreatmentFilterApplierTest {
             createSampleId("SA_2", "ST_1"),
             createSampleId("SA_3", "ST_1")
         );
-        List<String> studies = Arrays.asList(
-            "ST_0",
-            "ST_1"
-        );
         AndedPatientTreatmentFilters andedFilters = createAndedFilters(
             Arrays.asList("Improvizox", "Madeupanib"),
             Arrays.asList("Fabricada", "Fakeamab")
@@ -75,7 +70,7 @@ public class PatientTreatmentFilterApplierTest {
             .when(treatmentService.getAllPatientTreatmentRows(Mockito.anyList(), Mockito.anyList()))
             .thenReturn(new ArrayList<>());
 
-        List<SampleIdentifier> actual = subject.filter(samples, andedFilters, studies);
+        List<SampleIdentifier> actual = subject.filter(samples, andedFilters);
         List<SampleIdentifier> expected = new ArrayList<>();
 
         Assert.assertEquals(expected, actual);
@@ -88,10 +83,6 @@ public class PatientTreatmentFilterApplierTest {
             createSampleId("SA_1", "ST_0"),
             createSampleId("SA_2", "ST_1"),
             createSampleId("SA_3", "ST_1")
-        );
-        List<String> studies = Arrays.asList(
-            "ST_0",
-            "ST_1"
         );
         AndedPatientTreatmentFilters andedFilters = createAndedFilters(
             // so each sample needs to be from a patient that has recieved...
@@ -107,7 +98,7 @@ public class PatientTreatmentFilterApplierTest {
                 new PatientTreatmentRow("Fabricada", 2, toSet(createEvent("SA_2", "ST_1"), createEvent("SA_3", "ST_1")))
             ));
 
-        List<SampleIdentifier> actual = subject.filter(samples, andedFilters, studies);
+        List<SampleIdentifier> actual = subject.filter(samples, andedFilters);
         List<SampleIdentifier> expected = Arrays.asList(
             createSampleId("SA_0", "ST_0"),
             createSampleId("SA_1", "ST_0"),

--- a/web/src/test/java/org/cbioportal/web/util/appliers/SampleTreatmentFilterApplierTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/appliers/SampleTreatmentFilterApplierTest.java
@@ -40,7 +40,6 @@ public class SampleTreatmentFilterApplierTest {
     @Test
     public void filterEmptyList() {
         List<SampleIdentifier> samples = new ArrayList<>();
-        List<String> studies = new ArrayList<>();
         AndedSampleTreatmentFilters andedFilters = createAndedFilters(
             Arrays.asList(new Pair<>("Fakeazil", Pre), new Pair<>("Madeupanib", Post)),
             Arrays.asList(new Pair<>("Fabricada", Pre), new Pair<>("Fakeamab", Post))
@@ -49,7 +48,7 @@ public class SampleTreatmentFilterApplierTest {
             .when(treatmentService.getAllSampleTreatmentRows(Mockito.anyList(), Mockito.anyList()))
             .thenReturn(new ArrayList<>());
 
-        List<SampleIdentifier> actual = subject.filter(andedFilters, samples, studies);
+        List<SampleIdentifier> actual = subject.filter(andedFilters, samples);
         List<SampleIdentifier> expected = new ArrayList<>();
 
         Assert.assertEquals(expected, actual);
@@ -63,10 +62,6 @@ public class SampleTreatmentFilterApplierTest {
             createSampleId("SA_2", "ST_1"),
             createSampleId("SA_3", "ST_1")
         );
-        List<String> studies = Arrays.asList(
-            "ST_0",
-            "ST_1"
-        );
         AndedSampleTreatmentFilters andedFilters = createAndedFilters(
             Arrays.asList(new Pair<>("Improvizox", Pre), new Pair<>("Madeupanib", Post)),
             Arrays.asList(new Pair<>("Fabricada", Pre), new Pair<>("Fakeamab", Post))
@@ -75,7 +70,7 @@ public class SampleTreatmentFilterApplierTest {
             .when(treatmentService.getAllSampleTreatmentRows(Mockito.anyList(), Mockito.anyList()))
             .thenReturn(new ArrayList<>());
 
-        List<SampleIdentifier> actual = subject.filter(andedFilters, samples, studies);
+        List<SampleIdentifier> actual = subject.filter(andedFilters, samples);
         List<SampleIdentifier> expected = new ArrayList<>();
 
         Assert.assertEquals(expected, actual);
@@ -88,10 +83,6 @@ public class SampleTreatmentFilterApplierTest {
             createSampleId("SA_1", "ST_0"),
             createSampleId("SA_2", "ST_1"),
             createSampleId("SA_3", "ST_1")
-        );
-        List<String> studies = Arrays.asList(
-            "ST_0",
-            "ST_1"
         );
         AndedSampleTreatmentFilters andedFilters = createAndedFilters(
             // so each sample needs to be...
@@ -109,7 +100,7 @@ public class SampleTreatmentFilterApplierTest {
                 new SampleTreatmentRow(Pre, "Fabricada", 2, toSet(createEvent("SA_2", "ST_1"), createEvent("SA_3", "ST_1")))
             ));
 
-        List<SampleIdentifier> actual = subject.filter(andedFilters, samples, studies);
+        List<SampleIdentifier> actual = subject.filter(andedFilters, samples);
         List<SampleIdentifier> expected = Arrays.asList(
             createSampleId("SA_0", "ST_0"),
             createSampleId("SA_1", "ST_0"),


### PR DESCRIPTION
This was breaking stuff in the mybatis layer that needs those lists to be one to one.

Fix #7822 