### PR TITLE
add option for excluding redisson client from war

### DIFF
--- a/docs/Build-from-Source.md
+++ b/docs/Build-from-Source.md
@@ -1,6 +1,6 @@
 # Building from Source
 
-## Building with Maven
+## [Building with Maven](building-with-maven)
 
 While building, you must point the environment variable `PORTAL_HOME` to
 the root directory containing the portal source code.
@@ -21,5 +21,20 @@ After this command completes, you will find a `cbioportal.war` file suitable
 for Apache Tomcat deployment in `portal/target/`. It is not neccessary to
 install Tomcat yourself, since a command line runnable version of Tomcat is
 provided as a dependency in `portal/target/dependency/webapp-runner.jar`.
+
+However, if you will be deploying to a standalone Tomcat installation, and
+if you have configured Tomcat to use the Redisson client for user session
+management, you should expect a clash between the Redisson client being
+used for session management and the Redisson client which is embedded in
+the cbioportal.war file for the optional "redis" persitence layer caching
+mode. In this case, you should avoid using the "redis" option for the portal
+property `persistence.cache_type` and you should prevent the Redisson
+client from being packaged in cbioportal.war by building with this command
+instead:
+
+##### alternative for standalone tomcat deployments which use redis session management
+```
+mvn -Dexclude-redisson -DskipTests clean install
+```
 
 [Next Step: Importing the Seed Database](Import-the-Seed-Database.md)

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -372,7 +372,7 @@ cBioPortal is supported on the backend with Ehcache or Redis. These caches are c
 
 The cache type is set using `persistence.cache_type`. Valid values are `no-cache`, `redis` (redis), `ehache-heap` (ehcache heap-only), `ehache-disk` (ehcache disk-only), and `ehache-hybrid` (ehcache disk + heap). By default, `persistence.cache_type` is set to `no-cache` which disables the cache. When the cache is disabled, no responses will be stored in the cache.
 
-:warning: the 'redis' caching option will likely cause a conflict when installing the portal in a tomcat installation which uses redisson for session management
+:warning: the 'redis' caching option will likely cause a conflict when installing the portal in a Tomcat installation which uses redisson for session management. If you plan to deploy cbioportal to such a system, avoid the 'redis' caching option for `persistence.cache_type` and be sure to build cbioportal.war with the maven option `-Dexclude-redisson` (see [Building with Maven](Build-from-Source.md#building-with-maven)).
 ```
 persistence.cache_type=[no-cache or ehache-heap or ehcache-disk or ehcache-hybrid or redis]
 ```

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomRedisCachingProvider.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomRedisCachingProvider.java
@@ -72,7 +72,7 @@ public class CustomRedisCachingProvider {
     @Value("${redis.password}")
     private String password;
 
-    public RedissonClient getRedissionClient() {
+    public RedissonClient getRedissonClient() {
         Config config = new Config();
         LOG.debug("leaderAddress: " + leaderAddress);
         LOG.debug("followerAddress: " + followerAddress);

--- a/persistence/persistence-api/src/main/resources/applicationContext-rediscache.xml
+++ b/persistence/persistence-api/src/main/resources/applicationContext-rediscache.xml
@@ -21,7 +21,7 @@
 
         <bean id="redissonClient" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
             <property name="targetObject" ref="customRedisCacheProvider" />
-            <property name="targetMethod" value="getRedissionClient" />
+            <property name="targetMethod" value="getRedissonClient" />
         </bean>
 
         <bean id="cacheManager" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -124,6 +124,7 @@
         <artifactId>maven-war-plugin</artifactId>
         <version>2.2</version>
         <configuration>
+          <packagingExcludes>${exclude.redisson}</packagingExcludes>
           <warName>${final.war.name}</warName>
           <webappDirectory>${project.build.directory}/portal</webappDirectory>
           <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
@@ -248,7 +249,7 @@
         <filter>../src/main/resources/portal.properties</filter>
         <filter>../src/main/resources/maven.properties</filter>
     </filters>
-    
+
     <!-- prevent some resources from getting into war -->
     <resources>
       <resource>
@@ -292,8 +293,8 @@
     <netbeans.hint.deploy.server>Tomcat</netbeans.hint.deploy.server>
   </properties>
 
-  <!-- remove portal temp build files when building heroku -->
   <profiles>
+    <!-- remove portal temp build files when building heroku -->
     <profile>
       <id>heroku</id>
       <build>
@@ -325,6 +326,21 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <!-- if you are not using redis add '-Dexclude-redisson'
+           to your mvn install/package command
+           to exclude redisson*.jar from the war
+           because it could conflict with any redisson*.jar Tomcat has -->
+      <id>exclude-redisson</id>
+      <properties>
+        <exclude.redisson>WEB-INF/lib/redisson-*.jar</exclude.redisson>
+      </properties>
+      <activation>
+        <property>
+          <name>exclude-redisson</name>
+        </property>
+      </activation>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Building in the redission dependency for the persistence layer caching
causes a conflict when deploying to a standalone tomcat server configured to
use redission for user session management. This change add a maven build
command option to exclude the redission client dependency. Docs are updated.

Co-authored-by: Avery Wang <18199796+averyniceday@users.noreply.github.com>
Co-authored-by: Manda Wilson <1458628+mandawilson@users.noreply.github.com>
Co-authored-by: Robert Sheridan <7747489+sheridancbio@users.noreply.github.com>

# Checks
- [ ] Runs on heroku
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
