### PR TITLE
Report duplicated genes when loading gene panels

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanel.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanel.java
@@ -113,7 +113,7 @@ public class ImportGenePanel extends ConsoleRunnable {
             if (canonicalGenes != null) {
                 DaoGenePanel.addGenePanel(stableId, description, canonicalGenes);
             } else {
-                ProgressMonitor.logWarning("Gene panel " + stableId + " cannot be imported because one or more genes in the panel are not found in the database.");
+                ProgressMonitor.logWarning("Gene panel " + stableId + " cannot be imported because one or more genes in the panel are not found in the database, or are duplicated.");
             }
         }
     }

--- a/core/src/main/java/org/mskcc/cbio/portal/util/GenePanelUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GenePanelUtil.java
@@ -63,6 +63,15 @@ public class GenePanelUtil {
         Set<CanonicalGene> canonicalGenes = new HashSet<>();
         DaoGeneOptimized daoGeneOptimized = DaoGeneOptimized.getInstance();
 
+        //Check if genes are duplicated and report them
+        for (int i = 0; i < genes.length; i++) {
+            for (int j = i + 1 ; j < genes.length; j++) {
+                if (genes[i].equals(genes[j])) {
+                    ProgressMonitor.logWarning("The following gene is duplicated: "+genes[i]);
+                }
+            }
+        }
+
         for (String panelGene : genes) {
             try {
                 long geneId = Long.parseLong(panelGene);


### PR DESCRIPTION
Now if we attempt to import a gene panel with duplicated genes in the `gene_list`, the importer fails to load the panel with the error:

```
Warnings / Errors:
-------------------
0. Gene panel X cannot be imported because one or more genes in the panel are not found in the database.; 1x
```

This PR clarifies this error, adding that the failure on loading the panel can be caused by duplicated genes, and it reports the duplicated genes:
```
Warnings / Errors:
-------------------
0.  Gene panel X cannot be imported because one or more genes in the panel are not found in the database, or are duplicated.; 1x
1.  The following gene is duplicated: KMT2B; 1x
```