### PR TITLE
Fix bug in validator (join integers as strings)

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -876,7 +876,7 @@ class Validator(object):
                 self.logger.error(
                     'Gene symbol maps to multiple Entrez gene ids (%s), '
                     'please specify which one you mean.',
-                    '/'.join(self.portal.hugo_entrez_map[gene_symbol]),
+                    '/'.join(str(entrez) for entrez in self.portal.hugo_entrez_map[gene_symbol]),
                     extra={'line_number': self.line_number,
                           'cause': gene_symbol})
             # no canonical symbol, but a single unambiguous alias


### PR DESCRIPTION
Fix this issue reported in Google Groups: https://groups.google.com/u/0/g/cbioportal/c/CIsHDnL5sTg/m/tAds9rL0AgAJ 

Basically, the validator throws this error:
```
TypeError: sequence item 0: expected str instance, int found
```