### PR TITLE
Fix Scripts Jar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
                 name: Build image and generate checksum of data that populates the test database
                 command: |         
                     $TEST_HOME/local/runtime-config/db_content_fingerprint.sh | tee /tmp/db_data_md5key
+                no_output_timeout: 1h
             - restore_cache:
                 keys:
                     - v4-e2e-database-files-{{ checksum "/tmp/db_data_md5key" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,7 @@ jobs:
             - run:
                 name: Build image and generate checksum of data that populates the test database
                 command: |         
-                    $TEST_HOME/local/runtime-config/db_content_fingerprint.sh > /tmp/db_data_md5key
-                no_output_timeout: 1h
+                    $TEST_HOME/local/runtime-config/db_content_fingerprint.sh | tee /tmp/db_data_md5key
             - restore_cache:
                 keys:
                     - v4-e2e-database-files-{{ checksum "/tmp/db_data_md5key" }}

--- a/scripts/pom.xml
+++ b/scripts/pom.xml
@@ -19,6 +19,11 @@
       <artifactId>core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Describe changes proposed in this pull request:
- This is the first time we've made a servlet filter that uses the
application context. Turns out this breaks the scripts jar, because
that jar doesn't know about the Filter class, and when you run the
importer, it will try to wire up your filter anyways
- Added the javax.servlet dependecy to the scripts jar