### PR TITLE
Skip records with empty driver and tiers fields (custom_driver_annotation table)

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCnaEvent.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCnaEvent.java
@@ -64,7 +64,8 @@ public final class DaoCnaEvent {
                     Integer.toString(cnaEvent.getCnaProfileId())
                     );
 
-            if (cnaEvent.getDriverFilter() != null || cnaEvent.getDriverTiersFilter() != null) {
+            if ((cnaEvent.getDriverFilter() != null && !cnaEvent.getDriverFilter().isEmpty())
+                || (cnaEvent.getDriverTiersFilter() != null && !cnaEvent.getDriverTiersFilter().isEmpty())) {
                 MySQLbulkLoader.getMySQLbulkLoader("alteration_driver_annotation").insertRecord(
                     Long.toString(eventId),
                     Integer.toString(cnaEvent.getCnaProfileId()),

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
@@ -60,7 +60,8 @@ public final class DaoMutation {
                 //add event first, as mutation has a Foreign key constraint to the event:
                 result = addMutationEvent(mutation.getEvent())+1;
             }
-            if (mutation.getDriverFilter() != null || mutation.getDriverTiersFilter() != null) {
+            if ((mutation.getDriverFilter() != null && !mutation.getDriverFilter().isEmpty())
+                || (mutation.getDriverTiersFilter() != null && !mutation.getDriverTiersFilter().isEmpty())) {
                 MySQLbulkLoader.getMySQLbulkLoader("alteration_driver_annotation").insertRecord(
                     Long.toString(mutation.getMutationEventId()),
                     Integer.toString(mutation.getGeneticProfileId()),

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoStructuralVariant.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoStructuralVariant.java
@@ -123,7 +123,8 @@ public class DaoStructuralVariant {
            structuralVariant.getComments(),
            structuralVariant.getExternalAnnotation());
 
-        if (structuralVariant.getDriverFilter() != null || structuralVariant.getDriverTiersFilter() != null) {
+        if ((structuralVariant.getDriverFilter() != null && !structuralVariant.getDriverFilter().isEmpty())
+            || (structuralVariant.getDriverTiersFilter() != null && !structuralVariant.getDriverTiersFilter().isEmpty())) {
             MySQLbulkLoader.getMySQLbulkLoader("alteration_driver_annotation").insertRecord(
                 Long.toString(structuralVariant.getInternalId()),
                 Integer.toString(structuralVariant.getGeneticProfileId()),


### PR DESCRIPTION
## Current behavior
When both DRIVER_FILTER and DRIVER_TIERS_FILTER are empty a record is incorrectly imported into the _custom_driver_annotation_ table.

## Problem
_custom_driver_annotation_ table contains many useless records. This was not according to desired behavior when this feature was created.

## Solution
JAVA importer skips annotations when both DRIVER_FILTER and DRIVER_TIERS_FILTER are 1) null, 2) empty string or 3) 'NA' or 'na'.

Note: I decided not to add this change to migration.sql because the feature is still not announced to the public.