### PR TITLE
Fix invoker plugin goals

### DIFF
--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -222,7 +222,10 @@
           <cloneProjectsTo>${project.build.directory}/integration-tests</cloneProjectsTo>
           <skipInstallation>${skipTests}</skipInstallation>
           <skipInvocation>${skipTests}</skipInvocation>
-          <goals>clean verify</goals>
+          <goals>
+            <goal>clean</goal>
+            <goal>verify</goal>
+          </goals>
           <environmentVariables>
               <CBIO_WAR_LOCATION>${project.build.directory}/cbioportal.war</CBIO_WAR_LOCATION>
               <!-- We neither create nor populate the database here. Instead we rely on DB created for the integration tests in the core module. -->


### PR DESCRIPTION
## Problem
Building on CircleCI results in an error on incorrect definition of the goals section for _maven-invoker-plugin_ on portal/pom.xml. The current format for this section does not comply with [documentation](https://maven.apache.org/plugins/maven-invoker-plugin/usage.html) for _maven-invoker-plugin_:

```
        <executions>
          <execution>
            <id>integration-test</id>
            <goals>
              <goal>install</goal>
              <goal>run</goal>
            </goals>
          </execution>
        </executions>
```

## Solution
This PR corrects the goals section according to documentation. This solves build on CircleCI. 
