### PR TITLE
add integration test to load study_es_0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,10 @@ env:
   - MAVEN_VERSION=3.5.4 TEST=python-validator
   - MAVEN_VERSION=3.5.4 TEST=sanity-checks
   - MAVEN_VERSION=3.5.4 TEST=end-to-end
+  - MAVEN_VERSION=3.5.4 TEST=integration-test-load-study
 install:
 - |
-  if [[ "${TEST}" == core || "${TEST}" == end-to-end ]]
+  if [[ "${TEST}" == core || "${TEST}" == end-to-end  || "${TEST}" == integration-test-load-study ]]
   then
       mkdir -p ~/maven
       test -d ~/maven/$MAVEN_VERSION/bin || { \
@@ -74,7 +75,7 @@ script:
           integration-test
   fi
 - |
-  if [[ "${TEST}" == end-to-end ]]
+  if [[ "${TEST}" == end-to-end || "${TEST}" == integration-test-load-study ]]
   then
       ~/maven/$MAVEN_VERSION/bin/mvn \
           -q \
@@ -96,4 +97,28 @@ script:
       # spot visual regression by comparing screenshots in the repo with
       # screenshots of this portal loaded with the data from the amazon db
       bash test/end-to-end/test_make_screenshots.sh test/end-to-end/screenshots.yml
+  fi
+- |
+  if [[ "${TEST}" == integration-test-load-study ]]
+  then
+      # test for loading study_es_0 on a complete working instance
+      # download compose and init
+      git clone https://github.com/cBioPortal/cbioportal-docker-compose.git && \
+      cd cbioportal-docker-compose && bash init.sh
+
+      # creates cbioportal container with local maven build
+      docker-compose -f docker-compose.yml -f ../test/integration/docker-compose-localbuild.yml up -d
+
+      # wait for up to 15m until all services are up and running
+      for i in {1..30}; do
+          [[ $(curl -sf http://localhost:8080/api/health) ]] && { healthy=1; break; } || echo "Waiting for cBioPortal services..."
+          sleep 30s
+      done
+      [ -z "$healthy" ] && { echo "Error starting cBioPortal services."; exit 1; } || echo "Successful deploy."
+
+      # load gene panels and study_es_0
+      bash ../test/integration/test_load_study.sh
+
+      # back to main dir
+      cd -
   fi

--- a/test/integration/docker-compose-localbuild.yml
+++ b/test/integration/docker-compose-localbuild.yml
@@ -1,0 +1,12 @@
+# this YAML file overrides settings in the cbioportal-docker-compose YAML
+# and maps a local maven build to appropriate locations in the container (which is retrieved by image).
+
+version: '3'
+
+services:
+  cbioportal:
+    command: /bin/sh -c "java -Xms2g -Xmx4g -Dauthenticate=noauthsessionservice -Dsession.service.url=http://cbioportal_session:5000/api/sessions/my_portal/ -jar webapp-runner.jar -AmaxHttpHeaderSize=16384 -AconnectionTimeout=20000 --enable-compression /app.war"
+    volumes:
+     - ./portalinfo/:/portalinfo/
+     - ../:/cbioportal
+     - ../portal/target/cbioportal.war:/app.war

--- a/test/integration/test_load_study.sh
+++ b/test/integration/test_load_study.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# exit when any of these fails
+set -e
+
+run_in_service() {
+    service=$1
+    shift
+    docker-compose -f docker-compose.yml -f ../test/integration/docker-compose-localbuild.yml \
+        run --rm \
+        "$service" bash -c "$@"
+}
+
+# load panels
+echo "Testing the loading of gene panels..."
+run_in_service cbioportal "cd /cbioportal/core/src/main/scripts/ && perl importGenePanel.pl --data \
+                          /cbioportal/core/src/test/scripts/test_data/study_es_0/data_gene_panel_testpanel1.txt"
+run_in_service cbioportal "cd /cbioportal/core/src/main/scripts/ && perl importGenePanel.pl --data \
+                          /cbioportal/core/src/test/scripts/test_data/study_es_0/data_gene_panel_testpanel2.txt"
+
+# dump portal info
+echo "Testing the dump of local portal info directory..."
+run_in_service cbioportal 'cd cbioportal/core/src/main/scripts/ && perl dumpPortalInfo.pl /portalinfo'
+
+# validate study_es_0 using local portal info directory
+echo "Testing validation based on local portalinfo..."
+run_in_service cbioportal 'validateData.py -v -p /portalinfo -s /cbioportal/core/src/test/scripts/test_data/study_es_0/'
+
+# load study_es_0 using API validation
+echo "Testing loading of study with API validation..."
+run_in_service cbioportal 'metaImport.py -v -u http://cbioportal:8080 -o -s /cbioportal/core/src/test/scripts/test_data/study_es_0/'
+
+exit 0


### PR DESCRIPTION
This PR adds an integration test for the loading of `study_es_0` and associated gene panels, based on a local portal dump, and using the `cbioportal-docker-compose` solution.
To ensure the local repository is used instead of the docker image, we override the war file.