### PR TITLE
Fixes absence of "No session service configured" during endless loop context

### DIFF
--- a/web/src/main/resources/applicationContext-proxy.xml
+++ b/web/src/main/resources/applicationContext-proxy.xml
@@ -16,8 +16,8 @@
         <property name="ignoreUnresolvablePlaceholders" value="true" />
         <property name="locations">
             <list>
-                <value>file:///${PORTAL_HOME}/portal.properties</value>
                 <value>classpath:portal.properties</value>
+                <value>file:///${PORTAL_HOME}/portal.properties</value>
                 <value>classpath:maven.properties</value>
                 <value>classpath:git.properties</value>
             </list>

--- a/web/src/main/resources/applicationContext-url-shortener.xml
+++ b/web/src/main/resources/applicationContext-url-shortener.xml
@@ -16,8 +16,8 @@
         <property name="ignoreUnresolvablePlaceholders" value="true" />
         <property name="locations">
             <list>
-                <value>file:///${PORTAL_HOME}/portal.properties</value>
                 <value>classpath:portal.properties</value>
+                <value>file:///${PORTAL_HOME}/portal.properties</value>
                 <value>classpath:maven.properties</value>
             </list>
         </property>

--- a/web/src/main/resources/applicationContext-web.xml
+++ b/web/src/main/resources/applicationContext-web.xml
@@ -18,8 +18,8 @@
         <property name="ignoreUnresolvablePlaceholders" value="true" />
         <property name="locations">
             <list>
-                <value>file:///${PORTAL_HOME}/portal.properties</value>
                 <value>classpath:portal.properties</value>
+                <value>file:///${PORTAL_HOME}/portal.properties</value>
                 <value>classpath:maven.properties</value>
                 <value>classpath:git.properties</value>
             </list>


### PR DESCRIPTION
Fixes missing "No session service configured" in endless loop context.   Reason:

config_service.jsp feeds frontend "sessionServiceEnabled" get value from GlobalProperties.  GlobalProperties looks in following order:
1 - PORTAL_HOME/portal.properties
2- portal.properties baked into war

SessionServiceController gets session.service.url (used to set isSessionServiceEnabled()) via Spring injection.  Before fix, Spring looks for portal.properties in following order:
1- PORTAL_HOME/portal.properties
2- portal.properties baked into war

The difference is that Spring will override properties found in location 1 with properties found in location 2, and GlobalProperties will not.