### PR TITLE
support a non-default MySQL database port in 'mysqladmin ping` command

### DIFF
--- a/docker/web-and-data/docker-entrypoint.sh
+++ b/docker/web-and-data/docker-entrypoint.sh
@@ -37,11 +37,11 @@ check_db_connection() {
     eval "$(parse_db_params_from_config_and_command_line $@ | sed 's/^db\./db_/g')"
     POTENTIAL_DB_PARAMS=$@
 
-    while ! mysqladmin ping -s -h$(echo ${db_host} | cut -d: -f1) -u${db_user} -p${db_password};
+    while ! mysqladmin ping -s -h$(echo ${db_host} | cut -d: -f1) -P$(echo ${db_host} | cut -d: -f2) -u${db_user} -p${db_password};
     do
         sleep 5s;
         if [ -n "$SHOW_DEBUG_INFO" ] && [ "$SHOW_DEBUG_INFO" != "false" ]; then
-            echo mysqladmin ping -s -h$(echo ${db_host} | cut -d: -f1) -u${db_user} -p${db_password}
+            echo mysqladmin ping -s -h$(echo ${db_host} | cut -d: -f1) -P$(echo ${db_host} | cut -d: -f2) -u${db_user} -p${db_password}
         fi
         echo "Database not available yet (first time can take a few minutes to load seed database)... Attempting reconnect..."
     done

--- a/docker/web-and-data/docker-entrypoint.sh
+++ b/docker/web-and-data/docker-entrypoint.sh
@@ -37,11 +37,21 @@ check_db_connection() {
     eval "$(parse_db_params_from_config_and_command_line $@ | sed 's/^db\./db_/g')"
     POTENTIAL_DB_PARAMS=$@
 
-    while ! mysqladmin ping -s -h$(echo ${db_host} | cut -d: -f1) -P$(echo ${db_host} | cut -d: -f2) -u${db_user} -p${db_password};
+    if [ -z ${db_port+x} ] # is $db_port unset?
+    then 
+        if [[ $db_host == *":"* ]]; then # does $db_host contain a ':'?
+            db_port=$(echo ${db_host} | cut -d: -f2) # grab what's after the ':'
+        else
+            db_port="3306" # use default port
+        fi
+    fi
+
+
+    while ! mysqladmin ping -s -h$(echo ${db_host} | cut -d: -f1) -P${db_port} -u${db_user} -p${db_password};
     do
         sleep 5s;
         if [ -n "$SHOW_DEBUG_INFO" ] && [ "$SHOW_DEBUG_INFO" != "false" ]; then
-            echo mysqladmin ping -s -h$(echo ${db_host} | cut -d: -f1) -P$(echo ${db_host} | cut -d: -f2) -u${db_user} -p${db_password}
+            echo mysqladmin ping -s -h$(echo ${db_host} | cut -d: -f1) -P${db_port} -u${db_user} -p${db_password}
         fi
         echo "Database not available yet (first time can take a few minutes to load seed database)... Attempting reconnect..."
     done


### PR DESCRIPTION
Fix # (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- Added port flag (`-P`) to `mysqladmin ping` command in Docker entrypoint script. This was done because at my institution we would like our production deployment to use a MySQL database that is provided by a DBaaS service that we have which creates databases on non-default ports (instead of using a containerized database).

# Checks
- [ ] Runs on heroku
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
