### PR TITLE
Custom Redis Cache

### DIFF
--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -1,3 +1,4 @@
+
 This page describes the main properties within portal.properties.
 
 - [Database Settings](#database-settings)
@@ -417,6 +418,16 @@ redis.follower_address=redis://{host/servicename}:6379
 redis.database=0
 redis.password=password
 ```
+
+There are also some optional parameters:
+
+
+`redis.clear_on_startup`: If `true`, the caches will clear on startup. This is important
+to do to avoid reading old study data from the cache. You may want to turn it off and clear
+redis yourself if you are running in a clustered environments, as you'll have frequent 
+restarts that do not require you to clear the redis cache.  
+`redis.ttl_mins`: The time to live of items in the general cache, in minutes. The default value is 10000,
+or just under 7 days. 
 
 For more information on Redis, refer to the official documentation [here](https://redis.io/documentation)
 

--- a/persistence/persistence-api/pom.xml
+++ b/persistence/persistence-api/pom.xml
@@ -29,6 +29,10 @@
       <artifactId>redisson</artifactId>
       <version>3.13.2</version>
     </dependency>
+      <dependency>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+      </dependency>
   </dependencies>
 
   <build>

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomKeyGenerator.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomKeyGenerator.java
@@ -33,17 +33,27 @@
 package org.cbioportal.persistence.util;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cbioportal.model.util.Select;
 import org.cbioportal.persistence.CacheEnabledConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.interceptor.KeyGenerator;
-import org.springframework.util.StringUtils;
+import org.springframework.util.DigestUtils;
+
 
 public class CustomKeyGenerator implements KeyGenerator {
+    public static final String DELIMITER = "_";
 
     @Autowired
     private CacheEnabledConfig cacheEnabledConfig;
+    
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     private static final Logger LOG = LoggerFactory.getLogger(CustomKeyGenerator.class);
 
@@ -51,10 +61,33 @@ public class CustomKeyGenerator implements KeyGenerator {
         if (!cacheEnabledConfig.isEnabled()) {
             return "";
         }
-        String key = target.getClass().getSimpleName() + "_"
-            + method.getName() + "_"
-            + StringUtils.arrayToDelimitedString(params, "_");
+        String key = target.getClass().getSimpleName() + DELIMITER
+            + method.getName() + DELIMITER
+            + Arrays.stream(params)
+                .map(this::exceptionlessWrite)
+                .collect(Collectors.joining(DELIMITER));
         LOG.debug("Created key: " + key);
         return key;
+    }
+    
+    private String exceptionlessWrite(Object toSerialize) {
+        if (toSerialize instanceof Select && ((Select) toSerialize).hasAll()) {
+            // Select implements Iterable, but Select.All throws an exception
+            // when you call iterator(), which breaks Jackson, so we need some custom logic
+            return "Select.ALL";
+        }
+        try {
+            String json = mapper.writeValueAsString(toSerialize);
+            if (json.length() > 1024) {
+                // hash long keys
+                return DigestUtils.md5DigestAsHex(json.getBytes());
+            } else {
+                // leave short keys intact, but remove semicolons to make things look cleaner in redis
+                return json.replaceAll(":", DELIMITER);
+            }
+        } catch (JsonProcessingException e) {
+            LOG.error("Could not serialize param to string: ", e);
+            return "";
+        }
     }
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomRedisCache.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomRedisCache.java
@@ -1,0 +1,185 @@
+package org.cbioportal.persistence.util;
+
+import org.redisson.api.RedissonClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.support.AbstractValueAdaptingCache;
+import org.springframework.cache.support.SimpleValueWrapper;
+import org.springframework.lang.Nullable;
+
+import java.io.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class CustomRedisCache extends AbstractValueAdaptingCache {
+    private static final Logger LOG = LoggerFactory.getLogger(CustomRedisCache.class);
+    public static final String DELIMITER = ":";
+    public static final int INFINITE_TTL = -1;
+
+    private final String name;
+    private final long ttlMinutes;
+    private final RedissonClient store;
+
+    /**
+     * Create a new ConcurrentMapCache with the specified name.
+     * @param name the name of the cache
+     */
+    public CustomRedisCache(String name, RedissonClient client, long ttlMinutes) {
+        super(true);
+        this.name = name;
+        this.store = client;
+        this.ttlMinutes = ttlMinutes;
+    }
+
+    @Override
+    public final String getName() {
+        return name;
+    }
+
+    @Override
+    public final RedissonClient getNativeCache() {
+        return this.store;
+    }
+
+    @Override
+    @Nullable
+    protected Object lookup(Object key) {
+        Object value = this.store.getBucket(name + DELIMITER + key).get();
+        if (value != null){
+            value = fromStoreValue(value);
+            asyncRefresh(key);
+        }
+        return value;
+    }
+    
+    private void asyncRefresh(Object key) {
+        if (ttlMinutes != INFINITE_TTL) {
+            this.store.getBucket(name + DELIMITER + key).expireAsync(ttlMinutes, TimeUnit.MINUTES);
+        }
+    }
+
+    @Override
+    @Nullable
+    public <T> T get(Object key, Callable<T> valueLoader) {
+        Object zippedValue = this.store.getBucket(name + DELIMITER + key).get();
+        T value = null;
+        if (zippedValue != null) {
+            value = (T) fromStoreValue(zippedValue);
+            asyncRefresh(key);
+        }
+        try {
+            return value == null ? valueLoader.call() : value;
+        } catch (Exception ex) {
+            throw new ValueRetrievalException(key, valueLoader, ex);
+        }
+    }
+
+    @Override
+    public void put(Object key, @Nullable Object value) {
+        if (ttlMinutes == INFINITE_TTL) {
+            this.store.getBucket(name + DELIMITER + key).setAsync(toStoreValue(value));
+        } else {
+            this.store.getBucket(name + DELIMITER + key).setAsync(toStoreValue(value), ttlMinutes, TimeUnit.MINUTES);
+        }
+    }
+
+    @Override
+    @Nullable
+    public ValueWrapper putIfAbsent(Object key, @Nullable Object value) {
+        Object cached = lookup(key);
+        if (cached != null) {
+            return toValueWrapper(cached);
+        } else {
+            put(key, value);
+        }
+        return toValueWrapper(value);
+    }
+
+    @Override
+    public void evict(Object key) {
+        // no op: Redis handles evictions
+    }
+
+    @Override
+    public boolean evictIfPresent(Object key) {
+        // no op: Redis handles evictions
+        return false;
+    }
+
+    @Override
+    public void clear() {
+        this.store.getKeys().deleteByPattern(name + DELIMITER + "*");
+    }
+
+    @Override
+    public boolean invalidate() {
+        return this.store.getKeys().deleteByPattern(name + DELIMITER + "*") > 0;
+    }
+
+    @Override
+    protected Object toStoreValue(@Nullable Object userValue) {
+        if (userValue == null) {
+            LOG.warn("Storing null value in cache. That's probably not great.");
+            return null;
+        }
+        
+        ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        ObjectOutputStream objectOut;
+        try {
+            // serialize to byte array
+            objectOut = new ObjectOutputStream(byteOut);
+            objectOut.writeObject(userValue);
+            objectOut.flush();
+            byte[] uncompressedByteArray = byteOut.toByteArray();
+            
+            // compress byte array
+            byteOut = new ByteArrayOutputStream(uncompressedByteArray.length);
+            GZIPOutputStream g = new GZIPOutputStream(byteOut);
+            g.write(uncompressedByteArray);
+            g.close();
+            return byteOut.toByteArray();
+        } catch (IOException e) {
+            LOG.warn("Error compressing object for cache: ", e);
+            return null;
+        }
+    }
+
+    @Override
+    protected Object fromStoreValue(@Nullable Object storeValue) {
+        if (storeValue == null) {
+            return null;
+        }
+        
+        byte[] bytes = (byte[]) storeValue;
+        ByteArrayInputStream byteIn = new ByteArrayInputStream(bytes);
+        ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        GZIPInputStream gzipIn;
+        try {
+            // inflate to byte array
+            gzipIn = new GZIPInputStream(byteIn);
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = gzipIn.read(buffer)) != -1) {
+                byteOut.write(buffer, 0, len);
+            }
+            byte[] unzippedBytes = byteOut.toByteArray();
+            
+            // deserialize byte array to object
+            byteIn = new ByteArrayInputStream(unzippedBytes);
+            ObjectInputStream oi = new ObjectInputStream(byteIn);
+            return oi.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            LOG.warn("Error inflating object from cache: ", e);
+            return null;
+        }
+    }
+
+    @Nullable
+    @Override
+    protected Cache.ValueWrapper toValueWrapper(@Nullable Object storeValue) {
+        return (storeValue != null ? new SimpleValueWrapper(storeValue) : null);
+    }
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomRedisCacheManager.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomRedisCacheManager.java
@@ -1,0 +1,57 @@
+package org.cbioportal.persistence.util;
+
+import org.redisson.api.RedissonClient;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.validation.constraints.NotNull;
+
+public class CustomRedisCacheManager implements CacheManager {
+    private final ConcurrentMap<String, CustomRedisCache> caches = new ConcurrentHashMap<>();
+    private final RedissonClient client;
+    private final long ttlInMins;
+
+    public CustomRedisCacheManager(RedissonClient client, long ttlInMins) {
+        this.client = client;
+        this.ttlInMins = ttlInMins;
+    }
+
+    /**
+     * Get the cache associated with the given name.
+     * <p>Note that the cache may be lazily created at runtime if the
+     * native provider supports it.
+     *
+     * @param name the cache identifier (must not be {@code null})
+     * @return the associated cache, or {@code null} if such a cache
+     * does not exist or could be not created
+     */
+    @Override
+    public Cache getCache(String name) {
+        // !name.toLowerCase().contains("static") is a hack. Sometimes spring calls this getCache method from
+        // a place I can't control, so I needed a way in this method to determine whether or not the cache
+        // it's getting should have a ttl.
+        // In practice, any cache we have that is static should not expire. 
+        // (I mean, we have two caches, so this isn't rocket science)
+        return getCache(name, !name.toLowerCase().contains("static"));
+    }
+    
+    @NotNull
+    public Cache getCache(String name, boolean expires) {
+        long clientTTLInMinutes = expires ? ttlInMins : CustomRedisCache.INFINITE_TTL;
+        return caches.computeIfAbsent(name, k -> new CustomRedisCache(name, client, clientTTLInMinutes));
+    }
+
+    /**
+     * Get a collection of the cache names known by this manager.
+     *
+     * @return the names of all caches known by the cache manager
+     */
+    @Override
+    public Collection<String> getCacheNames() {
+        return caches.keySet();
+    }
+}

--- a/persistence/persistence-api/src/main/resources/applicationContext-rediscache.xml
+++ b/persistence/persistence-api/src/main/resources/applicationContext-rediscache.xml
@@ -11,7 +11,7 @@
 
     <beans profile="redis">
 
-        <cache:annotation-driven cache-manager="redisCacheManager" key-generator="customKeyGenerator"/>
+        <cache:annotation-driven cache-manager="cacheManager" key-generator="customKeyGenerator"/>
 
         <bean id="cacheEnabledConfig" class="org.cbioportal.persistence.CacheEnabledConfig">
             <constructor-arg value="${persistence.cache_type:no-cache}"/>
@@ -32,17 +32,13 @@
             </property>
         </bean>
 
-        <bean id="redisCacheManager" class="org.springframework.cache.jcache.JCacheCacheManager">
-            <property name="cacheManager" ref="cacheManager"/>
-        </bean>
-
         <bean id="generalRepositoryCacheResolver" class="org.springframework.cache.interceptor.NamedCacheResolver">
-            <constructor-arg index="0" ref="redisCacheManager"/>
+            <constructor-arg index="0" ref="cacheManager"/>
             <constructor-arg index="1" value="${app.name:cbioportal}GeneralRepositoryCache"/>
         </bean>
 
         <bean id="staticRepositoryCacheOneResolver" class="org.springframework.cache.interceptor.NamedCacheResolver">
-            <constructor-arg index="0" ref="redisCacheManager"/>
+            <constructor-arg index="0" ref="cacheManager"/>
             <constructor-arg index="1" value="${app.name:cbioportal}StaticRepositoryCacheOne"/>
         </bean>
 

--- a/service/src/main/java/org/cbioportal/service/impl/CacheStatisticsServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CacheStatisticsServiceImpl.java
@@ -13,7 +13,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 @Service
-@Profile({"ehcache-heap", "ehcache-disk", "ehcache-hybrid", "redis"})
+@Profile({"ehcache-heap", "ehcache-disk", "ehcache-hybrid"})
 public class CacheStatisticsServiceImpl implements CacheStatisticsService {
 
     @Autowired

--- a/service/src/main/java/org/cbioportal/service/impl/RedisCacheStatisticsServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/RedisCacheStatisticsServiceImpl.java
@@ -1,0 +1,90 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.persistence.util.CustomKeyGenerator;
+import org.cbioportal.persistence.util.CustomRedisCache;
+import org.cbioportal.service.CacheStatisticsService;
+import org.cbioportal.service.exception.CacheNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Profile({"redis"})
+public class RedisCacheStatisticsServiceImpl implements CacheStatisticsService {
+
+    @Autowired
+    public CacheManager cacheManager;
+
+    @Value("${cache.statistics_endpoint_enabled:false}")
+    public boolean cacheStatisticsEndpointEnabled;
+
+    protected void checkIfCacheStatisticsEndpointEnabled() {
+        if (!cacheStatisticsEndpointEnabled) {
+            throw new AccessDeniedException("Cache statistics is not enabled for this instance of the portal.");
+        }
+    }
+
+    @Override
+    public List<String> getKeyCountsPerClass(String cacheName) throws CacheNotFoundException {
+        checkIfCacheStatisticsEndpointEnabled();
+        if (!cacheManager.getCacheNames().contains(cacheName)) {
+            throw new CacheNotFoundException(cacheName);
+        }
+
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache instanceof CustomRedisCache) {
+            CustomRedisCache redisCache = (CustomRedisCache) cache;
+            Map<String, Long> keyCountPerClass = redisCache.getNativeCache()
+                .getKeys()
+                .getKeysStream()
+                .filter(k -> k.startsWith(redisCache.getName()))
+                // cut off cache name from key
+                .map(k -> k.substring(redisCache.getName().length() + CustomRedisCache.DELIMITER.length()))
+                // cut off everything after the class of the class of the cached method
+                .map(k -> k.substring(0, k.indexOf(CustomKeyGenerator.DELIMITER)))
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+            
+            return keyCountPerClass.entrySet().stream()
+                .map(e -> e.getKey() + ": " + e.getValue() + " keys")
+                .collect(Collectors.toList());
+        }
+        
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<String> getKeysInCache(String cacheName) throws CacheNotFoundException {
+        checkIfCacheStatisticsEndpointEnabled();
+        if (!cacheManager.getCacheNames().contains(cacheName)) {
+            throw new CacheNotFoundException(cacheName);
+        }
+        
+        Cache cache = cacheManager.getCache(cacheName);        
+        
+        if (cache instanceof CustomRedisCache) {
+            CustomRedisCache redisCache = (CustomRedisCache) cache;
+            return redisCache.getNativeCache()
+                .getKeys()
+                .getKeysStream()
+                .filter(k -> k.startsWith(redisCache.getName()))
+                .collect(Collectors.toList());
+        }
+        
+        return new ArrayList<>();
+    }
+
+    @Override
+    public String getCacheStatistics() {
+        throw new UnsupportedOperationException("Requested API is not implemented yet");
+    }
+}

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -270,6 +270,8 @@ persistence.cache_type=no-cache
 #redis.follower_address=
 #redis.database=
 #redis.password=
+#redis.ttl_mins=10000
+#redis.clear_on_startup=true
 
 # Ehcache properties
 #ehcache.xml_configuration=/ehcache.xml

--- a/web/src/main/java/org/cbioportal/web/parameter/StudyViewFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/StudyViewFilter.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -16,10 +16,22 @@ import org.cbioportal.web.parameter.GeneFilter.SingleGeneQuery;
 import org.cbioportal.web.util.appliers.PatientTreatmentFilterApplier;
 import org.cbioportal.web.util.appliers.SampleTreatmentFilterApplier;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
 
 @Component
 public class StudyViewFilterApplier {
+    @Autowired
+    private ApplicationContext applicationContext;
+    StudyViewFilterApplier instance;
+    @PostConstruct
+    private void init() {
+        instance = applicationContext.getBean(StudyViewFilterApplier.class);
+    }
+
 
     @Autowired
     private SampleService sampleService;
@@ -69,6 +81,14 @@ public class StudyViewFilterApplier {
     };
 
     public List<SampleIdentifier> apply(StudyViewFilter studyViewFilter) {
+        return (instance == null ? this : instance).cachedApply(studyViewFilter);
+    }
+    
+    @Cacheable(
+        cacheResolver = "generalRepositoryCacheResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
+    public List<SampleIdentifier> cachedApply(StudyViewFilter studyViewFilter) {
         return this.apply(studyViewFilter, false);
     }
 

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.collections.map.MultiKeyMap;
 import org.cbioportal.model.ClinicalDataBin;
 import org.cbioportal.model.ClinicalDataCount;
@@ -152,5 +153,19 @@ public class StudyViewFilterUtil {
             clinicalDataCountItem.setCounts(clinicalDataCounts);
             return clinicalDataCountItem;
         }).collect(Collectors.toList());
+    }
+    
+    public boolean isSingleStudyUnfiltered(StudyViewFilter filter) {
+            return filter.getStudyIds() != null &&
+                filter.getStudyIds().size() == 1 &&
+                (filter.getClinicalDataFilters() == null || filter.getClinicalDataFilters().isEmpty()) &&
+                (filter.getGeneFilters() == null || filter.getGeneFilters().isEmpty()) &&
+                (filter.getSampleTreatmentFilters() == null || filter.getSampleTreatmentFilters().getFilters().isEmpty()) &&
+                (filter.getPatientTreatmentFilters() == null || filter.getPatientTreatmentFilters().getFilters().isEmpty()) &&
+                (filter.getGenomicProfiles() == null || filter.getGenomicProfiles().isEmpty()) &&
+                (filter.getGenomicDataFilters() == null || filter.getGenomicDataFilters().isEmpty()) &&
+                (filter.getGenericAssayDataFilters() == null || filter.getGenericAssayDataFilters().isEmpty()) &&
+                (filter.getCaseLists() == null || filter.getCaseLists().isEmpty()) &&
+                (filter.getCustomDataFilters() == null || filter.getCustomDataFilters().isEmpty());
     }
 }

--- a/web/src/test/java/org/cbioportal/persistence/util/CustomRedisCacheIntegrationTest.java
+++ b/web/src/test/java/org/cbioportal/persistence/util/CustomRedisCacheIntegrationTest.java
@@ -1,0 +1,34 @@
+package org.cbioportal.persistence.util;
+
+import org.cbioportal.persistence.util.fakeclient.MockInMemoryRedissonClient;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * This test is... not great, but it's my attempt to create a
+ * runnable integration test for the CustomRedisCache that doesn't
+ * have a ton of dependencies or a long runtime. Believe it or not,
+ * this test did catch some bugs; so while it isn't a perfect integration
+ * test by any means, I think it is worth something.
+ * 
+ * What I've done is create a hollow implementation of RedissionClient that
+ * acts as a _very_ primitive in memory cache. This test just runs some basic
+ * caching operations, namely set, get, and clear.
+ */
+public class CustomRedisCacheIntegrationTest {
+    @Test
+    public void shouldAddThenEvict() {
+        MockInMemoryRedissonClient fakeClient = new MockInMemoryRedissonClient();
+        CustomRedisCache subject = new CustomRedisCache("generalCache", fakeClient, 100);
+        
+        subject.put("key", "value");
+        Object actualValue = subject.lookup("key");
+        assertEquals("value", actualValue);
+        
+        subject.clear();
+        actualValue = subject.lookup("key");
+        assertNull(actualValue);        
+    }
+}

--- a/web/src/test/java/org/cbioportal/persistence/util/CustomRedisCacheManagerTest.java
+++ b/web/src/test/java/org/cbioportal/persistence/util/CustomRedisCacheManagerTest.java
@@ -1,0 +1,55 @@
+package org.cbioportal.persistence.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.redisson.api.RedissonClient;
+import org.springframework.cache.Cache;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CustomRedisCacheManagerTest {
+    @Mock
+    RedissonClient client;
+
+    @Test
+    public void shouldGetStaticCache() {
+        CustomRedisCacheManager subject = new CustomRedisCacheManager(client, 100);
+
+        Cache actualFirstCall = subject.getCache("aStaticFunkyCache");
+        Cache actualSecondCall = subject.getCache("aStaticFunkyCache");
+        
+        assertEquals("aStaticFunkyCache", actualFirstCall.getName());
+        assertEquals(client, actualFirstCall.getNativeCache());
+        // the first and second call should return the same cache object
+        assertSame(actualFirstCall, actualSecondCall);
+    }
+
+    @Test
+    public void shouldReturnNamesOfCachesWhenNonePresent() {
+        CustomRedisCacheManager subject = new CustomRedisCacheManager(client, 100);
+        Collection<String> actual = subject.getCacheNames();
+        assertEquals(new HashSet<>(), new HashSet<>(actual));
+    }
+    
+    @Test
+    public void shouldReturnNamesOfCachesWhenSomePresent() {
+        CustomRedisCacheManager subject = new CustomRedisCacheManager(client, 100);
+        subject.getCache("cache and release", false);
+        subject.getCache("Cache-22", true);
+        subject.getCache("cache money", false);
+
+        Set<String> actual = new HashSet<>(subject.getCacheNames());
+        HashSet<String> expected = 
+            new HashSet<>(Arrays.asList("cache and release", "Cache-22", "cache money"));
+        
+        assertEquals(expected, actual);
+    }
+}

--- a/web/src/test/java/org/cbioportal/persistence/util/CustomRedisCacheTest.java
+++ b/web/src/test/java/org/cbioportal/persistence/util/CustomRedisCacheTest.java
@@ -1,0 +1,274 @@
+package org.cbioportal.persistence.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.redisson.api.RBucket;
+import org.redisson.api.RKeys;
+import org.redisson.api.RedissonClient;
+import org.springframework.cache.Cache;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CustomRedisCacheTest {
+    @Mock
+    RedissonClient client;
+
+    @Test
+    public void shouldHaveGetters() {
+        CustomRedisCache subject = new CustomRedisCache("subject", client, -1);
+        
+        assertEquals("subject", subject.getName());
+        assertEquals(client, subject.getNativeCache());
+    }
+
+    @Test
+    public void shouldLookupObjectThatDoesNotExist() {
+        RBucket bucket = Mockito.mock(RBucket.class);
+        when(bucket.get()).thenReturn(null);
+        when(client.getBucket("subject:57_onions"))
+            .thenReturn(bucket);
+        
+        CustomRedisCache subject = new CustomRedisCache("subject", client, -1);
+        Object actual = subject.lookup("57_onions");
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void shouldLookupObjectThatDoesExistForStaticCache() {
+        RBucket bucket = Mockito.mock(RBucket.class);
+        when(bucket.get()).thenReturn(toStoreValue("success"));
+        when(client.getBucket("subject:57_onions"))
+            .thenReturn(bucket);
+
+        CustomRedisCache subject = new CustomRedisCache("subject", client, -1);
+        Object actual = subject.lookup("57_onions");
+
+        assertEquals("success", actual);
+        // cache is static, so don't refresh
+        verify(bucket, times(0)).expireAsync(-1, TimeUnit.MINUTES);
+    }
+
+    @Test
+    public void shouldLookupObjectThatDoesExistForGeneralCache() {
+        RBucket bucket = Mockito.mock(RBucket.class);
+        when(bucket.get()).thenReturn(toStoreValue("success"));
+        when(client.getBucket("subject:57_onions"))
+            .thenReturn(bucket);
+
+        CustomRedisCache subject = new CustomRedisCache("subject", client, 100);
+        Object actual = subject.lookup("57_onions");
+
+        assertEquals("success", actual);
+        // cache is not static, so refresh
+        verify(bucket, times(1)).expireAsync(100, TimeUnit.MINUTES);
+    }
+
+    @Test
+    public void shouldGetObjectThatDoesNotExist() {
+        String defaultReturn = "this gets returned if the object DNE in cache";
+        RBucket bucket = Mockito.mock(RBucket.class);
+        when(bucket.get()).thenReturn(null);
+        when(client.getBucket("subject:57_onions"))
+            .thenReturn(bucket);
+
+        CustomRedisCache subject = new CustomRedisCache("subject", client, -1);
+        Object actual = subject.get("57_onions", () -> defaultReturn);
+
+        assertEquals(defaultReturn, actual);
+    }
+
+    @Test
+    public void shouldGetObjectThatDoesExistForStaticCache() {
+        String defaultReturn = "this gets returned if the object DNE in cache";
+        RBucket bucket = Mockito.mock(RBucket.class);
+        when(bucket.get()).thenReturn(toStoreValue("success"));
+        when(client.getBucket("subject:57_onions"))
+            .thenReturn(bucket);
+
+        CustomRedisCache subject = new CustomRedisCache("subject", client, -1);
+        Object actual = subject.get("57_onions", () -> defaultReturn);
+
+        assertEquals("success", actual);
+        // cache is static, so don't refresh
+        verify(bucket, times(0)).expireAsync(-1, TimeUnit.MINUTES);
+    }
+
+    @Test
+    public void shouldGetObjectThatDoesExistForGeneralCache() {
+        String defaultReturn = "this gets returned if the object DNE in cache";
+        RBucket bucket = Mockito.mock(RBucket.class);
+        when(bucket.get()).thenReturn(toStoreValue("success"));
+        when(client.getBucket("subject:57_onions"))
+            .thenReturn(bucket);
+
+        CustomRedisCache subject = new CustomRedisCache("subject", client, 100);
+        Object actual = subject.get("57_onions", () -> defaultReturn);
+
+        assertEquals("success", actual);
+        // cache is not static, so refresh
+        verify(bucket, times(1)).expireAsync(100, TimeUnit.MINUTES);
+    }
+
+
+    @Test(expected = Cache.ValueRetrievalException.class)
+    public void shouldPropagateValueLoaderException() {
+        String defaultReturn = "this gets returned if the object DNE in cache";
+        RBucket bucket = Mockito.mock(RBucket.class);
+        when(bucket.get()).thenReturn(null);
+        when(client.getBucket("subject:57_onions"))
+            .thenReturn(bucket);
+
+        CustomRedisCache subject = new CustomRedisCache("subject", client, -1);
+        subject.get("57_onions", () -> {throw new RuntimeException("uh oh");});
+    }
+
+    @Test
+    public void shouldPutObjectInStaticCache() {
+        RBucket bucket = Mockito.mock(RBucket.class);
+        when(client.getBucket("subject:57_onions"))
+            .thenReturn(bucket);
+
+        CustomRedisCache subject = new CustomRedisCache("subject", client, -1);
+        subject.put("57_onions", "success");
+
+        // this is tricky to verify, because the value is compressed before
+        // it gets added to the cache
+        verify(bucket, times(1)).setAsync(any());
+        verify(bucket, times(0)).setAsync(any(), anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
+    public void shouldPutObjectInGeneralCache() {
+        RBucket bucket = Mockito.mock(RBucket.class);
+        when(client.getBucket("subject:57_onions"))
+            .thenReturn(bucket);
+
+        CustomRedisCache subject = new CustomRedisCache("subject", client, 100);
+        subject.put("57_onions", "success");
+
+        // this is tricky to verify, because the value is compressed before
+        // it gets added to the cache
+        verify(bucket, times(0)).setAsync(any());
+        verify(bucket, times(1)).setAsync(any(), anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
+    public void shouldPutAbsentObject() {
+        RBucket bucket = Mockito.mock(RBucket.class);
+        when(bucket.get()).thenReturn(null);
+        when(client.getBucket("subject:57_onions"))
+            .thenReturn(bucket);
+
+        CustomRedisCache subject = new CustomRedisCache("subject", client, 100);
+        Cache.ValueWrapper actual = subject.putIfAbsent("57_onions", "success");
+
+        // the value is absent, so there should be a put
+        verify(bucket, times(1)).setAsync(any(), anyLong(), any(TimeUnit.class));
+        assertEquals("success", actual.get());
+    }
+
+    @Test
+    public void shouldNotPutPresentObject() {
+        RBucket bucket = Mockito.mock(RBucket.class);
+        when(bucket.get()).thenReturn(toStoreValue("success"));
+        when(client.getBucket("subject:57_onions"))
+            .thenReturn(bucket);
+
+        CustomRedisCache subject = new CustomRedisCache("subject", client, 100);
+        Cache.ValueWrapper actual = subject.putIfAbsent("57_onions", "success");
+
+        // the value is absent, so there should be a put
+        verify(bucket, times(0)).setAsync(any(), anyLong(), any(TimeUnit.class));
+        assertEquals("success", actual.get());
+    }
+
+    @Test
+    public void shouldNoopForEvict() {
+        CustomRedisCache subject = new CustomRedisCache("subject", client, 100);
+        subject.evict("sdrazil");
+
+        // evict is a no op, so there should be no calls to the client
+        verify(client, times(0)).getBucket(any());
+    }
+
+    @Test
+    public void shouldNoopForEvictIfPresent() {
+        CustomRedisCache subject = new CustomRedisCache("subject", client, 100);
+        subject.evictIfPresent("sdrazil");
+
+        // evict is a no op, so there should be no calls to the client
+        verify(client, times(0)).getBucket(any());
+    }
+
+    @Test
+    public void shouldClear() {
+        RKeys allKeys = mock(RKeys.class);
+        when(client.getKeys()).thenReturn(allKeys);
+        CustomRedisCache subject = new CustomRedisCache("subject", client, 100);
+        subject.clear();
+
+        // evict is a no op, so there should be no calls to the client
+        verify(client, times(1)).getKeys();
+        verify(allKeys, times(1)).deleteByPattern("subject:*");
+    }
+
+    @Test
+    public void shouldInvalidateEmptyCache() {
+        RKeys allKeys = mock(RKeys.class);
+        when(allKeys.deleteByPattern("subject:*")).thenReturn(0L);
+        when(client.getKeys()).thenReturn(allKeys);
+        CustomRedisCache subject = new CustomRedisCache("subject", client, 100);
+        boolean actual = subject.invalidate();
+
+        // evict is a no op, so there should be no calls to the client
+        verify(client, times(1)).getKeys();
+        verify(allKeys, times(1)).deleteByPattern("subject:*");
+        assertFalse(actual);
+    }
+
+    @Test
+    public void shouldRoundTripObject() {
+        String toRoundTrip = "The quick brown fox jumped over the lazy dog";
+        CustomRedisCache subject = new CustomRedisCache("subject", client, -1);
+
+        Object compressed = subject.toStoreValue(toRoundTrip);
+        String roundTripped = (String) subject.fromStoreValue(compressed);
+        
+        assertEquals(toRoundTrip, roundTripped);
+    }
+
+    @Test
+    public void shouldRoundTripPrimitive() {
+        int toRoundTrip = Integer.MAX_VALUE;
+        CustomRedisCache subject = new CustomRedisCache("subject", client, -1);
+
+        Object compressed = subject.toStoreValue(toRoundTrip);
+        int roundTripped = (int) subject.fromStoreValue(compressed);
+
+        assertEquals(toRoundTrip, roundTripped);
+    }
+
+    @Test
+    public void shouldRoundTripNull() {
+        Object toRoundTrip = null;
+        CustomRedisCache subject = new CustomRedisCache("subject", client, -1);
+
+        Object compressed = subject.toStoreValue(toRoundTrip);
+        Object roundTripped = subject.fromStoreValue(compressed);
+
+        assertEquals(toRoundTrip, roundTripped);
+    }
+    
+    private Object toStoreValue(Object rawValue) {
+        CustomRedisCache converter = new CustomRedisCache("", client, -1);
+        return converter.toStoreValue(rawValue);
+    }
+}

--- a/web/src/test/java/org/cbioportal/persistence/util/fakeclient/MockInMemoryRedissonClient.java
+++ b/web/src/test/java/org/cbioportal/persistence/util/fakeclient/MockInMemoryRedissonClient.java
@@ -1,0 +1,578 @@
+package org.cbioportal.persistence.util.fakeclient;
+
+import org.redisson.api.*;
+import org.redisson.api.redisnode.BaseRedisNodes;
+import org.redisson.api.redisnode.RedisNodes;
+import org.redisson.client.codec.Codec;
+import org.redisson.config.Config;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public class MockInMemoryRedissonClient implements RedissonClient {
+    private final ConcurrentHashMap<String, RBucket> rBucketMap;
+    private final ConcurrentHashMap<String, Object> valueMap;
+
+    public MockInMemoryRedissonClient() {
+        rBucketMap = new ConcurrentHashMap<>();
+        valueMap = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public <V> RBucket<V> getBucket(String s) {
+        return rBucketMap.computeIfAbsent(s, (key) -> new MockRBucket(valueMap, key));
+    }
+
+    /*
+     * Methods we don't use
+     */
+    @Override
+    public RKeys getKeys() {
+        return new MockRKeys(rBucketMap, valueMap);
+    }
+        
+    @Override
+    public <V> RTimeSeries<V> getTimeSeries(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RTimeSeries<V> getTimeSeries(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RStream<K, V> getStream(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RStream<K, V> getStream(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RRateLimiter getRateLimiter(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RBinaryStream getBinaryStream(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RGeo<V> getGeo(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RGeo<V> getGeo(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RSetCache<V> getSetCache(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RSetCache<V> getSetCache(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RMapCache<K, V> getMapCache(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RMapCache<K, V> getMapCache(String s, Codec codec, MapOptions<K, V> mapOptions) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RMapCache<K, V> getMapCache(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RMapCache<K, V> getMapCache(String s, MapOptions<K, V> mapOptions) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RBucket<V> getBucket(String s, Codec codec) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RBuckets getBuckets() {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RBuckets getBuckets(Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RHyperLogLog<V> getHyperLogLog(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RHyperLogLog<V> getHyperLogLog(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RList<V> getList(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RList<V> getList(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RListMultimap<K, V> getListMultimap(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RListMultimap<K, V> getListMultimap(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RListMultimapCache<K, V> getListMultimapCache(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RListMultimapCache<K, V> getListMultimapCache(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RLocalCachedMap<K, V> getLocalCachedMap(String s, LocalCachedMapOptions<K, V> localCachedMapOptions) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RLocalCachedMap<K, V> getLocalCachedMap(String s, Codec codec, LocalCachedMapOptions<K, V> localCachedMapOptions) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RMap<K, V> getMap(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RMap<K, V> getMap(String s, MapOptions<K, V> mapOptions) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RMap<K, V> getMap(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RMap<K, V> getMap(String s, Codec codec, MapOptions<K, V> mapOptions) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RSetMultimap<K, V> getSetMultimap(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RSetMultimap<K, V> getSetMultimap(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RSetMultimapCache<K, V> getSetMultimapCache(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <K, V> RSetMultimapCache<K, V> getSetMultimapCache(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RSemaphore getSemaphore(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RPermitExpirableSemaphore getPermitExpirableSemaphore(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RLock getLock(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RLock getMultiLock(RLock... rLocks) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    /**
+     * @param rLocks
+     * @deprecated
+     */
+    @Override
+    public RLock getRedLock(RLock... rLocks) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RLock getFairLock(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RReadWriteLock getReadWriteLock(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RSet<V> getSet(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RSet<V> getSet(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RSortedSet<V> getSortedSet(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RSortedSet<V> getSortedSet(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RScoredSortedSet<V> getScoredSortedSet(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RScoredSortedSet<V> getScoredSortedSet(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RLexSortedSet getLexSortedSet(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RTopic getTopic(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RTopic getTopic(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RPatternTopic getPatternTopic(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RPatternTopic getPatternTopic(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RQueue<V> getQueue(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RTransferQueue<V> getTransferQueue(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RTransferQueue<V> getTransferQueue(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RDelayedQueue<V> getDelayedQueue(RQueue<V> rQueue) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RQueue<V> getQueue(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RRingBuffer<V> getRingBuffer(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RRingBuffer<V> getRingBuffer(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RPriorityQueue<V> getPriorityQueue(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RPriorityQueue<V> getPriorityQueue(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RPriorityBlockingQueue<V> getPriorityBlockingQueue(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RPriorityBlockingQueue<V> getPriorityBlockingQueue(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RPriorityBlockingDeque<V> getPriorityBlockingDeque(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RPriorityBlockingDeque<V> getPriorityBlockingDeque(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RPriorityDeque<V> getPriorityDeque(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RPriorityDeque<V> getPriorityDeque(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RBlockingQueue<V> getBlockingQueue(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RBlockingQueue<V> getBlockingQueue(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RBoundedBlockingQueue<V> getBoundedBlockingQueue(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RBoundedBlockingQueue<V> getBoundedBlockingQueue(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RDeque<V> getDeque(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RDeque<V> getDeque(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RBlockingDeque<V> getBlockingDeque(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RBlockingDeque<V> getBlockingDeque(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RAtomicLong getAtomicLong(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RAtomicDouble getAtomicDouble(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RLongAdder getLongAdder(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RDoubleAdder getDoubleAdder(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RCountDownLatch getCountDownLatch(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RBitSet getBitSet(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RBloomFilter<V> getBloomFilter(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <V> RBloomFilter<V> getBloomFilter(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RScript getScript() {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RScript getScript(Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RScheduledExecutorService getExecutorService(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RScheduledExecutorService getExecutorService(String s, ExecutorOptions executorOptions) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RScheduledExecutorService getExecutorService(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RScheduledExecutorService getExecutorService(String s, Codec codec, ExecutorOptions executorOptions) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RRemoteService getRemoteService() {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RRemoteService getRemoteService(Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RRemoteService getRemoteService(String s) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RRemoteService getRemoteService(String s, Codec codec) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RTransaction createTransaction(TransactionOptions transactionOptions) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RBatch createBatch(BatchOptions batchOptions) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RBatch createBatch() {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public RLiveObjectService getLiveObjectService() {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+
+    @Override
+    public void shutdown(long l, long l1, TimeUnit timeUnit) {
+
+    }
+
+    @Override
+    public Config getConfig() {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public <T extends BaseRedisNodes> T getRedisNodes(RedisNodes<T> redisNodes) {
+        throw new UnsupportedOperationException(); 
+    }
+
+    /**
+     * @deprecated
+     */
+    @Override
+    public NodesGroup<Node> getNodesGroup() {
+        throw new UnsupportedOperationException(); 
+    }
+
+    /**
+     * @deprecated
+     */
+    @Override
+    public ClusterNodesGroup getClusterNodesGroup() {
+        throw new UnsupportedOperationException(); 
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean isShuttingDown() {
+        return false;
+    }
+
+    @Override
+    public String getId() {
+        throw new UnsupportedOperationException(); 
+    }
+}

--- a/web/src/test/java/org/cbioportal/persistence/util/fakeclient/MockRBucket.java
+++ b/web/src/test/java/org/cbioportal/persistence/util/fakeclient/MockRBucket.java
@@ -1,0 +1,388 @@
+package org.cbioportal.persistence.util.fakeclient;
+
+import org.redisson.api.ObjectListener;
+import org.redisson.api.RBucket;
+import org.redisson.api.RFuture;
+import org.redisson.client.codec.Codec;
+
+import java.util.Date;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public class MockRBucket implements RBucket {
+    private final ConcurrentHashMap<String, Object> rBucketCache;
+    private final String key;
+    
+    public MockRBucket(ConcurrentHashMap<String, Object> rBucketCache, String key) {
+        this.rBucketCache = rBucketCache;
+        this.key = key;
+    }
+
+    @Override
+    public Object get() {
+        return rBucketCache.get(key);
+    }
+
+    @Override
+    public void set(Object o) {
+        rBucketCache.put(key, o);
+    }
+
+    @Override
+    public void set(Object o, long l, TimeUnit timeUnit) {
+        // This cache is really primitive, so ttl isn't fully implemented
+        // Instead, if the ttl is 0, the object isn't added, but for any other value, it is
+        // in the cache forever.
+        if (l == 0) {
+            set(null);
+        } else {
+            set(o);
+        }
+    }
+
+    @Override
+    public RFuture<Void> setAsync(Object o) {
+        set(o);
+        return null;
+    }
+
+    @Override
+    public RFuture<Void> setAsync(Object o, long l, TimeUnit timeUnit) {
+        set(o, l, timeUnit);
+        return null;
+    }
+
+    @Override
+    public RFuture<Boolean> expireAsync(long l, TimeUnit timeUnit) {
+        // This cache is really primitive, so ttl isn't fully implemented
+        // Instead, if the ttl is 0, the object removed, but for any other value,
+        // it isn't touched.
+        if (l == 0) {
+            set(null);
+        }
+        return null;
+    }
+
+    /*
+     * Methods we don't use
+     */
+    @Override
+    public long size() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAndDelete() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean trySet(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean trySet(Object o, long l, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean setIfExists(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean setIfExists(Object o, long l, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean compareAndSet(Object o, Object v1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAndSet(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAndSet(Object o, long l, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long sizeInMemory() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void restore(byte[] bytes) {
+
+    }
+
+    @Override
+    public void restore(byte[] bytes, long l, TimeUnit timeUnit) {
+
+    }
+
+    @Override
+    public void restoreAndReplace(byte[] bytes) {
+
+    }
+
+    @Override
+    public void restoreAndReplace(byte[] bytes, long l, TimeUnit timeUnit) {
+
+    }
+
+    @Override
+    public byte[] dump() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean touch() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void migrate(String s, int i, int i1, long l) {
+
+    }
+
+    @Override
+    public void copy(String s, int i, int i1, long l) {
+
+    }
+
+    @Override
+    public boolean move(int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean delete() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean unlink() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void rename(String s) {
+
+    }
+
+    @Override
+    public boolean renamenx(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isExists() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Codec getCodec() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int addListener(ObjectListener objectListener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeListener(int i) {
+
+    }
+
+    @Override
+    public RFuture<Long> sizeAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture getAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture getAndDeleteAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> trySetAsync(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> trySetAsync(Object o, long l, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> setIfExistsAsync(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> setIfExistsAsync(Object o, long l, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> compareAndSetAsync(Object o, Object v1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture getAndSetAsync(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture getAndSetAsync(Object o, long l, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean expire(long l, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean expireAt(long l) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean expireAt(Date date) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean clearExpire() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long remainTimeToLive() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> expireAtAsync(Date date) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> expireAtAsync(long l) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> clearExpireAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Long> remainTimeToLiveAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Long> sizeInMemoryAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> restoreAsync(byte[] bytes) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> restoreAsync(byte[] bytes, long l, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> restoreAndReplaceAsync(byte[] bytes) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> restoreAndReplaceAsync(byte[] bytes, long l, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<byte[]> dumpAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> touchAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> migrateAsync(String s, int i, int i1, long l) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> copyAsync(String s, int i, int i1, long l) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> moveAsync(int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> deleteAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> unlinkAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> renameAsync(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> renamenxAsync(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> isExistsAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Integer> addListenerAsync(ObjectListener objectListener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> removeListenerAsync(int i) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/web/src/test/java/org/cbioportal/persistence/util/fakeclient/MockRKeys.java
+++ b/web/src/test/java/org/cbioportal/persistence/util/fakeclient/MockRKeys.java
@@ -1,0 +1,312 @@
+package org.cbioportal.persistence.util.fakeclient;
+
+import org.redisson.api.*;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class MockRKeys implements RKeys {
+    private final ConcurrentMap<String, RBucket> cache;
+    private final ConcurrentHashMap<String, Object> valueMap;
+
+    public MockRKeys(ConcurrentMap<String, RBucket> cache, ConcurrentHashMap<String, Object> valueMap) {
+        this.cache = cache;
+        this.valueMap = valueMap;
+    }
+
+    @Override
+    public long deleteByPattern(String s) {
+        Predicate<String> matches = Pattern.compile(s).asPredicate();
+        
+        valueMap.keySet().stream()
+            .filter(matches)
+            .forEach(valueMap::remove);
+        
+        return cache.keySet().stream()
+            .filter(matches)
+            .peek(cache::remove)
+            .count();
+    }
+
+    /*
+     * Methods we don't use
+     */
+    @Override
+    public boolean move(String s, int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void migrate(String s, String s1, int i, int i1, long l) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void copy(String s, String s1, int i, int i1, long l) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean expire(String s, long l, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean expireAt(String s, long l) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean clearExpire(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean renamenx(String s, String s1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void rename(String s, String s1) {
+
+    }
+
+    @Override
+    public long remainTimeToLive(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long touch(String... strings) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long countExists(String... strings) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RType getType(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getSlot(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterable<String> getKeysByPattern(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterable<String> getKeysByPattern(String s, int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterable<String> getKeys() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterable<String> getKeys(int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Stream<String> getKeysStreamByPattern(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Stream<String> getKeysStreamByPattern(String s, int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Stream<String> getKeysStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Stream<String> getKeysStream(int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String randomKey() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long delete(RObject... rObjects) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long delete(String... strings) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long unlink(String... strings) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long count() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void swapdb(int i, int i1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void flushdb() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void flushdbParallel() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void flushall() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void flushallParallel() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> moveAsync(String s, int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> migrateAsync(String s, String s1, int i, int i1, long l) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> copyAsync(String s, String s1, int i, int i1, long l) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> expireAsync(String s, long l, TimeUnit timeUnit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> expireAtAsync(String s, long l) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> clearExpireAsync(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Boolean> renamenxAsync(String s, String s1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> renameAsync(String s, String s1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Long> remainTimeToLiveAsync(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Long> touchAsync(String... strings) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Long> countExistsAsync(String... strings) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<RType> getTypeAsync(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Integer> getSlotAsync(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<String> randomKeyAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Long> deleteByPatternAsync(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Long> deleteAsync(RObject... rObjects) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Long> deleteAsync(String... strings) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Long> unlinkAsync(String... strings) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Long> countAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> swapdbAsync(int i, int i1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> flushdbAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> flushallAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> flushdbParallelAsync() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RFuture<Void> flushallParallelAsync() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
This PR provides a custom implementation of Spring's cache, backed
by Redis. We decided to do this because we found that the
CachingProvider that Spring uses for Redis did not work well with
our set up. Specifically, it did not give us enough autonomy
over expiry, and did not allow us to compress objects.

This PR provides:
- A custom redis cache manager that compresses values and sets ttls
- A revamped key generator
- A ton of tests for the cache
- Caching of a few controller methods

Fix #8583

I have also verified that I didn't break any wiring for ehcache or no cache