### PR TITLE
Add new api's to support saving custom data charts

### DIFF
--- a/web/src/main/java/org/cbioportal/web/CustomAttributeWithData.java
+++ b/web/src/main/java/org/cbioportal/web/CustomAttributeWithData.java
@@ -1,0 +1,121 @@
+package org.cbioportal.web;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.validation.constraints.NotNull;
+
+import org.cbioportal.web.parameter.CustomDataValue;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CustomAttributeWithData implements Serializable{
+
+    private String owner = "anonymous";
+    private Set<String> origin = new HashSet<>();
+    private Long created = System.currentTimeMillis();
+    private Long lastUpdated = System.currentTimeMillis();
+    private Set<String> users = new HashSet<>();
+
+    @NotNull
+    private String displayName;
+    private String description;
+    private String datatype;
+    @NotNull
+    private Boolean patientAttribute;
+    private String priority;
+
+    private List<CustomDataValue> data;
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public void setOrigin(Set<String> origin) {
+        this.origin = origin;
+    }
+
+    public Long getCreated() {
+        return created;
+    }
+
+    public void setCreated(Long created) {
+        this.created = created;
+    }
+
+    public Long getLastUpdated() {
+        return lastUpdated;
+    }
+
+    public void setLastUpdated(Long lastUpdated) {
+        this.lastUpdated = lastUpdated;
+    }
+
+    public Set<String> getUsers() {
+        return users;
+    }
+
+    public void setUsers(Set<String> users) {
+        this.users = users;
+    }
+
+    public Set<String> getOrigin() {
+        return this.origin;
+    }
+
+    public List<CustomDataValue> getData() {
+        return data;
+    }
+
+    public void setData(List<CustomDataValue> data) {
+        this.data = data;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDatatype() {
+        return datatype;
+    }
+
+    public void setDatatype(String datatype) {
+        this.datatype = datatype;
+    }
+
+    public Boolean getPatientAttribute() {
+        return patientAttribute;
+    }
+
+    public void setPatientAttribute(Boolean patientAttribute) {
+        this.patientAttribute = patientAttribute;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    public void setPriority(String priority) {
+        this.priority = priority;
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/web/config/CustomObjectMapper.java
+++ b/web/src/main/java/org/cbioportal/web/config/CustomObjectMapper.java
@@ -66,11 +66,13 @@ import org.cbioportal.model.Sample;
 import org.cbioportal.model.SampleList;
 import org.cbioportal.session_service.domain.Session;
 import org.cbioportal.model.TypeOfCancer;
+import org.cbioportal.web.parameter.CustomDataSession;
 import org.cbioportal.web.parameter.PageSettings;
 import org.cbioportal.web.parameter.PageSettingsData;
 import org.cbioportal.web.parameter.StudyPageSettings;
 import org.cbioportal.web.parameter.VirtualStudy;
 import org.cbioportal.web.parameter.VirtualStudyData;
+import org.cbioportal.web.CustomAttributeWithData;
 import org.cbioportal.web.mixin.CancerStudyMixin;
 import org.cbioportal.web.mixin.ClinicalAttributeCountMixin;
 import org.cbioportal.web.mixin.ClinicalAttributeMixin;
@@ -139,6 +141,8 @@ public class CustomObjectMapper extends ObjectMapper {
         mixinMap.put(ResourceDefinition.class, ResourceDefinitionMixin.class);
         mixinMap.put(VirtualStudy.class, SessionMixin.class);
         mixinMap.put(VirtualStudyData.class, SessionDataMixin.class);
+        mixinMap.put(CustomAttributeWithData.class, SessionDataMixin.class);
+        mixinMap.put(CustomDataSession.class, SessionMixin.class);
         super.setMixIns(mixinMap);
     }
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/CustomDataSession.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/CustomDataSession.java
@@ -6,29 +6,30 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cbioportal.session_service.domain.Session;
 import org.cbioportal.session_service.domain.SessionType;
+import org.cbioportal.web.CustomAttributeWithData;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class VirtualStudy extends Session {
+public class CustomDataSession extends Session {
 
-    private final Log LOG = LogFactory.getLog(VirtualStudy.class);
-    private VirtualStudyData data;
+    private final Log LOG = LogFactory.getLog(CustomDataSession.class);
+    private CustomAttributeWithData data;
 
     @Override
     public void setData(Object data) {
         ObjectMapper mapper = new ObjectMapper();
         try {
-            this.data = mapper.readValue(mapper.writeValueAsString(data), VirtualStudyData.class);
+            this.data = mapper.readValue(mapper.writeValueAsString(data), CustomAttributeWithData.class);
         } catch (IOException e) {
             LOG.error(e);
         }
     }
 
     @Override
-    public VirtualStudyData getData() {
+    public CustomAttributeWithData getData() {
         return data;
     }
 

--- a/web/src/main/java/org/cbioportal/web/parameter/CustomDataValue.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/CustomDataValue.java
@@ -1,0 +1,52 @@
+package org.cbioportal.web.parameter;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CustomDataValue implements Serializable {
+
+    private String sampleId;
+    @NotNull
+    private String patientId;
+    @NotNull
+    private String studyId;
+
+    private String value;
+
+    public String getSampleId() {
+        return sampleId;
+    }
+
+    public void setSampleId(String sampleId) {
+        this.sampleId = sampleId;
+    }
+
+    public String getPatientId() {
+        return patientId;
+    }
+
+    public void setPatientId(String patientId) {
+        this.patientId = patientId;
+    }
+
+    public String getStudyId() {
+        return studyId;
+    }
+
+    public void setStudyId(String studyId) {
+        this.studyId = studyId;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/web/parameter/PageSettings.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/PageSettings.java
@@ -5,7 +5,9 @@ import java.io.IOException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cbioportal.session_service.domain.Session;
+import org.cbioportal.session_service.domain.SessionType;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -28,6 +30,18 @@ public class PageSettings extends Session {
     @Override
     public PageSettingsData getData() {
         return data;
+    }
+
+    @JsonIgnore
+    @Override
+    public String getSource() {
+        return super.getSource();
+    }
+
+    @JsonIgnore
+    @Override
+    public SessionType getType() {
+        return super.getType();
     }
 
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/StudyViewFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/StudyViewFilter.java
@@ -28,6 +28,7 @@ public class StudyViewFilter implements Serializable {
     private List<GenomicDataFilter> genomicDataFilters;
     private List<GenericAssayDataFilter> genericAssayDataFilters;
     private List<List<String>> caseLists;
+    private List<ClinicalDataFilter> customDataFilters;
 
     @AssertTrue
     private boolean isEitherSampleIdentifiersOrStudyIdsPresent() {
@@ -36,42 +37,29 @@ public class StudyViewFilter implements Serializable {
 
     @AssertTrue
     private boolean isEitherValueOrRangePresentInClinicalDataIntervalFilters() {
-        long invalidCount = 0;
-
-        if (clinicalDataFilters != null) {
-            invalidCount = clinicalDataFilters.stream()
-                    .flatMap(f -> f.getValues().stream())
-                    .filter(Objects::nonNull)
-                    .filter(v -> v.getValue() != null == (v.getStart() != null || v.getEnd() != null))
-                    .count();
-        }
-
-        return invalidCount == 0;
+        return validateDataFilters(clinicalDataFilters);
     }
 
     @AssertTrue
     private boolean isEitherValueOrRangePresentInGenomicDataIntervalFilters() {
-        long invalidCount = 0;
-
-        if (genomicDataFilters != null) {
-            invalidCount = genomicDataFilters
-                    .stream()
-                    .flatMap(f -> f.getValues().stream())
-                    .filter(Objects::nonNull)
-                    .filter(v -> v.getValue() != null == (v.getStart() != null || v.getEnd() != null))
-                    .count();
-        }
-
-        return invalidCount == 0;
+        return validateDataFilters(genomicDataFilters);
     }
 
     @AssertTrue
     private boolean isEitherValueOrRangePresentInGenericAssayDataIntervalFilters() {
+        return validateDataFilters(genericAssayDataFilters);
+    }
+
+    @AssertTrue
+    private boolean isEitherValueOrRangePresentInCustomDataFilters() {
+        return validateDataFilters(customDataFilters);
+    }
+
+    private <T extends DataFilter> boolean validateDataFilters(List<T> dataFilters) {
         long invalidCount = 0;
 
-        if (genericAssayDataFilters != null) {
-            invalidCount = genericAssayDataFilters
-                    .stream()
+        if (dataFilters != null) {
+            invalidCount = dataFilters.stream()
                     .flatMap(f -> f.getValues().stream())
                     .filter(Objects::nonNull)
                     .filter(v -> v.getValue() != null == (v.getStart() != null || v.getEnd() != null))
@@ -160,5 +148,13 @@ public class StudyViewFilter implements Serializable {
 	public void setGenericAssayDataFilters(List<GenericAssayDataFilter> genericAssayDataFilters) {
 		this.genericAssayDataFilters = genericAssayDataFilters;
 	}
+
+    public List<ClinicalDataFilter> getCustomDataFilters() {
+        return customDataFilters;
+    }
+
+    public void setCustomDataFilters(List<ClinicalDataFilter> customDataFilters) {
+        this.customDataFilters = customDataFilters;
+    }
 
 }

--- a/web/src/main/java/org/cbioportal/web/studyview/CustomDataController.java
+++ b/web/src/main/java/org/cbioportal/web/studyview/CustomDataController.java
@@ -1,0 +1,125 @@
+package org.cbioportal.web.studyview;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.validation.Valid;
+
+import org.cbioportal.model.ClinicalDataCountItem;
+import org.cbioportal.model.Patient;
+import org.cbioportal.service.PatientService;
+import org.cbioportal.session_service.domain.SessionType;
+import org.cbioportal.web.config.annotation.InternalApi;
+import org.cbioportal.web.parameter.ClinicalDataCountFilter;
+import org.cbioportal.web.parameter.ClinicalDataFilter;
+import org.cbioportal.web.parameter.CustomDataSession;
+import org.cbioportal.web.parameter.SampleIdentifier;
+import org.cbioportal.web.parameter.StudyViewFilter;
+import org.cbioportal.web.util.SessionServiceRequestHandler;
+import org.cbioportal.web.util.StudyViewFilterApplier;
+import org.cbioportal.web.util.StudyViewFilterUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import springfox.documentation.annotations.ApiIgnore;
+
+@InternalApi
+@RestController
+@Validated
+@Api(tags = "Study View", description = " ")
+public class CustomDataController {
+
+    @Autowired
+    private StudyViewFilterApplier studyViewFilterApplier;
+    @Autowired
+    private StudyViewFilterUtil studyViewFilterUtil;
+    @Autowired
+    private SessionServiceRequestHandler sessionServiceRequestHandler;
+    @Autowired
+    private PatientService patientService;
+
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @RequestMapping(value = "/custom-data-counts/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Fetch custom data counts by study view filter")
+    public ResponseEntity<List<ClinicalDataCountItem>> fetchCustomDataCounts(
+            @ApiParam(required = true, value = "Custom data count filter") @Valid @RequestBody(required = false) ClinicalDataCountFilter clinicalDataCountFilter,
+            @ApiIgnore // prevent reference to this attribute in the swagger-ui
+                       // interface
+            @RequestAttribute(required = false, value = "involvedCancerStudies") Collection<String> involvedCancerStudies,
+            @ApiIgnore // prevent reference to this attribute in the swagger-ui
+                       // interface. this attribute is needed for the
+                       // @PreAuthorize tag above.
+            @Valid @RequestAttribute(required = false, value = "interceptedClinicalDataCountFilter") ClinicalDataCountFilter interceptedClinicalDataCountFilter) {
+
+        List<ClinicalDataFilter> attributes = interceptedClinicalDataCountFilter.getAttributes();
+        StudyViewFilter studyViewFilter = interceptedClinicalDataCountFilter.getStudyViewFilter();
+        if (attributes.size() == 1) {
+            studyViewFilterUtil.removeSelfCustomDataFromFilter(attributes.get(0).getAttributeId(), studyViewFilter);
+        }
+        List<SampleIdentifier> filteredSampleIdentifiers = studyViewFilterApplier.apply(studyViewFilter);
+
+        if (filteredSampleIdentifiers.isEmpty()) {
+            return new ResponseEntity<>(new ArrayList<>(), HttpStatus.OK);
+        }
+
+        List<CompletableFuture<CustomDataSession>> postFutures = attributes.stream().map(clinicalDataFilter -> {
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    return (CustomDataSession) sessionServiceRequestHandler.getSession(SessionType.custom_data,
+                            clinicalDataFilter.getAttributeId());
+                } catch (Exception e) {
+                    return null;
+                }
+            });
+        }).collect(Collectors.toList());
+
+        CompletableFuture.allOf(postFutures.toArray(new CompletableFuture[postFutures.size()])).join();
+        
+        List<CustomDataSession> customDataSessions = postFutures
+        .stream()
+        .map(CompletableFuture::join)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+
+        Map<String, SampleIdentifier> filteredSamplesMap = filteredSampleIdentifiers.stream()
+                .collect(Collectors.toMap(sampleIdentifier -> {
+                    return studyViewFilterUtil.getCaseUniqueKey(sampleIdentifier.getStudyId(),
+                            sampleIdentifier.getSampleId());
+                }, Function.identity()));
+
+        List<String> studyIds = new ArrayList<>();
+        List<String> sampleIds = new ArrayList<>();
+        studyViewFilterUtil.extractStudyAndSampleIds(filteredSampleIdentifiers, studyIds, sampleIds);
+
+        long patientCustomDataSessionsCount = customDataSessions.stream()
+                .filter(customDataSession -> customDataSession.getData().getPatientAttribute()).count();
+        List<Patient> patients = new ArrayList<Patient>();
+        if (patientCustomDataSessionsCount > 0) {
+            patients.addAll(patientService.getPatientsOfSamples(studyIds, sampleIds));
+        }
+
+        List<ClinicalDataCountItem> result = studyViewFilterUtil.getClinicalDataCountsFromCustomData(customDataSessions,
+                filteredSamplesMap, patients);
+
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataEqualityFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataEqualityFilterApplier.java
@@ -1,17 +1,13 @@
 package org.cbioportal.web.util;
 
+import java.util.List;
+
 import org.apache.commons.collections.map.MultiKeyMap;
-import org.cbioportal.model.ClinicalData;
 import org.cbioportal.service.ClinicalDataService;
 import org.cbioportal.service.PatientService;
 import org.cbioportal.web.parameter.ClinicalDataFilter;
-import org.cbioportal.web.parameter.DataFilterValue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Component
 public class ClinicalDataEqualityFilterApplier extends ClinicalDataFilterApplier {
@@ -21,6 +17,9 @@ public class ClinicalDataEqualityFilterApplier extends ClinicalDataFilterApplier
                                              StudyViewFilterUtil studyViewFilterUtil) {
         super(patientService, clinicalDataService, studyViewFilterUtil);
     }
+    
+    @Autowired
+    private StudyViewFilterUtil studyViewFilterUtil;
 
     @Override
     public Integer apply(List<ClinicalDataFilter> attributes,
@@ -28,28 +27,6 @@ public class ClinicalDataEqualityFilterApplier extends ClinicalDataFilterApplier
                          String entityId,
                          String studyId,
                          Boolean negateFilters) {
-        Integer count = 0;
-
-        for (ClinicalDataFilter s : attributes) {
-            List<ClinicalData> entityClinicalData = (List<ClinicalData>)clinicalDataMap.get(entityId, studyId);
-            List<String> filteredValues = s.getValues().stream().map(DataFilterValue::getValue)
-                    .collect(Collectors.toList());
-            filteredValues.replaceAll(String::toUpperCase);
-            if (entityClinicalData != null) {
-                Optional<ClinicalData> clinicalData = entityClinicalData.stream().filter(
-                    c -> c.getAttrId().toUpperCase()
-                    .equals(s.getAttributeId().toUpperCase())
-                ).findFirst();
-                if (clinicalData.isPresent() && (negateFilters ^ filteredValues.contains(clinicalData.get().getAttrValue()))) {
-                    count++;
-                } else if (!clinicalData.isPresent() && (negateFilters ^ filteredValues.contains("NA"))) {
-                    count++;
-                }
-            } else if (negateFilters ^ filteredValues.contains("NA")) {
-                count++;
-            }
-        }
-
-        return count;
+        return studyViewFilterUtil.getFilteredCountByDataEquality(attributes, clinicalDataMap, entityId, studyId, negateFilters);
     }
 }

--- a/web/src/main/java/org/cbioportal/web/util/CustomDataFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/CustomDataFilterApplier.java
@@ -1,0 +1,88 @@
+package org.cbioportal.web.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.map.MultiKeyMap;
+import org.cbioportal.service.ClinicalDataService;
+import org.cbioportal.service.PatientService;
+import org.cbioportal.session_service.domain.SessionType;
+import org.cbioportal.web.parameter.ClinicalDataFilter;
+import org.cbioportal.web.parameter.CustomDataSession;
+import org.cbioportal.web.parameter.SampleIdentifier;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomDataFilterApplier extends ClinicalDataEqualityFilterApplier {
+
+    @Autowired
+    public CustomDataFilterApplier(PatientService patientService, ClinicalDataService clinicalDataService,
+            StudyViewFilterUtil studyViewFilterUtil) {
+        super(patientService, clinicalDataService, studyViewFilterUtil);
+    }
+
+    @Autowired
+    private SessionServiceRequestHandler sessionServiceRequestHandler;
+
+    @Override
+    public List<SampleIdentifier> apply(List<SampleIdentifier> sampleIdentifiers,
+            List<ClinicalDataFilter> customDataFilters, Boolean negateFilters) {
+        if (!customDataFilters.isEmpty() && !sampleIdentifiers.isEmpty()) {
+
+            List<CompletableFuture<CustomDataSession>> postFutures = customDataFilters.stream()
+                    .map(clinicalDataFilter -> {
+                        return CompletableFuture.supplyAsync(() -> {
+                            try {
+                                return (CustomDataSession) sessionServiceRequestHandler
+                                        .getSession(SessionType.custom_data, clinicalDataFilter.getAttributeId());
+                            } catch (Exception e) {
+                                return null;
+                            }
+                        });
+                    }).collect(Collectors.toList());
+
+            CompletableFuture.allOf(postFutures.toArray(new CompletableFuture[postFutures.size()])).join();
+
+            Map<String, CustomDataSession> customDataSessionById = postFutures
+                    .stream()
+                    .map(CompletableFuture::join)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toMap(CustomDataSession::getId, Function.identity()));
+
+            MultiKeyMap clinicalDataMap = new MultiKeyMap();
+
+            customDataSessionById.values()
+            .stream()
+            .forEach(customDataSession -> {
+                customDataSession.getData().getData().forEach(datum -> {
+                    String value = datum.getValue().toUpperCase();
+                    if (value.equals("NAN") || value.equals("N/A")) {
+                        value = "NA";
+                    }
+                    clinicalDataMap.put(datum.getStudyId(), datum.getSampleId(), customDataSession.getId(), value);
+                });
+            });
+
+            List<SampleIdentifier> newSampleIdentifiers = new ArrayList<>();
+
+            sampleIdentifiers.forEach(sampleIdentifier -> {
+                int count = apply(customDataFilters, clinicalDataMap,
+                        sampleIdentifier.getSampleId(), sampleIdentifier.getStudyId(), negateFilters);
+
+                if (count == customDataFilters.size()) {
+                    newSampleIdentifiers.add(sampleIdentifier);
+                }
+            });
+
+            return newSampleIdentifiers;
+        }
+        return sampleIdentifiers;
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
+++ b/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
@@ -94,6 +94,7 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
     public static final String STUDY_VIEW_GENOMICL_DATA_BIN_COUNTS_PATH = "/genomic-data-bin-counts/fetch";
     public static final String STUDY_VIEW_GENERIC_ASSAY_DATA_BIN_COUNTS_PATH = "/generic-assay-data-bin-counts/fetch";
     public static final String STUDY_VIEW_CLINICAL_DATA_COUNTS_PATH = "/clinical-data-counts/fetch";
+    public static final String STUDY_VIEW_CUSTOM_DATA_COUNTS_PATH = "/custom-data-counts/fetch";
     public static final String STUDY_VIEW_CLINICAL_DATA_DENSITY_PATH = "/clinical-data-density-plot/fetch";
     public static final String STUDY_VIEW_CNA_GENES = "/cna-genes/fetch";
     public static final String STUDY_VIEW_FILTERED_SAMPLES = "/filtered-samples/fetch";
@@ -142,7 +143,8 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
             return extractAttributesFromGenomicDataBinCountFilter(request);
         } else if (requestPathInfo.equals(STUDY_VIEW_GENERIC_ASSAY_DATA_BIN_COUNTS_PATH)) {
             return extractAttributesFromGenericAssayDataBinCountFilter(request);
-        } else if (requestPathInfo.equals(STUDY_VIEW_CLINICAL_DATA_COUNTS_PATH)) {
+        } else if (Arrays.asList(STUDY_VIEW_CLINICAL_DATA_COUNTS_PATH, STUDY_VIEW_CUSTOM_DATA_COUNTS_PATH)
+                .contains(requestPathInfo)) {
             return extractAttributesFromClinicalDataCountFilter(request);
         } else if (Arrays.asList(STUDY_VIEW_CLINICAL_DATA_DENSITY_PATH, STUDY_VIEW_CNA_GENES,
                 STUDY_VIEW_FILTERED_SAMPLES, STUDY_VIEW_MUTATED_GENES, STUDY_VIEW_FUSION_GENES,

--- a/web/src/main/java/org/cbioportal/web/util/SessionServiceRequestHandler.java
+++ b/web/src/main/java/org/cbioportal/web/util/SessionServiceRequestHandler.java
@@ -1,0 +1,84 @@
+package org.cbioportal.web.util;
+
+import java.nio.charset.Charset;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
+import org.cbioportal.session_service.domain.Session;
+import org.cbioportal.session_service.domain.SessionType;
+import org.cbioportal.web.parameter.CustomDataSession;
+import org.cbioportal.web.parameter.PageSettings;
+import org.cbioportal.web.parameter.VirtualStudy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class SessionServiceRequestHandler {
+
+    @Value("${session.service.url:}")
+    private String sessionServiceURL;
+
+    @Value("${session.service.user:}")
+    private String sessionServiceUser;
+
+    @Value("${session.service.password:}")
+    private String sessionServicePassword;
+
+    private Boolean isBasicAuthEnabled() {
+        return isSessionServiceEnabled() && sessionServicePassword != null && !sessionServicePassword.equals("");
+    }
+
+    private Boolean isSessionServiceEnabled() {
+        return !StringUtils.isEmpty(sessionServiceURL);
+    }
+
+    public HttpHeaders getHttpHeaders() {
+
+        return new HttpHeaders() {
+            {
+                if (isBasicAuthEnabled()) {
+                    String auth = sessionServiceUser + ":" + sessionServicePassword;
+                    byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(Charset.forName("US-ASCII")));
+                    String authHeader = "Basic " + new String(encodedAuth);
+                    set("Authorization", authHeader);
+                }
+                set("Content-Type", "application/json");
+            }
+        };
+    }
+
+    public Session getSession(SessionType type, String id) throws Exception {
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        // add basic authentication in header
+        HttpEntity<String> headers = new HttpEntity<String>(getHttpHeaders());
+        ResponseEntity<String> responseEntity = restTemplate.exchange(sessionServiceURL + type + "/" + id,
+                HttpMethod.GET, headers, String.class);
+
+        ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        Session session;
+
+        if (type.equals(SessionType.virtual_study) || type.equals(SessionType.group)) {
+            session = mapper.readValue(responseEntity.getBody(), VirtualStudy.class);
+        } else if (type.equals(SessionType.settings)) {
+            session = mapper.readValue(responseEntity.getBody(), PageSettings.class);
+        } else if (type.equals(SessionType.custom_data)) {
+            session = mapper.readValue(responseEntity.getBody(), CustomDataSession.class);
+        } else {
+            session = mapper.readValue(responseEntity.getBody(), Session.class);
+        }
+
+        return session;
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
@@ -4,11 +4,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections.map.MultiKeyMap;
 import org.cbioportal.model.ClinicalDataBin;
+import org.cbioportal.model.ClinicalDataCount;
+import org.cbioportal.model.ClinicalDataCountItem;
 import org.cbioportal.model.DataBin;
 import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.Patient;
 import org.cbioportal.model.SampleList;
 import org.cbioportal.web.parameter.ClinicalDataBinFilter;
+import org.cbioportal.web.parameter.ClinicalDataFilter;
+import org.cbioportal.web.parameter.CustomDataSession;
+import org.cbioportal.web.parameter.CustomDataValue;
+import org.cbioportal.web.parameter.DataFilterValue;
 import org.cbioportal.web.parameter.SampleIdentifier;
 import org.cbioportal.web.parameter.StudyViewFilter;
 import org.springframework.stereotype.Component;
@@ -28,6 +36,13 @@ public class StudyViewFilterUtil {
         }
     }
 
+
+    public void removeSelfCustomDataFromFilter(String attributeId, StudyViewFilter studyViewFilter) {
+        if (studyViewFilter!= null && studyViewFilter.getCustomDataFilters() != null) {
+            studyViewFilter.getCustomDataFilters().removeIf(f -> f.getAttributeId().equals(attributeId));
+        }
+    }
+    
     public String getCaseUniqueKey(String studyId, String caseId) {
         return studyId + caseId;
     }
@@ -62,5 +77,80 @@ public class StudyViewFilterUtil {
         return sampleLists.stream().collect(Collectors.groupingBy(sampleList -> {
             return sampleList.getStableId().replace(sampleList.getCancerStudyIdentifier() + "_", "");
         }));
+    }
+
+    public Integer getFilteredCountByDataEquality(List<ClinicalDataFilter> attributes, MultiKeyMap clinicalDataMap,
+            String entityId, String studyId, Boolean negateFilters) {
+        Integer count = 0;
+        for (ClinicalDataFilter s : attributes) {
+            List<String> filteredValues = s.getValues()
+                    .stream()
+                    .map(DataFilterValue::getValue)
+                    .collect(Collectors.toList());
+            filteredValues.replaceAll(String::toUpperCase);
+            if (clinicalDataMap.containsKey(studyId, entityId, s.getAttributeId())) {
+                String value = (String) clinicalDataMap.get(studyId, entityId, s.getAttributeId());
+                if (negateFilters ^ filteredValues.contains(value)) {
+                    count++;
+                }
+            } else if (negateFilters ^ filteredValues.contains("NA")) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public List<ClinicalDataCountItem> getClinicalDataCountsFromCustomData(List<CustomDataSession> customDataSessions,
+            Map<String, SampleIdentifier> filteredSamplesMap, List<Patient> patients) {
+        int totalSamplesCount = filteredSamplesMap.keySet().size();
+        int totalPatientsCount = patients.size();
+
+        return customDataSessions.stream().map(customDataSession -> {
+
+            Map<String, List<CustomDataValue>> groupedDatabyValue = customDataSession.getData().getData().stream()
+                    .filter(datum -> {
+                        return filteredSamplesMap
+                                .containsKey(getCaseUniqueKey(datum.getStudyId(), datum.getSampleId()));
+                    }).collect(Collectors.groupingBy(CustomDataValue::getValue));
+
+            ClinicalDataCountItem clinicalDataCountItem = new ClinicalDataCountItem();
+            clinicalDataCountItem.setAttributeId(customDataSession.getId());
+
+            List<ClinicalDataCount> clinicalDataCounts = groupedDatabyValue.entrySet().stream()
+                    .map(entry -> {
+                        long count = entry.getValue().stream().map(datum -> {
+                            return getCaseUniqueKey(datum.getStudyId(),
+                                    customDataSession.getData().getPatientAttribute()
+                                            ? datum.getPatientId()
+                                            : datum.getSampleId());
+        
+                        }).distinct().count();
+                        ClinicalDataCount dataCount = new ClinicalDataCount();
+                        dataCount.setValue(entry.getKey());
+                        dataCount.setCount(Math.toIntExact(count));
+                        return dataCount;
+                    })
+                    .filter(c -> !c.getValue().toUpperCase().equals("NA") && !c.getValue().toUpperCase().equals("NAN")
+                            && !c.getValue().toUpperCase().equals("N/A"))
+                    .collect(Collectors.toList());
+
+            int totalCount = clinicalDataCounts.stream().mapToInt(ClinicalDataCount::getCount).sum();
+            int naCount = 0;
+            if (customDataSession.getData().getPatientAttribute()) {
+                naCount = totalPatientsCount - totalCount;
+            } else {
+                naCount = totalSamplesCount - totalCount;
+            }
+            if (naCount > 0) {
+                ClinicalDataCount clinicalDataCount = new ClinicalDataCount();
+                clinicalDataCount.setAttributeId(customDataSession.getId());
+                clinicalDataCount.setValue("NA");
+                clinicalDataCount.setCount(naCount);
+                clinicalDataCounts.add(clinicalDataCount);
+            }
+
+            clinicalDataCountItem.setCounts(clinicalDataCounts);
+            return clinicalDataCountItem;
+        }).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Backend changes related to
https://github.com/cBioPortal/cbioportal/issues/7726, https://github.com/cBioPortal/cbioportal/issues/6482, https://github.com/cBioPortal/cbioportal/issues/7609, https://github.com/cBioPortal/cbioportal/issues/8044, https://github.com/cBioPortal/cbioportal/issues/8057

This includes
1. saving custom data( for both authenticated and unauthenticated portal)
2. retrieving saved custom data using id
3. retrieving saved custom data objects for a user
4. new study-view api to retrieve custom data counts(similar to clinical-data-counts) and also support filtering through `StudyViewFilter`

data model for custom chart that is saved to session-service
```
{
	"owner": "string",
	"origin": ["string"],
	"created": "number",
	"lastUpdated": "number",
	"users": ["string"],
	"displayName": "string",
	"description": "string",
	"datatype": "string",
	"patientAttribute": "boolean",
	"priority": "string",
	"data": [{
		"sampleId": "string",
		"patientId": "string",
		"studyId": "string",
		"value": "string"
	}]
}
```


New API, `/custom-data-counts/fetch` similar to `/clinical-data-counts/fetch`. Request and response are similar, only difference is where is look for data. request attributes for `/custom-data-counts/fetch` fetches data from session-service. All filters related to custom data are set to `customDataFilters` in `StudyViewFilter`.

Note: Currently api and filtering only supports for categorical data. New api and filters for continuous data will be addressed in another pr.

To test
https://cbioportal-fix-7726-bs0ipkcana.herokuapp.com and setting localStorage.netlify = "deploy-preview-3448--cbioportalfrontend"
