### PR TITLE
Compress problematically large request bodies

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GzippedInputStreamRequestWrapper.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GzippedInputStreamRequestWrapper.java
@@ -1,0 +1,72 @@
+package org.mskcc.cbio.portal.util;
+
+import com.google.common.io.CountingInputStream;
+
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.zip.GZIPInputStream;
+
+public class GzippedInputStreamRequestWrapper extends HttpServletRequestWrapper {
+    private final int maxInflatedRequestBodySize;
+    private final CountingInputStream inputStream;
+
+    GzippedInputStreamRequestWrapper(final HttpServletRequest request, int maxInflatedRequestBodySize) throws IOException {
+        super(request);
+        this.maxInflatedRequestBodySize = maxInflatedRequestBodySize;
+        inputStream = new CountingInputStream(new GZIPInputStream(request.getInputStream()));
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        return new ServletInputStream() {
+            @Override
+            public int read() throws IOException {
+                checkByteCount();
+                return inputStream.read();
+            }
+
+            @Override
+            public int readLine(byte[] b, int off, int len) throws IOException {
+                checkByteCount();
+                return super.readLine(b, off, len);
+            }
+
+            @Override
+            public int read(byte[] bytes) throws IOException {
+                checkByteCount();
+                return super.read(bytes);
+            }
+
+            @Override
+            public int read(byte[] bytes, int i, int i1) throws IOException {
+                checkByteCount();
+                return super.read(bytes, i, i1);
+            }
+            
+            private void checkByteCount() throws IOException {
+                if (inputStream.getCount() > maxInflatedRequestBodySize) {
+                    throw new IOException(
+                        "Inflated request body too large (> "
+                            + maxInflatedRequestBodySize
+                            + " bytes)"
+                    );
+                }
+            }
+
+            @Override
+            public void close() throws IOException {
+                super.close();
+                inputStream.close();
+            }
+        };
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        return new BufferedReader(new InputStreamReader(getInputStream()));
+    }
+}

--- a/core/src/main/java/org/mskcc/cbio/portal/util/RequestBodyGZipFilter.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/RequestBodyGZipFilter.java
@@ -1,0 +1,79 @@
+package org.mskcc.cbio.portal.util;
+
+import com.google.common.net.HttpHeaders;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component("requestBodyGZipFilter")
+public class RequestBodyGZipFilter implements Filter {
+    /**
+     * We need to limit the size of the gzipped request bodies to avoid denial of memory attacks.
+     * Because gzip can achieve text compression rates of around 1000x, without a common sense limit for
+     * request body size, it would be very easy to send a request body that, when inflated, consumes the
+     * entirety of a server's memory.
+     */
+    @Value("${request_gzip_body_size_bytes:80000000}")
+    private int maxInflatedRequestBodySize;
+    
+    @Value("${enable_request_body_gzip_compression:false}")
+    private boolean enabled;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        // Nothing to init (Sonar asks you to comment if you leave a method empty)
+    }
+
+    /**
+     * Analyzes servlet request for possible gzipped body.
+     * When Content-Encoding header has "gzip" value and request method is POST, we read all the
+     * gzipped stream and if it has any data unzip it. In case when gzip Content-Encoding header
+     * specified but body is not actually in gzip format we will throw ZipException.
+     *
+     * @param servletRequest  servlet request
+     * @param servletResponse servlet response
+     * @param chain           filter chain
+     * @throws IOException      throws when fails
+     * @throws ServletException thrown when fails
+     */
+    @Override
+    public final void doFilter(
+        final ServletRequest servletRequest,
+        final ServletResponse servletResponse,
+        final FilterChain chain
+    ) throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+        boolean isGzipped = request.getHeader(HttpHeaders.CONTENT_ENCODING) != null
+            && request.getHeader(HttpHeaders.CONTENT_ENCODING).contains("gzip");
+        boolean requestTypeSupported = "POST".equals(request.getMethod());
+
+        if (isGzipped) {
+            if (!enabled) {
+                throw new IllegalStateException(
+                    "Received gzipped request body, but enable_request_body_gzip_compression is not set or is false"
+                );
+            }
+            if (!requestTypeSupported) {
+                throw new IllegalStateException(
+                    "Received request with a Content-Encoding: gzip header and a request method of: " +
+                    request.getMethod()
+                    + " Only POST requests are supported."
+                );
+            }
+
+            request = new GzippedInputStreamRequestWrapper((HttpServletRequest) servletRequest, maxInflatedRequestBodySize);
+        }
+
+        chain.doFilter(request, response);
+    }
+    
+    @Override
+    public final void destroy() {
+        // Nothing to destroy (Sonar asks you to comment if you leave a method empty)
+    }
+}

--- a/core/src/test/java/org/mskcc/cbio/portal/util/TestRequestBodyGZipFilter.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/util/TestRequestBodyGZipFilter.java
@@ -1,0 +1,174 @@
+package org.mskcc.cbio.portal.util;
+
+import com.google.common.net.HttpHeaders;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.HttpMethod;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.stream.Collectors;
+
+public class TestRequestBodyGZipFilter {
+    // This is the byte representation of a gzipped json file with the following contents: {"field":"value"}
+    private static final byte[] GZIPPED_JSON_FILE_BYTES = {
+        31, -117, 8, 8, -58, -49, -50, 95, 0, 3, 103, 122, 105, 112, 95, 102, 105, 108, 116, 101, 114, 46, 106, 115,
+        111, 110, 0, -85, 86, 74, -53, 76, -51, 73, 81, -78, 82, 42, 75, -52, 41, 77, 85, -86, -27, 2, 0, 47, 99,
+        109, 9, 18, 0, 0, 0
+    };
+
+    /**
+     * When I filter a request that doesn't have the gzip header,
+     * the request should not be wrapped, and chain.doFilter should
+     * be called on the same request object passed to the method.
+     */
+    @Test
+    public void testDoFilterEnabledNotGZipped() throws Exception {
+        RequestBodyGZipFilter subject = createRequestBodyGZipFilter(true, 50000000);
+
+        HttpServletRequest request = createHttpServletRequest(null, HttpMethod.POST);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        subject.doFilter(request, response, chain);
+        
+        // request should not be wrapped
+        Mockito.verify(chain, Mockito.times(1)).doFilter(request, response);
+    }
+
+    /**
+     * When I filter a request that has the gzip header, but the gzip
+     * feature is disabled, the doFilter method should throw an exception.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testDoFilterDisabledGZipped() throws Exception {
+        RequestBodyGZipFilter subject = createRequestBodyGZipFilter(false, 50000000);
+
+        HttpServletRequest request = createHttpServletRequest("gzip", HttpMethod.POST);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        subject.doFilter(request, response, chain);
+    }
+
+    /**
+     * When I filter a request that has the gzip header and the gzip
+     * feature is enabled, but the method is something other than POST,
+     * the doFilter method should throw an exception.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testDoFilterEnabledGZippedBadMethod() throws Exception {
+        RequestBodyGZipFilter subject = createRequestBodyGZipFilter(true, 50000000);
+
+        HttpServletRequest request = createHttpServletRequest("gzip", HttpMethod.GET);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        subject.doFilter(request, response, chain);
+    }
+
+    /**
+     * When I filter a request that has the gzip header and the gzip
+     * feature is enabled and the method is POST, the doFilter method
+     * should wrap the request with a GzippedInputStreamWrapper.
+     * The BufferedReader for this GzippedInputStreamWrapper should return
+     * the contents of the gzipped file used to create the original input stream.
+     */
+    @Test
+    public void testDoFilterEnabledGZipped() throws Exception {
+        RequestBodyGZipFilter subject = createRequestBodyGZipFilter(true, 50000000);
+        
+        GzippedJsonFileInputStream stream = new GzippedJsonFileInputStream();
+        HttpServletRequest request = createHttpServletRequest("gzip", HttpMethod.POST);
+        Mockito.when(request.getInputStream()).thenReturn(stream);
+        
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        FilterChain chain = Mockito.mock(FilterChain.class);
+        
+        subject.doFilter(request, response, chain);
+
+        // Request should be wrapped, so the request should now be a GzippedInputStreamWrapper
+        ArgumentCaptor<GzippedInputStreamRequestWrapper> requestArg =
+            ArgumentCaptor.forClass(GzippedInputStreamRequestWrapper.class);
+        ArgumentCaptor<HttpServletResponse> responseArg = ArgumentCaptor.forClass(HttpServletResponse.class);
+        Mockito.verify(chain, Mockito.times(1)).doFilter(requestArg.capture(), responseArg.capture());
+        GzippedInputStreamRequestWrapper wrappedStream = requestArg.getValue();
+        
+        String actualRequestBody = wrappedStream.getReader().lines().collect(Collectors.joining());
+        String expectedRequestBody = "{\"field\":\"value\"}";
+        Assert.assertEquals(expectedRequestBody, actualRequestBody);
+    }
+
+    /**
+     * When I filter a request that has the gzip header and the gzip
+     * feature is enabled and the method is POST, but the unzipped message
+     * body is larger than maxInflatedRequestBodySize, the doFilter method
+     * should wrap the request with a GzippedInputStreamWrapper.
+     * The BufferedReader for this GzippedInputStreamWrapper should throw an
+     * IOException as it is read. This exception gets turned into
+     * an UncheckedIOException by something, so we'll check for that instead.
+     */
+    @Test(expected = UncheckedIOException.class)
+    public void testDoFilterEnabledGZippedButTooLong() throws Exception {
+        RequestBodyGZipFilter subject = createRequestBodyGZipFilter(true, 1);
+
+        GzippedJsonFileInputStream stream = new GzippedJsonFileInputStream();
+        HttpServletRequest request = createHttpServletRequest("gzip", HttpMethod.POST);
+        Mockito.when(request.getInputStream()).thenReturn(stream);
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        FilterChain chain = Mockito.mock(FilterChain.class);
+        
+        subject.doFilter(request, response, chain);
+
+        // Request should be wrapped, so the request should now be a GzippedInputStreamWrapper
+        ArgumentCaptor<GzippedInputStreamRequestWrapper> requestArg =
+            ArgumentCaptor.forClass(GzippedInputStreamRequestWrapper.class);
+        ArgumentCaptor<HttpServletResponse> responseArg = ArgumentCaptor.forClass(HttpServletResponse.class);
+        Mockito.verify(chain, Mockito.times(1)).doFilter(requestArg.capture(), responseArg.capture());
+        GzippedInputStreamRequestWrapper wrappedStream = requestArg.getValue();
+
+        //this should cause an IOException
+        wrappedStream.getReader().lines().collect(Collectors.joining());
+    }
+
+
+    private RequestBodyGZipFilter createRequestBodyGZipFilter(boolean enabled, int requestBodySize) {
+        RequestBodyGZipFilter subject = new RequestBodyGZipFilter();
+        ReflectionTestUtils.setField(subject, "maxInflatedRequestBodySize", requestBodySize);
+        ReflectionTestUtils.setField(subject, "enabled", enabled);
+        return subject;
+    }
+    
+    private HttpServletRequest createHttpServletRequest(String gzip, String httpMethod) {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getHeader(HttpHeaders.CONTENT_ENCODING)).thenReturn(gzip);
+        Mockito.when(request.getMethod()).thenReturn(httpMethod);
+        return request;
+    }
+
+    /**
+     * TestInputStream wraps a FileInputStream so that it can be ServletInputStream
+     * and passed to Filter::doFilter.
+     */
+    private static class GzippedJsonFileInputStream extends ServletInputStream {
+        private final ByteArrayInputStream byteInputStream;
+
+        GzippedJsonFileInputStream() {
+            this.byteInputStream = new ByteArrayInputStream(GZIPPED_JSON_FILE_BYTES);
+        }
+
+        @Override
+        public int read() throws IOException {
+            return byteInputStream.read();
+        }
+    }
+}

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -18,6 +18,7 @@ This page describes the main properties within portal.properties.
 - [Gene sets used for gene querying](#gene-sets-used-for-gene-querying)
 - [Ehcache Settings](#ehcache-settings)
 - [Enable GSVA functionality](#enable-gsva-functionality)
+- [Request Body Compression](#request-body-compression)
 
 # Database Settings
 
@@ -416,3 +417,44 @@ For more information on how Ehcache is implemented in cBioPortal refer to the [C
 ```
 skin.show_gsva=true
 ```
+
+# Request Body Compression
+
+## Background
+Some REST endpoints that the cBioPortal frontend uses have request bodies that scale as your dataset increases. In
+portals where users commonly query more than 100,000 samples, we found that some of these request bodies could
+get as large as 20 Mb. These large request bodies pose a significant problem for users with poor upload speeds - some
+users experienced upload times of more than five minutes for these requests. Request body compression is our temporary 
+solution to this problem. When this feature is toggled on, we compress the request bodies of a few problematic endpoints.
+
+## Properties
+There are two `portal.property` values related to this feature:
+- `enable_request_body_gzip_compression`: when `true`, the feature will be enabled.
+- `request_gzip_body_size_bytes`: the maximum allowable unzipped request body in bytes. Defaults to 80000000 (80 Mb).
+
+## Behavior
+- This is a nonbreaking change. Any consumers of the cBioPortal API you have that send requests with uncompressed request
+bodies will continue to work, regardless of whether you turn this feature on or off.
+- If you turn this feature on, the cBioPortal API will now be able to handle any request with a gzipped request body,
+provided:
+  - It is a POST request.
+  - It has a `Content-Encoding: gzip` header.
+
+## Reasons to Enable This Feature
+- You have studies with tens of thousands of samples.
+- You have users with poor upload speeds (< 1mb up).
+
+## Reasons to Disable This Feature
+- It is harder to debug gzipped requests
+  - Chrome's `copy request as CURL` will not work.
+  - The compressed request body is not human-readable.
+- It is a potential vector for denial of memory attacks.
+  - Any request that has a body that takes significantly more space in memory than it does in the request body is
+    potentially dangerous. We try to mitigate this by limiting the size of the unzipped request body via the
+    `request_gzip_body_size_bytes` property, but at a fundamental level, this is still a concern.
+  - Along these lines, if you do enable this feature, setting `request_gzip_body_size_bytes` to an arbitrarily large
+    number would be unwise.
+- This is not a cure-all for performance issues
+  - Most requests the cBioPortal makes do not have large request bodies, so most requests will not be compressed, and
+    will see no performance improvement.
+  - Users with good upload speeds will see minimal performance improvements, as their upload speed is not a bottleneck.

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -64,6 +64,21 @@
     </listener>
 
     <!-- filters -->
+    
+    <!--
+        This filter is a bit misleading. This is actually an org.mskcc.cbio.portal.util.RequestBodyGZipFilter,
+        not an org.springframework.web.filter.DelegatingFilterProxy. We declare this as DelegatingFilterProxy
+        so that it has access to the application context, which it needs to see if this feature is enabled.
+    -->
+    <filter>
+        <filter-name>requestBodyGZipFilter</filter-name>
+        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>requestBodyGZipFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    
     <filter>
         <filter-name>CorsFilter</filter-name>
         <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>
@@ -77,7 +92,7 @@
         </init-param>
         <init-param>
             <param-name>cors.allowed.headers</param-name>
-            <param-value>Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers</param-value>
+            <param-value>Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers,Content-Encoding</param-value>
         </init-param>
         <!-- expose cors headers defined in HeaderKeyConstants.java -->
         <init-param>

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -114,6 +114,7 @@
             "oncoprint.custom_driver_annotation.tiers.default",
             "ensembl.transcript_url",
             "enable_persistent_cache",
+            "enable_request_body_gzip_compression",
             "query_product_limit",
             "skin.show_gsva",
             "saml.logout.local",

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -327,3 +327,9 @@ ehcache.cache_type=none
 
 # Enable gsva to query
 # skin.show_gsva=true
+
+# Compress some particularly large request bodies. enable_request_body_gzip_compression enables the feature, and
+# request_gzip_body_size_bytes sets the maximum allowable uncompressed request body size in bytes. Requests larger than
+# this value will be rejected. If unset, the default value will be 50000000, or 50 Mb.
+# enable_request_body_gzip_compression=true
+# request_gzip_body_size_bytes=80000000


### PR DESCRIPTION
Fix #8026

Describe changes proposed in this pull request:
Problem:
- Some request bodies were so large (20+ Mb) that they resulted in
significantly degraded performance for people with poor upload speeds

Solution:
- Create RequestBodyGZipFilter. It:
  - Catches requests with a `Content-Encoding: gzip` header
  - Reads and inflates the input stream
  - Prevents excessively large requests from consuming too much memory
- Add filter to web.xml
- Add configurations for filter in portal.properties
  - Feature toggle
  - Inflated request body size limit
- Add Content-Encoding header to list of accepted headers for
Cors filter.
