### PR TITLE
Modify ClinicalDataBinFilter so Jackson ignores unknown JSON properties

### DIFF
--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataBinFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalDataBinFilter.java
@@ -1,7 +1,10 @@
 package org.cbioportal.web.parameter;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ClinicalDataBinFilter extends DataBinFilter implements Serializable {
 
     private String attributeId;


### PR DESCRIPTION
Fix #7527 
Describe changes proposed in this pull request:
- Added Jackson decorator such that when an ObjectMapper sees an unknown JSON property, it doesn't throw an exception and hence return a null result
