### PR TITLE
Fix cache related issues

### DIFF
--- a/model/src/main/java/org/cbioportal/model/GenericAssayAdditionalProperty.java
+++ b/model/src/main/java/org/cbioportal/model/GenericAssayAdditionalProperty.java
@@ -1,6 +1,8 @@
 package org.cbioportal.model;
 
-public class GenericAssayAdditionalProperty {
+import java.io.Serializable;
+
+public class GenericAssayAdditionalProperty implements Serializable {
     private String name;
     private String value;
     private String stableId;

--- a/model/src/main/java/org/cbioportal/model/ResourceDefinition.java
+++ b/model/src/main/java/org/cbioportal/model/ResourceDefinition.java
@@ -1,8 +1,9 @@
 package org.cbioportal.model;
 
+import java.io.Serializable;
 import javax.validation.constraints.NotNull;
 
-public class ResourceDefinition {
+public class ResourceDefinition implements Serializable {
 
     @NotNull
     private String resourceId;

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
@@ -21,7 +21,6 @@ public interface MolecularDataRepository {
     List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
                                                               String projection);
 
-    @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     Iterable<GeneMolecularAlteration> getGeneMolecularAlterationsIterable(String molecularProfileId, List<Integer> entrezGeneIds,
                                                                           String projection);
 
@@ -38,7 +37,6 @@ public interface MolecularDataRepository {
     List<GenericAssayMolecularAlteration> getGenericAssayMolecularAlterations(String molecularProfileId, List<String> stableIds,
         String projection);
 
-	@Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
 	Iterable<GenericAssayMolecularAlteration> getGenericAssayMolecularAlterationsIterable(String molecularProfileId,
 			List<String> stableIds, String projection);
 }


### PR DESCRIPTION
There are two cache related issues:
1. All cacheable classes should be serializable (related to `GenericAssayAdditionalProperty` and `ResourceDefinition`)
2. Iterable shouldn't be cached (related to `getGeneMolecularAlterationsIterable` and `getGenericAssayMolecularAlterationsIterable`)