### PR TITLE
update documentation for Google Analytics

### DIFF
--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -214,7 +214,11 @@ Then, go to:  https://bitly.com/a/your_api_key
 
 # Google Analytics
 
-If you so desire, the following property is used to track your site's usage via google analytics.
+When the following property is defined, Google Analytics will track site usage.
+
+:warning: In contrast to what this property's name suggests, this should be the **GA Universal Analytics ID** (UA-XXXXX-YY), not to be confused with the new [GA-4 ID, introduced in 2020](https://support.google.com/analytics/answer/10089681). A Universal Analytics GA property can be created at [Google Analytics](https://analytics.google.com/analytics/web/provision/), create a new GA property, and make sure to click **Show advanced options** and switch on **Create a Universal Analytics property**. After creating a Universal Analytics property, the tracking ID can be found at **Admin**, column **property**, under **Property Settings**
+
+:warning: Adblockers may block site tracking by GA
 ```
 google_analytics_profile_id
 ```


### PR DESCRIPTION
The documentation for Google Analytics was outdated, somewhat misleading, but mostly very brief.

I added some documentation updates. The property `google_analytics_profile_id` is supposed to be the **UA tracking ID**, which is an identifier that you explicitly have to create, as it is based on an outdated version of GA.
Are there any plans for updating the GA code to handle GA-4? Perhaps this property should be renamed in any case.