### PR TITLE
Make console logging default

### DIFF
--- a/src/main/resources/log4j.properties.EXAMPLE
+++ b/src/main/resources/log4j.properties.EXAMPLE
@@ -1,19 +1,19 @@
 # Change INFO to DEBUG, if you want to see debugging info on underlying libraries we use.
 log4j.rootLogger=INFO, a
 
-# Change INFO to DEBUG, if you want see debugging info on our packages and spring security packages.
+# Change INFO to DEBUG, if you want see debugging info on our packages only.
 log4j.category.org.mskcc=INFO
-log4j.logger.org.springframework.security=INFO
-
-# Use the JVM option, e.g.: "java -DPORTAL_HOME=/pathto/portal_homedir",
-# or - "java -DPORTAL_HOME=$PORTAL_HOME", where PORTAL_HOME is shell (environment) variable.
+#log4j.category.org.springframework=ALL
 
 ## IMPORTANT - THRESHOLD SHOULD NOT BE DEBUG FOR PRODUCTION, CREDENTIALS CAN BE DISPLAYED!
+#log4j.logger.org.springframework.security=DEBUG
+#log4j.logger.org.springframework.integration=DEBUG
 
-log4j.appender.a = org.apache.log4j.rolling.RollingFileAppender
-log4j.appender.a.rollingPolicy = org.apache.log4j.rolling.TimeBasedRollingPolicy
-log4j.appender.a.rollingPolicy.FileNamePattern = ${java.io.tmpdir}/cbioportal.log.%d.gz
-log4j.appender.a.File = ${java.io.tmpdir}/cbioportal.log
+log4j.appender.a = org.apache.log4j.ConsoleAppender
+log4j.appender.a.target=System.out
+log4j.appender.a.immediateFlush=true
+log4j.appender.a.encoding=UTF-8
+log4j.appender.a.threshold=Error
+
 log4j.appender.a.layout = org.apache.log4j.PatternLayout
 log4j.appender.a.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} [%t] %-5p %c - %m%n
-log4j.appender.a.append = true


### PR DESCRIPTION
Previously we recommended using files for logging. That makes a lot of
sense when using a separate tomcat setup. Now with docker the tomcat is
included in the container. It's not very common with containers to log
to a file

Fix https://github.com/cBioPortal/cbioportal/issues/8338