### PR TITLE
zscores readme: updated script location & added new argument

### DIFF
--- a/docs/Z-Score-normalization-script.md
+++ b/docs/Z-Score-normalization-script.md
@@ -9,7 +9,7 @@ Please keep in mind that the z-scores are calculated using only patient data. He
 cBioPortal currently generates two z-score profiles using two different base populations:
 - Distribution based on **diploid** samples only: The expression distribution for unaltered copies of the gene is estimated by calculating the mean and variance of the expression values for samples in which the gene is diploid (i.e. value is "0" as reported by [discrete CNA data](File-Formats.md#discrete-copy-number-data)). We call this the unaltered distribution. If the gene has no diploid samples, then its normalized expression is reported as NA.
 
-- Distribution based on **all** samples: The expression distribution of the gene is estimated by calculating the mean and variance of all samples with expression values (excludes zero's and non-numeric values like NA, Null or NaN). If the gene has samples whose expression values are all zeros or non-numeric, then its normalized expression is reported as NA.
+- Distribution based on **all** samples: The expression distribution of the gene is estimated by calculating the mean and variance of all samples with expression values. If the gene has samples whose expression values are all zeros or non-numeric, then its normalized expression is reported as NA.
 
 Otherwise for every sample, the gene's normalized expression for both the profiles is reported as
 
@@ -21,7 +21,7 @@ where `r` is the raw expression value, and `mu` and `sigma` are the mean and sta
 ### How to proceed
 cBioPortal expects z-score normalization to take place per gene. You can calculate z-scores with your own preferred method, or use one of the cBioPortal provided approaches:
 - [convertExpressionZscores.pl](https://github.com/cBioPortal/cbioportal/blob/master/core/src/main/scripts/convertExpressionZscores.pl) applies Method 1 (diploid samples as base population)
-- [NormalizeExpressionLevels_allsampleref.py](https://github.com/cBioPortal/datahub-study-curation-tools/tree/master/generate_Zscores) applies Method 2 (all samples as base population)
+- [NormalizeExpressionLevels_allsampleref.py](https://github.com/cBioPortal/datahub-study-curation-tools/tree/master/zscores/zscores_relative_allsamples) applies Method 2 (all samples as base population)
 
 Examples of the calculation and running the programs are below.
 
@@ -96,28 +96,32 @@ and then
 Given the expression data for a set of samples, generate normalized expression values with the reference population of all samples independent of sample diploid status.
 
 ### Parameters
-`-i <expression_file> -o <output_file> [-l]`
+`<expression_file> <output_file> <[log_transform]> <[exclude_zero_negative_values]>`
 
 - `<expression_file>` : the [expression (exp) data file](File-Formats.md#expression-data).
-- `<output_file>` : the output file to be generated
-- Use the `-l` option to log transform the data before calculating z-scores.
+- `<output_file>` : the output file to be generated.
+- `<log_transform>` : Use this to log transform the data before calculating z-scores (optional).
+- `<exclude_zero_negative_values>` : Use this to exclude zero's or negative counts from the reference population when normalizing the data (optional). 
 
 ### Algorithm
 Input [expression data file](File-Formats.md#expression-data)
 ```
-for each gene:
+for each gene{
   log-transform the raw data, if -l is passed
-  compute mean and standard deviation for samples ( n = # of samples where expression value is not Zero or non-numeric)
-  for each sample:
-    compute Zscore when standard deviation != 0
-    output NA for genes with standard deviation = 0
+  identify the base population (if -e is passed, n = # of samples where expression value is not zero or negative)
+  compute mean and standard deviation for samples in the base poplulation 
+  for each sample in the input dataset{
+    Z-Score <- (value - mean)/sd when standard deviation != 0
+    Z-Score <- NA when standard deviation = 0
+  }
+}
 ```
 ### Log-transforming the data
 Using the `-l` option above calculates log base 2 of the expression values.
 
 Here's how we handle the Negative values when log transforming:
 ```
-Replace the negative values to 0 and add a constant value(+1) to data pior to applying log transform.
+Replace the negative values to 0 and add a pseudo-count (+1) to all observed counts prior to applying log transform.
 example, if raw value is -1, the log transform would be log(0+1)
          if the value is 0, the log transform would be log(0+1)
          if the value is 1, the log transform would be log(1+1)
@@ -125,18 +129,18 @@ example, if raw value is -1, the log transform would be log(0+1)
 
 ### Example Calculation:
 
-Log transform and calculate the z-scores:
+Log transform and calculate the z-scores (without -e option):
 <table>
 <tr><td>Hugo_Symbol</td><td>Entrez_Gene_Id</td><td>A1-A0SD-01</td><td>A1-A0SE-01</td><td>A1-A0SH-01</td><td>A1-A0SJ-01</td><td>A1-A0SK-01</td><td>A1-A0SM-01</td><td>A1-A0SO-01</td><td>A1-A0SP-01</td><td>A2-A04N-01</td><td>A2-A04P-01</td><td>A2-A04Q-01</td><td>A2-A04R-01</td><td>A2-A04T-01</td><td>A2-A04U-01</td><td>A2-A04V-01</td><td>A2-A04W-01</td><td>A2-A04X-01</td><td>A2-A04Y-01</td></tr>
 <tr><td>RPS11 Expr</td><td>6205</td><td>0.765</td><td>0.716</td><td>0.417125</td><td>0.115</td><td>0.492875</td><td>-0.525</td><td>-0.169</td><td>0.396</td><td>0.50475</td><td>0.400875</td><td>0.393125</td><td>0.9165</td><td>0.627125</td><td>0.337125</td><td>0.705</td><td>0.16425</td><td>0.325</td><td>0.11175</td></tr>
-<tr><td>Output</td><td>6205</td><td>1.2803</td><td>1.1007</td><td>-0.1195</td><td>-1.6485</td><td>0.2125</td><td>-2.3426</td><td>-2.3426</td><td>-0.2153</td><td>0.263</td><td>-0.1931</td><td>-0.2285</td><td>1.8054</td><td>0.7616</td><td>-0.4901</td><td>1.0597</td><td>-1.3729</td><td>-0.5482</td><td>-1.6671</td></tr>
+<tr><td>Output</td><td>6205</td><td>1.2879</td><td>1.1378</td><td>0.1177</td><td>-1.1605</td><td>0.3953</td><td>-1.7408</td><td>-1.7408</td><td>0.0376</td><td>0.4375</td><td>0.0562</td><td>0.0266</td><td>1.7268</td><td>0.8543</td><td>-0.1921</td><td>1.1035</td><td>-0.9301</td><td>-0.2407</td><td>-1.1761</td></tr>
   </table>
-  
+
 ### Running the script
-To run the script clone the datahub-study-curation-tools from [here](https://github.com/cBioPortal/datahub-study-curation-tools) and type the commands when in the folder `generate_Zscores`:
+To run the script clone the datahub-study-curation-tools from [here](https://github.com/cBioPortal/datahub-study-curation-tools) and type the commands when in the folder `zscores/zscores_relative_allsamples`:
 
 ```
-python NormalizeExpressionLevels_allsampleref.py -i <expression_file> -o <output_file> [-l]
+python NormalizeExpressionLevels_allsampleref.py -i <expression_file> -o <output_file> [-l] [-e]
 ```
 
 #### Example:


### PR DESCRIPTION
The all sample ref zscore script is updated for microarray and rppa profiles to include zero and negative values in the base population (detailed info in https://github.com/cBioPortal/datahub-study-curation-tools/pull/32). The readme is updated accordingly.
