### PR TITLE
Implement skin.hide_download_controls property

### DIFF
--- a/docs/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/Customizing-your-instance-of-cBioPortal.md
@@ -241,6 +241,12 @@ Below you can find the complete list of all the available skin properties.
             <td>false</td>
             <td>true / false</td>
         </tr>
+		<tr>
+            <td>skin.hide_download_controls</td>
+            <td>removes all download and copy-to-clipboard options.</td>
+            <td>false</td>
+            <td>true / false</td>
+        </tr>
         <tr>
             <td>skin.show_settings_menu</td>
             <td>controls the appearance of the settings menu in study view and group comparison that controls annotation-based filtering.</td>

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -162,6 +162,11 @@ Add a custom logo in the right side of the menu. Place here the full name of the
 skin.right_logo=
 ```
 
+Prevent users from saving data by removing all Download tabs and download and copy-to-clipboard controls.
+```
+skin.hide_download_controls=
+```
+
 ## Control default setting for filtering of genes in mutation and CNA tables of patient view
 Different samples of a patient may have been analyzed with different gene panels. In patient view mutations and discrete CNA's can be filtered based on whether the gene of respective mutations/CNA's was profiled in all samples of the patient (mutations profiled in `all samples`), or not (mutations profiled in `any sample`). Setting this field to `true` will make patient view select the `all samples` filter at startup. When set to false or left blank the patient view will default to the `any samples` filter setting.
 ```

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -137,7 +137,8 @@
             "skin.geneset_hierarchy.default_gsva_score",
             "skin.geneset_hierarchy.collapse_by_default",
             "skin.mutation_table.namespace_column.show_by_default",
-            "comparison.categorical_na_values"
+            "comparison.categorical_na_values",
+            "skin.hide_download_controls"
         };
 
 

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -99,6 +99,9 @@ skin.study_view.link_text=To build your own case set, try out our enhanced Study
 ## enable this to configure a global message for the studies that are unauthorized; the message can contain placecards like {$.Owner.email} for the studies that have the information in the study tags 
 # skin.home_page.unauthorized_studies_global_message=The study is unauthorized. You need to request access.
 
+setting controlling whether Download tabs and download/copy-to-clipboard controls should be shown
+# skin.hide_download_controls=true
+
 ## enable and set this property to specify a study group to be used to identify public studies for which no specific authorization entries are needed in the `authorities` table
 # always_show_study_group=
 


### PR DESCRIPTION
# Implement new _skin.hide_download_controls_ property

This property will control new front-end behavior that hides all download/copy-to-clipboard functionality (see [this PR](https://github.com/cBioPortal/cbioportal-frontend/pull/3716)).
