### PR TITLE
Treatments API Tweaks

### DIFF
--- a/model/src/main/java/org/cbioportal/model/TemporalRelation.java
+++ b/model/src/main/java/org/cbioportal/model/TemporalRelation.java
@@ -2,6 +2,5 @@ package org.cbioportal.model;
 
 public enum TemporalRelation {
     Pre,
-    Post,
-    Unknown
+    Post
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/TreatmentRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/TreatmentRepository.java
@@ -19,5 +19,8 @@ public interface TreatmentRepository {
     public Set<String> getAllUniqueTreatments(List<String> sampleIds, List<String> studyIds);
 
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
-    public Integer getTreatmentCount(List<String> samples, List<String> studies);
+    public Integer getTreatmentCount(List<String> studies);
+
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    public Integer getSampleCount(List<String> studies);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/TreatmentMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/TreatmentMapper.java
@@ -14,4 +14,6 @@ public interface TreatmentMapper {
     Set<String> getAllUniqueTreatments(List<String> sampleIds, List<String> studyIds);
 
     Integer getTreatmentCount(List<String> sampleIds, List<String> studyIds);
+
+    Integer getSampleCount(List<String> sampleIds, List<String> studyIds);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/TreatmentMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/TreatmentMyBatisRepository.java
@@ -38,7 +38,12 @@ public class TreatmentMyBatisRepository implements TreatmentRepository {
     }
 
     @Override
-    public Integer getTreatmentCount(List<String> samples, List<String> studies) {
-        return treatmentMapper.getTreatmentCount(samples, studies);
+    public Integer getTreatmentCount(List<String> studies) {
+        return treatmentMapper.getTreatmentCount(null, studies);
+    }
+
+    @Override
+    public Integer getSampleCount(List<String> studies) {
+        return treatmentMapper.getSampleCount(null, studies);
     }
 }

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/TreatmentMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/TreatmentMapper.xml
@@ -5,7 +5,7 @@
     <select id="getAllTreatments" resultType="org.cbioportal.model.Treatment">
         SELECT
             clinical_event_data.VALUE as treatment,
-            clinical_event.PATIENT_ID as patientId,
+            patient.STABLE_ID as patientId,
             cancer_study.CANCER_STUDY_IDENTIFIER as studyId,
             clinical_event.START_DATE as start,
             clinical_event.STOP_DATE as stop
@@ -22,7 +22,7 @@
     <select id="getAllSamples" resultType="org.cbioportal.model.ClinicalEventSample">
         SELECT
             sample.STABLE_ID as sampleId,
-            clinical_event.PATIENT_ID as patientId,
+            patient.STABLE_ID as patientId,
             cancer_study.CANCER_STUDY_IDENTIFIER as studyId,
             clinical_event.START_DATE as timeTaken
         FROM
@@ -60,6 +60,20 @@
             INNER JOIN cancer_study ON patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
         <include refid="where"/>
             AND clinical_event_data.KEY = "AGENT"
+    </select>
+
+    <select id="getSampleCount" resultType="java.lang.Integer">
+        SELECT
+            COUNT(sample.STABLE_ID)
+        FROM
+            clinical_event
+            INNER JOIN clinical_event_data ON clinical_event.CLINICAL_EVENT_ID = clinical_event_data.CLINICAL_EVENT_ID
+            INNER JOIN patient ON clinical_event.PATIENT_ID = patient.INTERNAL_ID
+            INNER JOIN sample ON patient.INTERNAL_ID = sample.PATIENT_ID
+            INNER JOIN cancer_study ON patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
+        <include refid="where"/>
+            AND clinical_event_data.KEY = "SAMPLE_ID"
+            AND clinical_event.EVENT_TYPE != "SEQUENCING"
     </select>
     
 

--- a/service/src/main/java/org/cbioportal/service/TreatmentService.java
+++ b/service/src/main/java/org/cbioportal/service/TreatmentService.java
@@ -8,5 +8,6 @@ import org.cbioportal.model.SampleTreatmentRow;
 public interface TreatmentService {
     public List<SampleTreatmentRow> getAllSampleTreatmentRows(List<String> samples, List<String> studies);
     public List<PatientTreatmentRow> getAllPatientTreatmentRows(List<String> samples, List<String> studies);
-    public Boolean containsTreatmentData(List<String> samples, List<String> studies);
+    public Boolean containsTreatmentData(List<String> studies);
+    public Boolean containsSampleTreatmentData(List<String> studyIds);
 }

--- a/web/src/main/java/org/cbioportal/web/TreatmentController.java
+++ b/web/src/main/java/org/cbioportal/web/TreatmentController.java
@@ -9,6 +9,7 @@ import org.cbioportal.service.TreatmentService;
 import org.cbioportal.web.config.annotation.PublicApi;
 import org.cbioportal.web.parameter.*;
 import org.cbioportal.web.util.StudyViewFilterApplier;
+import org.cbioportal.web.util.StudyViewFilterUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -19,15 +20,18 @@ import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Size;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @PublicApi
 @RestController
 @Validated
 @Api(tags = "Treatments", description = " ")
 public class TreatmentController {
+    @Autowired
+    private StudyViewFilterUtil filterUtil;
 
     @Autowired
     private TreatmentService treatmentService;
@@ -54,12 +58,10 @@ public class TreatmentController {
         StudyViewFilter interceptedStudyViewFilter
     ) {
         List<SampleIdentifier> sampleIdentifiers = studyViewFilterApplier.apply(interceptedStudyViewFilter);
-        List<String> sampleIds = sampleIdentifiers.stream()
-            .map(SampleIdentifier::getSampleId)
-            .collect(Collectors.toList());
-        List<String> studyIds = sampleIdentifiers.stream()
-            .map(SampleIdentifier::getStudyId)
-            .collect(Collectors.toList());
+        List<String> sampleIds = new ArrayList<>();
+        List<String> studyIds = new ArrayList<>();
+        filterUtil.extractStudyAndSampleIds(sampleIdentifiers, studyIds, sampleIds);
+        
         List<PatientTreatmentRow> treatments = treatmentService.getAllPatientTreatmentRows(sampleIds, studyIds);
         return new ResponseEntity<>(treatments, HttpStatus.OK);
     }
@@ -84,42 +86,37 @@ public class TreatmentController {
         StudyViewFilter interceptedStudyViewFilter
     ) {
         List<SampleIdentifier> sampleIdentifiers = studyViewFilterApplier.apply(interceptedStudyViewFilter);
-        List<String> sampleIds = sampleIdentifiers.stream()
-            .map(SampleIdentifier::getSampleId)
-            .collect(Collectors.toList());
-        List<String> studyIds = sampleIdentifiers.stream()
-            .map(SampleIdentifier::getStudyId)
-            .collect(Collectors.toList());
+        List<String> sampleIds = new ArrayList<>();
+        List<String> studyIds = new ArrayList<>();
+        filterUtil.extractStudyAndSampleIds(sampleIdentifiers, studyIds, sampleIds);
+        
         List<SampleTreatmentRow> treatments = treatmentService.getAllSampleTreatmentRows(sampleIds, studyIds);
         return new ResponseEntity<>(treatments, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
-    @RequestMapping(value = "/treatments/display", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation("Should sample level treatments be displayed")
+    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', 'read')")
+    @RequestMapping(value = "/treatments/display-patient", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Should patient level treatments be displayed")
     public ResponseEntity<Boolean> getContainsTreatmentData(
-        @ApiParam(required = true, value = "Study view filter")
-        @Valid
-        @RequestBody(required = false)
-            StudyViewFilter studyViewFilter,
-
-        @ApiIgnore // prevent reference to this attribute in the swagger-ui interface
-        @RequestAttribute(required = false, value = "involvedCancerStudies")
-            Collection<String> involvedCancerStudies,
-
-        @ApiIgnore // prevent reference to this attribute in the swagger-ui interface. this attribute is needed for the @PreAuthorize tag above.
-        @Valid
-        @RequestAttribute(required = false, value = "interceptedStudyViewFilter")
-            StudyViewFilter interceptedStudyViewFilter
+        @ApiParam(required = true, value = "List of Study IDs")
+        @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
+        @RequestBody
+        List<String> studyIds
     ) {
-        List<SampleIdentifier> sampleIdentifiers = studyViewFilterApplier.apply(interceptedStudyViewFilter);
-        List<String> sampleIds = sampleIdentifiers.stream()
-            .map(SampleIdentifier::getSampleId)
-            .collect(Collectors.toList());
-        List<String> studyIds = sampleIdentifiers.stream()
-            .map(SampleIdentifier::getStudyId)
-            .collect(Collectors.toList());
-        Boolean containsTreatmentData = treatmentService.containsTreatmentData(sampleIds, studyIds);
+        Boolean containsTreatmentData = treatmentService.containsTreatmentData(studyIds);
+        return new ResponseEntity<>(containsTreatmentData, HttpStatus.OK);
+    }
+
+    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', 'read')")
+    @RequestMapping(value = "/treatments/display-sample", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Should sample level treatments be displayed")
+    public ResponseEntity<Boolean> getContainsSampleTreatmentData(
+        @ApiParam(required = true, value = "List of Study IDs")
+        @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
+        @RequestBody
+        List<String> studyIds
+    ) {
+        Boolean containsTreatmentData = treatmentService.containsSampleTreatmentData(studyIds);
         return new ResponseEntity<>(containsTreatmentData, HttpStatus.OK);
     }
 }

--- a/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
+++ b/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
@@ -110,7 +110,6 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
     public static final String GENERIC_ASSAY_DATA_MULTIPLE_STUDY_FETCH_PATH = "/generic_assay_data/fetch";
     public static final String GENERIC_ASSAY_META_FETCH_PATH = "/generic_assay_meta/fetch";
     public static final String TREATMENTS_PATIENT_PATH = "/treatments/patient";
-    public static final String TREATMENTS_PATIENT_EXISTS_PATH = "/treatments/display";
     public static final String TREATMENTS_SAMPLE_PATH = "/treatments/sample";
     public static final String GENERIC_ASSAY_ENRICHMENT_FETCH_PATH = "/generic-assay-enrichments/fetch";
 
@@ -148,8 +147,7 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
         } else if (Arrays.asList(STUDY_VIEW_CLINICAL_DATA_DENSITY_PATH, STUDY_VIEW_CNA_GENES,
                 STUDY_VIEW_FILTERED_SAMPLES, STUDY_VIEW_MUTATED_GENES, STUDY_VIEW_FUSION_GENES,
                 STUDY_VIEW_SAMPLE_COUNTS, STUDY_VIEW_SAMPLE_LIST_COUNTS_PATH,
-                TREATMENTS_PATIENT_PATH, TREATMENTS_SAMPLE_PATH,
-                TREATMENTS_PATIENT_EXISTS_PATH
+                TREATMENTS_PATIENT_PATH, TREATMENTS_SAMPLE_PATH
         ).contains(requestPathInfo)) {
             return extractAttributesFromStudyViewFilter(request);
         } else if (requestPathInfo.equals(CLINICAL_DATA_ENRICHMENT_FETCH_PATH)) {

--- a/web/src/test/java/org/cbioportal/web/TreatmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/TreatmentControllerTest.java
@@ -139,18 +139,18 @@ public class TreatmentControllerTest {
 
     @Test
     public void getContainsTreatmentData() throws Exception {
+        List<String> studies = Arrays.asList("study_0", "study_1");
         Mockito
             .when(studyViewFilterApplier.apply(Mockito.any()))
             .thenReturn(sampleIdentifiers);
 
         Mockito
-            .when(treatmentService.containsTreatmentData(Mockito.anyList(), Mockito.anyList()))
+            .when(treatmentService.containsTreatmentData(Mockito.anyList()))
             .thenReturn(true);
 
-        mockMvc.perform(MockMvcRequestBuilders.post(
-            "/treatments/display")
+        mockMvc.perform(MockMvcRequestBuilders.post("/treatments/display-patient")
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(studyViewFilter)))
+            .content(objectMapper.writeValueAsString(studies)))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.jsonPath("$").value("true"));
     }


### PR DESCRIPTION
Fix #7928

Describe changes proposed in this pull request:
- Add new endpoint for determining if sample treatments should be displayed.
  This needed to be separated because for `gbm_columbia_2019`, sample treatments
  should not be displayed, but patient treatments should.
- Filter out unknown treatments from sample treatments API
- Switch from using internal ID to stable ID for the patient field

