### PR TITLE
Avoid redundant filter and clinical data fetch calls

### DIFF
--- a/web/src/main/java/org/cbioportal/web/StudyViewController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyViewController.java
@@ -15,19 +15,15 @@ import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.service.util.ClinicalAttributeUtil;
 import org.cbioportal.web.config.annotation.InternalApi;
 import org.cbioportal.web.parameter.ClinicalDataBinCountFilter;
-import org.cbioportal.web.parameter.ClinicalDataBinFilter;
 import org.cbioportal.web.parameter.ClinicalDataCountFilter;
 import org.cbioportal.web.parameter.ClinicalDataFilter;
-import org.cbioportal.web.parameter.ClinicalDataType;
 import org.cbioportal.web.parameter.DataBinMethod;
 import org.cbioportal.web.parameter.GenericAssayDataBinCountFilter;
 import org.cbioportal.web.parameter.GenomicDataBinCountFilter;
 import org.cbioportal.web.parameter.Projection;
 import org.cbioportal.web.parameter.SampleIdentifier;
 import org.cbioportal.web.parameter.StudyViewFilter;
-import org.cbioportal.web.util.DataBinner;
-import org.cbioportal.web.util.StudyViewFilterApplier;
-import org.cbioportal.web.util.StudyViewFilterUtil;
+import org.cbioportal.web.util.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationContext;
@@ -69,6 +65,8 @@ public class StudyViewController {
     @Autowired
     private ClinicalDataService clinicalDataService;
     @Autowired
+    private ClinicalDataFetcher clinicalDataFetcher;
+    @Autowired
     private MolecularProfileService molecularProfileService;
     @Autowired
     private AlterationCountService alterationCountService;
@@ -81,8 +79,6 @@ public class StudyViewController {
     @Autowired
     private SignificantCopyNumberRegionService significantCopyNumberRegionService;
     @Autowired
-    private DataBinner dataBinner;
-    @Autowired
     private StudyViewFilterUtil studyViewFilterUtil;
     @Autowired
     private ClinicalAttributeService clinicalAttributeService;
@@ -92,6 +88,8 @@ public class StudyViewController {
     private SampleListService sampleListService;
     @Autowired
     private StudyViewService studyViewService;
+    @Autowired
+    private ClinicalDataBinUtil clinicalDataBinUtil;
 
     private static final List<CNA> CNA_TYPES_AMP_AND_HOMDEL = Collections.unmodifiableList(Arrays.asList(CNA.AMP, CNA.HOMDEL));
 
@@ -141,17 +139,10 @@ public class StudyViewController {
         @ApiIgnore // prevent reference to this attribute in the swagger-ui interface. this attribute is needed for the @PreAuthorize tag above.
         @Valid @RequestAttribute(required = false, value = "interceptedClinicalDataBinCountFilter") ClinicalDataBinCountFilter interceptedClinicalDataBinCountFilter
     ) {
-
-        List<ClinicalDataBinFilter> attributes = interceptedClinicalDataBinCountFilter.getAttributes();
-        StudyViewFilter studyViewFilter = interceptedClinicalDataBinCountFilter.getStudyViewFilter();
-
-        if (attributes.size() == 1) {
-            studyViewFilterUtil.removeSelfFromFilter(attributes.get(0).getAttributeId(), studyViewFilter);
-        }
-
+        StudyViewFilter studyViewFilter = clinicalDataBinUtil.removeSelfFromFilter(interceptedClinicalDataBinCountFilter);
         boolean singleStudyUnfiltered = studyViewFilterUtil.isSingleStudyUnfiltered(studyViewFilter);
         List<ClinicalDataBin> clinicalDataBins = 
-            instance.cachableFetchClinicalDataBinCounts(dataBinMethod, attributes, studyViewFilter, singleStudyUnfiltered);
+            instance.cachableFetchClinicalDataBinCounts(dataBinMethod, interceptedClinicalDataBinCountFilter, singleStudyUnfiltered);
 
         return new ResponseEntity<>(clinicalDataBins, HttpStatus.OK);
     }
@@ -162,147 +153,15 @@ public class StudyViewController {
     )
     public List<ClinicalDataBin> cachableFetchClinicalDataBinCounts(
         DataBinMethod dataBinMethod,
-        List<ClinicalDataBinFilter> attributes,
-        StudyViewFilter studyViewFilter,
+        ClinicalDataBinCountFilter interceptedClinicalDataBinCountFilter,
         boolean singleStudyUnfiltered
     ) {
-        List<SampleIdentifier> filteredSampleIdentifiers = studyViewFilterApplier.apply(studyViewFilter);
-        List<String> filteredStudyIds = new ArrayList<>();
-        List<ClinicalDataBin> clinicalDataBins = new ArrayList<>();
-        List<String> filteredSampleIds = new ArrayList<>();
-        studyViewFilterUtil.extractStudyAndSampleIds(filteredSampleIdentifiers, filteredStudyIds, filteredSampleIds);
-
-        List<String> attributeIds = attributes.stream().map(ClinicalDataBinFilter::getAttributeId).collect(Collectors.toList());
-
-        List<String> filteredPatientIds = new ArrayList<>();
-        List<String> studyIdsOfFilteredPatients = new ArrayList<>();
-        patientService.getPatientsOfSamples(filteredStudyIds, filteredSampleIds).stream().forEach(patient -> {
-            filteredPatientIds.add(patient.getStableId());
-            studyIdsOfFilteredPatients.add(patient.getCancerStudyIdentifier());
-        });
-
-        List<String> sampleAttributeIds = new ArrayList<>();
-        List<String> patientAttributeIds = new ArrayList<>();
-        // patient attributes which are also sample attributes in other studies
-        List<String> conflictingPatientAttributeIds = new ArrayList<>();
-
-        List<ClinicalAttribute> clinicalAttributes = clinicalAttributeService
-            .getClinicalAttributesByStudyIdsAndAttributeIds(filteredStudyIds, attributeIds);
-        clinicalAttributeUtil.extractCategorizedClinicalAttributes(clinicalAttributes, sampleAttributeIds,
-            patientAttributeIds, conflictingPatientAttributeIds);
-
-        List<ClinicalData> filteredClinicalData = fetchClinicalData(filteredStudyIds,
-            filteredSampleIds,
-            filteredPatientIds,
-            studyIdsOfFilteredPatients,
-            sampleAttributeIds,
-            patientAttributeIds,
-            conflictingPatientAttributeIds);
-
-        Map<String, ClinicalDataType> attributeDatatypeMap = new HashMap<>();
-
-        sampleAttributeIds.forEach(attribute->{
-            attributeDatatypeMap.put(attribute, ClinicalDataType.SAMPLE);
-        });
-        patientAttributeIds.forEach(attribute->{
-            attributeDatatypeMap.put(attribute, ClinicalDataType.PATIENT);
-        });
-        conflictingPatientAttributeIds.forEach(attribute->{
-            attributeDatatypeMap.put(attribute, ClinicalDataType.SAMPLE);
-        });
-
-        Map<String, List<ClinicalData>> filteredClinicalDataByAttributeId =
-            filteredClinicalData.stream().collect(Collectors.groupingBy(ClinicalData::getAttrId));
-
-        List<String> filteredUniqueSampleKeys =  studyViewFilterApplier.getUniqkeyKeys(filteredStudyIds, filteredSampleIds);
-        List<String> filteredUniquePatientKeys =  studyViewFilterApplier.getUniqkeyKeys(studyIdsOfFilteredPatients, filteredPatientIds);
-
-        if (dataBinMethod == DataBinMethod.STATIC) {
-            StudyViewFilter filter = studyViewFilter == null ? null : new StudyViewFilter();
-
-            if (filter != null) {
-                filter.setStudyIds(studyViewFilter.getStudyIds());
-                filter.setSampleIdentifiers(studyViewFilter.getSampleIdentifiers());
-            }
-            List<String> unfilteredStudyIds = new ArrayList<>();
-            List<String> unfilteredSampleIds = new ArrayList<>();
-
-            List<SampleIdentifier> unFilteredSampleIdentifiers = studyViewFilterApplier.apply(filter);
-            studyViewFilterUtil.extractStudyAndSampleIds(unFilteredSampleIdentifiers, unfilteredStudyIds,
-                unfilteredSampleIds);
-
-            if (!unFilteredSampleIdentifiers.isEmpty()) {
-                List<String> unfilteredPatientIds = new ArrayList<>();
-                List<String> unfilteredStudyIdsOfPatients = new ArrayList<>();
-                patientService.getPatientsOfSamples(unfilteredStudyIds, unfilteredSampleIds).stream()
-                    .forEach(patient -> {
-                        unfilteredPatientIds.add(patient.getStableId());
-                        unfilteredStudyIdsOfPatients.add(patient.getCancerStudyIdentifier());
-                    });
-
-                List<ClinicalData> unfilteredClinicalData = fetchClinicalData(unfilteredStudyIds, unfilteredSampleIds,
-                    unfilteredPatientIds, unfilteredStudyIdsOfPatients, new ArrayList<>(sampleAttributeIds),
-                    new ArrayList<>(patientAttributeIds), new ArrayList<>(conflictingPatientAttributeIds));
-
-                if (!unfilteredClinicalData.isEmpty()) {
-                    List<String> unfilteredUniqueSampleKeys =  studyViewFilterApplier.getUniqkeyKeys(unfilteredStudyIds, unfilteredSampleIds);
-                    List<String> unfilteredUniquePatientKeys =  studyViewFilterApplier.getUniqkeyKeys(unfilteredStudyIdsOfPatients, unfilteredPatientIds);
-
-                    Map<String, List<ClinicalData>> unfilteredClinicalDataByAttributeId = unfilteredClinicalData.stream()
-                        .collect(Collectors.groupingBy(ClinicalData::getAttrId));
-
-                    clinicalDataBins = new ArrayList<>();
-                    for (ClinicalDataBinFilter attribute : attributes) {
-                        if (attributeDatatypeMap.containsKey(attribute.getAttributeId())) {
-                            ClinicalDataType clinicalDataType = attributeDatatypeMap.get(attribute.getAttributeId());
-                            List<String> filteredIds = clinicalDataType == ClinicalDataType.PATIENT ? filteredUniquePatientKeys
-                                : filteredUniqueSampleKeys;
-                            List<String> unfilteredIds = clinicalDataType == ClinicalDataType.PATIENT
-                                ? unfilteredUniquePatientKeys
-                                : unfilteredUniqueSampleKeys;
-
-                            List<ClinicalDataBin> dataBins = dataBinner
-                                .calculateClinicalDataBins(attribute, clinicalDataType,
-                                    filteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(),
-                                        Collections.emptyList()),
-                                    unfilteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(),
-                                        Collections.emptyList()),
-                                    filteredIds, unfilteredIds)
-                                .stream()
-                                .map(dataBin -> studyViewFilterUtil.dataBinToClinicalDataBin(attribute, dataBin))
-                                .collect(Collectors.toList());
-
-                            clinicalDataBins.addAll(dataBins);
-                        }
-                    }
-                }
-
-            }
-        }
-        else { // dataBinMethod == DataBinMethod.DYNAMIC
-            if (!filteredClinicalData.isEmpty()) {
-                for (ClinicalDataBinFilter attribute : attributes) {
-
-                    if (attributeDatatypeMap.containsKey(attribute.getAttributeId())) {
-                        ClinicalDataType clinicalDataType = attributeDatatypeMap.get(attribute.getAttributeId());
-                        List<String> filteredIds = clinicalDataType == ClinicalDataType.PATIENT
-                            ? filteredUniquePatientKeys
-                            : filteredUniqueSampleKeys;
-
-                        List<ClinicalDataBin> dataBins = dataBinner
-                            .calculateDataBins(attribute, clinicalDataType,
-                                filteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(),
-                                    Collections.emptyList()),
-                                filteredIds)
-                            .stream()
-                            .map(dataBin -> studyViewFilterUtil.dataBinToClinicalDataBin(attribute, dataBin))
-                            .collect(Collectors.toList());
-                        clinicalDataBins.addAll(dataBins);
-                    }
-                }
-            }
-        }
-        return clinicalDataBins;
+        return clinicalDataBinUtil.fetchClinicalDataBinCounts(
+            dataBinMethod,
+            interceptedClinicalDataBinCountFilter,
+            // we don't need to remove filter again since we already did it in the previous step 
+            false 
+        );
     }
 
     @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
@@ -554,8 +413,9 @@ public class StudyViewController {
             studyIdsOfPatients = patients.stream().map(Patient::getCancerStudyIdentifier).collect(Collectors.toList());
         }
 
-        List<ClinicalData> clinicalDataList = fetchClinicalData(studyIds, sampleIds, patientIds, studyIdsOfPatients,
-                sampleAttributeIds, patientAttributeIds, null);
+        List<ClinicalData> clinicalDataList = clinicalDataFetcher.fetchClinicalData(
+            studyIds, sampleIds, patientIds, studyIdsOfPatients, sampleAttributeIds, patientAttributeIds, null
+        );
 
         Map<String, Map<String, List<ClinicalData>>> clinicalDataMap;
         if (!sampleAttributeIds.isEmpty()) {
@@ -701,37 +561,6 @@ public class StudyViewController {
                 .filter(dataCount -> dataCount.getCount() > 0)
                 .collect(Collectors.toList());
 
-    }
-
-    private List<ClinicalData> fetchClinicalData(List<String> studyIds,
-            List<String> sampleIds,
-            List<String> patientIds,
-            List<String> studyIdsOfPatients,
-            List<String> sampleAttributeIds,
-            List<String> patientAttributeIds,
-            List<String> conflictingPatientAttributes) {
-
-        List<ClinicalData> combinedResult = new ArrayList<>();
-
-        if (CollectionUtils.isNotEmpty(sampleAttributeIds)) {
-            List<ClinicalData> filteredClinicalDataForSamples = clinicalDataService.fetchClinicalData(studyIds,
-                    sampleIds, sampleAttributeIds, "SAMPLE", Projection.SUMMARY.name());
-            combinedResult.addAll(filteredClinicalDataForSamples);
-        }
-
-        if (CollectionUtils.isNotEmpty(patientAttributeIds)) {
-            List<ClinicalData> filteredClinicalDataForPatients = clinicalDataService.fetchClinicalData(
-                    studyIdsOfPatients, patientIds, patientAttributeIds, "PATIENT", Projection.SUMMARY.name());
-            combinedResult.addAll(filteredClinicalDataForPatients);
-        }
-
-        if (CollectionUtils.isNotEmpty(conflictingPatientAttributes)) {
-            List<ClinicalData> filteredClinicalDataForPatients = clinicalDataService.getPatientClinicalDataDetailedToSample(
-                    studyIdsOfPatients, patientIds, conflictingPatientAttributes);
-            combinedResult.addAll(filteredClinicalDataForPatients);
-        }
-
-        return combinedResult;
     }
     
     @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")

--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataBinUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataBinUtil.java
@@ -1,0 +1,375 @@
+package org.cbioportal.web.util;
+
+import org.cbioportal.model.ClinicalAttribute;
+import org.cbioportal.model.ClinicalData;
+import org.cbioportal.model.ClinicalDataBin;
+import org.cbioportal.service.ClinicalAttributeService;
+import org.cbioportal.service.PatientService;
+import org.cbioportal.service.util.ClinicalAttributeUtil;
+import org.cbioportal.web.parameter.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+public class ClinicalDataBinUtil {
+
+    @Autowired
+    private StudyViewFilterApplier studyViewFilterApplier;
+    @Autowired
+    private ClinicalDataFetcher clinicalDataFetcher;
+    @Autowired
+    private DataBinner dataBinner;
+    @Autowired
+    private StudyViewFilterUtil studyViewFilterUtil;
+    @Autowired
+    private ClinicalAttributeService clinicalAttributeService;
+    @Autowired
+    private ClinicalAttributeUtil clinicalAttributeUtil;
+    @Autowired
+    private PatientService patientService;
+    
+    public StudyViewFilter removeSelfFromFilter(ClinicalDataBinCountFilter dataBinCountFilter) {
+        List<ClinicalDataBinFilter> attributes = dataBinCountFilter.getAttributes();
+        StudyViewFilter studyViewFilter = dataBinCountFilter.getStudyViewFilter();
+
+        if (attributes.size() == 1) {
+            studyViewFilterUtil.removeSelfFromFilter(attributes.get(0).getAttributeId(), studyViewFilter);
+        }
+        
+        return studyViewFilter;
+    }
+
+    public List<ClinicalDataBin> fetchClinicalDataBinCounts(
+        DataBinMethod dataBinMethod,
+        ClinicalDataBinCountFilter dataBinCountFilter
+    ) {
+        return this.fetchClinicalDataBinCounts(
+            dataBinMethod, 
+            dataBinCountFilter, 
+            // by default call the method to remove self from filter
+            true
+        );
+    }
+    
+    public List<ClinicalDataBin> fetchClinicalDataBinCounts(
+        DataBinMethod dataBinMethod,
+        ClinicalDataBinCountFilter dataBinCountFilter,
+        boolean shouldRemoveSelfFromFilter
+    ) {
+        List<ClinicalDataBinFilter> attributes = dataBinCountFilter.getAttributes();
+        StudyViewFilter studyViewFilter = dataBinCountFilter.getStudyViewFilter();
+
+        if (shouldRemoveSelfFromFilter) {
+            studyViewFilter = removeSelfFromFilter(dataBinCountFilter);
+        }
+
+        List<String> attributeIds = attributes.stream().map(ClinicalDataBinFilter::getAttributeId).collect(Collectors.toList());
+
+        // filter only by study id and sample identifiers, ignore rest
+        List<SampleIdentifier> unfilteredSampleIdentifiers = filterByStudyAndSample(studyViewFilter);
+
+        List<String> unfilteredStudyIds = new ArrayList<>();
+        List<String> unfilteredSampleIds = new ArrayList<>();
+        List<String> unfilteredPatientIds = new ArrayList<>();
+        List<String> studyIdsOfUnfilteredPatients = new ArrayList<>();
+        List<String> unfilteredUniqueSampleKeys = new ArrayList<>();
+        List<String> unfilteredUniquePatientKeys = new ArrayList<>();
+        List<String> unfilteredSampleAttributeIds = new ArrayList<>();
+        List<String> unfilteredPatientAttributeIds = new ArrayList<>();
+        // patient attributes which are also sample attributes in other studies
+        List<String> unfilteredConflictingPatientAttributeIds = new ArrayList<>();
+
+        populateIdLists(
+            // input
+            unfilteredSampleIdentifiers,
+            attributeIds,
+
+            // output
+            unfilteredStudyIds,
+            unfilteredSampleIds,
+            unfilteredPatientIds,
+            studyIdsOfUnfilteredPatients,
+            unfilteredUniqueSampleKeys,
+            unfilteredUniquePatientKeys,
+            unfilteredSampleAttributeIds,
+            unfilteredPatientAttributeIds,
+            unfilteredConflictingPatientAttributeIds
+        );
+
+        Map<String, ClinicalDataType> attributeDatatypeMap = constructAttributeDataMap(
+            unfilteredSampleAttributeIds,
+            unfilteredPatientAttributeIds,
+            unfilteredConflictingPatientAttributeIds
+        );
+
+        List<ClinicalData> unfilteredClinicalDataForSamples = clinicalDataFetcher.fetchClinicalDataForSamples(
+            unfilteredStudyIds,
+            unfilteredSampleIds,
+            new ArrayList<>(unfilteredSampleAttributeIds)
+        );
+
+        List<ClinicalData> unfilteredClinicalDataForPatients = clinicalDataFetcher.fetchClinicalDataForPatients(
+            studyIdsOfUnfilteredPatients,
+            unfilteredPatientIds,
+            new ArrayList<>(unfilteredPatientAttributeIds)
+        );
+
+        List<ClinicalData> unfilteredClinicalDataForConflictingPatientAttributes = clinicalDataFetcher.fetchClinicalDataForConflictingPatientAttributes(
+            studyIdsOfUnfilteredPatients,
+            unfilteredPatientIds,
+            new ArrayList<>(unfilteredConflictingPatientAttributeIds)
+        );
+
+        List<ClinicalData> unfilteredClinicalData = Stream.of(
+            unfilteredClinicalDataForSamples,
+            unfilteredClinicalDataForPatients,
+            unfilteredClinicalDataForConflictingPatientAttributes
+        ).flatMap(Collection::stream).collect(Collectors.toList());
+
+        // if filters are practically the same no need to re-apply them
+        List<SampleIdentifier> filteredSampleIdentifiers =
+            studyViewFilterUtil.shouldSkipFilterForClinicalDataBins(studyViewFilter) ?
+                unfilteredSampleIdentifiers : studyViewFilterApplier.apply(studyViewFilter);
+
+        List<String> filteredUniqueSampleKeys;
+        List<String> filteredUniquePatientKeys;
+        List<ClinicalData> filteredClinicalData;
+
+        // if filtered and unfiltered samples are exactly the same, no need to fetch clinical data again
+        if (filteredSampleIdentifiers.equals(unfilteredSampleIdentifiers)) {
+            filteredUniqueSampleKeys = unfilteredUniqueSampleKeys;
+            filteredUniquePatientKeys = unfilteredUniquePatientKeys;
+            filteredClinicalData = unfilteredClinicalData;
+        }
+        else {
+            List<String> filteredStudyIds = new ArrayList<>();
+            List<String> filteredSampleIds = new ArrayList<>();
+            List<String> filteredPatientIds = new ArrayList<>();
+            List<String> studyIdsOfFilteredPatients = new ArrayList<>();
+            filteredUniqueSampleKeys = new ArrayList<>();
+            filteredUniquePatientKeys = new ArrayList<>();
+            List<String> filteredSampleAttributeIds = new ArrayList<>();
+            List<String> filteredPatientAttributeIds = new ArrayList<>();
+            // patient attributes which are also sample attributes in other studies
+            List<String> filteredConflictingPatientAttributeIds = new ArrayList<>();
+
+            populateIdLists(
+                // input
+                filteredSampleIdentifiers,
+                attributeIds,
+
+                // output
+                filteredStudyIds,
+                filteredSampleIds,
+                filteredPatientIds,
+                studyIdsOfFilteredPatients,
+                filteredUniqueSampleKeys,
+                filteredUniquePatientKeys,
+                filteredSampleAttributeIds,
+                filteredPatientAttributeIds,
+                filteredConflictingPatientAttributeIds
+            );
+
+            filteredClinicalData = studyViewFilterUtil.filterClinicalData(
+                unfilteredClinicalDataForSamples,
+                unfilteredClinicalDataForPatients,
+                unfilteredClinicalDataForConflictingPatientAttributes,
+                filteredStudyIds,
+                filteredSampleIds,
+                studyIdsOfFilteredPatients,
+                filteredPatientIds,
+                filteredSampleAttributeIds,
+                filteredPatientAttributeIds,
+                filteredConflictingPatientAttributeIds
+            );
+        }
+
+        Map<String, List<ClinicalData>> unfilteredClinicalDataByAttributeId =
+            unfilteredClinicalData.stream().collect(Collectors.groupingBy(ClinicalData::getAttrId));
+
+        Map<String, List<ClinicalData>> filteredClinicalDataByAttributeId =
+            filteredClinicalData.stream().collect(Collectors.groupingBy(ClinicalData::getAttrId));
+
+        List<ClinicalDataBin> clinicalDataBins = Collections.emptyList();
+
+        if (dataBinMethod == DataBinMethod.STATIC) {
+            if (!unfilteredSampleIdentifiers.isEmpty() && !unfilteredClinicalData.isEmpty()) {
+                clinicalDataBins = calculateStaticDataBins(
+                    attributes,
+                    attributeDatatypeMap,
+                    unfilteredClinicalDataByAttributeId,
+                    filteredClinicalDataByAttributeId,
+                    unfilteredUniqueSampleKeys,
+                    unfilteredUniquePatientKeys,
+                    filteredUniqueSampleKeys,
+                    filteredUniquePatientKeys
+                );
+            }
+        }
+        else { // dataBinMethod == DataBinMethod.DYNAMIC
+            if (!filteredClinicalData.isEmpty()) {
+                clinicalDataBins = calculateDynamicDataBins(
+                    attributes,
+                    attributeDatatypeMap,
+                    filteredClinicalDataByAttributeId,
+                    filteredUniqueSampleKeys,
+                    filteredUniquePatientKeys
+                );
+            }
+        }
+        
+        return clinicalDataBins;
+    }
+    
+    public void populateIdLists(
+        // input lists
+        List<SampleIdentifier> sampleIdentifiers,
+        List<String> attributeIds,
+        // lists to get populated
+        List<String> studyIds,
+        List<String> sampleIds,
+        List<String> patientIds,
+        List<String> studyIdsOfPatients,
+        List<String> uniqueSampleKeys,
+        List<String> uniquePatientKeys,
+        List<String> sampleAttributeIds,
+        List<String> patientAttributeIds,
+        List<String> conflictingPatientAttributeIds
+    ) {
+        studyViewFilterUtil.extractStudyAndSampleIds(
+            sampleIdentifiers,
+            studyIds,
+            sampleIds
+        );
+
+        patientService.getPatientsOfSamples(studyIds, sampleIds).stream().forEach(patient -> {
+            patientIds.add(patient.getStableId());
+            studyIdsOfPatients.add(patient.getCancerStudyIdentifier());
+        });
+
+        uniqueSampleKeys.addAll(studyViewFilterApplier.getUniqkeyKeys(studyIds, sampleIds));
+        uniquePatientKeys.addAll(studyViewFilterApplier.getUniqkeyKeys(studyIdsOfPatients, patientIds));
+
+        if (attributeIds != null) {
+            List<ClinicalAttribute> clinicalAttributes = clinicalAttributeService
+                .getClinicalAttributesByStudyIdsAndAttributeIds(studyIds, attributeIds);
+
+            clinicalAttributeUtil.extractCategorizedClinicalAttributes(
+                clinicalAttributes,
+                sampleAttributeIds,
+                patientAttributeIds,
+                conflictingPatientAttributeIds
+            );
+        }
+    }
+
+    public List<ClinicalDataBin> calculateStaticDataBins(
+        List<ClinicalDataBinFilter> attributes,
+        Map<String, ClinicalDataType> attributeDatatypeMap,
+        Map<String, List<ClinicalData>> unfilteredClinicalDataByAttributeId,
+        Map<String, List<ClinicalData>> filteredClinicalDataByAttributeId,
+        List<String> unfilteredUniqueSampleKeys,
+        List<String> unfilteredUniquePatientKeys,
+        List<String> filteredUniqueSampleKeys,
+        List<String> filteredUniquePatientKeys
+    ) {
+        List<ClinicalDataBin> clinicalDataBins = new ArrayList<>();
+
+        for (ClinicalDataBinFilter attribute : attributes) {
+            if (attributeDatatypeMap.containsKey(attribute.getAttributeId())) {
+                ClinicalDataType clinicalDataType = attributeDatatypeMap.get(attribute.getAttributeId());
+                List<String> filteredIds = clinicalDataType == ClinicalDataType.PATIENT ? filteredUniquePatientKeys
+                    : filteredUniqueSampleKeys;
+                List<String> unfilteredIds = clinicalDataType == ClinicalDataType.PATIENT
+                    ? unfilteredUniquePatientKeys
+                    : unfilteredUniqueSampleKeys;
+
+                List<ClinicalDataBin> dataBins = dataBinner
+                    .calculateClinicalDataBins(attribute, clinicalDataType,
+                        filteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(),
+                            Collections.emptyList()),
+                        unfilteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(),
+                            Collections.emptyList()),
+                        filteredIds, unfilteredIds)
+                    .stream()
+                    .map(dataBin -> studyViewFilterUtil.dataBinToClinicalDataBin(attribute, dataBin))
+                    .collect(Collectors.toList());
+
+                clinicalDataBins.addAll(dataBins);
+            }
+        }
+
+        return clinicalDataBins;
+    }
+
+    public List<ClinicalDataBin> calculateDynamicDataBins(
+        List<ClinicalDataBinFilter> attributes,
+        Map<String, ClinicalDataType> attributeDatatypeMap,
+        Map<String, List<ClinicalData>> filteredClinicalDataByAttributeId,
+        List<String> filteredUniqueSampleKeys,
+        List<String> filteredUniquePatientKeys
+    ) {
+        List<ClinicalDataBin> clinicalDataBins = new ArrayList<>();
+
+        for (ClinicalDataBinFilter attribute : attributes) {
+
+            if (attributeDatatypeMap.containsKey(attribute.getAttributeId())) {
+                ClinicalDataType clinicalDataType = attributeDatatypeMap.get(attribute.getAttributeId());
+                List<String> filteredIds = clinicalDataType == ClinicalDataType.PATIENT
+                    ? filteredUniquePatientKeys
+                    : filteredUniqueSampleKeys;
+
+                List<ClinicalDataBin> dataBins = dataBinner
+                    .calculateDataBins(attribute, clinicalDataType,
+                        filteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(),
+                            Collections.emptyList()),
+                        filteredIds)
+                    .stream()
+                    .map(dataBin -> studyViewFilterUtil.dataBinToClinicalDataBin(attribute, dataBin))
+                    .collect(Collectors.toList());
+                clinicalDataBins.addAll(dataBins);
+            }
+        }
+
+        return clinicalDataBins;
+    }
+
+    public Map<String, ClinicalDataType> constructAttributeDataMap(
+        List<String> sampleAttributeIds,
+        List<String> patientAttributeIds,
+        List<String> conflictingPatientAttributeIds
+    ) {
+        Map<String, ClinicalDataType> attributeDatatypeMap = new HashMap<>();
+
+        sampleAttributeIds.forEach(attribute->{
+            attributeDatatypeMap.put(attribute, ClinicalDataType.SAMPLE);
+        });
+        patientAttributeIds.forEach(attribute->{
+            attributeDatatypeMap.put(attribute, ClinicalDataType.PATIENT);
+        });
+        conflictingPatientAttributeIds.forEach(attribute->{
+            attributeDatatypeMap.put(attribute, ClinicalDataType.SAMPLE);
+        });
+
+        return attributeDatatypeMap;
+    }
+
+    public List<SampleIdentifier> filterByStudyAndSample(
+        StudyViewFilter studyViewFilter
+    ) {
+        StudyViewFilter filter = null;
+
+        // only filter by study id and sample identifiers
+        if (studyViewFilter != null) {
+            filter = new StudyViewFilter();
+            filter.setStudyIds(studyViewFilter.getStudyIds());
+            filter.setSampleIdentifiers(studyViewFilter.getSampleIdentifiers());
+        }
+
+        return studyViewFilterApplier.apply(filter);
+    }
+}

--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataFetcher.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataFetcher.java
@@ -1,0 +1,114 @@
+package org.cbioportal.web.util;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.cbioportal.model.ClinicalData;
+import org.cbioportal.service.ClinicalDataService;
+import org.cbioportal.web.parameter.ClinicalDataType;
+import org.cbioportal.web.parameter.Projection;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+public class ClinicalDataFetcher {
+
+    @Autowired
+    private ClinicalDataService clinicalDataService;
+    
+    public List<ClinicalData> fetchClinicalDataForSamples(
+        List<String> studyIds,
+        List<String> sampleIds,
+        List<String> sampleAttributeIds
+    ) {
+        List<ClinicalData> filteredClinicalDataForSamples = Collections.emptyList();
+
+        if (CollectionUtils.isNotEmpty(sampleAttributeIds)) {
+            filteredClinicalDataForSamples = clinicalDataService.fetchClinicalData(
+                studyIds,
+                sampleIds,
+                sampleAttributeIds,
+                ClinicalDataType.SAMPLE.name(),
+                Projection.SUMMARY.name()
+            );
+        }
+
+        return filteredClinicalDataForSamples;
+    }
+
+    public List<ClinicalData> fetchClinicalDataForPatients(
+        List<String> studyIdsOfPatients,
+        List<String> patientIds,
+        List<String> patientAttributeIds
+    ) {
+        List<ClinicalData> filteredClinicalDataForPatients = Collections.emptyList();
+
+        if (CollectionUtils.isNotEmpty(patientAttributeIds)) {
+            filteredClinicalDataForPatients = clinicalDataService.fetchClinicalData(
+                studyIdsOfPatients,
+                patientIds,
+                patientAttributeIds,
+                ClinicalDataType.PATIENT.name(),
+                Projection.SUMMARY.name()
+            );
+        }
+
+        return filteredClinicalDataForPatients;
+    }
+
+    public List<ClinicalData> fetchClinicalDataForConflictingPatientAttributes(
+        List<String> studyIdsOfPatients,
+        List<String> patientIds,
+        List<String> conflictingPatientAttributes
+    ) {
+        List<ClinicalData> filteredClinicalDataForPatients = Collections.emptyList();
+
+        if (CollectionUtils.isNotEmpty(conflictingPatientAttributes)) {
+            filteredClinicalDataForPatients = clinicalDataService.getPatientClinicalDataDetailedToSample(
+                studyIdsOfPatients,
+                patientIds,
+                conflictingPatientAttributes
+            );
+        }
+
+        return filteredClinicalDataForPatients;
+    }
+
+    public List<ClinicalData> fetchClinicalData(
+        List<String> studyIds,
+        List<String> sampleIds,
+        List<String> patientIds,
+        List<String> studyIdsOfPatients,
+        List<String> sampleAttributeIds,
+        List<String> patientAttributeIds,
+        List<String> conflictingPatientAttributes
+    ) {
+        List<ClinicalData> unfilteredClinicalDataForSamples = fetchClinicalDataForSamples(
+            studyIds,
+            sampleIds,
+            sampleAttributeIds
+        );
+
+        List<ClinicalData> unfilteredClinicalDataForPatients = fetchClinicalDataForPatients(
+            studyIdsOfPatients,
+            patientIds,
+            patientAttributeIds
+        );
+
+        List<ClinicalData> unfilteredClinicalDataForConflictingPatientAttributes = fetchClinicalDataForConflictingPatientAttributes(
+            studyIdsOfPatients,
+            patientIds,
+            conflictingPatientAttributes
+        );
+
+        return Stream.of(
+            unfilteredClinicalDataForSamples,
+            unfilteredClinicalDataForPatients,
+            unfilteredClinicalDataForConflictingPatientAttributes
+        ).flatMap(Collection::stream).collect(Collectors.toList());
+    }
+}

--- a/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
+++ b/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
@@ -259,9 +259,9 @@ public class DataBinHelper {
     }
 
     public boolean isNA(String value) {
-        return value.toUpperCase().equals("NA") ||
-            value.toUpperCase().equals("NAN") ||
-            value.toUpperCase().equals("N/A");
+        return value.equalsIgnoreCase("NA") ||
+            value.equalsIgnoreCase("NAN") ||
+            value.equalsIgnoreCase("N/A");
     }
 
     public boolean isSmallData(List<BigDecimal> sortedValues) {

--- a/web/src/main/java/org/cbioportal/web/util/DataBinner.java
+++ b/web/src/main/java/org/cbioportal/web/util/DataBinner.java
@@ -529,10 +529,10 @@ public class DataBinner {
 
         if (clinicalData != null) {
             uniqueClinicalDataIds = clinicalData
-                    .stream()
-                    .map(datum -> computeUniqueCaseId(datum, clinicalDataType))
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toSet());
+                .stream()
+                .filter(Objects::nonNull)
+                .map(datum -> computeUniqueCaseId(datum, clinicalDataType))
+                .collect(Collectors.toSet());
         } else {
             uniqueClinicalDataIds = Collections.emptySet();
         }

--- a/web/src/test/java/org/cbioportal/web/util/ClinicalDataBinUtilTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/ClinicalDataBinUtilTest.java
@@ -1,0 +1,764 @@
+package org.cbioportal.web.util;
+
+import org.cbioportal.model.ClinicalAttribute;
+import org.cbioportal.model.ClinicalData;
+import org.cbioportal.model.ClinicalDataBin;
+import org.cbioportal.model.Patient;
+import org.cbioportal.service.ClinicalAttributeService;
+import org.cbioportal.service.PatientService;
+import org.cbioportal.service.util.ClinicalAttributeUtil;
+import org.cbioportal.web.parameter.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.ArgumentMatcher;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClinicalDataBinUtilTest {
+    private static String STUDY_ID = "genie_bpc_test";
+    private static Integer STUDY_ID_INT = 205;
+    
+    @Spy
+    @InjectMocks
+    private ClinicalDataBinUtil clinicalDataBinUtil;
+    @Mock
+    private StudyViewFilterApplier studyViewFilterApplier;
+    @Mock
+    private ClinicalDataFetcher clinicalDataFetcher;
+    @Mock
+    private ClinicalAttributeService clinicalAttributeService;
+    @Mock
+    private PatientService patientService;
+    @Spy
+    private StudyViewFilterUtil studyViewFilterUtil;
+    @Spy
+    private ClinicalAttributeUtil clinicalAttributeUtil;
+    
+    @Spy
+    @InjectMocks
+    private DataBinner dataBinner;
+    @Spy
+    @InjectMocks
+    private DiscreteDataBinner discreteDataBinner;
+    @Spy
+    @InjectMocks
+    private LinearDataBinner linearDataBinner;
+    @Spy
+    @InjectMocks
+    private ScientificSmallDataBinner scientificSmallDataBinner;
+    @Spy
+    @InjectMocks
+    private LogScaleDataBinner logScaleDataBinner;
+    @Spy
+    private DataBinHelper dataBinHelper;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+    
+    @Test
+    public void testUnfilteredFetchClinicalDataBinCounts() {
+        mockUnfilteredQuery();
+        
+        List<ClinicalDataBin> dataBins = clinicalDataBinUtil.fetchClinicalDataBinCounts(
+            DataBinMethod.STATIC,
+            mockBaseFilter()
+        );
+
+        
+        // assert data bin counts
+        
+        Assert.assertEquals(33, dataBins.size());
+        
+        List<ClinicalDataBin> mutationCountBins = 
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("MUTATION_COUNT")).collect(Collectors.toList());
+        Assert.assertEquals(6, mutationCountBins.size());
+        Assert.assertEquals(2, mutationCountBins.get(0).getCount().intValue());
+        Assert.assertEquals(1, mutationCountBins.get(1).getCount().intValue());
+        Assert.assertEquals(1, mutationCountBins.get(2).getCount().intValue());
+        Assert.assertEquals(1, mutationCountBins.get(3).getCount().intValue());
+        Assert.assertEquals(1, mutationCountBins.get(4).getCount().intValue());
+        Assert.assertEquals(1, mutationCountBins.get(5).getCount().intValue());
+
+        List<ClinicalDataBin> fractionGenomeAlteredBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("FRACTION_GENOME_ALTERED")).collect(Collectors.toList());
+        Assert.assertEquals(7, fractionGenomeAlteredBins.size());
+        Assert.assertEquals(1, fractionGenomeAlteredBins.get(0).getCount().intValue());
+        Assert.assertEquals(1, fractionGenomeAlteredBins.get(1).getCount().intValue());
+        Assert.assertEquals(1, fractionGenomeAlteredBins.get(2).getCount().intValue());
+        Assert.assertEquals(1, fractionGenomeAlteredBins.get(3).getCount().intValue());
+        Assert.assertEquals(1, fractionGenomeAlteredBins.get(4).getCount().intValue());
+        Assert.assertEquals(1, fractionGenomeAlteredBins.get(5).getCount().intValue());
+        Assert.assertEquals(1, fractionGenomeAlteredBins.get(6).getCount().intValue());
+
+        List<ClinicalDataBin> ageAtSeqReportedYearsBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("AGE_AT_SEQ_REPORTED_YEARS")).collect(Collectors.toList());
+        Assert.assertEquals(6, ageAtSeqReportedYearsBins.size());
+        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(0).getCount().intValue());
+        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(1).getCount().intValue());
+        Assert.assertEquals(2, ageAtSeqReportedYearsBins.get(2).getCount().intValue());
+        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(3).getCount().intValue());
+        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(4).getCount().intValue());
+        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(5).getCount().intValue());
+        
+        List<ClinicalDataBin> caAgeBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("CA_AGE")).collect(Collectors.toList());
+        Assert.assertEquals(5, caAgeBins.size());
+        Assert.assertEquals(1, caAgeBins.get(0).getCount().intValue());
+        Assert.assertEquals(1, caAgeBins.get(1).getCount().intValue());
+        Assert.assertEquals(1, caAgeBins.get(2).getCount().intValue());
+        Assert.assertEquals(1, caAgeBins.get(3).getCount().intValue());
+        Assert.assertEquals(1, caAgeBins.get(4).getCount().intValue());
+
+        List<ClinicalDataBin> cptSeqBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("CPT_SEQ_DATE")).collect(Collectors.toList());
+        Assert.assertEquals(3, cptSeqBins.size());
+        Assert.assertEquals(1, cptSeqBins.get(0).getCount().intValue());
+        Assert.assertEquals(3, cptSeqBins.get(1).getCount().intValue());
+        Assert.assertEquals(3, cptSeqBins.get(2).getCount().intValue());
+        
+        List<ClinicalDataBin> cptOrderIntBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("CPT_ORDER_INT")).collect(Collectors.toList());
+        Assert.assertEquals(1, cptOrderIntBins.size());
+        Assert.assertEquals(7, cptOrderIntBins.get(0).getCount().intValue());
+        
+        List<ClinicalDataBin> hybridDeathIntBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("HYBRID_DEATH_INT")).collect(Collectors.toList());
+        Assert.assertEquals(5, hybridDeathIntBins.size());
+        Assert.assertEquals(1, hybridDeathIntBins.get(0).getCount().intValue());
+        Assert.assertEquals(1, hybridDeathIntBins.get(1).getCount().intValue());
+        Assert.assertEquals(1, hybridDeathIntBins.get(2).getCount().intValue());
+        Assert.assertEquals(1, hybridDeathIntBins.get(3).getCount().intValue());
+        Assert.assertEquals(1, hybridDeathIntBins.get(4).getCount().intValue());
+        
+        
+        // assert function calls
+        
+        // we don't expect filterClinicalData to be called for an unfiltered query
+        verify(studyViewFilterUtil, never())
+            .filterClinicalData(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+        
+        // study view filter should be applied only once
+        verify(studyViewFilterApplier, times(1)).apply(any());
+        
+        // ids should be populated only once
+        verify(clinicalDataBinUtil, times(1))
+            .populateIdLists(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+
+        // should call the correct bin calculate method only once for the given binning method
+        verify(clinicalDataBinUtil, times(1))
+            .calculateStaticDataBins(any(), any(), any(), any(), any(), any(), any(), any());
+        verify(clinicalDataBinUtil, never())
+            .calculateDynamicDataBins(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testFilteredFetchClinicalDataBinCounts() {
+        mockUnfilteredQuery();
+        mockFilteredQuery();
+
+        List<ClinicalDataBin> dataBins = clinicalDataBinUtil.fetchClinicalDataBinCounts(
+            DataBinMethod.STATIC,
+            mockQueryFilter()
+        );
+
+        
+        // assert data bin counts
+        
+        Assert.assertEquals(33, dataBins.size());
+
+        List<ClinicalDataBin> mutationCountBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("MUTATION_COUNT")).collect(Collectors.toList());
+        Assert.assertEquals(6, mutationCountBins.size());
+        Assert.assertEquals(0, mutationCountBins.get(0).getCount().intValue());
+        Assert.assertEquals(0, mutationCountBins.get(1).getCount().intValue());
+        Assert.assertEquals(0, mutationCountBins.get(2).getCount().intValue());
+        Assert.assertEquals(1, mutationCountBins.get(3).getCount().intValue());
+        Assert.assertEquals(1, mutationCountBins.get(4).getCount().intValue());
+        Assert.assertEquals(0, mutationCountBins.get(5).getCount().intValue());
+
+        List<ClinicalDataBin> fractionGenomeAlteredBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("FRACTION_GENOME_ALTERED")).collect(Collectors.toList());
+        Assert.assertEquals(7, fractionGenomeAlteredBins.size());
+        Assert.assertEquals(1, fractionGenomeAlteredBins.get(0).getCount().intValue());
+        Assert.assertEquals(0, fractionGenomeAlteredBins.get(1).getCount().intValue());
+        Assert.assertEquals(1, fractionGenomeAlteredBins.get(2).getCount().intValue());
+        Assert.assertEquals(0, fractionGenomeAlteredBins.get(3).getCount().intValue());
+        Assert.assertEquals(0, fractionGenomeAlteredBins.get(4).getCount().intValue());
+        Assert.assertEquals(0, fractionGenomeAlteredBins.get(5).getCount().intValue());
+        Assert.assertEquals(0, fractionGenomeAlteredBins.get(6).getCount().intValue());
+
+        List<ClinicalDataBin> ageAtSeqReportedYearsBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("AGE_AT_SEQ_REPORTED_YEARS")).collect(Collectors.toList());
+        Assert.assertEquals(6, ageAtSeqReportedYearsBins.size());
+        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(0).getCount().intValue());
+        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(1).getCount().intValue());
+        Assert.assertEquals(0, ageAtSeqReportedYearsBins.get(2).getCount().intValue());
+        Assert.assertEquals(0, ageAtSeqReportedYearsBins.get(3).getCount().intValue());
+        Assert.assertEquals(0, ageAtSeqReportedYearsBins.get(4).getCount().intValue());
+        Assert.assertEquals(0, ageAtSeqReportedYearsBins.get(5).getCount().intValue());
+
+        List<ClinicalDataBin> caAgeBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("CA_AGE")).collect(Collectors.toList());
+        Assert.assertEquals(5, caAgeBins.size());
+        Assert.assertEquals(1, caAgeBins.get(0).getCount().intValue());
+        Assert.assertEquals(1, caAgeBins.get(1).getCount().intValue());
+        Assert.assertEquals(0, caAgeBins.get(2).getCount().intValue());
+        Assert.assertEquals(0, caAgeBins.get(3).getCount().intValue());
+        Assert.assertEquals(0, caAgeBins.get(4).getCount().intValue());
+
+        List<ClinicalDataBin> cptSeqBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("CPT_SEQ_DATE")).collect(Collectors.toList());
+        Assert.assertEquals(3, cptSeqBins.size());
+        Assert.assertEquals(0, cptSeqBins.get(0).getCount().intValue());
+        Assert.assertEquals(2, cptSeqBins.get(1).getCount().intValue());
+        Assert.assertEquals(0, cptSeqBins.get(2).getCount().intValue());
+
+        List<ClinicalDataBin> cptOrderIntBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("CPT_ORDER_INT")).collect(Collectors.toList());
+        Assert.assertEquals(1, cptOrderIntBins.size());
+        Assert.assertEquals(2, cptOrderIntBins.get(0).getCount().intValue());
+
+        List<ClinicalDataBin> hybridDeathIntBins =
+            dataBins.stream().filter(bin -> bin.getAttributeId().equals("HYBRID_DEATH_INT")).collect(Collectors.toList());
+        Assert.assertEquals(5, hybridDeathIntBins.size());
+        Assert.assertEquals(1, hybridDeathIntBins.get(0).getCount().intValue());
+        Assert.assertEquals(0, hybridDeathIntBins.get(1).getCount().intValue());
+        Assert.assertEquals(0, hybridDeathIntBins.get(2).getCount().intValue());
+        Assert.assertEquals(1, hybridDeathIntBins.get(3).getCount().intValue());
+        Assert.assertEquals(0, hybridDeathIntBins.get(4).getCount().intValue());
+        
+        
+        // assert function calls
+        
+        // expect filterClinicalData to be called for a filtered query
+        verify(studyViewFilterUtil, times(1))
+            .filterClinicalData(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+
+        // study view filter should be applied twice
+        verify(studyViewFilterApplier, times(2)).apply(any());
+
+        // ids should be populated twice
+        verify(clinicalDataBinUtil, times(2))
+            .populateIdLists(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+
+        // should call the correct bin calculate method only once for the given binning method
+        verify(clinicalDataBinUtil, times(1))
+            .calculateStaticDataBins(any(), any(), any(), any(), any(), any(), any(), any());
+        verify(clinicalDataBinUtil, never())
+            .calculateDynamicDataBins(any(), any(), any(), any(), any());
+    }
+    
+    private void mockUnfilteredQuery()
+    {
+        mockMethods(
+            mockUnfilteredSampleIdentifiers(),
+            mockUnfilteredSampleIds(),
+            mockUnfilteredStudyIds(),
+            mockUnfilteredSampleAttributeIds(),
+            mockUnfilteredStudySampleUniqueKeys(),
+            mockUnfilteredClinicalDataForSamples(),
+            mockUnfilteredPatients(),
+            mockUnfilteredPatientIds(),
+            mockUnfilteredStudyIdsOfPatients(),
+            mockUnfilteredPatientAttributeIds(),
+            mockUnfilteredStudyPatientUniqueKeys(),
+            mockUnfilteredClinicalDataForPatients(),
+            mockUnfilteredStudyViewFilter(),
+            mockUnfilteredAttributeIds(),
+            mockUnfilteredClinicalAttributes()
+        );
+    }
+
+    private void mockFilteredQuery()
+    {
+        mockMethods(
+            mockFilteredSampleIdentifiers(),
+            mockFilteredSampleIds(),
+            mockFilteredStudyIds(),
+            mockUnfilteredSampleAttributeIds(),
+            mockFilteredStudySampleUniqueKeys(),
+            null,
+            mockFilteredPatients(),
+            mockFilteredPatientIds(),
+            mockFilteredStudyIdsOfPatients(),
+            mockUnfilteredPatientAttributeIds(),
+            mockFilteredStudyPatientUniqueKeys(),
+            null,
+            mockFilteredStudyViewFilter(),
+            mockUnfilteredAttributeIds(),
+            mockFilteredClinicalAttributes()
+        );
+    }
+    
+    private void mockMethods(
+        List<SampleIdentifier> sampleIdentifiers,
+        List<String> sampleIds,
+        List<String> studyIds,
+        List<String> sampleAttributeIds,
+        List<String> studySampleUniqueKeys,
+        List<ClinicalData> clinicalDataForSamples,
+        List<Patient> patients,
+        List<String> patientIds,
+        List<String> studyIdsOfPatients,
+        List<String> patientAttributeIds,
+        List<String> studyPatientUniqueKeys,
+        List<ClinicalData> clinicalDataForPatients,
+        StudyViewFilter studyViewFilter,
+        List<String> attributeIds,
+        List<ClinicalAttribute> clinicalAttributes
+    ) {
+        when(
+            patientService.getPatientsOfSamples(eq(studyIds), eq(sampleIds))
+        ).thenReturn(patients);
+        when(
+            clinicalAttributeService.getClinicalAttributesByStudyIdsAndAttributeIds(eq(studyIds), eq(attributeIds))
+        ).thenReturn(clinicalAttributes);
+
+        when(
+            studyViewFilterApplier.apply(argThat(new StudyViewFilterMatcher(studyViewFilter)))
+        ).thenReturn(sampleIdentifiers);
+        when(
+            studyViewFilterApplier.getUniqkeyKeys(eq(studyIds), eq(sampleIds))
+        ).thenReturn(studySampleUniqueKeys);
+        when(
+            studyViewFilterApplier.getUniqkeyKeys(eq(studyIdsOfPatients), eq(patientIds))
+        ).thenReturn(studyPatientUniqueKeys);
+
+        when(
+            clinicalDataFetcher.fetchClinicalDataForSamples(eq(studyIds), eq(sampleIds), eq(sampleAttributeIds))
+        ).thenReturn(clinicalDataForSamples);
+        when(
+            clinicalDataFetcher.fetchClinicalDataForPatients(eq(studyIdsOfPatients), eq(patientIds), eq(patientAttributeIds))
+        ).thenReturn(clinicalDataForPatients);
+    }
+    
+    private ClinicalDataBinCountFilter mockBaseFilter() {
+        ClinicalDataBinCountFilter filter = new ClinicalDataBinCountFilter();
+        
+        filter.setAttributes(mockUnfilteredAttributes());
+        filter.setStudyViewFilter(mockUnfilteredStudyViewFilter());
+        
+        return filter;
+    }
+
+    private ClinicalDataBinCountFilter mockQueryFilter() {
+        ClinicalDataBinCountFilter filter = new ClinicalDataBinCountFilter();
+
+        filter.setAttributes(mockUnfilteredAttributes());
+        filter.setStudyViewFilter(mockFilteredStudyViewFilter());
+
+        return filter;
+    }
+    
+    private List<String> mockUnfilteredStudySampleUniqueKeys() {
+        List<String> keys = new ArrayList<>();
+        
+        keys.add("genie_bpc_testGENIE-MSK-P-0003156-T01-IM5");
+        keys.add("genie_bpc_testGENIE-MSK-P-0009680-T01-IM5");
+        keys.add("genie_bpc_testGENIE-MSK-P-0012393-T01-IM5");
+        keys.add("genie_bpc_testGENIE-MSK-P-0012393-T02-IM6");
+        keys.add("genie_bpc_testGENIE-MSK-P-0015492-T01-IM6");
+        keys.add("genie_bpc_testGENIE-MSK-P-0017284-T01-IM6");
+        keys.add("genie_bpc_testGENIE-MSK-P-0017284-T02-IM5");
+        
+        return keys;
+    }
+    
+    private List<String> mockFilteredStudySampleUniqueKeys() {
+        List<String> keys = new ArrayList<>();
+        
+        keys.add("genie_bpc_testGENIE-MSK-P-0009680-T01-IM5");
+        keys.add("genie_bpc_testGENIE-MSK-P-0015492-T01-IM6");
+        
+        return keys;
+    }
+    
+    private List<String> mockUnfilteredStudyPatientUniqueKeys() {
+        List<String> keys = new ArrayList<>();
+        
+        keys.add("genie_bpc_testGENIE-MSK-P-0015492");
+        keys.add("genie_bpc_testGENIE-MSK-P-0003156");
+        keys.add("genie_bpc_testGENIE-MSK-P-0009680");
+        keys.add("genie_bpc_testGENIE-MSK-P-0012393");
+        keys.add("genie_bpc_testGENIE-MSK-P-0017284");
+        
+        return keys;
+    }
+    
+    private List<String> mockFilteredStudyPatientUniqueKeys() {
+        List<String> keys = new ArrayList<>();
+        
+        keys.add("genie_bpc_testGENIE-MSK-P-0015492");
+        keys.add("genie_bpc_testGENIE-MSK-P-0009680");
+        
+        return keys;
+    }
+    
+    private List<String> mockUnfilteredSampleIds() {
+        List<String> sampleIds = new ArrayList<>();
+
+        sampleIds.add("GENIE-MSK-P-0003156-T01-IM5");
+        sampleIds.add("GENIE-MSK-P-0009680-T01-IM5");
+        sampleIds.add("GENIE-MSK-P-0012393-T01-IM5");
+        sampleIds.add("GENIE-MSK-P-0012393-T02-IM6");
+        sampleIds.add("GENIE-MSK-P-0015492-T01-IM6");
+        sampleIds.add("GENIE-MSK-P-0017284-T01-IM6");
+        sampleIds.add("GENIE-MSK-P-0017284-T02-IM5");
+
+        return sampleIds;
+    }
+    
+    private List<String> mockFilteredSampleIds() {
+        List<String> sampleIds = new ArrayList<>();
+
+        sampleIds.add("GENIE-MSK-P-0009680-T01-IM5");
+        sampleIds.add("GENIE-MSK-P-0015492-T01-IM6");
+
+        return sampleIds;
+    }
+
+    private List<String> mockUnfilteredPatientIds() {
+        List<String> patientIds = new ArrayList<>();
+
+        patientIds.add("GENIE-MSK-P-0015492");
+        patientIds.add("GENIE-MSK-P-0003156");
+        patientIds.add("GENIE-MSK-P-0009680");
+        patientIds.add("GENIE-MSK-P-0012393");
+        patientIds.add("GENIE-MSK-P-0017284");
+
+        return patientIds;
+    }
+    
+    private List<String> mockFilteredPatientIds() {
+        List<String> patientIds = new ArrayList<>();
+
+        patientIds.add("GENIE-MSK-P-0015492");
+        patientIds.add("GENIE-MSK-P-0009680");
+
+        return patientIds;
+    }
+    
+    private List<Patient> mockUnfilteredPatients() {
+        return mockPatients(mockUnfilteredPatientIds());
+    }
+
+    private List<Patient> mockFilteredPatients() {
+        return mockPatients(mockFilteredPatientIds());
+    }
+    
+    private List<Patient> mockPatients(List<String> patientIds) {
+        List<Patient> patients = new ArrayList<>();
+        
+        for (String patientId: patientIds) {
+            Patient patient = new Patient();
+            patient.setCancerStudyIdentifier(STUDY_ID);
+            patient.setStableId(patientId);
+            patients.add(patient);
+        }
+        
+        return patients;
+    }
+
+    private List<String> mockUnfilteredStudyIds() {
+        return Collections.nCopies(7, STUDY_ID);
+    }
+    
+    private List<String> mockFilteredStudyIds() {
+        return Collections.nCopies(2, STUDY_ID);
+    }
+
+    private List<String> mockUnfilteredStudyIdsOfPatients() {
+        return Collections.nCopies(5, STUDY_ID);
+    }
+    
+    private List<String> mockFilteredStudyIdsOfPatients() {
+        return Collections.nCopies(2, STUDY_ID);
+    }
+    
+    private List<SampleIdentifier> mockUnfilteredSampleIdentifiers() {
+        return mockSampleIdentifiers(mockUnfilteredSampleIds());
+    }
+
+    private List<SampleIdentifier> mockFilteredSampleIdentifiers() {
+        return mockSampleIdentifiers(mockFilteredSampleIds());
+    }
+
+    private List<SampleIdentifier> mockSampleIdentifiers(List<String> sampleIds) {
+        List<SampleIdentifier> sampleIdentifiers = new ArrayList<>();
+
+        for (String sampleId: sampleIds) {
+            SampleIdentifier identifier = new SampleIdentifier();
+            identifier.setSampleId(sampleId);
+            identifier.setStudyId(STUDY_ID);
+            sampleIdentifiers.add(identifier);
+        }
+
+        return sampleIdentifiers;
+    }
+    
+    private List<String> mockUnfilteredAttributeIds() {
+        List<String> attributeIds = new ArrayList<>();
+        
+        attributeIds.addAll(mockUnfilteredSampleAttributeIds());
+        attributeIds.addAll(mockUnfilteredPatientAttributeIds());
+        
+        return attributeIds;
+    }
+
+    private List<String> mockUnfilteredSampleAttributeIds() {
+        List<String> attributeIds = new ArrayList<>();
+        
+        attributeIds.add("CPT_SEQ_DATE");
+        attributeIds.add("CPT_ORDER_INT");
+        attributeIds.add("MUTATION_COUNT");
+        attributeIds.add("AGE_AT_SEQ_REPORTED_YEARS");
+        attributeIds.add("FRACTION_GENOME_ALTERED");
+
+        return attributeIds;
+    }
+
+    private List<String> mockUnfilteredPatientAttributeIds() {
+        List<String> attributeIds = new ArrayList<>();
+
+        attributeIds.add("CA_AGE");
+        attributeIds.add("HYBRID_DEATH_INT");
+
+        return attributeIds;
+    }
+    
+    private List<ClinicalDataBinFilter> mockUnfilteredAttributes() {
+        List<ClinicalDataBinFilter> attributes = new ArrayList<>();
+        List<String> attributeIds = mockUnfilteredAttributeIds();
+        
+        for (String attributeId: attributeIds) {
+            ClinicalDataBinFilter filter = new ClinicalDataBinFilter();
+            filter.setAttributeId(attributeId);
+            attributes.add(filter);
+        }
+        
+        return attributes;
+    }
+    
+    private ClinicalAttribute mockClinicalAttribute(String attrId, String displayName, boolean isPatientAttribute) {
+        ClinicalAttribute attr = new ClinicalAttribute();
+        
+        attr.setAttrId(attrId);
+        attr.setDisplayName(displayName);
+        attr.setDatatype("NUMBER");
+        attr.setPatientAttribute(isPatientAttribute);
+        attr.setCancerStudyId(STUDY_ID_INT);
+        attr.setCancerStudyIdentifier(STUDY_ID);
+        
+        return attr;
+    }
+    
+    private List<ClinicalAttribute> mockUnfilteredClinicalAttributes() {
+        List<ClinicalAttribute> clinicalAttributes = new ArrayList<>();
+        
+        clinicalAttributes.add(mockClinicalAttribute("AGE_AT_SEQ_REPORTED_YEARS", "Age at Which Sequencing was Reported (Years)", false));
+        clinicalAttributes.add(mockClinicalAttribute("CA_AGE", "Curated Patient Age at Diagnosis", true));
+        clinicalAttributes.add(mockClinicalAttribute("CPT_ORDER_INT", "Interval in Days from Date of Birth to Cancer Order Date", false));
+        clinicalAttributes.add(mockClinicalAttribute("CPT_SEQ_DATE", "GENIE Sequence Date (quarter year)", false));
+        clinicalAttributes.add(mockClinicalAttribute("FRACTION_GENOME_ALTERED", "Fraction Genome Altered", false));
+        clinicalAttributes.add(mockClinicalAttribute("HYBRID_DEATH_INT", "Interval in Months from DOB to Date of Death", true));
+        clinicalAttributes.add(mockClinicalAttribute("MUTATION_COUNT", "Mutation Count", false));
+
+        return clinicalAttributes;
+    }
+
+    private List<ClinicalAttribute> mockFilteredClinicalAttributes() {
+        List<ClinicalAttribute> clinicalAttributes = new ArrayList<>();
+
+        clinicalAttributes.add(mockClinicalAttribute("AGE_AT_SEQ_REPORTED_YEARS", "Age at Which Sequencing was Reported (Years)", false));
+        clinicalAttributes.add(mockClinicalAttribute("CA_AGE", "Curated Patient Age at Diagnosis", true));
+        clinicalAttributes.add(mockClinicalAttribute("CPT_SEQ_DATE", "GENIE Sequence Date (quarter year)", false));
+        clinicalAttributes.add(mockClinicalAttribute("FRACTION_GENOME_ALTERED", "Fraction Genome Altered", false));
+        clinicalAttributes.add(mockClinicalAttribute("HYBRID_DEATH_INT", "Interval in Months from DOB to Date of Death", true));
+        clinicalAttributes.add(mockClinicalAttribute("MUTATION_COUNT", "Mutation Count", false));
+
+        return clinicalAttributes;
+    }
+    
+    private ClinicalData mockClinicalData(String id, String value, String patientId, String sampleId)
+    {
+        ClinicalData data = new ClinicalData();
+        
+        data.setAttrId(id);
+        data.setAttrValue(value);
+        data.setPatientId(patientId);
+        data.setSampleId(sampleId);
+        data.setStudyId(STUDY_ID);
+        
+        return data;
+    }
+    
+    private List<ClinicalData> mockUnfilteredClinicalDataForSamples() {
+        List<ClinicalData> data = new ArrayList<>();
+        
+        data.add(mockClinicalData("AGE_AT_SEQ_REPORTED_YEARS", "53.03", "GENIE-MSK-P-0015492", "GENIE-MSK-P-0015492-T01-IM6"));
+        data.add(mockClinicalData("CPT_SEQ_DATE", "2016", "GENIE-MSK-P-0015492", "GENIE-MSK-P-0015492-T01-IM6"));
+        data.add(mockClinicalData("FRACTION_GENOME_ALTERED", "0.0460", "GENIE-MSK-P-0015492", "GENIE-MSK-P-0015492-T01-IM6"));
+        data.add(mockClinicalData("MUTATION_COUNT", "7", "GENIE-MSK-P-0015492", "GENIE-MSK-P-0015492-T01-IM6"));
+        data.add(mockClinicalData("AGE_AT_SEQ_REPORTED_YEARS", "78.05", "GENIE-MSK-P-0003156", "GENIE-MSK-P-0003156-T01-IM5"));
+        data.add(mockClinicalData("CPT_SEQ_DATE", "2015", "GENIE-MSK-P-0003156", "GENIE-MSK-P-0003156-T01-IM5"));
+        data.add(mockClinicalData("FRACTION_GENOME_ALTERED", "0.2164", "GENIE-MSK-P-0003156", "GENIE-MSK-P-0003156-T01-IM5"));
+        data.add(mockClinicalData("MUTATION_COUNT", "8", "GENIE-MSK-P-0003156", "GENIE-MSK-P-0003156-T01-IM5"));
+        data.add(mockClinicalData("AGE_AT_SEQ_REPORTED_YEARS", "59.04", "GENIE-MSK-P-0009680", "GENIE-MSK-P-0009680-T01-IM5"));
+        data.add(mockClinicalData("CPT_SEQ_DATE", "2016", "GENIE-MSK-P-0009680", "GENIE-MSK-P-0009680-T01-IM5"));
+        data.add(mockClinicalData("FRACTION_GENOME_ALTERED", "0.2073", "GENIE-MSK-P-0009680", "GENIE-MSK-P-0009680-T01-IM5"));
+        data.add(mockClinicalData("MUTATION_COUNT", "6", "GENIE-MSK-P-0009680", "GENIE-MSK-P-0009680-T01-IM5"));
+        data.add(mockClinicalData("AGE_AT_SEQ_REPORTED_YEARS", "72.04", "GENIE-MSK-P-0012393", "GENIE-MSK-P-0012393-T01-IM5"));
+        data.add(mockClinicalData("CPT_SEQ_DATE", "2016", "GENIE-MSK-P-0012393", "GENIE-MSK-P-0012393-T01-IM5"));
+        data.add(mockClinicalData("FRACTION_GENOME_ALTERED", "0.5280", "GENIE-MSK-P-0012393", "GENIE-MSK-P-0012393-T01-IM5"));
+        data.add(mockClinicalData("MUTATION_COUNT", "3", "GENIE-MSK-P-0012393", "GENIE-MSK-P-0012393-T01-IM5"));
+        data.add(mockClinicalData("AGE_AT_SEQ_REPORTED_YEARS", "73.04", "GENIE-MSK-P-0012393", "GENIE-MSK-P-0012393-T02-IM6"));
+        data.add(mockClinicalData("CPT_SEQ_DATE", "2017", "GENIE-MSK-P-0012393", "GENIE-MSK-P-0012393-T02-IM6"));
+        data.add(mockClinicalData("FRACTION_GENOME_ALTERED", "0.1297", "GENIE-MSK-P-0012393", "GENIE-MSK-P-0012393-T02-IM6"));
+        data.add(mockClinicalData("MUTATION_COUNT", "3", "GENIE-MSK-P-0012393", "GENIE-MSK-P-0012393-T02-IM6"));
+        data.add(mockClinicalData("AGE_AT_SEQ_REPORTED_YEARS", "64.04", "GENIE-MSK-P-0017284", "GENIE-MSK-P-0017284-T01-IM6"));
+        data.add(mockClinicalData("CPT_SEQ_DATE", "2017", "GENIE-MSK-P-0017284", "GENIE-MSK-P-0017284-T01-IM6"));
+        data.add(mockClinicalData("FRACTION_GENOME_ALTERED", "0.2796", "GENIE-MSK-P-0017284", "GENIE-MSK-P-0017284-T01-IM6"));
+        data.add(mockClinicalData("MUTATION_COUNT", "5", "GENIE-MSK-P-0017284", "GENIE-MSK-P-0017284-T01-IM6"));
+        data.add(mockClinicalData("AGE_AT_SEQ_REPORTED_YEARS", "64.04", "GENIE-MSK-P-0017284", "GENIE-MSK-P-0017284-T02-IM5"));
+        data.add(mockClinicalData("CPT_SEQ_DATE", "2017", "GENIE-MSK-P-0017284", "GENIE-MSK-P-0017284-T02-IM5"));
+        data.add(mockClinicalData("FRACTION_GENOME_ALTERED", "0.7233", "GENIE-MSK-P-0017284", "GENIE-MSK-P-0017284-T02-IM5"));
+        data.add(mockClinicalData("MUTATION_COUNT", "4", "GENIE-MSK-P-0017284", "GENIE-MSK-P-0017284-T02-IM5"));
+        
+        return data;
+    }
+
+    private List<ClinicalData> mockUnfilteredClinicalDataForPatients() {
+        List<ClinicalData> data = new ArrayList<>();
+
+        data.add(mockClinicalData("CA_AGE", "52", "GENIE-MSK-P-0015492", null));
+        data.add(mockClinicalData("HYBRID_DEATH_INT", "657.3", "GENIE-MSK-P-0015492", null));
+        data.add(mockClinicalData("CA_AGE", "77", "GENIE-MSK-P-0003156", null));
+        data.add(mockClinicalData("HYBRID_DEATH_INT", "968.1", "GENIE-MSK-P-0003156", null));
+        data.add(mockClinicalData("CA_AGE", "56", "GENIE-MSK-P-0009680", null));
+        data.add(mockClinicalData("HYBRID_DEATH_INT", "8765.7", "GENIE-MSK-P-0009680", null));
+        data.add(mockClinicalData("CA_AGE", "71", "GENIE-MSK-P-0012393", null));
+        data.add(mockClinicalData("HYBRID_DEATH_INT", "730.4", "GENIE-MSK-P-0012393", null));
+        data.add(mockClinicalData("CA_AGE", "62", "GENIE-MSK-P-0017284", null));
+
+        return data;
+    }
+    
+    private StudyViewFilter mockUnfilteredStudyViewFilter() {
+        StudyViewFilter studyViewFilter = new StudyViewFilter();
+
+        List<String> studyIds = new ArrayList<>();
+        studyIds.add("genie_bpc_test");
+        studyViewFilter.setStudyIds(studyIds);
+        
+        return studyViewFilter;
+    }
+    
+    private StudyViewFilter mockFilteredStudyViewFilter() {
+        StudyViewFilter studyViewFilter = mockUnfilteredStudyViewFilter();
+        
+        ClinicalDataFilter sexFilter = new ClinicalDataFilter();
+        sexFilter.setAttributeId("SEX");
+        List<DataFilterValue> sexValues = new ArrayList<>();
+        DataFilterValue female = new DataFilterValue();
+        female.setValue("Female");
+        sexValues.add(female);
+        sexFilter.setValues(sexValues);
+
+        ClinicalDataFilter sampleCountFilter = new ClinicalDataFilter();
+        sampleCountFilter.setAttributeId("SAMPLE_COUNT");
+        List<DataFilterValue> sampleCountValues = new ArrayList<>();
+        DataFilterValue one = new DataFilterValue();
+        one.setValue("1");
+        sampleCountValues.add(one);
+        sampleCountFilter.setValues(sampleCountValues);
+
+        List<ClinicalDataFilter> filters = new ArrayList<>();
+        filters.add(sexFilter);
+        filters.add(sampleCountFilter);
+        
+        studyViewFilter.setClinicalDataFilters(filters);
+        
+        return studyViewFilter;
+    }
+
+    private class StudyViewFilterMatcher implements ArgumentMatcher<StudyViewFilter> {
+        private StudyViewFilter source;
+
+        public StudyViewFilterMatcher(StudyViewFilter source) {
+            this.source = source;
+        }
+
+        @Override
+        public boolean matches(StudyViewFilter target) {
+            return (
+                target != null &&
+                Objects.equals(target.getStudyIds(), source.getStudyIds()) &&
+                Objects.equals(target.getSampleIdentifiers(), source.getSampleIdentifiers()) && 
+                equalClinicalDataFilters(source.getClinicalDataFilters(), target.getClinicalDataFilters())
+            );
+        }
+        
+        private boolean equalClinicalDataFilters(List<ClinicalDataFilter> sourceFilters, List<ClinicalDataFilter> targetFilters) {
+            if (sourceFilters == null && targetFilters == null) {
+                return true;
+            }
+            
+            if (sourceFilters != null && targetFilters != null && sourceFilters.size() == targetFilters.size()) {
+                for (int i = 0; i < sourceFilters.size(); i++) {
+                    if (
+                        !Objects.equals(sourceFilters.get(i).getAttributeId(), targetFilters.get(i).getAttributeId()) ||
+                        !equalDataFilterValues(sourceFilters.get(i).getValues(), targetFilters.get(i).getValues())
+                    ) {
+                        return false;
+                    }
+                }
+            }
+            else {
+                return false;
+            }
+            
+            return true;
+        }
+        
+        private boolean equalDataFilterValues(List<DataFilterValue> sourceValues, List<DataFilterValue> targetValues)
+        {
+            if (sourceValues == null && targetValues == null) {
+                return true;
+            }
+
+            if (sourceValues != null && targetValues != null && sourceValues.size() == targetValues.size()) {
+                for (int i = 0; i < sourceValues.size(); i++) {
+                    if (
+                        !Objects.equals(sourceValues.get(i).getStart(), targetValues.get(i).getStart()) ||
+                        !Objects.equals(sourceValues.get(i).getEnd(), targetValues.get(i).getEnd()) ||
+                        !Objects.equals(sourceValues.get(i).getValue(), targetValues.get(i).getValue())
+                    ) {
+                        return false;
+                    }
+                }
+            }
+            else {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fix #8584 

- Avoid redundant database queries by implementing in-memory clinical data filtering
- Avoid applying the same filter twice
- Move out clinical data bin count endpoint logic to the new `ClinicalDataBinUtil` class.
- Add unit tests for the new util class