### PR TITLE
Add CNA Gene Filter to StudyViewFilter

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImpl.java
@@ -92,8 +92,21 @@ public class DiscreteCopyNumberServiceImpl implements DiscreteCopyNumberService 
                                                                                           List<Integer> alterationTypes, 
                                                                                           String projection) {
         
-        return discreteCopyNumberRepository.getDiscreteCopyNumbersInMultipleMolecularProfiles(molecularProfileIds, 
-            sampleIds, entrezGeneIds, alterationTypes, projection);
+        if (isHomdelOrAmpOnly(alterationTypes)) {
+            return discreteCopyNumberRepository.getDiscreteCopyNumbersInMultipleMolecularProfiles(molecularProfileIds,
+                sampleIds, entrezGeneIds, alterationTypes, projection);
+        }
+        
+        return molecularDataService.getMolecularDataInMultipleMolecularProfiles(
+                molecularProfileIds,
+                sampleIds,
+                entrezGeneIds,
+                projection)
+            .stream()
+            .filter(g -> isValidAlteration(alterationTypes, g))
+            .map(this::convert)
+            .collect(Collectors.toList());
+        
 	}
 
     @Override
@@ -213,6 +226,7 @@ public class DiscreteCopyNumberServiceImpl implements DiscreteCopyNumberService 
 
         DiscreteCopyNumberData discreteCopyNumberData = new DiscreteCopyNumberData();
         discreteCopyNumberData.setMolecularProfileId(molecularData.getMolecularProfileId());
+        discreteCopyNumberData.setStudyId(molecularData.getStudyId());
         discreteCopyNumberData.setSampleId(molecularData.getSampleId());
         discreteCopyNumberData.setEntrezGeneId(molecularData.getEntrezGeneId());
         discreteCopyNumberData.setGene(molecularData.getGene());

--- a/web/src/main/java/org/cbioportal/web/parameter/GeneFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/GeneFilter.java
@@ -16,7 +16,7 @@ public class GeneFilter implements Serializable {
     private Set<String> molecularProfileIds;
     private List<List<String>> geneQueries;
 
-    private final String GENE_QUERY_PATTERN = "^(\\w+)[\\s]*?(?:\\:(?:[\\s]*(?:(AMP)|(HOMDEL))\\b)+)?$";
+    private final String GENE_QUERY_PATTERN = "^(\\w+)[\\s]*?(?:\\:(?:[\\s]*(?:(AMP)|(GAIN)|(DIPLOID)|(HETLOSS)|(HOMDEL))\\b)+)?$";
 
     public class SingleGeneQuery implements Serializable {
         private String hugoGeneSymbol;

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -362,7 +362,7 @@ public class StudyViewFilterApplier {
                     }
                 }
 
-                List<DiscreteCopyNumberData> resultList = DiscreteCopyNumberEventType.HOMDEL_AND_AMP
+                List<DiscreteCopyNumberData> resultList = DiscreteCopyNumberEventType.ALL
                         .getAlterationTypes().stream().flatMap(alterationType -> {
 
                             List<SingleGeneQuery> filteredGeneQueries = geneQueries.stream()


### PR DESCRIPTION
Fix #7870

Describe changes proposed in this pull request:
- There is an existing filter that is used for the CNA table in the study view: `geneFilters`
- This filter only supports CNA alts of -2, or 2.
- This PR improves the logic for the service method that backs this filter so that it can filter by -2, -1, 0, 1, 2
