### PR TITLE
Updates to fix SerializerException when running EhCache

### DIFF
--- a/model/src/main/java/org/cbioportal/model/ClinicalEventSample.java
+++ b/model/src/main/java/org/cbioportal/model/ClinicalEventSample.java
@@ -1,8 +1,9 @@
 package org.cbioportal.model;
 
 import java.util.Objects;
+import java.io.Serializable;
 
-public class ClinicalEventSample {
+public class ClinicalEventSample implements Serializable {
     private String patientId;
     private String sampleId;
     private String studyId;

--- a/model/src/main/java/org/cbioportal/model/Treatment.java
+++ b/model/src/main/java/org/cbioportal/model/Treatment.java
@@ -1,6 +1,8 @@
 package org.cbioportal.model;
 
-public class Treatment {
+import java.io.Serializable;
+
+public class Treatment implements Serializable {
     private String treatment;
     private String studyId;
     private String patientId;


### PR DESCRIPTION
Exceptions are being thrown in an EhCache enabled  backend due to missed _implements Serializable_ interface declarations for both Treatment & ClinicalEventSample.java.


`Caused by: java.io.NotSerializableException: org.cbioportal.model.Treatment
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at java.util.ArrayList.writeObject(ArrayList.java:762)
	at sun.reflect.GeneratedMethodAccessor137.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.io.ObjectStreamClass.invokeWriteObject(ObjectStreamClass.java:1028)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1496)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at java.util.HashMap.internalWriteEntries(HashMap.java:1785)
	at java.util.HashMap.writeObject(HashMap.java:1362)
	at sun.reflect.GeneratedMethodAccessor352.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.io.ObjectStreamClass.invokeWriteObject(ObjectStreamClass.java:1028)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1496)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at org.ehcache.impl.serialization.PlainJavaSerializer.serialize(PlainJavaSerializer.java:49)
`
