### PR TITLE
Skip records with empty driver and tiers fields (custom_driver_annotation table) -- UPDATED

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCnaEvent.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCnaEvent.java
@@ -64,8 +64,13 @@ public final class DaoCnaEvent {
                     Integer.toString(cnaEvent.getCnaProfileId())
                     );
 
-            if ((cnaEvent.getDriverFilter() != null && !cnaEvent.getDriverFilter().isEmpty())
-                || (cnaEvent.getDriverTiersFilter() != null && !cnaEvent.getDriverTiersFilter().isEmpty())) {
+            if ((cnaEvent.getDriverFilter() != null
+                && !cnaEvent.getDriverFilter().isEmpty()
+                && !cnaEvent.getDriverFilter().toLowerCase().equals("na"))
+                || 
+                (cnaEvent.getDriverTiersFilter() != null
+                && !cnaEvent.getDriverTiersFilter().isEmpty()
+                && !cnaEvent.getDriverTiersFilter().toLowerCase().equals("na"))) {
                 MySQLbulkLoader.getMySQLbulkLoader("alteration_driver_annotation").insertRecord(
                     Long.toString(eventId),
                     Integer.toString(cnaEvent.getCnaProfileId()),

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoMutation.java
@@ -32,17 +32,34 @@
 
 package org.mskcc.cbio.portal.dao;
 
-import org.mskcc.cbio.portal.model.*;
-import org.mskcc.cbio.portal.util.MutationKeywordUtils;
-
-import org.apache.commons.lang.StringUtils;
-
-import java.sql.*;
-import java.util.*;
-import java.util.regex.*;
 import org.apache.commons.collections.MapIterator;
 import org.apache.commons.collections.keyvalue.MultiKey;
 import org.apache.commons.collections.map.MultiKeyMap;
+import org.apache.commons.lang.StringUtils;
+import org.mskcc.cbio.portal.model.CancerStudy;
+import org.mskcc.cbio.portal.model.CanonicalGene;
+import org.mskcc.cbio.portal.model.ClinicalAttribute;
+import org.mskcc.cbio.portal.model.ExtendedMutation;
+import org.mskcc.cbio.portal.model.GeneticAlterationType;
+import org.mskcc.cbio.portal.model.GeneticProfile;
+import org.mskcc.cbio.portal.model.Sample;
+import org.mskcc.cbio.portal.util.MutationKeywordUtils;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Data access object for Mutation table
@@ -60,8 +77,14 @@ public final class DaoMutation {
                 //add event first, as mutation has a Foreign key constraint to the event:
                 result = addMutationEvent(mutation.getEvent())+1;
             }
-            if ((mutation.getDriverFilter() != null && !mutation.getDriverFilter().isEmpty())
-                || (mutation.getDriverTiersFilter() != null && !mutation.getDriverTiersFilter().isEmpty())) {
+
+            if ((mutation.getDriverFilter() != null
+                && !mutation.getDriverFilter().isEmpty()
+                && !mutation.getDriverFilter().toLowerCase().equals("na"))
+                ||
+                (mutation.getDriverTiersFilter() != null
+                && !mutation.getDriverTiersFilter().isEmpty()
+                && !mutation.getDriverTiersFilter().toLowerCase().equals("na"))) {
                 MySQLbulkLoader.getMySQLbulkLoader("alteration_driver_annotation").insertRecord(
                     Long.toString(mutation.getMutationEventId()),
                     Integer.toString(mutation.getGeneticProfileId()),

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoStructuralVariant.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoStructuralVariant.java
@@ -123,8 +123,13 @@ public class DaoStructuralVariant {
            structuralVariant.getComments(),
            structuralVariant.getExternalAnnotation());
 
-        if ((structuralVariant.getDriverFilter() != null && !structuralVariant.getDriverFilter().isEmpty())
-            || (structuralVariant.getDriverTiersFilter() != null && !structuralVariant.getDriverTiersFilter().isEmpty())) {
+        if ((structuralVariant.getDriverFilter() != null
+            && !structuralVariant.getDriverFilter().isEmpty()
+            && !structuralVariant.getDriverFilter().toLowerCase().equals("na"))
+            ||
+            (structuralVariant.getDriverTiersFilter() != null
+            && !structuralVariant.getDriverTiersFilter().isEmpty()
+            && !structuralVariant.getDriverTiersFilter().toLowerCase().equals("na"))) {
             MySQLbulkLoader.getMySQLbulkLoader("alteration_driver_annotation").insertRecord(
                 Long.toString(structuralVariant.getInternalId()),
                 Integer.toString(structuralVariant.getGeneticProfileId()),


### PR DESCRIPTION
Note: one commit in the previous PR with the same title was not included. This PR corrects this. 

## Current behavior
When both DRIVER_FILTER and DRIVER_TIERS_FILTER are empty a record is incorrectly imported into the _custom_driver_annotation_ table.

## Problem
_custom_driver_annotation_ table contains many useless records. This was not according to desired behavior when this feature was created.

## Solution
JAVA importer skips annotations when both DRIVER_FILTER and DRIVER_TIERS_FILTER are 1) null, 2) empty string or 3) 'NA' or 'na'.

Note: I decided not to add this change to migration.sql because the feature is still not announced to the public.