### PR TITLE
Mutation: query independently for each profile

### DIFF
--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
@@ -6,6 +6,7 @@ import org.cbioportal.model.MutationCountByGene;
 import org.cbioportal.model.meta.MutationMeta;
 
 import java.util.List;
+import java.util.Set;
 
 public interface MutationMapper {
 
@@ -24,7 +25,7 @@ public interface MutationMapper {
     MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
                                                              List<Integer> entrezGeneIds, Boolean snpOnly);
 
-    List<Mutation> getMutationsBySampleIds(String molecularProfileId, List<String> sampleIds, 
+    List<Mutation> getMutationsBySampleIds(String molecularProfileId, Set<String> sampleIds, 
                                            List<Integer> entrezGeneIds, Boolean snpOnly, String projection, 
                                            Integer limit, Integer offset, String sortBy, String direction);
 

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
@@ -9,7 +9,8 @@ import org.cbioportal.persistence.mybatis.util.OffsetCalculator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Repository
 public class MutationMyBatisRepository implements MutationRepository {
@@ -43,8 +44,36 @@ public class MutationMyBatisRepository implements MutationRepository {
                                                                   String projection, Integer pageSize, 
                                                                   Integer pageNumber, String sortBy, String direction) {
 
-        return mutationMapper.getMutationsInMultipleMolecularProfiles(molecularProfileIds, sampleIds, entrezGeneIds, 
-            null, projection, pageSize, offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction);
+        return getGroupedCasesByMolecularProfileId(molecularProfileIds, sampleIds)
+            .entrySet()
+            .stream()
+            .flatMap(entry -> mutationMapper.getMutationsBySampleIds(entry.getKey(),
+                entry.getValue(),
+                entrezGeneIds,
+                null,
+                projection,
+                pageSize,
+                offsetCalculator.calculate(pageSize, pageNumber),
+                sortBy,
+                direction).stream())
+            .collect(Collectors.toList());
+    }
+
+    private Map<String,Set<String>> getGroupedCasesByMolecularProfileId(List<String> molecularProfileIds, List<String> caseIds) {
+        Map<String,Set<String>> groupMolecularProfileSamples = new HashMap<>();
+
+        for(int i = 0; i< molecularProfileIds.size(); i++) {
+            String molecularProfileId = molecularProfileIds.get(i);
+            String caseId = caseIds.get(i);
+            if(!groupMolecularProfileSamples.containsKey(molecularProfileId)) {
+                Set<String> filteredCaseIds = new HashSet<>();
+                filteredCaseIds.add(caseId);
+                groupMolecularProfileSamples.put(molecularProfileId,filteredCaseIds);
+            } else {
+                groupMolecularProfileSamples.get(molecularProfileId).add(caseId);
+            }
+        }
+        return groupMolecularProfileSamples;
     }
 
     @Override
@@ -62,7 +91,7 @@ public class MutationMyBatisRepository implements MutationRepository {
                                                            String projection, Integer pageSize, Integer pageNumber,
                                                            String sortBy, String direction) {
 
-        return mutationMapper.getMutationsBySampleIds(molecularProfileId, sampleIds, entrezGeneIds, snpOnly, projection,
+        return mutationMapper.getMutationsBySampleIds(molecularProfileId, new HashSet<>(sampleIds), entrezGeneIds, snpOnly, projection,
             pageSize, offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction);
     }
 
@@ -86,8 +115,19 @@ public class MutationMyBatisRepository implements MutationRepository {
             List<String> sampleIds, List<Integer> entrezGeneIds, String projection, Integer pageSize,
             Integer pageNumber, String sortBy, String direction) {
 
-        return mutationMapper.getFusionsInMultipleMolecularProfiles(molecularProfileIds, sampleIds, entrezGeneIds,
-                null, projection, pageSize, offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction);
+        return getGroupedCasesByMolecularProfileId(molecularProfileIds, sampleIds)
+            .entrySet()
+            .stream()
+            .flatMap(entry -> mutationMapper.getFusionsInMultipleMolecularProfiles(Arrays.asList(entry.getKey()),
+                new ArrayList<>(entry.getValue()),
+                entrezGeneIds,
+                null,
+                projection,
+                pageSize,
+                offsetCalculator.calculate(pageSize, pageNumber),
+                sortBy,
+                direction).stream())
+            .collect(Collectors.toList());
     }
     // TODO: cleanup once fusion/structural data is fixed in database
 

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepositoryTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -230,13 +229,14 @@ public class MutationMyBatisRepositoryTest {
             sampleIds, null, "SUMMARY", null, null, null, null);
 
         Assert.assertEquals(3, result.size());
-        Mutation mutation1 = result.get(0);
+
+        Mutation mutation1 = result.get(2);
         Assert.assertEquals("study_tcga_pub_mutations", mutation1.getMolecularProfileId());
         Assert.assertEquals("TCGA-A1-A0SH-01", mutation1.getSampleId());
         Mutation mutation2 = result.get(1);
         Assert.assertEquals("study_tcga_pub_mutations", mutation2.getMolecularProfileId());
         Assert.assertEquals("TCGA-A1-A0SH-01", mutation2.getSampleId());
-        Mutation mutation3 = result.get(2);
+        Mutation mutation3 = result.get(0);
         Assert.assertEquals("acc_tcga_mutations", mutation3.getMolecularProfileId());
         Assert.assertEquals("TCGA-A1-B0SO-01", mutation3.getSampleId());
     }


### PR DESCRIPTION
Temporary fix for  https://github.com/cBioPortal/cbioportal/issues/8468

Problem might be related to sql queries having huge number(>100k) of multiple fields(`WHERE (sample.STABLE_ID, genetic_profile.STABLE_ID) IN....`). 

Workaround by querying for each molecular profile separately improved performance for 20.5 sec to 7.5 sec when tested locally for  2 studies(~20k samples) `/results?cancer_study_list=msk_ch_2020%2Cmsk_impact_2017&tab_index=tab_visualize&data_priority=0&case_set_id=all&Action=Submit&gene_list=TP53%250ADNMT3A%250ATMPRSS2%250AERG%250ACDKN2A%250ACDKN2B`