### PR TITLE
Fix generic meta endpoint error when fetching by stable ids only

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/GenericAssayServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenericAssayServiceImpl.java
@@ -58,16 +58,22 @@ public class GenericAssayServiceImpl implements GenericAssayService {
                 List<String> stableIdsInMolecularProfiles = genericAssayRepository.getGenericAssayStableIdsByMolecularIds(distinctMolecularProfileIds);
                 allStableIds.addAll(stableIdsInMolecularProfiles);
             }
-        } 
-        if (stableIds != null) {
-			Map<String, String> allStableIdMap = allStableIds
-					.stream()
-					.collect(Collectors.toMap(stableId -> stableId, stableId -> stableId));
+            // if stableIds and molecularProfileIds both exist, find the common
+            if (stableIds != null) {
+                Map<String, String> allStableIdMap = allStableIds
+                        .stream()
+                        .collect(Collectors.toMap(stableId -> stableId, stableId -> stableId));
 
-			allStableIds = stableIds
-					.stream()
-					.filter(stableId -> allStableIdMap.containsKey(stableId))
-					.collect(Collectors.toSet());
+                allStableIds = stableIds
+                        .stream()
+                        .filter(stableId -> allStableIdMap.containsKey(stableId))
+                        .collect(Collectors.toSet());
+            }
+        } else {
+            // add all stableIds since molecularProfileIds is null
+            if (stableIds != null) {
+                allStableIds.addAll(stableIds);
+            }
         }
         List<String> distinctStableIds = new ArrayList<String>(allStableIds);
         List<GenericAssayMeta> metaResults = new ArrayList<GenericAssayMeta>();


### PR DESCRIPTION
Fix https://github.com/cbioportal/cbioportal/issues/7841

When fetching generic assay meta by only giving the stable ids, since the allStableIdMap is empty, then given stable ids will be filtered out, and will get empty result.
Resolve this by using following logic:
1. have molecular profiles ids and stable ids: use the shared stable ids
2. only has molecular profiles ids: use stable ids derived from molecular profiles ids
3. only has stable ids: use the given stable ids 
