### PR TITLE
add signal to portal.properties

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -291,6 +291,10 @@ public class GlobalProperties {
     @Value("${show.mutation_mappert_tool.grch38:true}") // default is true
     public void setShowMutationMapperToolGrch38(String property) { showMutationMapperToolGrch38 = Boolean.parseBoolean(property); }
 
+    private static boolean showSignal;
+    @Value("${show.signal:false}") // default is false
+    public void setShowSignal(String property) { showSignal = Boolean.parseBoolean(property); }
+
 	/*
      * Trim whitespace of url and append / if it does not exist. Return empty
      * string otherwise.
@@ -932,6 +936,10 @@ public class GlobalProperties {
 
     public static boolean showMutationMapperToolGrch38() {
         return showMutationMapperToolGrch38;
+    }
+
+    public static boolean showSignal() {
+        return showSignal;
     }
 
     public static String getFrontendUrl() {

--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -18,6 +18,7 @@ window.legacySupportFrontendConfig = {
     showGenomeNexus : <%=GlobalProperties.showGenomeNexus()%>,
     showGenomeNexusAnnotationSources : <%=GlobalProperties.showGenomeNexusAnnotationSources()%>,
     showMutationMapperToolGrch38 : <%=GlobalProperties.showMutationMapperToolGrch38()%>,
+    showSignal : <%=GlobalProperties.showSignal()%>,
     querySetsOfGenes : JSON.parse('<%=GlobalProperties.getQuerySetsOfGenes()%>'),
     skinBlurb : '<%=GlobalProperties.getBlurb()%>',
     skinExampleStudyQueries : '<%=GlobalProperties.getExampleStudyQueries().replace("\n","\\n")%>'.split("\n"),

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -63,6 +63,7 @@
             "show.genomenexus.annotation_sources",
             "show.mutation_mappert_tool.grch38",
             "show.transcript_dropdown",
+            "show.signal",
             "survival.show_p_q_values_in_survival_type_table",
             "survival.initial_x_axis_limit",
             "skin.documentation.about",

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -209,6 +209,9 @@ mycancergenome.show=true
 # Available sources: mutation_assessor
 # show.genomenexus.annotation_sources=mutation_assessor
 
+# Enable SIGNAL column in mutations table(true, false)
+# show.signal=false
+
 # igv bam linking
 igv.bam.linking=
 # colon delimited


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/8217

`show.signal` will enable/disable SIGNAL column in mutations table. By default it's set to false. We can set it to true after publishing the paper.