### PR TITLE
Fix slow mutation query

### DIFF
--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
@@ -138,7 +138,7 @@
                     </foreach>
                 </if>
                 AND sample.INTERNAL_ID = mutation.SAMPLE_ID
-                AND genetic_profile.GENETIC_PROFILE_ID = mutation.GENETIC_PROFILE_ID)
+                )
             </if>
             <if test="sampleIds == null">
                 genetic_profile.STABLE_ID IN


### PR DESCRIPTION
We had a query that was running very slowly. This PR removes two tautological clauses from the query. The old query looks like this:
```sql
SELECT
	mutation.ENTREZ_GENE_ID AS entrezGeneId,
	gene.HUGO_GENE_SYMBOL AS hugoGeneSymbol,
	COUNT(*) AS totalCount,
	COUNT(DISTINCT(mutation.SAMPLE_ID)) AS numberOfAlteredCases
FROM mutation
	INNER JOIN mutation_event ON mutation_event.MUTATION_EVENT_ID = mutation.MUTATION_EVENT_ID AND mutation_event.MUTATION_TYPE != 'Fusion'
	INNER JOIN genetic_profile ON mutation.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
	INNER JOIN sample ON mutation.SAMPLE_ID = sample.INTERNAL_ID
	INNER JOIN gene ON mutation.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
WHERE
    mutation.SAMPLE_ID IN (
	SELECT
		sample.INTERNAL_ID
	FROM 
		sample
		INNER JOIN patient ON sample.PATIENT_ID = patient.INTERNAL_ID
		INNER JOIN genetic_profile ON patient.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID
	WHERE
		genetic_profile.STABLE_ID = 'ccle_broad_2019_mutations' AND
		sample.STABLE_ID IN ('127399_SOFT_TISSUE', '1321N1_CENTRAL_NERVOUS_SYSTEM')
		AND sample.INTERNAL_ID = mutation.SAMPLE_ID
		AND genetic_profile.GENETIC_PROFILE_ID = mutation.GENETIC_PROFILE_ID
	)
GROUP BY mutation.ENTREZ_GENE_ID
```

The new query is the same, but with these two lines in the nested query removed:
```sql
AND sample.INTERNAL_ID = mutation.SAMPLE_ID
AND genetic_profile.GENETIC_PROFILE_ID = mutation.GENETIC_PROFILE_ID
```

`mutation` in these two lines refers to the entire, unfiltered mutation table. So these two lines effectively say:
> AND the sample's internal_id matches some mutation's sample_id
AND the genetic_profile's genetic_profile_id matches some mutation's genetic_profile_id

This is tautological, because there are already constraints in the database that ensure that those conditions are always true.