### PR TITLE
Allow http content security policy to be configured

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -274,6 +274,10 @@ public class GlobalProperties {
     @Value("${sitemaps:false}") // default is false
     public void setSitemaps(String property) { sitemaps = Boolean.parseBoolean(property); }
 
+    private static String contentSecurityPolicy;
+    @Value("${content_security_policy:'self'}") // default is false
+    public void setContentSecurityPolicy(String property) { contentSecurityPolicy = property; }
+    
     private static boolean showTranscriptDropdown;
     @Value("${show.transcript_dropdown:false}") // default is false
     public void setShowTranscriptDropdown(String property) { showTranscriptDropdown = Boolean.parseBoolean(property); }
@@ -917,6 +921,8 @@ public class GlobalProperties {
     public static boolean showSitemaps() {
        return sitemaps;
     }
+    
+    public static String getContentSecurityPolicy() { return contentSecurityPolicy; }
 
     public static boolean showCivic() {
         return showCivic;

--- a/portal/src/main/webapp/index.jsp
+++ b/portal/src/main/webapp/index.jsp
@@ -27,6 +27,8 @@
 %>
 
 
+<% response.addHeader("Content-Security-Policy", GlobalProperties.getContentSecurityPolicy()); %>
+
 <!DOCTYPE html>
 <html class="cbioportal-frontend">
 <head>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -349,3 +349,7 @@ persistence.cache_type=no-cache
 # Installation map URL for installation map iframes. 
 # If blank or commented out, no map will be shown and that page will be hidden.
 # installation_map_url=https://installationmap.netlify.app/
+
+# Set content security policy http header here
+# For example to allow specified domains to load your portal in an iframe
+# content_security_policy='frame-ancestors http://www.example.org'


### PR DESCRIPTION
Installers should be able to allow specified domains to load their portals in iframes.   This PR allows them to do so by setting content security policy.