### PR TITLE
Backend changes to detect noauthsessionservice for e2e group tests

### DIFF
--- a/web/src/main/java/org/cbioportal/web/SessionServiceController.java
+++ b/web/src/main/java/org/cbioportal/web/SessionServiceController.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.HashSet;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.Size;
@@ -66,6 +67,9 @@ public class SessionServiceController {
     @Value("${session.service.password:}")
     private String sessionServicePassword;
 
+    @Value("${authenticate:}")
+    private String authenticate;
+
     private Boolean isBasicAuthEnabled() {
         return isSessionServiceEnabled() && sessionServicePassword != null && !sessionServicePassword.equals("");
     }
@@ -93,6 +97,12 @@ public class SessionServiceController {
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         return !(authentication == null || (authentication instanceof AnonymousAuthenticationToken));
+    }
+
+    private boolean isNoAuthSessionServiceActive() {
+        if (authenticate.equals("noauthsessionservice"))
+            return true;
+        return false;
     }
 
     private String userName() {
@@ -297,10 +307,9 @@ public class SessionServiceController {
     public ResponseEntity<List<VirtualStudy>> fetchUserGroups(
             @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE) @RequestBody List<String> studyIds,
             HttpServletResponse response) throws IOException {
+        if ((isSessionServiceEnabled() && isAuthorized()) || isNoAuthSessionServiceActive()) {
+            String username = isNoAuthSessionServiceActive() ? "anonymous" : userName();
 
-        if (isSessionServiceEnabled() && isAuthorized()) {
-
-            String username = userName();
             Map<String, Object> map = new HashMap<>();
             map.put("data.owner", username);
             map.put("data.origin", studyIds);
@@ -370,26 +379,35 @@ public class SessionServiceController {
     public void updateSession(@PathVariable SessionType type, @PathVariable String id, @RequestBody JSONObject body,
             HttpServletResponse response) throws IOException {
 
-        if (isAuthorized()) {
+        if (isNoAuthSessionServiceActive() || isAuthorized()) {
 
             ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
                     false);
 
             Session session = getSession(type, id, response).getBody();
-
             if (session.getType().equals(SessionType.group)) {
 
                 VirtualStudy virtualStudy = mapper.readValue(mapper.writeValueAsString(session), VirtualStudy.class);
 
                 VirtualStudyData virtualStudyData = virtualStudy.getData();
+
                 // only allow owner to update virtual study
-                if (userName().equals(virtualStudyData.getOwner()) && virtualStudy.getType().equals(type)) {
+                String username = isNoAuthSessionServiceActive() ? "anonymous" : userName();
+                if (isNoAuthSessionServiceActive() || (username.equals(virtualStudyData.getOwner()) && virtualStudy.getType().equals(type))) {
 
                     VirtualStudyData updatedVirtualStudyData = mapper.readValue(body.toString(),
                             VirtualStudyData.class);
                     updatedVirtualStudyData.setCreated(virtualStudyData.getCreated());
-                    updatedVirtualStudyData.setOwner(virtualStudyData.getOwner());
-                    updatedVirtualStudyData.setUsers(virtualStudyData.getUsers());
+                    if (isNoAuthSessionServiceActive()) {
+                        updatedVirtualStudyData.setOwner("anonymous");
+                        Set<String> users = new HashSet<String>();
+                        users.add("anonymous");
+                        updatedVirtualStudyData.setUsers(users);
+                    }
+		    else {
+                        updatedVirtualStudyData.setOwner(virtualStudyData.getOwner());
+                        updatedVirtualStudyData.setUsers(virtualStudyData.getUsers());
+		    }
 
                     virtualStudy.setData(mapper.writeValueAsString(updatedVirtualStudyData));
                     RestTemplate restTemplate = new RestTemplate();
@@ -397,8 +415,8 @@ public class SessionServiceController {
 
                     restTemplate.put(sessionServiceURL + type + "/" + id, httpEntity);
                     response.setStatus(HttpStatus.OK.value());
-                } else {
-
+                }
+                else {
                     response.setStatus(HttpStatus.UNAUTHORIZED.value());
                 }
             } else {


### PR DESCRIPTION
Added necessary changes to backend SessionServiceController in order to have the e2e tests for groups working when noauthsessionservice is used.

This way the /group/id and /groups/fetch controllers will work when noauthsessionservice is used instead of returning error 503.