### PR TITLE
Add patient ID for discrete CNA response for alteration type ALL

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImpl.java
@@ -185,6 +185,7 @@ public class DiscreteCopyNumberServiceImpl implements DiscreteCopyNumberService 
         DiscreteCopyNumberData discreteCopyNumberData = new DiscreteCopyNumberData();
         discreteCopyNumberData.setMolecularProfileId(molecularData.getMolecularProfileId());
         discreteCopyNumberData.setStudyId(molecularData.getStudyId());
+        discreteCopyNumberData.setPatientId(molecularData.getPatientId());
         discreteCopyNumberData.setSampleId(molecularData.getSampleId());
         discreteCopyNumberData.setEntrezGeneId(molecularData.getEntrezGeneId());
         discreteCopyNumberData.setGene(molecularData.getGene());


### PR DESCRIPTION
Describe changes proposed in this pull request:
- patientId did not exist on the DiscreteCopyNumberData objects returned by
`getDiscreteCopyNumbersInMolecularProfileBySampleListId` if the alteration
type was `ALL`
- This also caused the `uniquePatientKey` to be incorrect
- Fixed these issues by adding the patientId