### PR TITLE
Optimize mutation count by keyword calculation

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
@@ -116,7 +116,7 @@ public class ImportExtendedMutationData{
 
         Map<ExtendedMutation,ExtendedMutation> mutations = new HashMap<ExtendedMutation,ExtendedMutation>();
         long mutationEventId = DaoMutation.getLargestMutationEventId();
-        
+
         List<AlleleSpecificCopyNumber> ascnRecords = new ArrayList<AlleleSpecificCopyNumber>();
 
         FileReader reader = new FileReader(mutationFile);
@@ -487,8 +487,8 @@ public class ImportExtendedMutationData{
                 throw ex;
             }
         }
- 
-        for (AlleleSpecificCopyNumber ascn : ascnRecords) { 
+
+        for (AlleleSpecificCopyNumber ascn : ascnRecords) {
             try {
                 DaoAlleleSpecificCopyNumber.addAlleleSpecificCopyNumber(ascn);
             } catch (DaoException ex) {
@@ -515,6 +515,7 @@ public class ImportExtendedMutationData{
         }
         // the mutation count by keyword is on a per genetic profile basis so
         // fine to calculate for any genetic profile
+        ProgressMonitor.setCurrentMessage("Calculating mutation counts by keyword...");
         DaoMutation.calculateMutationCountByKeyword(geneticProfileId);
 
         if( MySQLbulkLoader.isBulkLoad()) {


### PR DESCRIPTION
Fix # (see https://help.github.com/en/articles/closing-issues-using-keywords)
Improves runtime for calculation of mutation count by keyword during import.


Current implementation of this calculation is extremely time consuming
for studies with large and/or multiple MAFs.

With the changes in this PR the runtime for the calculation is reduced
from greater than 60 minutes to approximately 18 minutes for the
mskimpact study.

In short the changes in this PR implement the use of the bulk loader as
well as a step that pre-calculates the gene counts and mutation keyword
counts for the current study being imported before creating the insert
statements with the bulk loader and executing the import.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>


# Checks
- [ ] Runs on heroku
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
