### PR TITLE
Add separate image with redis enabled

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo "##[set-output name=image_tag_names;]$(echo ${GITHUB_REF##*/} | sed 's/^v/latest,/g')"
         id: extract_tags
       - name: 'Docker build with cache'
-        uses: whoan/docker-build-with-cache-action@v4
+        uses: whoan/docker-build-with-cache-action@v5
         with:
           username: "${{ secrets.DOCKER_USERNAME }}"
           password: "${{ secrets.DOCKER_PASSWORD }}"
@@ -48,13 +48,36 @@ jobs:
           run: echo "##[set-output name=image_tag_names;]$(echo ${GITHUB_REF##*/} | sed 's/^v//g')"
           id: extract_tags
         - name: 'Docker build with cache'
-          uses: whoan/docker-build-with-cache-action@v4
+          uses: whoan/docker-build-with-cache-action@v5
           with:
             username: "${{ secrets.DOCKER_USERNAME }}"
             password: "${{ secrets.DOCKER_PASSWORD }}"
             image_name: cbioportal/cbioportal
             image_tag: ${{ steps.extract_tags.outputs.image_tag_names }}-web-shenandoah
             context: .
+            dockerfile: docker/web/Dockerfile
+            pull_image_and_stages: false
+
+  build_and_publish_redis_web:
+      if: github.repository == 'cBioPortal/cbioportal'
+      runs-on: ubuntu-latest
+      steps:
+        - name: 'Checkout git repo'
+          uses: actions/checkout@v1
+        - name: Extract branch or tag name
+          # For the web docker image we don't publish it as latest
+          # just extract branch/tag name and strip v prefix
+          run: echo "##[set-output name=image_tag_names;]$(echo ${GITHUB_REF##*/} | sed 's/^v//g')"
+          id: extract_tags
+        - name: 'Docker build with cache'
+          uses: whoan/docker-build-with-cache-action@v5
+          with:
+            username: "${{ secrets.DOCKER_USERNAME }}"
+            password: "${{ secrets.DOCKER_PASSWORD }}"
+            image_name: cbioportal/cbioportal
+            image_tag: ${{ steps.extract_tags.outputs.image_tag_names }}-redis-web-shenandoah
+            context: .
+            build_extra_args: '{"--build-arg": "MAVEN_OPTS=-DskipTests -Dpersistence.cache_type=redis"}'
             dockerfile: docker/web/Dockerfile
             pull_image_and_stages: false
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -13,14 +13,11 @@
 #
 # WARNING: the shendoah image is a nightly, untested, experimental build. If
 # you want to use an official openjdk image instead use the web-and-data image.
-#
-# WARNING: Be careful about publishing images generated like this publicly
-# because your .git folder is exposed in the build step. We are not sure if
-# this is a security risk: stackoverflow.com/questions/56278325
 FROM maven:3-openjdk-11 as build
 COPY $PWD /cbioportal
 WORKDIR /cbioportal
-RUN mvn -DskipTests clean install
+ARG MAVEN_OPTS=-DskipTests
+RUN mvn ${MAVEN_OPTS} clean install
 
 FROM shipilev/openjdk-shenandoah:11
 

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -260,8 +260,9 @@ oncoprint.hotspots.default=true
 # querypage.setsofgenes.location=file:/<path>
 
 # valid cache types are (ehcache-heap, ehcache-disk, ehcache-hybrid, redis), or use 'no-cache' to disable caching
-# caution : the 'redis' caching option will likely cause a conflict when installing the portal in a tomcat installation which uses redisson for session management
-persistence.cache_type=redis
+# caution 1: the 'redis' caching option will likely cause a conflict when installing the portal in a tomcat installation which uses redisson for session management
+# caution 2: this configuration needs to be set both at compile time and run time. See also https://github.com/cBioPortal/cbioportal/issues/8629
+persistence.cache_type=no-cache
 # Enable cache statistics endpoint for cache monitoring
 #cache.statistics_endpoint_enabled=false
 


### PR DESCRIPTION
Related to #8629

For testing I did this to confirm:

image with redis (shows redis replaced value in `web.xml`):
```
$ docker run -it --rm cbioportal/cbioportal:release-genie-performance-test-cache-type-redis-web-shenandoah /bin/sh
# jar xf app.war WEB-INF/web.xml
# cat WEB-INF/web.xml | grep redis
        <param-value>${dbconnector:dbcp},${authenticate},${google.analytics.tracking:ga-api-tracking-disabled},redis</param-value>
        <param-value>classpath:applicationContext-persistenceConnections.xml classpath:applicationContext-security.xml classpath:applicationContext-logging.xml classpath:applicationContext-ehcache.xml classpath:applicationContext-rediscache.xml</param-value>
```
image w/o redis (does not show redis replaced value in `web.xml`):
```
$ docker run -it --rm cbioportal/cbioportal:release-genie-performance-test-cache-type-web-shenandoah /bin/sh
# jar xf app.war WEB-INF/web.xml
#  cat WEB-INF/web.xml | grep redis
        <param-value>classpath:applicationContext-persistenceConnections.xml classpath:applicationContext-security.xml classpath:applicationContext-logging.xml classpath:applicationContext-ehcache.xml classpath:applicationContext-rediscache.xml</param-value>
```