### PR TITLE
Filter patient treatments without using sample treatments

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/TreatmentRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/TreatmentRepository.java
@@ -16,6 +16,9 @@ public interface TreatmentRepository {
     public Map<String, List<ClinicalEventSample>> getSamplesByPatientId(List<String> sampleIds, List<String> studyIds);
 
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    public Map<String, List<ClinicalEventSample>> getShallowSamplesByPatientId(List<String> sampleIds, List<String> studyIds);
+
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     public Set<String> getAllUniqueTreatments(List<String> sampleIds, List<String> studyIds);
 
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/TreatmentMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/TreatmentMapper.java
@@ -10,6 +10,8 @@ public interface TreatmentMapper {
     List<Treatment> getAllTreatments(List<String> sampleIds, List<String> studyIds);
 
     List<ClinicalEventSample> getAllSamples(List<String> sampleIds, List<String> studyIds);
+    
+    List<ClinicalEventSample> getAllShallowSamples(List<String> sampleIds, List<String> studyIds);
 
     Set<String> getAllUniqueTreatments(List<String> sampleIds, List<String> studyIds);
 

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/TreatmentMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/TreatmentMyBatisRepository.java
@@ -32,6 +32,13 @@ public class TreatmentMyBatisRepository implements TreatmentRepository {
             .collect(groupingBy(ClinicalEventSample::getPatientId));
     }
 
+    public Map<String, List<ClinicalEventSample>> getShallowSamplesByPatientId(List<String> sampleIds, List<String> studyIds) {
+        return treatmentMapper.getAllShallowSamples(sampleIds, studyIds)
+            .stream()
+            .distinct()
+            .collect(groupingBy(ClinicalEventSample::getPatientId));
+    }
+
     @Override
     public Set<String> getAllUniqueTreatments(List<String> sampleIds, List<String> studyIds) {
         return treatmentMapper.getAllUniqueTreatments(sampleIds, studyIds);

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/TreatmentMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/TreatmentMapper.xml
@@ -36,6 +36,18 @@
             AND clinical_event.EVENT_TYPE != 'SEQUENCING'
     </select>
 
+    <select id="getAllShallowSamples" resultType="org.cbioportal.model.ClinicalEventSample">
+        SELECT
+            sample.STABLE_ID as sampleId,
+            patient.STABLE_ID as patientId,
+            cancer_study.CANCER_STUDY_IDENTIFIER as studyId
+        FROM
+            sample
+            INNER JOIN patient ON sample.PATIENT_ID = patient.INTERNAL_ID
+            INNER JOIN cancer_study ON patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
+        <include refid="where"/>
+    </select>
+
     <select id="getAllUniqueTreatments" resultType="java.lang.String">
         SELECT 
             DISTINCT clinical_event_data.VALUE

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/TreatmentMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/TreatmentMyBatisRepositoryTest.java
@@ -66,6 +66,27 @@ public class TreatmentMyBatisRepositoryTest {
     }
 
     @Test
+    public void getShallowSamplesByPatientId() {
+        ClinicalEventSample clinicalEventSample = new ClinicalEventSample();
+        clinicalEventSample.setPatientId("TCGA-A1-A0SD");
+        clinicalEventSample.setSampleId("TCGA-A1-A0SD-01");
+        clinicalEventSample.setStudyId("study_tcga_pub");
+        clinicalEventSample.setTimeTaken(213);
+
+        HashMap<String, List<ClinicalEventSample>> expected = new HashMap<>();
+        expected.put("TCGA-A1-A0SD", Collections.singletonList(clinicalEventSample));
+
+
+        Map<String, List<ClinicalEventSample>> actual = treatmentRepository.getShallowSamplesByPatientId(
+            Collections.singletonList("TCGA-A1-A0SD-01"),
+            Collections.singletonList("study_tcga_pub")
+        );
+
+
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
     public void getAllUniqueTreatments() {
         HashSet<String> expected = new HashSet<>(Collections.singletonList("Madeupanib"));
         

--- a/service/src/main/java/org/cbioportal/service/impl/TreatmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/TreatmentServiceImpl.java
@@ -125,7 +125,7 @@ public class TreatmentServiceImpl implements TreatmentService {
     public List<PatientTreatmentRow> getAllPatientTreatmentRows(List<String> sampleIds, List<String> studyIds) {
         Map<String, List<Treatment>> treatmentsByPatient = treatmentRepository.getTreatmentsByPatientId(sampleIds, studyIds);
         Map<String, List<ClinicalEventSample>> samplesByPatient = treatmentRepository
-            .getSamplesByPatientId(sampleIds, studyIds)
+            .getShallowSamplesByPatientId(sampleIds, studyIds)
             .entrySet()
             .stream()
             .filter(e -> treatmentsByPatient.containsKey(e.getKey()))
@@ -142,7 +142,7 @@ public class TreatmentServiceImpl implements TreatmentService {
         Map<String, List<Treatment>> treatmentsByPatient,
         Map<String, List<ClinicalEventSample>> samplesByPatient
     ) {
-        // find all the patients that have received this treatments
+        // find all the patients that have received this treatment
         List<Map.Entry<String, List<Treatment>>> matchingPatients = matchingPatients(treatment, treatmentsByPatient);
 
         // from those patients, extract the unique samples

--- a/service/src/test/java/org/cbioportal/service/impl/TreatmentServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/TreatmentServiceImplTest.java
@@ -257,6 +257,8 @@ public class TreatmentServiceImplTest {
             .collect(Collectors.groupingBy(ClinicalEventSample::getPatientId));
         Mockito.when(treatmentRepository.getSamplesByPatientId(Mockito.any(), Mockito.any()))
             .thenReturn(samplesByPatient);
+        Mockito.when(treatmentRepository.getShallowSamplesByPatientId(Mockito.any(), Mockito.any()))
+            .thenReturn(samplesByPatient);
     }
     
     private void mockAllTreatments(String... treatments) {

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -51,7 +51,6 @@ public class StudyViewFilterApplier {
     private DataBinner dataBinner;
     @Autowired
     private PatientTreatmentFilterApplier patientTreatmentFilterApplier;
-    
     @Autowired
     private SampleTreatmentFilterApplier sampleTreatmentFilterApplier;
 


### PR DESCRIPTION
Fix #8074

Describe changes proposed in this pull request:
- We can show the patient treatment chart without showing the sample treatment chart
- Previously, filtering was breaking in this scenario because we unnecessarily
depended on sample level treatment data when filtering patient level treatment data
- Now it does not break, which is good