### PR TITLE
GetStop doesn't NPE

### DIFF
--- a/model/src/main/java/org/cbioportal/model/Treatment.java
+++ b/model/src/main/java/org/cbioportal/model/Treatment.java
@@ -34,7 +34,7 @@ public class Treatment implements Serializable {
         this.patientId = patientId;
     }
 
-    public int getStart() {
+    public Integer getStart() {
         return start;
     }
 
@@ -42,7 +42,7 @@ public class Treatment implements Serializable {
         this.start = start;
     }
 
-    public int getStop() {
+    public Integer getStop() {
         return stop;
     }
 


### PR DESCRIPTION
Treatment getStop calculation was getting error in genie portal

```
SLF4J: Failed toString() invocation on an object of type [org.redisson.client.RedisConnection]
Reported exception:
java.lang.NullPointerException
	at org.cbioportal.model.Treatment.getStop(Treatment.java:46)
	at org.cbioportal.model.Treatment.hashCode(Treatment.java:67)
	at java.base/java.lang.Object.toString(Object.java:246)
	at java.base/java.lang.String.valueOf(String.java:2951)
```