### PR TITLE
Exclude bouncycastle 1.64 from transitive dependencies

### DIFF
--- a/security/security-spring/pom.xml
+++ b/security/security-spring/pom.xml
@@ -45,6 +45,12 @@
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-jwt</artifactId>
         <version>1.0.11.RELEASE</version>
+        <exclusions>
+            <exclusion>
+              <groupId>org.bouncycastle</groupId>
+              <artifactId>bcprov-jdk15on</artifactId>
+            </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.springframework.security.oauth</groupId>


### PR DESCRIPTION
Fix #7993

# Problem
When starting cbioportal occasionally throws a cyclic dependency exception:

```
cbioportal_container           | Caused by: java.lang.IllegalStateException: Unable to complete the scan for annotations for web application [] due to a StackOverflowError. Possible root causes include a too low setting for -Xss and illegal cyclic inheritance dependencies. The class hierarchy being processed was [org.bouncycastle.asn1.ASN1EncodableVector->org.bouncycastle.asn1.DEREncodableVector->org.bouncycastle.asn1.ASN1EncodableVector]
cbioportal_container           | 	at org.apache.catalina.startup.ContextConfig.checkHandlesTypes(ContextConfig.java:2129)
cbioportal_container           | 	at org.apache.catalina.startup.ContextConfig.processAnnotationsStream(ContextConfig.java:2067)
cbioportal_container           | 	at org.apache.catalina.startup.ContextConfig.processAnnotationsJar(ContextConfig.java:2013)
cbioportal_container           | 	at org.apache.catalina.startup.ContextConfig.processAnnotationsUrl(ContextConfig.java:1983)
cbioportal_container           | 	at org.apache.catalina.startup.ContextConfig.processAnnotations(ContextConfig.java:1936)
cbioportal_container           | 	at org.apache.catalina.startup.ContextConfig.processClasses(ContextConfig.java:1237)
cbioportal_container           | 	at org.apache.catalina.startup.ContextConfig.webConfig(ContextConfig.java:1141)
cbioportal_container           | 	at org.apache.catalina.startup.ContextConfig.configureStart(ContextConfig.java:776)
cbioportal_container           | 	at org.apache.catalina.startup.ContextConfig.lifecycleEvent(ContextConfig.java:299)
cbioportal_container           | 	at org.apache.catalina.util.LifecycleBase.fireLifecycleEvent(LifecycleBase.java:123)
cbioportal_container           | 	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5063)
cbioportal_container           | 	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
cbioportal_container           | 	... 6 more
```

# Cause
The root cause is that the spring-security.jwt dependency introduced for the oauth2 functionality defines a org.bouncycastle:bcprov-jdk15on dependency that contains a conflicting class definition as present in org.bouncycastle:bcprov-jdk15 dependency (note missing _on_ suffix). The probabilistic behavior of this problem occurring has to do with how java-vm resolves the classes for a particular invocation (as described [here](https://stackoverflow.com/a/35914143)).

# Solution
The error is suppressed by excluding the org.bouncycastle:bcprov-jdk15on transitive dependency from the spring-security module. This approach is not without risk. However, the org.bouncycastle:bcprov-jdk15on dependency is only used in context with the oauth2 token functionality. This feature is well covered by unit and integration tests reducing the risk that the dependency exclusion breaks essential functionality.