### PR TITLE
Check inequality of stable_id & source_stable_id

### DIFF
--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -20,7 +20,7 @@ ERROR_FILE = sys.stderr
 OUTPUT_FILE = sys.stdout
 
 # global variables to check `source_stable_id` for `genomic_profile_link`
-expression_stable_ids = []
+expression_stable_ids = {}
 gsva_scores_stable_id = ""
 expression_zscores_source_stable_ids = {}
 gsva_scores_source_stable_id = ""
@@ -906,10 +906,10 @@ def parse_metadata_file(filename,
     global gsva_scores_filename
     global gsva_pvalues_filename
 
-    # save all expression `stable_id` in list
+    # save all expression `stable_id` in a dictionary with their filenames
     if meta_file_type is MetaFileTypes.EXPRESSION:
         if 'stable_id' in meta_dictionary:
-            expression_stable_ids.append(meta_dictionary['stable_id'])
+            expression_stable_ids[meta_dictionary['stable_id']] = filename
 
             # Save all zscore expression `source_stable_id` in dictionary with their filenames.
             # Multiple zscore expression files are possible, and we want to validate all their

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -4951,12 +4951,19 @@ def validate_data_relations(validators_by_meta_type, logger):
 
     # validation specific for Z-SCORE expression data
     for expression_zscores_source_stable_id in expression_zscores_source_stable_ids:
-
         # check if 'source_stable_id' of EXPRESSION Z-SCORE is an EXPRESSION 'stable_id'
-        if not expression_zscores_source_stable_id in expression_stable_ids:
+        if not expression_zscores_source_stable_id in expression_stable_ids.keys():
             logger.error(
-                "Invalid source_stable_id. Expected one of ['" + "', '".join(expression_stable_ids) +
+                "Invalid source_stable_id. Expected one of ['" + "', '".join(expression_stable_ids.keys()) +
                 "'], which are stable ids of expression files in this study",
+                extra={'filename_': expression_zscores_source_stable_ids[expression_zscores_source_stable_id],
+                       'cause': expression_zscores_source_stable_id})
+        # check that source_stable_id is not the same as source_id
+        for expression_stable_id in expression_stable_ids.keys():
+            if expression_zscores_source_stable_ids[expression_zscores_source_stable_id] == expression_stable_ids[expression_stable_id]:
+                if expression_zscores_source_stable_id == expression_stable_id:
+                    logger.error(
+                "Both source_stable_id and stable_id refers to the same profile",
                 extra={'filename_': expression_zscores_source_stable_ids[expression_zscores_source_stable_id],
                        'cause': expression_zscores_source_stable_id})
 
@@ -4981,9 +4988,9 @@ def validate_data_relations(validators_by_meta_type, logger):
         if not missing_gsva_file:
 
             # check if 'source_stable_id' of GSVA_SCORES is an EXPRESSION 'stable_id'
-            if not gsva_scores_source_stable_id in expression_stable_ids:
+            if not gsva_scores_source_stable_id in expression_stable_ids.keys():
                 logger.error(
-                    "Invalid source_stable_id. Expected one of ['" + "', '".join(expression_stable_ids) +
+                    "Invalid source_stable_id. Expected one of ['" + "', '".join(expression_stable_ids.keys()) +
                     "'], which are stable ids of expression files in this study",
                     extra={'filename_': gsva_scores_filename,
                            'cause': gsva_scores_source_stable_id})


### PR DESCRIPTION
Add validation check so that `stable_id` and `source_stable_id` are not referencing the same profile in the meta Z-score expression file.