### PR TITLE
add travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
 - |
   if [[ "${TEST}" == core ]]
   then
-      ~/maven/$MAVEN_VERSION/bin/mvn \
+      travis_wait ~/maven/$MAVEN_VERSION/bin/mvn \
           -q \
           -e \
           -U \


### PR DESCRIPTION
Should prevent failing core tests by increasing the reserved time.

https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received