### PR TITLE
Add redission clash warnings

### DIFF
--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -348,6 +348,7 @@ cBioPortal is supported on the backend with Ehcache or Redis. These caches are c
 
 The cache type is set using `persistence.cache_type`. Valid values are `no-cache`, `redis` (redis), `ehache-heap` (ehcache heap-only), `ehache-disk` (ehcache disk-only), and `ehache-hybrid` (ehcache disk + heap). By default, `persistence.cache_type` is set to `no-cache` which disables the cache. When the cache is disabled, no responses will be stored in the cache.
 
+:warning: the 'redis' caching option will likely cause a conflict when installing the portal in a tomcat installation which uses redisson for session management
 ```
 persistence.cache_type=[no-cache or ehache-heap or ehcache-disk or ehcache-hybrid or redis]
 ```

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -253,6 +253,7 @@ oncoprint.hotspots.default=true
 # querypage.setsofgenes.location=file:/<path>
 
 # valid cache types are (ehcache-heap, ehcache-disk, ehcache-hybrid, redis), or use 'no-cache' to disable caching
+# caution : the 'redis' caching option will likely cause a conflict when installing the portal in a tomcat installation which uses redisson for session management
 persistence.cache_type=no-cache
 # Enable cache statistics endpoint for cache monitoring
 #cache.statistics_endpoint_enabled=false


### PR DESCRIPTION
Add warning that using the redis cache type option will likely lead to clashes when deploying to an installed tomcat which uses redission for session management.

