### PR TITLE
Improve gene-panel api performance

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenePanelRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenePanelRepository.java
@@ -3,6 +3,7 @@ package org.cbioportal.persistence;
 import org.cbioportal.model.GenePanel;
 import org.cbioportal.model.GenePanelData;
 import org.cbioportal.model.GenePanelToGene;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.model.meta.BaseMeta;
 
 import org.springframework.cache.annotation.Cacheable;
@@ -31,12 +32,13 @@ public interface GenePanelRepository {
     List<GenePanelData> fetchGenePanelData(String molecularProfileId, List<String> sampleIds);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
-    List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<String> molecularProfileIds, 
-        List<String> sampleIds);
+    List<GenePanelData> fetchGenePanelDataByMolecularProfileIds(List<String> molecularProfileIds);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
-    List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(List<String> molecularProfileIds, 
-        List<String> patientIds);
+    List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers);
+
+    @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
+    List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<GenePanelToGene> getGenesOfPanels(List<String> genePanelIds);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenePanelMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenePanelMapper.java
@@ -3,6 +3,7 @@ package org.cbioportal.persistence.mybatis;
 import org.cbioportal.model.GenePanel;
 import org.cbioportal.model.GenePanelData;
 import org.cbioportal.model.GenePanelToGene;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.model.meta.BaseMeta;
 
 import java.util.List;
@@ -21,12 +22,12 @@ public interface GenePanelMapper {
     List<GenePanelData> getGenePanelDataBySampleListId(String molecularProfileId, String sampleListId);
 
     List<GenePanelData> getGenePanelDataBySampleIds(String molecularProfileId, List<String> sampleIds);
+    
+    List<GenePanelData> fetchGenePanelDataByMolecularProfileIds(List<String> molecularProfileIds);
 
-    List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<String> molecularProfileIds,
-                                                                      List<String> sampleIds);
+    List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers);
 
-    List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(List<String> molecularProfileIds,
-                                                                      List<String> patientIds);
+    List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers);
 
     List<GenePanelToGene> getGenesOfPanels(List<String> genePanelIds);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenePanelMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenePanelMyBatisRepository.java
@@ -3,6 +3,7 @@ package org.cbioportal.persistence.mybatis;
 import org.cbioportal.model.GenePanel;
 import org.cbioportal.model.GenePanelData;
 import org.cbioportal.model.GenePanelToGene;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.GenePanelRepository;
 import org.cbioportal.persistence.PersistenceConstants;
@@ -59,17 +60,19 @@ public class GenePanelMyBatisRepository implements GenePanelRepository {
     }
 
     @Override
-    public List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<String> molecularProfileIds, 
-        List<String> sampleIds) {
-        
-        return genePanelMapper.fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileIds, sampleIds);
-	}
+    public List<GenePanelData> fetchGenePanelDataByMolecularProfileIds(List<String> molecularProfileIds) {
+
+        return genePanelMapper.fetchGenePanelDataByMolecularProfileIds(molecularProfileIds);
+    }
 
     @Override
-    public List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(List<String> molecularProfileIds, 
-        List<String> patientIds) {
-        
-        return genePanelMapper.fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(molecularProfileIds, patientIds);
+    public List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers) {
+        return genePanelMapper.fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileSampleIdentifiers);
+    }
+
+    @Override
+    public List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers) {
+        return genePanelMapper.fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(molecularProfileSampleIdentifiers);
     }
 
     @Override

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenePanelMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenePanelMapper.xml
@@ -19,21 +19,16 @@
 	    patient.STABLE_ID AS patientId,
 	    cancer_study.CANCER_STUDY_IDENTIFIER AS studyId,
 	    genetic_profile.STABLE_ID AS molecularProfileId,
-	    CASE
-	        WHEN sample_profile.GENETIC_PROFILE_ID IS NOT NULL OR (genetic_profile.GENETIC_ALTERATION_TYPE = 'MUTATION_EXTENDED' AND sample_list_list.LIST_ID IS NOT NULL) THEN TRUE
-	        ELSE FALSE
-	    END AS profiled
+        true as profiled
     </sql>
 
     <sql id="fromGenePanelData">
-	    FROM sample
+        FROM sample_profile
+        INNER JOIN genetic_profile ON sample_profile.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
+        INNER JOIN sample ON sample_profile.SAMPLE_ID = sample.INTERNAL_ID
         INNER JOIN patient ON sample.PATIENT_ID = patient.INTERNAL_ID
         INNER JOIN cancer_study ON patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
-        LEFT JOIN genetic_profile ON cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID
-        LEFT JOIN sample_profile ON sample_profile.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID AND sample.INTERNAL_ID = sample_profile.SAMPLE_ID
         LEFT JOIN gene_panel ON sample_profile.PANEL_ID = gene_panel.INTERNAL_ID
-        LEFT JOIN sample_list ON sample_list.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID AND sample_list.CATEGORY = 'all_cases_with_mutation_data'
-        LEFT JOIN sample_list_list ON sample_list_list.SAMPLE_ID = sample.INTERNAL_ID AND sample_list_list.LIST_ID = sample_list.LIST_ID
     </sql>
     
     <select id="getAllGenePanels" resultType="org.cbioportal.model.GenePanel">
@@ -122,32 +117,43 @@
         </if>
     </select>
 
+    <select id="fetchGenePanelDataByMolecularProfileIds" resultType="org.cbioportal.model.GenePanelData">
+        SELECT
+        <include refid="selectGenePanelData"/>
+        <include refid="fromGenePanelData"/>
+        WHERE
+        genetic_profile.STABLE_ID IN <foreach item="item" collection="list" open="(" separator="," close=")">
+        #{item}
+    </foreach>
+    </select>
+
     <select id="fetchGenePanelDataInMultipleMolecularProfiles" resultType="org.cbioportal.model.GenePanelData">
         SELECT
         <include refid="selectGenePanelData"/>
         <include refid="fromGenePanelData"/>
         <where>
-            <if test="sampleIds != null">
-                <if test="@java.util.Arrays@stream(molecularProfileIds.toArray()).distinct().count() == 1">
-                    genetic_profile.STABLE_ID = #{molecularProfileIds[0]} AND
-                    sample.STABLE_ID IN
-                    <foreach item="item" collection="sampleIds" open="(" separator="," close=")">
-                        #{item}
-                    </foreach>
-                </if>
-                <if test="@java.util.Arrays@stream(molecularProfileIds.toArray()).distinct().count() > 1">
-                    (genetic_profile.STABLE_ID, sample.STABLE_ID) IN
-                    <foreach index="i" collection="sampleIds" open="(" separator="," close=")">
-                        (#{molecularProfileIds[${i}]}, #{sampleIds[${i}]})
-                    </foreach>
-                </if>
-            </if>
-            <if test="sampleIds == null">
-                genetic_profile.STABLE_ID IN
-                <foreach item="item" collection="molecularProfileIds" open="(" separator="," close=")">
-                    #{item}
-                </foreach>
-            </if>
+            <choose>
+                <when test="list == null or list.isEmpty()">
+                    AND NULL
+                </when>
+                <otherwise>
+                    <choose>
+                        <when test="@java.util.Arrays@stream(list.{molecularProfileId}).distinct().count() == 1">
+                            AND genetic_profile.STABLE_ID = #{list[0].molecularProfileId} AND
+                            sample.STABLE_ID IN
+                            <foreach item="id" collection="list" open="(" separator="," close=")">
+                                #{id.caseId}
+                            </foreach>
+                        </when>
+                        <otherwise>
+                            AND (genetic_profile.STABLE_ID, sample.STABLE_ID) IN
+                            <foreach item="id" collection="list" open="(" separator="," close=")">
+                                (#{id.molecularProfileId}, #{id.caseId})
+                            </foreach>
+                        </otherwise>
+                    </choose>
+                </otherwise>
+            </choose>
         </where>
     </select>
 
@@ -156,27 +162,28 @@
         <include refid="selectGenePanelData"/>
         <include refid="fromGenePanelData"/>
         <where>
-            <if test="patientIds != null">
-                <if test="@java.util.Arrays@stream(molecularProfileIds.toArray()).distinct().count() == 1">
-                    genetic_profile.STABLE_ID = #{molecularProfileIds[0]} AND
-                    patient.STABLE_ID IN
-                    <foreach item="item" collection="patientIds" open="(" separator="," close=")">
-                        #{item}
-                    </foreach>
-                </if>
-                <if test="@java.util.Arrays@stream(molecularProfileIds.toArray()).distinct().count() > 1">
-                    (genetic_profile.STABLE_ID, patient.STABLE_ID) IN
-                    <foreach index="i" collection="patientIds" open="(" separator="," close=")">
-                        (#{molecularProfileIds[${i}]}, #{patientIds[${i}]})
-                    </foreach>
-                </if>
-            </if>
-            <if test="patientIds == null">
-                genetic_profile.STABLE_ID IN
-                <foreach item="item" collection="molecularProfileIds" open="(" separator="," close=")">
-                    #{item}
-                </foreach>
-            </if>
+            <choose>
+                <when test="list == null or list.isEmpty()">
+                    AND NULL
+                </when>
+                <otherwise>
+                    <choose>
+                        <when test="@java.util.Arrays@stream(list.{molecularProfileId}).distinct().count() == 1">
+                            AND genetic_profile.STABLE_ID = #{list[0].molecularProfileId} AND
+                            patient.STABLE_ID IN
+                            <foreach item="id" collection="list" open="(" separator="," close=")">
+                                #{id.caseId}
+                            </foreach>
+                        </when>
+                        <otherwise>
+                            AND (genetic_profile.STABLE_ID, patient.STABLE_ID) IN
+                            <foreach item="id" collection="list" open="(" separator="," close=")">
+                                (#{id.molecularProfileId}, #{id.caseId})
+                            </foreach>
+                        </otherwise>
+                    </choose>
+                </otherwise>
+            </choose>
         </where>
     </select>
 </mapper>

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/GenePanelMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/GenePanelMyBatisRepositoryTest.java
@@ -3,6 +3,7 @@ package org.cbioportal.persistence.mybatis;
 import org.cbioportal.model.GenePanel;
 import org.cbioportal.model.GenePanelData;
 import org.cbioportal.model.GenePanelToGene;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.model.meta.BaseMeta;
 import org.junit.Assert;
 import org.junit.Test;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -78,7 +80,7 @@ public class GenePanelMyBatisRepositoryTest {
         List<GenePanelData> result = genePanelMyBatisRepository.getGenePanelDataBySampleListId("study_tcga_pub_mrna", 
             "study_tcga_pub_all");
         
-        Assert.assertEquals(14, result.size());
+        Assert.assertEquals(9, result.size());
         GenePanelData genePanelData = result.get(0);
         Assert.assertEquals("study_tcga_pub_mrna", genePanelData.getMolecularProfileId());
         Assert.assertEquals("TESTPANEL1", genePanelData.getGenePanelId());
@@ -101,8 +103,18 @@ public class GenePanelMyBatisRepositoryTest {
     @Test
     public void fetchGenePanelDataInMultipleMolecularProfiles() throws Exception {
 
-        List<GenePanelData> result = genePanelMyBatisRepository.fetchGenePanelDataInMultipleMolecularProfiles(Arrays.asList(
-            "study_tcga_pub_mrna", "study_tcga_pub_log2CNA"), Arrays.asList("TCGA-A1-A0SB-01", "TCGA-A1-A0SD-01"));
+        List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers = new ArrayList<>();
+        MolecularProfileCaseIdentifier profileCaseIdentifier = new MolecularProfileCaseIdentifier();
+        profileCaseIdentifier.setMolecularProfileId("study_tcga_pub_mrna");
+        profileCaseIdentifier.setCaseId("TCGA-A1-A0SB-01");
+        molecularProfileSampleIdentifiers.add(profileCaseIdentifier);
+
+        MolecularProfileCaseIdentifier profileCaseIdentifier2 = new MolecularProfileCaseIdentifier();
+        profileCaseIdentifier2.setMolecularProfileId("study_tcga_pub_log2CNA");
+        profileCaseIdentifier2.setCaseId("TCGA-A1-A0SD-01");
+        molecularProfileSampleIdentifiers.add(profileCaseIdentifier2);
+
+        List<GenePanelData> result = genePanelMyBatisRepository.fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileSampleIdentifiers);
 
         Assert.assertEquals(2, result.size());
         GenePanelData genePanelData = result.get(0);

--- a/service/src/main/java/org/cbioportal/service/GenePanelService.java
+++ b/service/src/main/java/org/cbioportal/service/GenePanelService.java
@@ -2,6 +2,7 @@ package org.cbioportal.service;
 
 import org.cbioportal.model.GenePanel;
 import org.cbioportal.model.GenePanelData;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.service.exception.GenePanelNotFoundException;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
@@ -23,11 +24,9 @@ public interface GenePanelService {
     List<GenePanelData> fetchGenePanelData(String molecularProfileId, List<String> sampleIds) 
         throws MolecularProfileNotFoundException;
 
-    List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<String> molecularProfileIds, 
-        List<String> sampleIds);
+    List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers);
 
-    List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(List<String> molecularProfileIds, 
-        List<String> patientIds);
+    List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers);
 
 	List<GenePanel> fetchGenePanels(List<String> genePanelIds, String projection);
 }

--- a/service/src/main/java/org/cbioportal/service/impl/GenePanelServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenePanelServiceImpl.java
@@ -1,16 +1,17 @@
 package org.cbioportal.service.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import static java.util.stream.Collectors.*;
 
 import org.apache.commons.math3.util.Pair;
 import org.cbioportal.model.GenePanel;
 import org.cbioportal.model.GenePanelData;
 import org.cbioportal.model.GenePanelToGene;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.GenePanelRepository;
 import org.cbioportal.service.GenePanelService;
@@ -23,11 +24,13 @@ import org.springframework.stereotype.Service;
 public class GenePanelServiceImpl implements GenePanelService {
     @Autowired
     private GenePanelRepository genePanelRepository;
+    
+    private final Integer maxCasesCountToIncludeInQuery = 30000;
 
     @Override
     public List<GenePanel> getAllGenePanels(String projection, Integer pageSize, Integer pageNumber, String sortBy, 
                                             String direction) {
-        
+
         List<GenePanel> genePanels = genePanelRepository.getAllGenePanels(projection, pageSize, pageNumber, sortBy, 
             direction);
 
@@ -39,13 +42,13 @@ public class GenePanelServiceImpl implements GenePanelService {
             genePanels.forEach(g -> g.setGenes(genePanelToGeneList.stream().filter(p -> p.getGenePanelId()
                 .equals(g.getStableId())).collect(toList())));
         }
-        
+
         return genePanels;
     }
 
     @Override
     public BaseMeta getMetaGenePanels() {
-        
+
         return genePanelRepository.getMetaGenePanels();
     }
 
@@ -56,16 +59,16 @@ public class GenePanelServiceImpl implements GenePanelService {
         if (genePanel == null) {
             throw new GenePanelNotFoundException(genePanelId);
         }
-        
-        genePanel.setGenes(genePanelRepository.getGenesOfPanels(Arrays.asList(genePanelId)));
+
+        genePanel.setGenes(genePanelRepository.getGenesOfPanels(Collections.singletonList(genePanelId)));
         return genePanel;
     }
 
     @Override
-	public List<GenePanel> fetchGenePanels(List<String> genePanelIds, String projection) {
+    public List<GenePanel> fetchGenePanels(List<String> genePanelIds, String projection) {
 
         List<GenePanel> genePanels = genePanelRepository.fetchGenePanels(genePanelIds, projection);
-        
+
         if (projection.equals("DETAILED")) {
 
             List<GenePanelToGene> genePanelToGeneList = genePanelRepository.getGenesOfPanels(genePanels
@@ -76,118 +79,150 @@ public class GenePanelServiceImpl implements GenePanelService {
         }
 
         return genePanels;
-	}
-    
+    }
+
     @Override
-    public List<GenePanelData> getGenePanelData(String molecularProfileId, String sampleListId) 
+    public List<GenePanelData> getGenePanelData(String molecularProfileId, String sampleListId)
         throws MolecularProfileNotFoundException {
 
         return genePanelRepository.getGenePanelDataBySampleListId(molecularProfileId, sampleListId);
     }
 
     @Override
-    public List<GenePanelData> fetchGenePanelData(String molecularProfileId, List<String> sampleIds) 
+    public List<GenePanelData> fetchGenePanelData(String molecularProfileId, List<String> sampleIds)
         throws MolecularProfileNotFoundException {
 
         return genePanelRepository.fetchGenePanelData(molecularProfileId, sampleIds);
     }
 
     @Override
-    public List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<String> molecularProfileIds,
-            List<String> sampleIds) {
+    public List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers) {
 
-        boolean hasFusionProfileIdsInQuery = molecularProfileIds
-            .stream()
-            .anyMatch(molecularProfileId -> molecularProfileId.endsWith("_fusion"));
-
-        if (!hasFusionProfileIdsInQuery) {
-            return genePanelRepository.fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileIds, sampleIds);
-        }
+        AtomicReference<Boolean> hasFusions = new AtomicReference<>(false);
 
         // TODO: remove this block after fusion are migrated to structural variant in database
-        List<String> updatedMolecularProfileIds = new ArrayList<>(molecularProfileIds);
-        List<String> updatedSampleIds = new ArrayList<>(sampleIds);
-
-        for (int i = 0; i < molecularProfileIds.size(); i++) {
-            String molecularProfileId = molecularProfileIds.get(i);
-            if(molecularProfileId.endsWith("_fusion")) {
-                updatedMolecularProfileIds.add(molecularProfileId.replace("_fusion", "_mutations"));
-                updatedSampleIds.add(sampleIds.get(i));
+        Set<MolecularProfileCaseIdentifier> updatedMolecularProfileSampleIdentifiers = molecularProfileSampleIdentifiers.stream().map(molecularProfileSampleIdentifier -> {
+            if (molecularProfileSampleIdentifier.getMolecularProfileId().endsWith("_fusion")) {
+                hasFusions.set(true);
+                MolecularProfileCaseIdentifier profileCaseIdentifier = new MolecularProfileCaseIdentifier();
+                profileCaseIdentifier.setMolecularProfileId(molecularProfileSampleIdentifier.getMolecularProfileId().replace("_fusion", "_mutations"));
+                profileCaseIdentifier.setCaseId(molecularProfileSampleIdentifier.getCaseId());
+                return profileCaseIdentifier;
             }
+            return molecularProfileSampleIdentifier;
+        }).collect(Collectors.toSet());
+        // TODO: remove this block after fusion are migrated to structural variant in database
+
+        List<GenePanelData> genePanelDataForQueriedProfiles;
+        if (updatedMolecularProfileSampleIdentifiers.size() < maxCasesCountToIncludeInQuery) {
+            genePanelDataForQueriedProfiles = genePanelRepository.fetchGenePanelDataInMultipleMolecularProfiles(new ArrayList<>(updatedMolecularProfileSampleIdentifiers));
+            if (!hasFusions.get()) {
+                //return response that is directly coming from database query are samples are already filtered
+                return genePanelDataForQueriedProfiles;
+            }
+        } else {
+            List<String> molecularProfileIds = updatedMolecularProfileSampleIdentifiers
+                .stream()
+                .map(MolecularProfileCaseIdentifier::getMolecularProfileId)
+                .distinct()
+                .collect(toList());
+            genePanelDataForQueriedProfiles = genePanelRepository.fetchGenePanelDataByMolecularProfileIds(molecularProfileIds);
         }
 
-        List<GenePanelData> genePanelData = genePanelRepository
-            .fetchGenePanelDataInMultipleMolecularProfiles(updatedMolecularProfileIds, updatedSampleIds);
-
-        Map<Pair<String, String>, GenePanelData> genePanelDataSet = genePanelData
+        Map<Pair<String, String>, GenePanelData> genePanelDataSet = genePanelDataForQueriedProfiles
             .stream()
             .collect(toMap(
-                    datum -> new Pair(datum.getMolecularProfileId(),
-                    datum.getSampleId()), Function.identity()));
+                datum -> new Pair<>(datum.getMolecularProfileId(), datum.getSampleId()), Function.identity()));
+        List<GenePanelData> genePanelData = new ArrayList<>();
 
-        return genePanelData.stream().map(datum -> {
-            String molecularProfileId = datum.getMolecularProfileId();
-            if(molecularProfileId.endsWith("_fusion")) {
-                String mutationProfileIdToSearch = molecularProfileId.replace("_fusion", "_mutations");
-                Pair key = new Pair(mutationProfileIdToSearch, datum.getSampleId());
-                if(genePanelDataSet.containsKey(key)) {
-                    GenePanelData mutationGenePanelData = genePanelDataSet.get(key);
-                    datum.setGenePanelId(mutationGenePanelData.getGenePanelId());
-                    datum.setProfiled(mutationGenePanelData.getProfiled());
+        for (MolecularProfileCaseIdentifier profileCaseIdentifier : molecularProfileSampleIdentifiers) {
+            String molecularProfileId = profileCaseIdentifier.getMolecularProfileId();
+            String sampleId = profileCaseIdentifier.getCaseId();
+            Pair<String, String> key = new Pair<>(molecularProfileId, sampleId);
+            if (genePanelDataSet.containsKey(key)) {
+                genePanelData.add(genePanelDataSet.get(key));
+            } else if (molecularProfileId.endsWith("_fusion")) {
+                // TODO: remove this block after fusion are migrated to structural variant in database
+                String mutationMolecularProfileId = molecularProfileId.replace("_fusion", "_mutations");
+                key = new Pair<>(mutationMolecularProfileId, sampleId);
+                if (genePanelDataSet.containsKey(key)) {
+                    GenePanelData mutationPanelData = genePanelDataSet.get(key);
+                    GenePanelData fusionPanelData = new GenePanelData();
+                    fusionPanelData.setMolecularProfileId(molecularProfileId);
+                    fusionPanelData.setSampleId(mutationPanelData.getSampleId());
+                    fusionPanelData.setPatientId(mutationPanelData.getPatientId());
+                    fusionPanelData.setStudyId(mutationPanelData.getStudyId());
+                    fusionPanelData.setProfiled(mutationPanelData.getProfiled());
+                    fusionPanelData.setGenePanelId(mutationPanelData.getGenePanelId());
+                    genePanelData.add(fusionPanelData);
                 }
             }
-            return datum;
-        }).collect(toList());
-        // TODO: remove this block after fusion are migrated to structural variant in database
-	}
+        }
+        return genePanelData;
+    }
 
     @Override
-    public List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(
-            List<String> molecularProfileIds, List<String> patientIds) {
+    public List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(List<MolecularProfileCaseIdentifier> molecularProfilePatientIdentifiers) {
 
-        boolean hasFusionProfileIdsInQuery = molecularProfileIds
-            .stream()
-            .anyMatch(molecularProfileId -> molecularProfileId.endsWith("_fusion"));
-
-        if (!hasFusionProfileIdsInQuery) {
-            return genePanelRepository
-                .fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(molecularProfileIds, patientIds);
-        }
+        AtomicReference<Boolean> hasFusions = new AtomicReference<>(false);
 
         // TODO: remove this block after fusion are migrated to structural variant in database
-        List<String> updatedMolecularProfileIds = new ArrayList<>(molecularProfileIds);
-        List<String> updatedPatientIds = new ArrayList<>(patientIds);
-
-        for (int i = 0; i < molecularProfileIds.size(); i++) {
-            String molecularProfileId = molecularProfileIds.get(i);
-            if(molecularProfileId.endsWith("_fusion")) {
-                updatedMolecularProfileIds.add(molecularProfileId.replace("_fusion", "_mutations"));
-                updatedPatientIds.add(patientIds.get(i));
+        Set<MolecularProfileCaseIdentifier> updatedMolecularProfilePatientIdentifiers = molecularProfilePatientIdentifiers.stream().map(molecularProfileSampleIdentifier -> {
+            if (molecularProfileSampleIdentifier.getMolecularProfileId().endsWith("_fusion")) {
+                hasFusions.set(true);
+                MolecularProfileCaseIdentifier profileCaseIdentifier = new MolecularProfileCaseIdentifier();
+                profileCaseIdentifier.setMolecularProfileId(molecularProfileSampleIdentifier.getMolecularProfileId().replace("_fusion", "_mutations"));
+                profileCaseIdentifier.setCaseId(molecularProfileSampleIdentifier.getCaseId());
+                return profileCaseIdentifier;
             }
+            return molecularProfileSampleIdentifier;
+        }).collect(Collectors.toSet());
+        // TODO: remove this block after fusion are migrated to structural variant in database
+
+        List<GenePanelData> genePanelDataForQueriedProfiles;
+        if (updatedMolecularProfilePatientIdentifiers.size() < maxCasesCountToIncludeInQuery) {
+            genePanelDataForQueriedProfiles = genePanelRepository.fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(new ArrayList<>(updatedMolecularProfilePatientIdentifiers));
+            if (!hasFusions.get()) {
+                //return response that is directly coming from database query are samples are already filtered
+                return genePanelDataForQueriedProfiles;
+            }
+        } else {
+            List<String> molecularProfileIds = updatedMolecularProfilePatientIdentifiers
+                .stream()
+                .map(MolecularProfileCaseIdentifier::getMolecularProfileId)
+                .distinct()
+                .collect(toList());
+            genePanelDataForQueriedProfiles = genePanelRepository.fetchGenePanelDataByMolecularProfileIds(molecularProfileIds);
         }
 
-        List<GenePanelData> genePanelData = genePanelRepository
-            .fetchGenePanelDataInMultipleMolecularProfiles(updatedMolecularProfileIds, updatedPatientIds);
-
-        Map<Pair<String, String>, GenePanelData> genePanelDataSet = genePanelData
+        Map<Object, List<GenePanelData>> genePanelDataSet = genePanelDataForQueriedProfiles
             .stream()
-            .collect(toMap(
-                datum -> new Pair(datum.getMolecularProfileId(),
-                    datum.getSampleId()), Function.identity()));
+            .collect(groupingBy(datum -> new Pair<>(datum.getMolecularProfileId(), datum.getPatientId())));
+        List<GenePanelData> genePanelData = new ArrayList<>();
 
-        return genePanelData.stream().map(datum -> {
-            String molecularProfileId = datum.getMolecularProfileId();
-            if(molecularProfileId.endsWith("_fusion")) {
-                String mutationProfileIdToSearch = molecularProfileId.replace("_fusion", "_mutations");
-                Pair key = new Pair(mutationProfileIdToSearch, datum.getSampleId());
-                if(genePanelDataSet.containsKey(key)) {
-                    GenePanelData mutationGenePanelData = genePanelDataSet.get(key);
-                    datum.setGenePanelId(mutationGenePanelData.getGenePanelId());
-                    datum.setProfiled(mutationGenePanelData.getProfiled());
+        for (MolecularProfileCaseIdentifier profileCaseIdentifier : molecularProfilePatientIdentifiers) {
+            String molecularProfileId = profileCaseIdentifier.getMolecularProfileId();
+            String patientId = profileCaseIdentifier.getCaseId();
+            Pair<String, String> key = new Pair<>(molecularProfileId, patientId);
+            if (genePanelDataSet.containsKey(key)) {
+                genePanelData.addAll(genePanelDataSet.get(key));
+            } else if (molecularProfileId.endsWith("_fusion")) {
+                // TODO: remove this block after fusion are migrated to structural variant in database
+                String mutationMolecularProfileId = molecularProfileId.replace("_fusion", "_mutations");
+                key = new Pair<>(mutationMolecularProfileId, patientId);
+                for (GenePanelData mutationPanelData : genePanelDataSet.getOrDefault(key, new ArrayList<>())) {
+                    GenePanelData fusionPanelData = new GenePanelData();
+                    fusionPanelData.setMolecularProfileId(molecularProfileId);
+                    fusionPanelData.setSampleId(mutationPanelData.getSampleId());
+                    fusionPanelData.setPatientId(mutationPanelData.getPatientId());
+                    fusionPanelData.setStudyId(mutationPanelData.getStudyId());
+                    fusionPanelData.setProfiled(mutationPanelData.getProfiled());
+                    fusionPanelData.setGenePanelId(mutationPanelData.getGenePanelId());
+                    genePanelData.add(fusionPanelData);
                 }
             }
-            return datum;
-        }).collect(toList());
-        // TODO: remove this block after fusion are migrated to structural variant in database
+        }
+        return genePanelData;
     }
+
 }

--- a/service/src/main/java/org/cbioportal/service/util/AlterationEnrichmentUtil.java
+++ b/service/src/main/java/org/cbioportal/service/util/AlterationEnrichmentUtil.java
@@ -173,7 +173,7 @@ public class AlterationEnrichmentUtil<T extends AlterationCountByGene> {
         });
 
         List<GenePanelData> genePanelDataList = genePanelService
-            .fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileIds, sampleIds);
+            .fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileCaseIdentifiers);
 
         profiledCasesCounter.calculate(alterationCountByGenes, genePanelDataList,
                 includeMissingAlterationsFromGenePanel, profiledCasesCounter.sampleUniqueIdentifier);
@@ -202,7 +202,7 @@ public class AlterationEnrichmentUtil<T extends AlterationCountByGene> {
         });
 
         List<GenePanelData> genePanelDataList = genePanelService
-            .fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(molecularProfileIds, patientIds);
+            .fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(molecularProfileCaseIdentifiers);
 
         profiledCasesCounter.calculate(alterationCountByGenes, genePanelDataList,
             includeMissingAlterationsFromGenePanel, profiledCasesCounter.patientUniqueIdentifier);

--- a/service/src/test/java/org/cbioportal/service/impl/GenePanelServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenePanelServiceImplTest.java
@@ -1,12 +1,12 @@
 package org.cbioportal.service.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import org.cbioportal.model.GenePanel;
 import org.cbioportal.model.GenePanelData;
 import org.cbioportal.model.GenePanelToGene;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.GenePanelRepository;
 import org.cbioportal.service.exception.GenePanelNotFoundException;
@@ -209,13 +209,28 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
         genePanelData2.setProfiled(true);
         genePanelDataList.add(genePanelData2);
 
-        Mockito.when(genePanelRepository.fetchGenePanelDataInMultipleMolecularProfiles(
-            Arrays.asList(MOLECULAR_PROFILE_ID, MOLECULAR_PROFILE_ID, "invalid_profile"), Arrays.asList(SAMPLE_ID1, SAMPLE_ID2, SAMPLE_ID3)))
+        Set<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers = new HashSet<>();
+        MolecularProfileCaseIdentifier profileCaseIdentifier = new MolecularProfileCaseIdentifier();
+        profileCaseIdentifier.setMolecularProfileId(MOLECULAR_PROFILE_ID);
+        profileCaseIdentifier.setCaseId(SAMPLE_ID1);
+        molecularProfileSampleIdentifiers.add(profileCaseIdentifier);
+
+        MolecularProfileCaseIdentifier profileCaseIdentifier2 = new MolecularProfileCaseIdentifier();
+        profileCaseIdentifier2.setMolecularProfileId(MOLECULAR_PROFILE_ID);
+        profileCaseIdentifier2.setCaseId(SAMPLE_ID2);
+        molecularProfileSampleIdentifiers.add(profileCaseIdentifier2);
+
+
+        MolecularProfileCaseIdentifier profileCaseIdentifier3 = new MolecularProfileCaseIdentifier();
+        profileCaseIdentifier3.setMolecularProfileId("invalid_profile");
+        profileCaseIdentifier3.setCaseId(SAMPLE_ID3);
+        molecularProfileSampleIdentifiers.add(profileCaseIdentifier3);
+        List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers = new ArrayList<>(molecularProfileSampleIdentifiers);
+
+        Mockito.when(genePanelRepository.fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileCaseIdentifiers))
             .thenReturn(genePanelDataList);
 
-        List<GenePanelData> result = genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(
-            new ArrayList<>(Arrays.asList(MOLECULAR_PROFILE_ID, MOLECULAR_PROFILE_ID, "invalid_profile")), 
-            new ArrayList<>(Arrays.asList(SAMPLE_ID1, SAMPLE_ID2, SAMPLE_ID3)));
+        List<GenePanelData> result = genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileCaseIdentifiers);
 
         Assert.assertEquals(2, result.size());
         GenePanelData resultGenePanelData1 = result.get(0);

--- a/web/src/main/java/org/cbioportal/web/StudyViewController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyViewController.java
@@ -508,21 +508,23 @@ public class StudyViewController {
         Map<String, List<MolecularProfile>> studyMolecularProfilesSet = molecularProfiles.stream()
                 .collect(Collectors.groupingBy(MolecularProfile::getCancerStudyIdentifier));
 
-        List<String> queryMolecularProfileIds = new ArrayList<>();
-        List<String> querySampleIds = new ArrayList<>();
+        List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers = new ArrayList<>();
+
         for (int i = 0; i < studyIds.size(); i++) {
             String studyId = studyIds.get(i);
             String sampleId = sampleIds.get(i);
             if (studyMolecularProfilesSet.containsKey(studyId)) {
                 studyMolecularProfilesSet.get(studyId).stream().forEach(molecularProfile -> {
-                    queryMolecularProfileIds.add(molecularProfile.getStableId());
-                    querySampleIds.add(sampleId);
+                    MolecularProfileCaseIdentifier profileCaseIdentifier = new MolecularProfileCaseIdentifier();
+                    profileCaseIdentifier.setMolecularProfileId(molecularProfile.getStableId());
+                    profileCaseIdentifier.setCaseId(sampleId);
+                    molecularProfileSampleIdentifiers.add(profileCaseIdentifier);
                 });
             }
         }
 
         List<GenePanelData> genePanelData = genePanelService
-                .fetchGenePanelDataInMultipleMolecularProfiles(queryMolecularProfileIds, querySampleIds);
+                .fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileSampleIdentifiers);
         HashMap<String, Integer> molecularPorfileSampleCountSet = new HashMap<String, Integer>();
 
         for (GenePanelData datum : genePanelData) {

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -184,17 +184,18 @@ public class StudyViewFilterApplier {
 
             Map<String, List<MolecularProfile>> molecularProfileSet = studyViewFilterUtil
                     .categorizeMolecularPorfiles(molecularProfiles);
-
-            List<String> queryMolecularProfileIds = new ArrayList<>();
-            List<String> querySampleIds = new ArrayList<>();
+            
+            List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers = new ArrayList<>();
 
             studyViewFilter.getGenomicProfiles().stream().forEach(profileValues -> {
                 profileValues.stream().forEach(profileValue -> {
                     molecularProfileSet.getOrDefault(profileValue, new ArrayList<>()).stream().forEach(profile -> {
                         groupStudySampleIdentifiers.getOrDefault(profile.getCancerStudyIdentifier(), new ArrayList<>())
                                 .stream().forEach(sampleIdentifier -> {
-                                    queryMolecularProfileIds.add(profile.getStableId());
-                                    querySampleIds.add(sampleIdentifier.getSampleId());
+                                    MolecularProfileCaseIdentifier profileCaseIdentifier = new MolecularProfileCaseIdentifier();
+                                    profileCaseIdentifier.setMolecularProfileId(profile.getStableId());
+                                    profileCaseIdentifier.setCaseId(sampleIdentifier.getSampleId());
+                                    molecularProfileSampleIdentifiers.add(profileCaseIdentifier);
                                 });
                     });
 
@@ -202,7 +203,7 @@ public class StudyViewFilterApplier {
             });
 
             List<GenePanelData> genePanelData = genePanelService
-                    .fetchGenePanelDataInMultipleMolecularProfiles(queryMolecularProfileIds, querySampleIds);
+                    .fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileSampleIdentifiers);
 
             studyViewFilter.getGenomicProfiles().stream().flatMap(profileValues -> profileValues.stream());
 

--- a/web/src/test/java/org/cbioportal/web/GenePanelControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GenePanelControllerTest.java
@@ -251,8 +251,7 @@ public class GenePanelControllerTest {
 
         List<GenePanelData> genePanelDataList = createExampleGenePanelData();
 
-        Mockito.when(genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(Mockito.anyList(),
-            Mockito.anyList())).thenReturn(genePanelDataList);
+        Mockito.when(genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(Mockito.anyList())).thenReturn(genePanelDataList);
 
         List<SampleMolecularIdentifier> sampleMolecularIdentifiers = new ArrayList<>();
         SampleMolecularIdentifier sampleMolecularIdentifier1 = new SampleMolecularIdentifier();

--- a/web/src/test/java/org/cbioportal/web/StudyViewControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StudyViewControllerTest.java
@@ -537,8 +537,8 @@ public class StudyViewControllerTest {
         genePanelData3.setProfiled(true);
         genePanelDataList.add(genePanelData3);
 
-        Mockito.when(genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(anyList(),
-            anyList())).thenReturn(genePanelDataList);
+        Mockito.when(genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(anyList()
+        )).thenReturn(genePanelDataList);
 
         StudyViewFilter studyViewFilter = new StudyViewFilter();
         studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));


### PR DESCRIPTION
Solution: if there are more than 30,000 objects(molecular case identifiers) then fetch gene panel data for all the samples/patients for queried molecular profiles and then filter the result

Also removed all the logic for finding whether the sample is profile or not based on sequenced case list.

This improved the performance by alteast 2x(11sec -> 4sec) when tested locally for `/results?cancer_study_list=msk_impact_2017&tab_index=tab_visualize&case_set_id=msk_impact_2017_all&Action=Submit&gene_list=TMPRSS2%250ATP53%250AKRAS%250ACDKN2A%250ACDKN2B`