### PR TITLE
Rfc56 driver filtering

### DIFF
--- a/core/src/test/java/org/cbioportal/model/util/AlterationFiltersTest.java
+++ b/core/src/test/java/org/cbioportal/model/util/AlterationFiltersTest.java
@@ -8,6 +8,7 @@ import org.cbioportal.model.MutationEventType;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class AlterationFiltersTest {
@@ -87,6 +88,15 @@ public class AlterationFiltersTest {
     }
 
     @Test
+    public void setSelectAllWhenCnaTypesEmpty() {
+        AlterationFilter f = new AlterationFilter();
+        f.setCnaBooleanMap(new HashMap<>());
+        Assert.assertFalse(f.getSelectedCnaTypes().hasValues());
+        Assert.assertFalse(f.getSelectedCnaTypes().hasAll());
+        Assert.assertTrue(f.getSelectedCnaTypes().hasNone());
+    }
+
+    @Test
     public void setSelectAllWhenAllMutationTypesTrue() {
         AlterationFilter f = new AlterationFilter();
         Map<MutationEventType, Boolean> types = new HashedMap();
@@ -132,6 +142,15 @@ public class AlterationFiltersTest {
     }
 
     @Test
+    public void setSelectAllWhenMutationTypesEmpty() {
+        AlterationFilter f = new AlterationFilter();
+        f.setMutationBooleanMap(new HashMap<>());
+        Assert.assertFalse(f.getSelectedMutationTypes().hasValues());
+        Assert.assertFalse(f.getSelectedMutationTypes().hasAll());
+        Assert.assertTrue(f.getSelectedMutationTypes().hasNone());
+    }
+
+    @Test
     public void setSelectAllWhenAllTiersTrue() {
         BaseAlterationFilter f = new BaseAlterationFilter();
         Map<String, Boolean> types = new HashedMap();
@@ -162,6 +181,15 @@ public class AlterationFiltersTest {
         types.put("Class 1", false);
         types.put("Class 2", false);
         f.setTiersBooleanMap(types);
+        Assert.assertFalse(f.getSelectedTiers().hasValues());
+        Assert.assertFalse(f.getSelectedTiers().hasAll());
+        Assert.assertTrue(f.getSelectedTiers().hasNone());
+    }
+
+    @Test
+    public void setSelectAllWhenTiersEmpty() {
+        BaseAlterationFilter f = new BaseAlterationFilter();
+        f.setTiersBooleanMap(new HashedMap());
         Assert.assertFalse(f.getSelectedTiers().hasValues());
         Assert.assertFalse(f.getSelectedTiers().hasAll());
         Assert.assertTrue(f.getSelectedTiers().hasNone());

--- a/core/src/test/java/org/cbioportal/model/util/AlterationFiltersTest.java
+++ b/core/src/test/java/org/cbioportal/model/util/AlterationFiltersTest.java
@@ -1,0 +1,179 @@
+package org.cbioportal.model.util;
+
+import org.apache.commons.collections4.map.HashedMap;
+import org.cbioportal.model.AlterationFilter;
+import org.cbioportal.model.BaseAlterationFilter;
+import org.cbioportal.model.CNA;
+import org.cbioportal.model.MutationEventType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class AlterationFiltersTest {
+
+    @Test
+    public void testAlterationFilterWithEmptyConstructor() {
+        AlterationFilter f = new AlterationFilter();
+        Assert.assertTrue(f.getSelectedMutationTypes().hasAll());
+        Assert.assertTrue(f.getSelectedCnaTypes().hasAll());
+        Assert.assertTrue(f.getIncludeDriver());
+        Assert.assertTrue(f.getIncludeVUS());
+        Assert.assertTrue(f.getIncludeUnknownOncogenicity());
+        Assert.assertTrue(f.getIncludeGermline());
+        Assert.assertTrue(f.getIncludeGermline());
+        Assert.assertTrue(f.getIncludeUnknownStatus());
+        Assert.assertTrue(f.getIncludeUnknownTier());
+        Assert.assertTrue(f.getSelectedTiers().hasAll());
+    }
+
+    @Test
+    public void testMutationStatusFilterWithEmptyConstructor() {
+        BaseAlterationFilter f = new BaseAlterationFilter();
+        Assert.assertTrue(f.getIncludeGermline());
+        Assert.assertTrue(f.getIncludeUnknownStatus());
+        Assert.assertTrue(f.getIncludeUnknownTier());
+        Assert.assertTrue(f.getSelectedTiers().hasAll());
+        Assert.assertTrue(f.getIncludeDriver());
+        Assert.assertTrue(f.getIncludeVUS());
+        Assert.assertTrue(f.getIncludeUnknownOncogenicity());
+        Assert.assertTrue(f.getIncludeUnknownTier());
+        Assert.assertTrue(f.getSelectedTiers().hasAll());
+    }
+    
+    @Test
+    public void setSelectAllWhenAllCnaTypesTrue() {
+        AlterationFilter f = new AlterationFilter();
+        Map<CNA, Boolean> types = new HashedMap();
+        types.put(CNA.HOMDEL, true);
+        types.put(CNA.DIPLOID, true);
+        f.setCnaBooleanMap(types);
+        Assert.assertTrue(f.getSelectedCnaTypes().hasValues());
+        Assert.assertTrue(f.getSelectedCnaTypes().hasAll());
+        Assert.assertFalse(f.getSelectedCnaTypes().hasNone());
+    }
+
+    @Test
+    public void setSelectAllWhenSomeCnaTypesTrue() {
+        AlterationFilter f = new AlterationFilter();
+        Map<CNA, Boolean> types = new HashedMap();
+        types.put(CNA.HOMDEL, false);
+        types.put(CNA.DIPLOID, true);
+        f.setCnaBooleanMap(types);
+        Assert.assertTrue(f.getSelectedCnaTypes().hasValues());
+        Assert.assertFalse(f.getSelectedCnaTypes().hasAll());
+        Assert.assertFalse(f.getSelectedCnaTypes().hasNone());
+    }
+
+    @Test
+    public void setSelectAllWhenAllCnaTypesFalse() {
+        AlterationFilter f = new AlterationFilter();
+        Map<CNA, Boolean> types = new HashedMap();
+        types.put(CNA.HOMDEL, false);
+        types.put(CNA.DIPLOID, false);
+        f.setCnaBooleanMap(types);
+        Assert.assertFalse(f.getSelectedCnaTypes().hasValues());
+        Assert.assertFalse(f.getSelectedCnaTypes().hasAll());
+        Assert.assertTrue(f.getSelectedCnaTypes().hasNone());
+    }
+
+    @Test
+    public void setSelectAllWhenCnaTypesNull() {
+        AlterationFilter f = new AlterationFilter();
+        f.setCnaBooleanMap(null);
+        Assert.assertFalse(f.getSelectedCnaTypes().hasValues());
+        Assert.assertTrue(f.getSelectedCnaTypes().hasAll());
+        Assert.assertFalse(f.getSelectedCnaTypes().hasNone());
+    }
+
+    @Test
+    public void setSelectAllWhenAllMutationTypesTrue() {
+        AlterationFilter f = new AlterationFilter();
+        Map<MutationEventType, Boolean> types = new HashedMap();
+        types.put(MutationEventType.feature_truncation, true);
+        types.put(MutationEventType.missense_mutation, true);
+        f.setMutationBooleanMap(types);
+        Assert.assertTrue(f.getSelectedMutationTypes().hasValues());
+        Assert.assertTrue(f.getSelectedMutationTypes().hasAll());
+        Assert.assertFalse(f.getSelectedMutationTypes().hasNone());
+    }
+
+    @Test
+    public void setSelectAllWhenSomeMutationTypesTrue() {
+        AlterationFilter f = new AlterationFilter();
+        Map<MutationEventType, Boolean> types = new HashedMap();
+        types.put(MutationEventType.feature_truncation, false);
+        types.put(MutationEventType.missense_mutation, true);
+        f.setMutationBooleanMap(types);
+        Assert.assertTrue(f.getSelectedMutationTypes().hasValues());
+        Assert.assertFalse(f.getSelectedMutationTypes().hasAll());
+        Assert.assertFalse(f.getSelectedMutationTypes().hasNone());
+    }
+
+    @Test
+    public void setSelectAllWhenAllMutationTypesFalse() {
+        AlterationFilter f = new AlterationFilter();
+        Map<MutationEventType, Boolean> types = new HashedMap();
+        types.put(MutationEventType.feature_truncation, false);
+        types.put(MutationEventType.missense_mutation, false);
+        f.setMutationBooleanMap(types);
+        Assert.assertFalse(f.getSelectedMutationTypes().hasValues());
+        Assert.assertFalse(f.getSelectedMutationTypes().hasAll());
+        Assert.assertTrue(f.getSelectedMutationTypes().hasNone());
+    }
+
+    @Test
+    public void setSelectAllWhenMutationTypesNull() {
+        AlterationFilter f = new AlterationFilter();
+        f.setMutationBooleanMap(null);
+        Assert.assertFalse(f.getSelectedMutationTypes().hasValues());
+        Assert.assertTrue(f.getSelectedMutationTypes().hasAll());
+        Assert.assertFalse(f.getSelectedMutationTypes().hasNone());
+    }
+
+    @Test
+    public void setSelectAllWhenAllTiersTrue() {
+        BaseAlterationFilter f = new BaseAlterationFilter();
+        Map<String, Boolean> types = new HashedMap();
+        types.put("Class 1", true);
+        types.put("Class 2", true);
+        f.setTiersBooleanMap(types);
+        Assert.assertTrue(f.getSelectedTiers().hasValues());
+        Assert.assertTrue(f.getSelectedTiers().hasAll());
+        Assert.assertFalse(f.getSelectedTiers().hasNone());
+    }
+
+    @Test
+    public void setSelectAllWhenSomeTiersTrue() {
+        BaseAlterationFilter f = new BaseAlterationFilter();
+        Map<String, Boolean> types = new HashedMap();
+        types.put("Class 1", false);
+        types.put("Class 2", true);
+        f.setTiersBooleanMap(types);
+        Assert.assertTrue(f.getSelectedTiers().hasValues());
+        Assert.assertFalse(f.getSelectedTiers().hasAll());
+        Assert.assertFalse(f.getSelectedTiers().hasNone());
+    }
+
+    @Test
+    public void setSelectAllWhenAllTiersFalse() {
+        BaseAlterationFilter f = new BaseAlterationFilter();
+        Map<String, Boolean> types = new HashedMap();
+        types.put("Class 1", false);
+        types.put("Class 2", false);
+        f.setTiersBooleanMap(types);
+        Assert.assertFalse(f.getSelectedTiers().hasValues());
+        Assert.assertFalse(f.getSelectedTiers().hasAll());
+        Assert.assertTrue(f.getSelectedTiers().hasNone());
+    }
+
+    @Test
+    public void setSelectAllWhenNullTiers() {
+        BaseAlterationFilter f = new BaseAlterationFilter();
+        f.setTiersBooleanMap(null);
+        Assert.assertFalse(f.getSelectedTiers().hasValues());
+        Assert.assertTrue(f.getSelectedTiers().hasAll());
+        Assert.assertFalse(f.getSelectedTiers().hasNone());
+    }
+    
+}

--- a/docs/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/Customizing-your-instance-of-cBioPortal.md
@@ -217,6 +217,12 @@ Below you can find the complete list of all the available skin properties.
             <td>false</td>
             <td>true / false</td>
         </tr>
+        <tr>
+            <td>skin.show_settings_menu</td>
+            <td>controls the appearance of the settings menu in study view and group comparison that controls annotation-based filtering.</td>
+            <td>false</td>
+            <td>true / false</td>
+        </tr>
       <tr>
             <td>google_analytics_profile_id</td>
             <td>enables google analaytics tracking on your site</td>

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -159,6 +159,16 @@ Different samples of a patient may have been analyzed with different gene panels
 skin.patientview.filter_genes_profiled_all_samples=
 ```
 
+## Control the appearance of the settings menu in study view and group comparison that controls custom annotation-based filtering
+A settings menu that allows the user to filter alterations in study view and group comparison may be used
+when [custom driver annotations](File-Formats.md#custom-driver-annotations) were loaded for the study or studies displayed
+in these sections. This menu will only appear, when setting the property _skin.show_settings_menu_ to _true_.
+
+```
+skin.show_settings_menu=
+```
+
+
 ## Hide p- and q-values in survival types table
 ```
 # Show/hide p- and q-values in survival types table (default is true)

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -16,6 +16,12 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
           </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.11.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/model/src/main/java/org/cbioportal/model/AlterationDriverAnnotation.java
+++ b/model/src/main/java/org/cbioportal/model/AlterationDriverAnnotation.java
@@ -1,0 +1,70 @@
+package org.cbioportal.model;
+
+import java.io.Serializable;
+
+public class AlterationDriverAnnotation implements Serializable {
+
+    private Integer alterationEventId;
+    private Integer geneticProfileId;
+    private Integer sampleId;
+    private String driverFilter;
+    private String driverFilterAnnotation;
+    private String driverTiersFilter;
+    private String driverTiersFilterAnnotation;
+
+    public Integer getAlterationEventId() {
+        return alterationEventId;
+    }
+
+    public void setAlterationEventId(Integer alterationEventId) {
+        this.alterationEventId = alterationEventId;
+    }
+
+    public Integer getGeneticProfileId() {
+        return geneticProfileId;
+    }
+
+    public void setGeneticProfileId(Integer geneticProfileId) {
+        this.geneticProfileId = geneticProfileId;
+    }
+
+    public Integer getSampleId() {
+        return sampleId;
+    }
+
+    public void setSampleId(Integer sampleId) {
+        this.sampleId = sampleId;
+    }
+
+    public String getDriverFilter() {
+        return driverFilter;
+    }
+
+    public void setDriverFilter(String driverFilter) {
+        this.driverFilter = driverFilter;
+    }
+
+    public String getDriverFilterAnnotation() {
+        return driverFilterAnnotation;
+    }
+
+    public void setDriverFilterAnnotation(String driverFilterAnnotation) {
+        this.driverFilterAnnotation = driverFilterAnnotation;
+    }
+
+    public String getDriverTiersFilter() {
+        return driverTiersFilter;
+    }
+
+    public void setDriverTiersFilter(String driverTiersFilter) {
+        this.driverTiersFilter = driverTiersFilter;
+    }
+
+    public String getDriverTiersFilterAnnotation() {
+        return driverTiersFilterAnnotation;
+    }
+
+    public void setDriverTiersFilterAnnotation(String driverTiersFilterAnnotation) {
+        this.driverTiersFilterAnnotation = driverTiersFilterAnnotation;
+    }
+}

--- a/model/src/main/java/org/cbioportal/model/AlterationFilter.java
+++ b/model/src/main/java/org/cbioportal/model/AlterationFilter.java
@@ -1,0 +1,101 @@
+package org.cbioportal.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.cbioportal.model.util.Select;
+
+import java.io.Serializable;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class AlterationFilter extends BaseAlterationFilter implements Serializable {
+    
+    private Map<MutationEventType, Boolean> mutationBooleanMap;
+    private Map<CNA, Boolean> cnaBooleanMap;
+    
+    @JsonIgnore
+    private Select<MutationEventType> mutationTypeSelect;
+    @JsonIgnore
+    private Select<CNA> cnaTypeSelect;
+
+    // When default constructor is called, the filter is inactive (excludes nothing)
+    public AlterationFilter() {}
+
+    public AlterationFilter(Select<MutationEventType> mutationTypesMap,
+                            Select<CNA> cnaEventTypes,
+                            boolean includeDriver,
+                            boolean includeVUS,
+                            boolean includeUnknownOncogenicity,
+                            boolean includeGermline,
+                            boolean includeSomatic,
+                            boolean includeUnknownStatus,
+                            Select<String> tiersSelect,
+                            boolean includeUnknownTier) {
+        super(includeDriver, includeVUS, includeUnknownOncogenicity, includeGermline, includeSomatic, includeUnknownStatus, tiersSelect, includeUnknownTier);
+        this.mutationTypeSelect = mutationTypesMap;
+        this.cnaTypeSelect = cnaEventTypes;
+    }
+
+    public void setMutationBooleanMap(Map<MutationEventType, Boolean> selectedTypes) {
+        this.mutationBooleanMap = selectedTypes;
+        if (selectedTypes == null) {
+            this.mutationTypeSelect = Select.all();
+        } else {
+            this.mutationTypeSelect = Select.byValues(
+                selectedTypes.entrySet().stream()
+                    .filter(e -> e.getValue())
+                    .map(e -> e.getKey()));
+            if (selectedTypes.entrySet().stream().allMatch(e -> e.getValue()))
+                this.mutationTypeSelect.hasAll(true);
+        }
+    }
+
+    public Map<MutationEventType, Boolean> getMutationBooleanMap() {
+        return mutationBooleanMap;
+    }
+
+    @JsonIgnore
+    public Select<MutationEventType> getSelectedMutationTypes() {
+        if (this.mutationTypeSelect == null)
+            return Select.all();
+        return this.mutationTypeSelect;
+    }
+
+    @JsonIgnore
+    public void setSelectedMutationTypes(Select<MutationEventType> typeSelect) {
+        this.mutationTypeSelect = typeSelect;
+    }
+    
+    public void setCnaBooleanMap(Map<CNA, Boolean> selectedTypes) {
+        this.cnaBooleanMap = selectedTypes;
+        if (selectedTypes == null) {
+            this.cnaTypeSelect = Select.all();
+        } else {
+            this.cnaTypeSelect = Select.byValues(
+                selectedTypes.entrySet().stream()
+                    .filter(e -> e.getValue())
+                    .map(e -> e.getKey()));
+            if (selectedTypes.entrySet().stream().allMatch(e -> e.getValue()))
+                this.cnaTypeSelect.hasAll(true);
+        }
+    }
+
+    public Map<CNA, Boolean> getCnaBooleanMap() {
+        return cnaBooleanMap;
+    }
+
+    @JsonIgnore
+    public Select<CNA> getSelectedCnaTypes() {
+        if (this.cnaTypeSelect == null)
+            return Select.all();
+        return this.cnaTypeSelect;
+    }
+
+    @JsonIgnore
+    public void setCnaTypeSelect(Select<CNA> typeSelect) {
+        this.cnaTypeSelect = typeSelect;
+    }
+}

--- a/model/src/main/java/org/cbioportal/model/AlterationFilter.java
+++ b/model/src/main/java/org/cbioportal/model/AlterationFilter.java
@@ -48,7 +48,7 @@ public class AlterationFilter extends BaseAlterationFilter implements Serializab
                 selectedTypes.entrySet().stream()
                     .filter(e -> e.getValue())
                     .map(e -> e.getKey()));
-            if (selectedTypes.entrySet().stream().allMatch(e -> e.getValue()))
+            if (selectedTypes.size() > 0 && selectedTypes.entrySet().stream().allMatch(e -> e.getValue()))
                 this.mutationTypeSelect.hasAll(true);
         }
     }
@@ -78,7 +78,7 @@ public class AlterationFilter extends BaseAlterationFilter implements Serializab
                 selectedTypes.entrySet().stream()
                     .filter(e -> e.getValue())
                     .map(e -> e.getKey()));
-            if (selectedTypes.entrySet().stream().allMatch(e -> e.getValue()))
+            if (selectedTypes.size() > 0 && selectedTypes.entrySet().stream().allMatch(e -> e.getValue()))
                 this.cnaTypeSelect.hasAll(true);
         }
     }

--- a/model/src/main/java/org/cbioportal/model/AlterationType.java
+++ b/model/src/main/java/org/cbioportal/model/AlterationType.java
@@ -1,0 +1,7 @@
+package org.cbioportal.model;
+
+public enum AlterationType {
+    MUTATION,
+    FUSION,
+    COPY_NUMBER_ALTERATION
+}

--- a/model/src/main/java/org/cbioportal/model/BaseAlterationFilter.java
+++ b/model/src/main/java/org/cbioportal/model/BaseAlterationFilter.java
@@ -1,0 +1,137 @@
+package org.cbioportal.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.cbioportal.model.util.Select;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class BaseAlterationFilter implements Serializable {
+
+    private boolean includeGermline = true;
+    private boolean includeSomatic = true;
+    private boolean includeUnknownStatus = true;
+    private boolean includeDriver = true;
+    private boolean includeVUS = true;
+    private boolean includeUnknownOncogenicity = true;
+    private Map<String, Boolean> tiersBooleanMap = new HashMap<>();
+    private boolean includeUnknownTier = true;
+
+    @JsonIgnore
+    private Select<String> tiersSelect;
+
+    // When default constructor is called, the filter is inactive (excludes nothing)
+    public BaseAlterationFilter() {
+    }
+
+    public BaseAlterationFilter(boolean includeDriver,
+                                boolean includeVUS,
+                                boolean includeUnknownOncogenicity,
+                                boolean includeGermline,
+                                boolean includeSomatic,
+                                boolean includeUnknownStatus,
+                                Select<String> tiersSelect,
+                                boolean includeUnknownTier) {
+        this.includeGermline = includeGermline;
+        this.includeSomatic = includeSomatic;
+        this.includeUnknownStatus = includeUnknownStatus;
+        this.includeDriver = includeDriver;
+        this.includeVUS = includeVUS;
+        this.includeUnknownOncogenicity = includeUnknownOncogenicity;
+        this.tiersSelect = tiersSelect;
+        this.includeUnknownTier = includeUnknownTier;
+    }
+
+    public boolean getIncludeGermline() {
+        return includeGermline;
+    }
+
+    public void setIncludeGermline(boolean includeGermline) {
+        this.includeGermline = includeGermline;
+    }
+
+    public boolean getIncludeSomatic() {
+        return includeSomatic;
+    }
+
+    
+    public void setIncludeSomatic(boolean includeSomatic) {
+        this.includeSomatic = includeSomatic;
+    }
+
+    public boolean getIncludeUnknownStatus() {
+        return includeUnknownStatus;
+    }
+
+    public void setIncludeUnknownStatus(boolean includeUnknownStatus) {
+        this.includeUnknownStatus = includeUnknownStatus;
+    }
+
+    public boolean getIncludeDriver() {
+        return includeDriver;
+    }
+
+    public void setIncludeDriver(boolean includeDriver) {
+        this.includeDriver = includeDriver;
+    }
+
+    public boolean getIncludeVUS() {
+        return includeVUS;
+    }
+
+    public void setIncludeVUS(boolean includeVUS) {
+        this.includeVUS = includeVUS;
+    }
+
+    public boolean getIncludeUnknownOncogenicity() {
+        return includeUnknownOncogenicity;
+    }
+
+    public void setIncludeUnknownOncogenicity(boolean includeUnknownOncogenicity) {
+        this.includeUnknownOncogenicity = includeUnknownOncogenicity;
+    }
+
+    public boolean getIncludeUnknownTier() {
+        return includeUnknownTier;
+    }
+
+    public void setIncludeUnknownTier(boolean includeUnknownTier) {
+        this.includeUnknownTier = includeUnknownTier;
+    }
+
+    public void setTiersBooleanMap(Map<String, Boolean> tiersBooleanMap) {
+        if (tiersBooleanMap == null) {
+            this.tiersSelect = Select.all();
+        } else {
+            this.tiersSelect = Select.byValues(
+                tiersBooleanMap.entrySet().stream()
+                    .filter(e -> e.getValue())
+                    .map(e -> e.getKey()));
+            if (tiersBooleanMap.entrySet().stream().allMatch(e -> e.getValue()))
+                this.tiersSelect.hasAll(true);
+        }
+    }
+
+    public Map<String, Boolean> getTiersBooleanMap() {
+        return tiersBooleanMap;
+    }
+    
+    @JsonIgnore
+    public Select<String> getSelectedTiers() {
+        if (tiersSelect == null)
+            return Select.all();
+        return tiersSelect;
+    }
+
+    @JsonIgnore
+    public void setSelectedTiers(Select<String> tiersSelect) {
+        this.tiersSelect = tiersSelect;
+    }
+
+}

--- a/model/src/main/java/org/cbioportal/model/BaseAlterationFilter.java
+++ b/model/src/main/java/org/cbioportal/model/BaseAlterationFilter.java
@@ -113,7 +113,7 @@ public class BaseAlterationFilter implements Serializable {
                 tiersBooleanMap.entrySet().stream()
                     .filter(e -> e.getValue())
                     .map(e -> e.getKey()));
-            if (tiersBooleanMap.entrySet().stream().allMatch(e -> e.getValue()))
+            if (tiersBooleanMap.size() > 0 && tiersBooleanMap.entrySet().stream().allMatch(e -> e.getValue()))
                 this.tiersSelect.hasAll(true);
         }
     }

--- a/model/src/main/java/org/cbioportal/model/CustomDriverAnnotationReport.java
+++ b/model/src/main/java/org/cbioportal/model/CustomDriverAnnotationReport.java
@@ -1,0 +1,24 @@
+package org.cbioportal.model;
+
+import java.io.Serializable;
+import java.util.Set;
+
+public class CustomDriverAnnotationReport implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
+    private final boolean hasBinary;
+    private final Set<String> tiers;
+    
+    public CustomDriverAnnotationReport(boolean hasBinary, Set<String> tiers) {
+        this.hasBinary = hasBinary;
+        this.tiers = tiers;
+    }
+    
+    public boolean getHasBinary() {
+        return hasBinary;
+    }
+
+    public Set<String> getTiers() {
+        return tiers;
+    }
+}

--- a/model/src/main/java/org/cbioportal/model/GeneFilter.java
+++ b/model/src/main/java/org/cbioportal/model/GeneFilter.java
@@ -1,0 +1,28 @@
+package org.cbioportal.model;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+
+public class GeneFilter implements Serializable {
+
+    private Set<String> molecularProfileIds;
+    private List<List<GeneFilterQuery>> geneQueries;
+
+    public Set<String> getMolecularProfileIds() {
+        return molecularProfileIds;
+    }
+
+    public void setMolecularProfileIds(Set<String> molecularProfileIds) {
+        this.molecularProfileIds = molecularProfileIds;
+    }
+
+    public List<List<GeneFilterQuery>> getGeneQueries() {
+        return geneQueries;
+    }
+
+    public void setGeneQueries(List<List<GeneFilterQuery>> geneQueries) {
+        this.geneQueries = geneQueries;
+    }
+
+}

--- a/model/src/main/java/org/cbioportal/model/GeneFilterQuery.java
+++ b/model/src/main/java/org/cbioportal/model/GeneFilterQuery.java
@@ -1,0 +1,57 @@
+package org.cbioportal.model;
+
+import org.cbioportal.model.util.Select;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class GeneFilterQuery extends BaseAlterationFilter implements Serializable {
+    
+    private String hugoGeneSymbol;
+    private Integer entrezGeneId;
+    private List<CNA> alterations;
+
+    public GeneFilterQuery() {}
+
+    public GeneFilterQuery(String hugoGeneSymbol,
+                           Integer entrezGeneId,
+                           List<CNA> alterations,
+                           boolean includeDriver,
+                           boolean includeVUS,
+                           boolean includeUnknownOncogenicity,
+                           Select<String> tiersSelect,
+                           boolean includeUnknownTier,
+                           boolean includeGermline,
+                           boolean includeSomatic,
+                           boolean includeUnknownStatus) {
+        super(includeDriver, includeVUS, includeUnknownOncogenicity, includeGermline, includeSomatic, includeUnknownStatus, tiersSelect, includeUnknownTier);
+        this.hugoGeneSymbol = hugoGeneSymbol;
+        this.entrezGeneId = entrezGeneId;
+        this.alterations = alterations;
+    }
+
+    public String getHugoGeneSymbol() {
+        return hugoGeneSymbol;
+    }
+
+    public void setHugoGeneSymbol(String hugoGeneSymbol) {
+        this.hugoGeneSymbol = hugoGeneSymbol;
+    }
+
+    public Integer getEntrezGeneId() {
+        return entrezGeneId;
+    }
+
+    public void setEntrezGeneId(int entrezGeneId) {
+        this.entrezGeneId = entrezGeneId;
+    }
+
+    public List<CNA> getAlterations() {
+        return alterations;
+    }
+
+    public void setAlterations(List<CNA> alterations) {
+        this.alterations = alterations;
+    }
+    
+}

--- a/model/src/main/java/org/cbioportal/model/QueryElement.java
+++ b/model/src/main/java/org/cbioportal/model/QueryElement.java
@@ -1,5 +1,13 @@
 package org.cbioportal.model;
 
+/*
+ QueryElement represents three types of behavior for a SQL statement in MyBatis mappers
+ - INACTIVE: exclude Query element from results
+ - ACTIVE: include Query element in results
+ - PASS: do not apply on Query element
+ Note: the specific behavior the represented by the three states 
+ of QueryElement is determined by the mapper-xml.
+*/
 public enum QueryElement {
     INACTIVE, ACTIVE, PASS
 }

--- a/model/src/main/java/org/cbioportal/model/util/QueryElement.java
+++ b/model/src/main/java/org/cbioportal/model/util/QueryElement.java
@@ -1,0 +1,5 @@
+package org.cbioportal.model.util;
+
+public enum QueryElement {
+    INACTIVE, ACTIVE, PASS
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/AlterationDriverAnnotationRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/AlterationDriverAnnotationRepository.java
@@ -1,0 +1,13 @@
+package org.cbioportal.persistence;
+
+import org.cbioportal.model.AlterationDriverAnnotation;
+import org.springframework.cache.annotation.Cacheable;
+
+import java.util.List;
+
+public interface AlterationDriverAnnotationRepository {
+
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    List<AlterationDriverAnnotation> getAlterationDriverAnnotations(List<String> molecularProfileCaseIdentifiers);
+
+}

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/AlterationRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/AlterationRepository.java
@@ -10,29 +10,25 @@ import java.util.List;
 public interface AlterationRepository {
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
-    // TODO write javadoc
     List<AlterationCountByGene> getSampleAlterationCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                           Select<Integer> entrezGeneIds,
-                                                          final Select<MutationEventType> mutationEventTypes,
-                                                          final Select<CNA> cnaEventTypes,
-                                                          QueryElement searchFusions);
+                                                          QueryElement searchFusions,
+                                                          AlterationFilter alterationFilter);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
-    // TODO write javadoc
     List<AlterationCountByGene> getPatientAlterationCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                            Select<Integer> entrezGeneIds,
-                                                           final Select<MutationEventType> mutationEventTypes,
-                                                           final Select<CNA> cnaEventTypes,
-                                                           QueryElement searchFusions);
+                                                           QueryElement searchFusions,
+                                                           AlterationFilter alterationFilter);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<CopyNumberCountByGene> getSampleCnaCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                    Select<Integer> entrezGeneIds,
-                                                   final Select<CNA> cnaEventTypes);
+                                                   AlterationFilter alterationFilter);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<CopyNumberCountByGene> getPatientCnaCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                     Select<Integer> entrezGeneIds,
-                                                    final Select<CNA> cnaEventTypes);
+                                                    AlterationFilter alterationFilter);
     
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/DiscreteCopyNumberRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/DiscreteCopyNumberRepository.java
@@ -2,8 +2,8 @@ package org.cbioportal.persistence;
 
 import org.cbioportal.model.CopyNumberCountByGene;
 import org.cbioportal.model.DiscreteCopyNumberData;
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.meta.BaseMeta;
-
 import org.springframework.cache.annotation.Cacheable;
 
 import java.util.List;
@@ -19,7 +19,8 @@ public interface DiscreteCopyNumberRepository {
 
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
-    BaseMeta getMetaDiscreteCopyNumbersInMolecularProfileBySampleListId(String molecularProfileId, String sampleListId,
+    BaseMeta getMetaDiscreteCopyNumbersInMolecularProfileBySampleListId(String molecularProfileId,
+                                                                        String sampleListId,
                                                                         List<Integer> entrezGeneIds,
                                                                         List<Integer> alterationTypes);
 
@@ -37,9 +38,17 @@ public interface DiscreteCopyNumberRepository {
                                                                                    List<Integer> alterationTypes, 
                                                                                    String projection);
 
+
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
+                                                                                                List<String> sampleIds,
+                                                                                                List<GeneFilterQuery> geneFilterQuery,
+                                                                                                String projection);
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
-    BaseMeta fetchMetaDiscreteCopyNumbersInMolecularProfile(String molecularProfileId, List<String> sampleIds,
-                                                            List<Integer> entrezGeneIds, List<Integer> alterationTypes);
+    BaseMeta fetchMetaDiscreteCopyNumbersInMolecularProfile(String molecularProfileId,
+                                                            List<String> sampleIds,
+                                                            List<Integer> entrezGeneIds,
+                                                            List<Integer> alterationTypes);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<CopyNumberCountByGene> getSampleCountByGeneAndAlterationAndSampleIds(String molecularProfileId,

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
@@ -1,13 +1,13 @@
 package org.cbioportal.persistence;
 
-import java.util.List;
-import java.util.Map;
-
 import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GenericAssayMolecularAlteration;
 import org.cbioportal.model.GenesetMolecularAlteration;
-import org.springframework.cache.annotation.Cacheable;
 import org.cbioportal.model.MolecularProfileSamples;
+import org.springframework.cache.annotation.Cacheable;
+
+import java.util.List;
+import java.util.Map;
 
 public interface MolecularDataRepository {
 
@@ -39,4 +39,5 @@ public interface MolecularDataRepository {
 
 	Iterable<GenericAssayMolecularAlteration> getGenericAssayMolecularAlterationsIterable(String molecularProfileId,
 			List<String> stableIds, String projection);
+
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
@@ -1,5 +1,6 @@
 package org.cbioportal.persistence;
 
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.Mutation;
 import org.cbioportal.model.MutationCountByPosition;
 import org.cbioportal.model.meta.MutationMeta;
@@ -26,6 +27,16 @@ public interface MutationRepository {
                                                            Integer pageSize, Integer pageNumber,
                                                            String sortBy, String direction);
 
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    List<Mutation> getMutationsInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
+                                                                      List<String> sampleIds,
+                                                                      List<GeneFilterQuery> geneQueries,
+                                                                      String projection,
+                                                                      Integer pageSize,
+                                                                      Integer pageNumber,
+                                                                      String sortBy,
+                                                                      String direction);
+
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
                                                              List<Integer> entrezGeneIds);
@@ -41,13 +52,24 @@ public interface MutationRepository {
                                                       List<Integer> entrezGeneIds);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
-    MutationCountByPosition getMutationCountByPosition(Integer entrezGeneId, Integer proteinPosStart, 
+    MutationCountByPosition getMutationCountByPosition(Integer entrezGeneId, Integer proteinPosStart,
                                                        Integer proteinPosEnd);
 
     // TODO: cleanup once fusion/structural data is fixed in database
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<Mutation> getFusionsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
-            List<Integer> entrezGeneIds, String projection, Integer pageSize, Integer pageNumber, String sortBy,
-            String direction);
+                                                         List<Integer> entrezGeneIds, String projection, Integer pageSize, Integer pageNumber, String sortBy,
+                                                         String direction);
+
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    List<Mutation> getFusionsInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
+                                                                      List<String> sampleIds,
+                                                                      List<GeneFilterQuery> geneQueries,
+                                                                      String projection,
+                                                                      Integer pageSize,
+                                                                      Integer pageNumber,
+                                                                      String sortBy,
+                                                                      String direction);
+
     // TODO: cleanup once fusion/structural data is fixed in database
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/StructuralVariantRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/StructuralVariantRepository.java
@@ -1,13 +1,18 @@
 package org.cbioportal.persistence;
 
-import java.util.List;
-
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.StructuralVariant;
 import org.springframework.cache.annotation.Cacheable;
+
+import java.util.List;
 
 public interface StructuralVariantRepository {
 
     @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
     List<StructuralVariant> fetchStructuralVariants(List<String> molecularProfileIds, List<Integer> entrezGeneIds,
+            List<String> sampleIds);
+    
+    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    List<StructuralVariant> fetchStructuralVariantsByGeneQueries(List<String> molecularProfileIds, List<GeneFilterQuery> geneQueries,
             List<String> sampleIds);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationCountsMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationCountsMapper.java
@@ -15,7 +15,14 @@ public interface AlterationCountsMapper {
      * @param entrezGeneIds  Gene ids to get counts for.
      * @param mutationTypes  Types of mutations to include in alteration counts. 
      * @param cnaTypes  Types of discrete copy number alteration types to include in alteration counts.
-     * @param searchFusions  'ACTIVE': counts are limited to fusion type. 'INACTIVE': counts are limited to non-fusion alterations.'PASS': no filtering on mutation vs fusions (mutation types and cnaTypes are used) 
+     * @param searchFusions  'ACTIVE': counts are limited to fusion type. 'INACTIVE': counts are limited to non-fusion alterations.'PASS': no filtering on mutation vs fusions (mutation types and cnaTypes are used)
+     * @param includeDriver Include Variants of Unknown significance. Uses annotations loaded as 'custom driver annotations'.
+     * @param includeVUS  Include Variants of Unknown significance. Uses annotations loaded as 'custom driver annotations'.
+     * @param includeUnknownOncogenicity  Include variants that are not annotated as driver or VUS. Uses annotations loaded as 'custom driver annotations'.
+     * @param selectedTiers  Force alterations assigned to a tier to be interpreted as driver events. Uses tier annotations loaded as 'custom driver annotation tiers'.
+     * @param includeUnknownTier Include mutations that have unspecified tier, or tiers with '', 'NA' or 'unknown' in alteration counts
+     * @param includeGermline  Include germline mutations in alteration counts
+     * @param includeSomatic  Include somatic mutations in alteration counts
      * @return  Gene-level counts of (1) the total number of alterations and (2) the number of altered samples.
      */
     List<AlterationCountByGene> getSampleAlterationCounts(List<MolecularProfileCaseIdentifier> mutationMolecularProfileCaseIdentifiers,
@@ -24,7 +31,14 @@ public interface AlterationCountsMapper {
                                                           Select<Integer> entrezGeneIds,
                                                           Select<String> mutationTypes,
                                                           Select<Short> cnaTypes,
-                                                          QueryElement searchFusions);
+                                                          QueryElement searchFusions,
+                                                          boolean includeDriver,
+                                                          boolean includeVUS,
+                                                          boolean includeUnknownOncogenicity,
+                                                          Select<String> selectedTiers,
+                                                          boolean includeUnknownTier, boolean includeGermline,
+                                                          boolean includeSomatic,
+                                                          boolean includeUnknownStatus);
 
     /**
      * Calculate patient-level counts of mutation and discrete CNA alteration events.
@@ -32,6 +46,14 @@ public interface AlterationCountsMapper {
      * @param mutationTypes  Types of mutations to include in alteration counts.
      * @param cnaTypes  Types of discrete copy number alteration types to include in alteration counts.
      * @param searchFusions  'ACTIVE': counts are limited to fusion type. 'INACTIVE': counts are limited to non-fusion alterations.'PASS': no filtering on mutation vs fusions (mutation types and cnaTypes are used) 
+     * @param includeDriver Include Variants of Unknown significance. Uses annotations loaded as 'custom driver annotations'.
+     * @param includeVUS  Include Variants of Unknown significance. Uses annotations loaded as 'custom driver annotations'.
+     * @param includeUnknownOncogenicity  Include variants that are not annotated as driver or VUS. Uses annotations loaded as 'custom driver annotations'.
+     * @param selectedTiers  Force alterations assigned to a tier to be interpreted as driver events. Uses tier annotations loaded as 'custom driver annotation tiers'.
+     * @param includeUnknownTier  Include mutations that have unspecified tier, or tiers with '', 'NA' or 'unknown' in alteration counts
+     * @param includeGermline  Include germline mutations in alteration counts
+     * @param includeSomatic  Include somatic mutations in alteration counts
+     * @param includeUnknownStatus  Include mutations that have mutation status 'unknown' in alteration counts
      * @return  Gene-level counts of (1) the total number of alterations and (2) the number of altered patients.
      */
     List<AlterationCountByGene> getPatientAlterationCounts(List<MolecularProfileCaseIdentifier> mutationMolecularProfileCaseIdentifiers,
@@ -40,15 +62,33 @@ public interface AlterationCountsMapper {
                                                            Select<Integer> entrezGeneIds,
                                                            Select<String> mutationTypes,
                                                            Select<Short> cnaTypes,
-                                                           QueryElement searchFusions);
+                                                           QueryElement searchFusions,
+                                                           boolean includeDriver,
+                                                           boolean includeVUS,
+                                                           boolean includeUnknownOncogenicity,
+                                                           Select<String> selectedTiers,
+                                                           boolean includeUnknownTier,
+                                                           boolean includeGermline,
+                                                           boolean includeSomatic,
+                                                           boolean includeUnknownStatus);
 
     // legacy method that returns CopyNumberCountByGene
     List<CopyNumberCountByGene> getSampleCnaCounts(List<MolecularProfileCaseIdentifier> cnaMolecularProfileCaseIdentifiers,
                                                    Select<Integer> entrezGeneIds,
-                                                   Select<Short> cnaTypes);
+                                                   Select<Short> cnaTypes,
+                                                   boolean includeDriver,
+                                                   boolean includeVUS,
+                                                   boolean includeUnknownOncogenicity,
+                                                   Select<String> selectedTiers,
+                                                   boolean includeUnknownTier);
 
     // legacy method that returns CopyNumberCountByGene
     List<CopyNumberCountByGene> getPatientCnaCounts(List<MolecularProfileCaseIdentifier> cnaMolecularProfileCaseIdentifiers,
                                                     Select<Integer> entrezGeneIds,
-                                                    Select<Short> cnaTypes);
+                                                    Select<Short> cnaTypes,
+                                                    boolean includeDriver,
+                                                    boolean includeVUS,
+                                                    boolean includeUnknownOncogenicity,
+                                                    Select<String> selectedTiers,
+                                                    boolean includeUnknownTier);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationDriverAnnotationMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationDriverAnnotationMapper.java
@@ -1,0 +1,12 @@
+package org.cbioportal.persistence.mybatis;
+
+import org.apache.ibatis.annotations.Param;
+import org.cbioportal.model.AlterationDriverAnnotation;
+
+import java.util.List;
+
+public interface AlterationDriverAnnotationMapper {
+
+    List<AlterationDriverAnnotation> getAlterationDriverAnnotations(@Param("molecularProfileIds") List<String> molecularProfileIds);
+    
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationDriverAnnotationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationDriverAnnotationMyBatisRepository.java
@@ -1,0 +1,28 @@
+package org.cbioportal.persistence.mybatis;
+
+import org.cbioportal.model.*;
+import org.cbioportal.persistence.AlterationDriverAnnotationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+
+@Repository
+public class AlterationDriverAnnotationMyBatisRepository implements AlterationDriverAnnotationRepository {
+
+    @Autowired
+    private AlterationDriverAnnotationMapper alterationDriverAnnotationMapper;
+
+    @Override
+    public List<AlterationDriverAnnotation> getAlterationDriverAnnotations(
+        List<String> molecularProfileIds) {
+
+        if (molecularProfileIds == null || molecularProfileIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return alterationDriverAnnotationMapper.getAlterationDriverAnnotations(molecularProfileIds);
+    }
+
+}

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationMyBatisRepository.java
@@ -1,6 +1,7 @@
 package org.cbioportal.persistence.mybatis;
 
 import org.cbioportal.model.AlterationCountByGene;
+import org.cbioportal.model.AlterationFilter;
 import org.cbioportal.model.CNA;
 import org.cbioportal.model.CopyNumberCountByGene;
 import org.cbioportal.model.MolecularProfile;
@@ -30,17 +31,16 @@ public class AlterationMyBatisRepository implements AlterationRepository {
     @Override
     public List<AlterationCountByGene> getSampleAlterationCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                                  Select<Integer> entrezGeneIds,
-                                                                 final Select<MutationEventType> mutationEventTypes,
-                                                                 final Select<CNA> cnaEventTypes,
-                                                                 QueryElement searchFusions) {
+                                                                 QueryElement searchFusions,
+                                                                 AlterationFilter alterationFilter) {
 
-        // TODO add test
-        if (mutationEventTypes != null && !mutationEventTypes.hasAll() && searchFusions != QueryElement.PASS)
+        if (!alterationFilter.getSelectedMutationTypes().hasAll() && searchFusions != QueryElement.PASS)
             throw new IllegalArgumentException("Filtering for mutations vs. fusions and specifying mutation types" +
                 "simultaneously is not permitted.");
 
-        if (((mutationEventTypes == null || mutationEventTypes.hasNone()) && (cnaEventTypes == null || cnaEventTypes.hasNone()))
-            || (molecularProfileCaseIdentifiers == null || molecularProfileCaseIdentifiers.isEmpty())) {
+        if ((alterationFilter.getSelectedMutationTypes().hasNone() && alterationFilter.getSelectedCnaTypes().hasNone())
+            || (molecularProfileCaseIdentifiers == null || molecularProfileCaseIdentifiers.isEmpty())
+            || (allAlterationsExcludedDriverAnnotation(alterationFilter) && allAlterationsExcludedMutationStatus(alterationFilter))) {
             return Collections.emptyList();
         }
 
@@ -60,24 +60,32 @@ public class AlterationMyBatisRepository implements AlterationRepository {
             groupedIdentifiersByProfileType.get(MolecularAlterationType.COPY_NUMBER_ALTERATION),
             groupedIdentifiersByProfileType.get(MolecularAlterationType.STRUCTURAL_VARIANT),
             entrezGeneIds,
-            createMutationTypeList(mutationEventTypes),
-            createCnaTypeList(cnaEventTypes),
-            searchFusions);
+            createMutationTypeList(alterationFilter),
+            createCnaTypeList(alterationFilter),
+            searchFusions,
+            alterationFilter.getIncludeDriver(),
+            alterationFilter.getIncludeVUS(),
+            alterationFilter.getIncludeUnknownOncogenicity(),
+            alterationFilter.getSelectedTiers(),
+            alterationFilter.getIncludeUnknownTier(),
+            alterationFilter.getIncludeGermline(),
+            alterationFilter.getIncludeSomatic(),
+            alterationFilter.getIncludeUnknownStatus());
     }
 
     @Override
     public List<AlterationCountByGene> getPatientAlterationCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                                   Select<Integer> entrezGeneIds,
-                                                                  Select<MutationEventType> mutationEventTypes,
-                                                                  Select<CNA> cnaEventTypes,
-                                                                  QueryElement searchFusions) {
+                                                                  QueryElement searchFusions,
+                                                                  AlterationFilter alterationFilter) {
 
-        if (mutationEventTypes != null && !mutationEventTypes.hasAll() && searchFusions != QueryElement.PASS)
+        if (!alterationFilter.getSelectedMutationTypes().hasAll() && searchFusions != QueryElement.PASS)
             throw new IllegalArgumentException("Filtering for mutations vs. fusions and specifying mutation types" +
                 "simultaneously is not permitted.");
 
-        if (((mutationEventTypes == null || mutationEventTypes.hasNone()) && (cnaEventTypes == null || cnaEventTypes.hasNone()))
-            || (molecularProfileCaseIdentifiers == null || molecularProfileCaseIdentifiers.isEmpty())) {
+        if ((alterationFilter.getSelectedMutationTypes().hasNone() && alterationFilter.getSelectedCnaTypes().hasNone())
+            || (molecularProfileCaseIdentifiers == null || molecularProfileCaseIdentifiers.isEmpty())
+            || (allAlterationsExcludedDriverAnnotation(alterationFilter) && allAlterationsExcludedMutationStatus(alterationFilter))) {
             return Collections.emptyList();
         }
 
@@ -98,55 +106,88 @@ public class AlterationMyBatisRepository implements AlterationRepository {
             groupedIdentifiersByProfileType.get(MolecularAlterationType.COPY_NUMBER_ALTERATION),
             groupedIdentifiersByProfileType.get(MolecularAlterationType.STRUCTURAL_VARIANT),
             entrezGeneIds,
-            createMutationTypeList(mutationEventTypes),
-            createCnaTypeList(cnaEventTypes),
-            searchFusions);
+            createMutationTypeList(alterationFilter),
+            createCnaTypeList(alterationFilter),
+            searchFusions,
+            alterationFilter.getIncludeDriver(),
+            alterationFilter.getIncludeVUS(),
+            alterationFilter.getIncludeUnknownOncogenicity(),
+            alterationFilter.getSelectedTiers(),
+            alterationFilter.getIncludeUnknownTier(),
+            alterationFilter.getIncludeGermline(),
+            alterationFilter.getIncludeSomatic(),
+            alterationFilter.getIncludeUnknownStatus());
     }
 
     @Override
     public List<CopyNumberCountByGene> getSampleCnaCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                           Select<Integer> entrezGeneIds,
-                                                          Select<CNA> cnaEventTypes) {
+                                                          AlterationFilter alterationFilter) {
 
-        if (molecularProfileCaseIdentifiers == null || molecularProfileCaseIdentifiers.isEmpty()
-            || cnaEventTypes == null || cnaEventTypes.hasNone()) {
+        if (alterationFilter.getSelectedCnaTypes().hasNone() || molecularProfileCaseIdentifiers == null
+            || molecularProfileCaseIdentifiers.isEmpty() || allAlterationsExcludedDriverAnnotation(alterationFilter)) {
             return Collections.emptyList();
         }
         
         return alterationCountsMapper.getSampleCnaCounts(
             molecularProfileCaseIdentifiers,
             entrezGeneIds,
-            createCnaTypeList(cnaEventTypes));
+            createCnaTypeList(alterationFilter),
+            alterationFilter.getIncludeDriver(),
+            alterationFilter.getIncludeVUS(),
+            alterationFilter.getIncludeUnknownOncogenicity(),
+            alterationFilter.getSelectedTiers(),
+            alterationFilter.getIncludeUnknownTier());
     }
 
     @Override
     public List<CopyNumberCountByGene> getPatientCnaCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                            Select<Integer> entrezGeneIds,
-                                                           Select<CNA> cnaEventTypes) {
+                                                           AlterationFilter alterationFilter) {
 
-        if (molecularProfileCaseIdentifiers == null || molecularProfileCaseIdentifiers.isEmpty()
-            || cnaEventTypes == null || cnaEventTypes.hasNone()) {
+        if (alterationFilter.getSelectedCnaTypes().hasNone() || molecularProfileCaseIdentifiers == null
+            || molecularProfileCaseIdentifiers.isEmpty() || allAlterationsExcludedDriverAnnotation(alterationFilter)) {
             return Collections.emptyList();
         }
         
         return alterationCountsMapper.getPatientCnaCounts(
             molecularProfileCaseIdentifiers,
             entrezGeneIds,
-            createCnaTypeList(cnaEventTypes));
+            createCnaTypeList(alterationFilter),
+            alterationFilter.getIncludeDriver(),
+            alterationFilter.getIncludeVUS(),
+            alterationFilter.getIncludeUnknownOncogenicity(),
+            alterationFilter.getSelectedTiers(),
+            alterationFilter.getIncludeUnknownTier());
     }
     
-    private Select<Short> createCnaTypeList(final Select<CNA> cnaEventTypes) {
-        return cnaEventTypes != null ? cnaEventTypes.map(CNA::getCode) : Select.none();
+    private Select<Short> createCnaTypeList(final AlterationFilter alterationFilter) {
+        if (alterationFilter.getSelectedCnaTypes().hasNone())
+            return Select.none();
+        if (alterationFilter.getSelectedCnaTypes().hasAll())
+            return Select.all();
+        return alterationFilter.getSelectedCnaTypes().map(CNA::getCode);
     }
 
-    private Select<String> createMutationTypeList(final Select<MutationEventType> mutationEventTypes) {
-        if (mutationEventTypes == null) {
+    private Select<String> createMutationTypeList(final AlterationFilter alterationFilter) {
+        if (alterationFilter.getSelectedMutationTypes().hasNone())
             return Select.none();
-        }
-        Select<String> mappedMutationTypes = mutationEventTypes.map(MutationEventType::getMutationType);
-        mappedMutationTypes.inverse(mutationEventTypes.inverse());
+        if (alterationFilter.getSelectedMutationTypes().hasAll())
+            return Select.all();
+        Select<String> mappedMutationTypes = alterationFilter.getSelectedMutationTypes().map(MutationEventType::getMutationType);
+        mappedMutationTypes.inverse(alterationFilter.getSelectedMutationTypes().inverse());
 
         return mappedMutationTypes;
+    }
+
+    private boolean allAlterationsExcludedMutationStatus(AlterationFilter alterationFilter) {
+        return !alterationFilter.getIncludeGermline() && !alterationFilter.getIncludeSomatic() && !alterationFilter.getIncludeUnknownStatus();
+    }
+    
+    private boolean allAlterationsExcludedDriverAnnotation(AlterationFilter alterationFilter) {
+        return !alterationFilter.getIncludeDriver() && !alterationFilter.getIncludeVUS()
+            && !alterationFilter.getIncludeUnknownOncogenicity() && alterationFilter.getSelectedTiers().hasNone()
+            && !alterationFilter.getIncludeUnknownTier();
     }
 
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.java
@@ -2,6 +2,7 @@ package org.cbioportal.persistence.mybatis;
 
 import org.cbioportal.model.CopyNumberCountByGene;
 import org.cbioportal.model.DiscreteCopyNumberData;
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.meta.BaseMeta;
 
 import java.util.List;
@@ -19,11 +20,16 @@ public interface DiscreteCopyNumberMapper {
                                                                    List<Integer> entrezGeneIds,
                                                                    List<Integer> alterationTypes, String projection);
 
-    List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMultipleMolecularProfiles(List<String> molecularProfileIds, 
+    List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMultipleMolecularProfiles(List<String> molecularProfileIds,
                                                                                    List<String> sampleIds,
                                                                                    List<Integer> entrezGeneIds,
-                                                                                   List<Integer> alterationTypes, 
+                                                                                   List<Integer> alterationTypes,
                                                                                    String projection);
+    
+    List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
+                                                                                                List<String> sampleIds,
+                                                                                                String projection,
+                                                                                                List<GeneFilterQuery> geneQueries);
 
     BaseMeta getMetaDiscreteCopyNumbersBySampleIds(String molecularProfileId, List<String> sampleIds,
                                                    List<Integer> entrezGeneIds, List<Integer> alterationTypes);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMyBatisRepository.java
@@ -2,6 +2,7 @@ package org.cbioportal.persistence.mybatis;
 
 import org.cbioportal.model.CopyNumberCountByGene;
 import org.cbioportal.model.DiscreteCopyNumberData;
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.DiscreteCopyNumberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,13 +51,22 @@ public class DiscreteCopyNumberMyBatisRepository implements DiscreteCopyNumberRe
 
     @Override
     public List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMultipleMolecularProfiles(List<String> molecularProfileIds,
-                                                                                           List<String> sampleIds,
-                                                                                           List<Integer> entrezGeneIds,
-                                                                                           List<Integer> alterationTypes,
-                                                                                           String projection) {
-
-        return discreteCopyNumberMapper.getDiscreteCopyNumbersInMultipleMolecularProfiles(molecularProfileIds, 
+                                                                                          List<String> sampleIds,
+                                                                                          List<Integer> entrezGeneIds,
+                                                                                          List<Integer> alterationTypes,
+                                                                                          String projection) {
+        return discreteCopyNumberMapper.getDiscreteCopyNumbersInMultipleMolecularProfiles(molecularProfileIds,
             sampleIds, entrezGeneIds, alterationTypes, projection);
+    }
+
+    @Override
+    public List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
+                                                                                           List<String> sampleIds,
+                                                                                           List<GeneFilterQuery> geneQueries,
+                                                                                           String projection) {
+        
+        return discreteCopyNumberMapper.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(molecularProfileIds, 
+            sampleIds, projection, geneQueries);
     }
 
     @Override

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
@@ -1,9 +1,6 @@
 package org.cbioportal.persistence.mybatis;
 
-import org.cbioportal.model.GeneMolecularAlteration;
-import org.cbioportal.model.GenericAssayMolecularAlteration;
-import org.cbioportal.model.GenesetMolecularAlteration;
-import org.cbioportal.model.MolecularProfileSamples;
+import org.cbioportal.model.*;
 import org.cbioportal.persistence.MolecularDataRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -62,7 +59,7 @@ public class MolecularDataMyBatisRepository implements MolecularDataRepository {
                 projection);
 	}
 
-	@Override
+    @Override
 	public List<GenesetMolecularAlteration> getGenesetMolecularAlterations(String molecularProfileId, 
                                                                            List<String> genesetIds, String projection) {
 

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
@@ -6,7 +6,6 @@ import org.cbioportal.model.MutationCountByPosition;
 import org.cbioportal.model.meta.MutationMeta;
 
 import java.util.List;
-import java.util.Set;
 
 public interface MutationMapper {
 
@@ -16,6 +15,13 @@ public interface MutationMapper {
 
     MutationMeta getMetaMutationsBySampleListId(String molecularProfileId, String sampleListId, 
                                                 List<Integer> entrezGeneIds, Boolean snpOnly);
+
+    
+    // TODO: cleanup searchFusions param once fusion/structural data is fixed in database
+    List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
+                                                                        List<Integer> entrezGeneIds, Boolean snpOnly,
+                                                                        boolean searchFusions, String projection, Integer limit,
+                                                                        Integer offset, String sortBy, String direction);
 
     // TODO: cleanup searchFusions param once fusion/structural data is fixed in database
     List<Mutation> getMutationsInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
@@ -28,19 +34,9 @@ public interface MutationMapper {
                                                                         String sortBy,
                                                                         String direction,
                                                                         List<GeneFilterQuery> geneQueries);
-    
-    // TODO: cleanup searchFusions param once fusion/structural data is fixed in database
-    List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
-                                                                        List<Integer> entrezGeneIds, Boolean snpOnly,
-                                                                        boolean searchFusions, String projection, Integer limit,
-                                                                        Integer offset, String sortBy, String direction);
 
     MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
                                                              List<Integer> entrezGeneIds, Boolean snpOnly);
-
-    List<Mutation> getMutationsBySampleIds(String molecularProfileId, Set<String> sampleIds, 
-                                           List<Integer> entrezGeneIds, Boolean snpOnly, String projection, 
-                                           Integer limit, Integer offset, String sortBy, String direction);
 
     MutationMeta getMetaMutationsBySampleIds(String molecularProfileId, List<String> sampleIds, 
                                              List<Integer> entrezGeneIds, Boolean snpOnly);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMapper.java
@@ -1,8 +1,8 @@
 package org.cbioportal.persistence.mybatis;
 
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.Mutation;
 import org.cbioportal.model.MutationCountByPosition;
-import org.cbioportal.model.MutationCountByGene;
 import org.cbioportal.model.meta.MutationMeta;
 
 import java.util.List;
@@ -17,10 +17,23 @@ public interface MutationMapper {
     MutationMeta getMetaMutationsBySampleListId(String molecularProfileId, String sampleListId, 
                                                 List<Integer> entrezGeneIds, Boolean snpOnly);
 
+    // TODO: cleanup searchFusions param once fusion/structural data is fixed in database
+    List<Mutation> getMutationsInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
+                                                                        List<String> sampleIds,
+                                                                        Boolean snpOnly,
+                                                                        boolean searchFusions,
+                                                                        String projection,
+                                                                        Integer limit,
+                                                                        Integer offset,
+                                                                        String sortBy,
+                                                                        String direction,
+                                                                        List<GeneFilterQuery> geneQueries);
+    
+    // TODO: cleanup searchFusions param once fusion/structural data is fixed in database
     List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
-                                                           List<Integer> entrezGeneIds, Boolean snpOnly,
-                                                           String projection, Integer limit, Integer offset,
-                                                           String sortBy, String direction);
+                                                                        List<Integer> entrezGeneIds, Boolean snpOnly,
+                                                                        boolean searchFusions, String projection, Integer limit,
+                                                                        Integer offset, String sortBy, String direction);
 
     MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
                                                              List<Integer> entrezGeneIds, Boolean snpOnly);
@@ -35,9 +48,4 @@ public interface MutationMapper {
     MutationCountByPosition getMutationCountByPosition(Integer entrezGeneId, Integer proteinPosStart, 
                                                        Integer proteinPosEnd);
 
-    // TODO: cleanup once fusion/structural data is fixed in database
-    List<Mutation> getFusionsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
-            List<Integer> entrezGeneIds, Boolean snpOnly, String projection, Integer limit, Integer offset,
-            String sortBy, String direction);
-    // TODO: cleanup once fusion/structural data is fixed in database
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
@@ -1,8 +1,8 @@
 package org.cbioportal.persistence.mybatis;
 
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.Mutation;
 import org.cbioportal.model.MutationCountByPosition;
-import org.cbioportal.model.MutationCountByGene;
 import org.cbioportal.model.meta.MutationMeta;
 import org.cbioportal.persistence.MutationRepository;
 import org.cbioportal.persistence.mybatis.util.OffsetCalculator;
@@ -39,9 +39,9 @@ public class MutationMyBatisRepository implements MutationRepository {
     }
 
     @Override
-    public List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
-                                                                  List<String> sampleIds, List<Integer> entrezGeneIds, 
-                                                                  String projection, Integer pageSize, 
+    public List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds,
+                                                                  List<String> sampleIds, List<Integer> entrezGeneIds,
+                                                                  String projection, Integer pageSize,
                                                                   Integer pageNumber, String sortBy, String direction) {
 
         return getGroupedCasesByMolecularProfileId(molecularProfileIds, sampleIds)
@@ -77,8 +77,36 @@ public class MutationMyBatisRepository implements MutationRepository {
     }
 
     @Override
+    public List<Mutation> getMutationsInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
+                                                                               List<String> sampleIds,
+                                                                               List<GeneFilterQuery> geneQueries,
+                                                                               String projection,
+                                                                               Integer pageSize,
+                                                                               Integer pageNumber,
+                                                                               String sortBy,
+                                                                               String direction) {
+        if (geneQueries.isEmpty())
+            return Collections.emptyList();
+
+        return getGroupedCasesByMolecularProfileId(molecularProfileIds, sampleIds)
+            .entrySet()
+            .stream()
+            .flatMap(entry -> mutationMapper.getMutationsBySampleIdsAndGeneQueries(entry.getKey(),
+                entry.getValue(),
+                entrezGeneIds,
+                null,
+                projection,
+                pageSize,
+                offsetCalculator.calculate(pageSize, pageNumber),
+                sortBy,
+                direction,
+                geneQueries).stream())
+            .collect(Collectors.toList());
+    }
+
+    @Override
     public MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds,
-                                                                    List<String> sampleIds, 
+                                                                    List<String> sampleIds,
                                                                     List<Integer> entrezGeneIds) {
 
         return mutationMapper.getMetaMutationsInMultipleMolecularProfiles(molecularProfileIds, sampleIds, entrezGeneIds,
@@ -115,6 +143,7 @@ public class MutationMyBatisRepository implements MutationRepository {
             List<String> sampleIds, List<Integer> entrezGeneIds, String projection, Integer pageSize,
             Integer pageNumber, String sortBy, String direction) {
 
+        boolean searchFusions = true;
         return getGroupedCasesByMolecularProfileId(molecularProfileIds, sampleIds)
             .entrySet()
             .stream()
@@ -122,11 +151,43 @@ public class MutationMyBatisRepository implements MutationRepository {
                 new ArrayList<>(entry.getValue()),
                 entrezGeneIds,
                 null,
+                searchFusions,
                 projection,
                 pageSize,
                 offsetCalculator.calculate(pageSize, pageNumber),
                 sortBy,
                 direction).stream())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Mutation> getFusionsInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
+                                                                             List<String> sampleIds,
+                                                                             List<GeneFilterQuery> geneQueries,
+                                                                             String projection,
+                                                                             Integer pageSize,
+                                                                             Integer pageNumber,
+                                                                             String sortBy,
+                                                                             String direction) {
+
+        if (geneQueries.isEmpty())
+            return Collections.emptyList();
+
+        boolean searchFusions = true;
+        return getGroupedCasesByMolecularProfileId(molecularProfileIds, sampleIds)
+            .entrySet()
+            .stream()
+            .flatMap(entry -> mutationMapper.getMutationsInMultipleMolecularProfilesByGeneQueries(Arrays.asList(entry.getKey()),
+                new ArrayList<>(entry.getValue()),
+                entrezGeneIds,
+                null,
+                searchFusions,
+                projection,
+                pageSize,
+                offsetCalculator.calculate(pageSize, pageNumber),
+                sortBy,
+                direction,
+                geneQueries).stream())
             .collect(Collectors.toList());
     }
     // TODO: cleanup once fusion/structural data is fixed in database

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepository.java
@@ -44,13 +44,16 @@ public class MutationMyBatisRepository implements MutationRepository {
                                                                   String projection, Integer pageSize,
                                                                   Integer pageNumber, String sortBy, String direction) {
 
+        boolean searchFusions = false;
         return getGroupedCasesByMolecularProfileId(molecularProfileIds, sampleIds)
             .entrySet()
             .stream()
-            .flatMap(entry -> mutationMapper.getMutationsBySampleIds(entry.getKey(),
-                entry.getValue(),
+            .flatMap(entry -> mutationMapper.getMutationsInMultipleMolecularProfiles(
+                Arrays.asList(entry.getKey()),
+                new ArrayList<>(entry.getValue()),
                 entrezGeneIds,
                 null,
+                searchFusions,
                 projection,
                 pageSize,
                 offsetCalculator.calculate(pageSize, pageNumber),
@@ -88,13 +91,15 @@ public class MutationMyBatisRepository implements MutationRepository {
         if (geneQueries.isEmpty())
             return Collections.emptyList();
 
+        boolean searchFusions = false;
         return getGroupedCasesByMolecularProfileId(molecularProfileIds, sampleIds)
             .entrySet()
             .stream()
-            .flatMap(entry -> mutationMapper.getMutationsBySampleIdsAndGeneQueries(entry.getKey(),
-                entry.getValue(),
-                entrezGeneIds,
+            .flatMap(entry -> mutationMapper.getMutationsInMultipleMolecularProfilesByGeneQueries(
+                Arrays.asList(entry.getKey()),
+                new ArrayList<>(entry.getValue()),
                 null,
+                searchFusions,
                 projection,
                 pageSize,
                 offsetCalculator.calculate(pageSize, pageNumber),
@@ -119,8 +124,18 @@ public class MutationMyBatisRepository implements MutationRepository {
                                                            String projection, Integer pageSize, Integer pageNumber,
                                                            String sortBy, String direction) {
 
-        return mutationMapper.getMutationsBySampleIds(molecularProfileId, new HashSet<>(sampleIds), entrezGeneIds, snpOnly, projection,
-            pageSize, offsetCalculator.calculate(pageSize, pageNumber), sortBy, direction);
+        boolean searchFusions = false;
+        return mutationMapper.getMutationsInMultipleMolecularProfiles(
+            Arrays.asList(molecularProfileId),
+            new ArrayList<>(sampleIds),
+            entrezGeneIds,
+            snpOnly,
+            searchFusions,
+            projection,
+            pageSize,
+            offsetCalculator.calculate(pageSize, pageNumber),
+            sortBy,
+            direction);
     }
 
     @Override
@@ -147,7 +162,8 @@ public class MutationMyBatisRepository implements MutationRepository {
         return getGroupedCasesByMolecularProfileId(molecularProfileIds, sampleIds)
             .entrySet()
             .stream()
-            .flatMap(entry -> mutationMapper.getFusionsInMultipleMolecularProfiles(Arrays.asList(entry.getKey()),
+            .flatMap(entry -> mutationMapper.getMutationsInMultipleMolecularProfiles(
+                Arrays.asList(entry.getKey()),
                 new ArrayList<>(entry.getValue()),
                 entrezGeneIds,
                 null,
@@ -177,9 +193,9 @@ public class MutationMyBatisRepository implements MutationRepository {
         return getGroupedCasesByMolecularProfileId(molecularProfileIds, sampleIds)
             .entrySet()
             .stream()
-            .flatMap(entry -> mutationMapper.getMutationsInMultipleMolecularProfilesByGeneQueries(Arrays.asList(entry.getKey()),
+            .flatMap(entry -> mutationMapper.getMutationsInMultipleMolecularProfilesByGeneQueries(
+                Arrays.asList(entry.getKey()),
                 new ArrayList<>(entry.getValue()),
-                entrezGeneIds,
                 null,
                 searchFusions,
                 projection,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StructuralVariantMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StructuralVariantMapper.java
@@ -23,12 +23,16 @@
 
 package org.cbioportal.persistence.mybatis;
 
-import java.util.List;
-
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.StructuralVariant;
+
+import java.util.List;
 
 public interface StructuralVariantMapper {
 
     List<StructuralVariant> fetchStructuralVariants(List<String> molecularProfileIds, List<Integer> entrezGeneIds,
+            List<String> sampleIds);
+
+    List<StructuralVariant> fetchStructuralVariantsByGeneQueries(List<String> molecularProfileIds, List<GeneFilterQuery> geneQueries,
             List<String> sampleIds);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StructuralVariantMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/StructuralVariantMyBatisRepository.java
@@ -23,6 +23,7 @@
 
 package org.cbioportal.persistence.mybatis;
 
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.StructuralVariant;
 import org.cbioportal.persistence.StructuralVariantRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,5 +42,11 @@ public class StructuralVariantMyBatisRepository implements StructuralVariantRepo
             List<Integer> entrezGeneIds, List<String> sampleIds) {
 
         return structuralVariantMapper.fetchStructuralVariants(molecularProfileIds, entrezGeneIds, sampleIds);
+    }
+
+    @Override
+    public List<StructuralVariant> fetchStructuralVariantsByGeneQueries(List<String> molecularProfileIds,
+            List<GeneFilterQuery> geneQueries, List<String> sampleIds) {
+        return structuralVariantMapper.fetchStructuralVariantsByGeneQueries(molecularProfileIds, geneQueries, sampleIds);
     }
 }

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/AlterationCountsMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/AlterationCountsMapper.xml
@@ -61,9 +61,11 @@
             gene.HUGO_GENE_SYMBOL AS hugoGeneSymbol,
             reference_genome_gene.CYTOBAND as cytoband,
             cna_event.ALTERATION AS alteration,
+            COUNT(*) AS totalCount,
             COUNT(DISTINCT(sample_cna_event.SAMPLE_ID)) AS numberOfAlteredCases
         FROM cna_event
         INNER JOIN sample_cna_event ON cna_event.CNA_EVENT_ID = sample_cna_event.CNA_EVENT_ID
+        <include refid="fromIncludeCustomAnnotationsCna"/>
         INNER JOIN genetic_profile ON sample_cna_event.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
         INNER JOIN gene ON cna_event.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
         INNER JOIN cancer_study ON cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID
@@ -81,6 +83,7 @@
                     </foreach>
                 </when>
             </choose>
+            <include refid="whereCustomAnnotations"/>
             <include refid="caseFilter">
                 <property name="case_type" value="SAMPLE_ID"/>
                 <property name="identifiers" value="cnaMolecularProfileCaseIdentifiers"/>
@@ -97,9 +100,11 @@
             cna_event.ENTREZ_GENE_ID AS entrezGeneId,
             gene.HUGO_GENE_SYMBOL AS hugoGeneSymbol,
             cna_event.ALTERATION AS alteration,
+            COUNT(*) AS totalCount,
             COUNT(DISTINCT(patient.INTERNAL_ID)) AS numberOfAlteredCases
         FROM cna_event
         INNER JOIN sample_cna_event ON cna_event.CNA_EVENT_ID = sample_cna_event.CNA_EVENT_ID
+        <include refid="fromIncludeCustomAnnotationsCna"/>
         INNER JOIN genetic_profile ON sample_cna_event.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
         INNER JOIN sample ON sample_cna_event.SAMPLE_ID = sample.INTERNAL_ID
         INNER JOIN patient ON sample.PATIENT_ID = patient.INTERNAL_ID
@@ -115,6 +120,7 @@
                     </foreach>
                 </when>
             </choose>
+            <include refid="whereCustomAnnotations"/>
             <include refid="caseFilter">
                 <property name="case_type" value="PATIENT_ID"/>
                 <property name="identifiers" value="cnaMolecularProfileCaseIdentifiers"/>
@@ -125,6 +131,111 @@
         </where>
         GROUP BY cna_event.ENTREZ_GENE_ID, cna_event.ALTERATION, gene.HUGO_GENE_SYMBOL
     </select>
+
+    <sql id="fromIncludeCustomAnnotationsMutation">
+        <if test="includeDriver or includeVUS or includeUnknownOncogenicity or (selectedTiers != null and selectedTiers.hasValues()) or includeUnknownTier">
+            LEFT JOIN alteration_driver_annotation ON
+            mutation.MUTATION_EVENT_ID = alteration_driver_annotation.ALTERATION_EVENT_ID
+            AND mutation.GENETIC_PROFILE_ID = alteration_driver_annotation.GENETIC_PROFILE_ID
+            AND mutation.SAMPLE_ID = alteration_driver_annotation.SAMPLE_ID
+        </if>
+    </sql>
+
+    <sql id="fromIncludeCustomAnnotationsCna">
+        <if test="includeDriver or includeVUS or includeUnknownOncogenicity or (selectedTiers != null and selectedTiers.hasValues()) or includeUnknownTier">
+            LEFT JOIN alteration_driver_annotation ON
+            sample_cna_event.CNA_EVENT_ID = alteration_driver_annotation.ALTERATION_EVENT_ID
+            AND sample_cna_event.GENETIC_PROFILE_ID = alteration_driver_annotation.GENETIC_PROFILE_ID
+            AND sample_cna_event.SAMPLE_ID = alteration_driver_annotation.SAMPLE_ID
+        </if>
+    </sql>
+    
+    <sql id="whereCustomAnnotations">
+        <if test="not includeDriver or not includeVUS or not includeUnknownOncogenicity">
+            <trim prefix="" prefixOverrides="AND ( )">
+                <trim prefix="AND (" prefixOverrides="OR">
+                    <include refid="whereIncludeDriver"/>
+                    <include refid="whereIncludeVUS"/>
+                    <include refid="whereIncludeUnknownOncogenicity"/>
+                    )
+                </trim>
+            </trim>
+        </if>
+        <include refid="whereIncludeTiers"/>
+    </sql>
+    
+    <sql id="whereMutationStatus">
+        <if test="not includeGermline or not includeSomatic or not includeUnknownStatus">
+            <trim prefix="" prefixOverrides="AND ( )">
+                <trim prefix="AND (" prefixOverrides="OR">
+                    <include refid="whereIncludeGermlineAlterations"/>
+                    <include refid="whereIncludeSomaticAlterations"/>
+                    <include refid="whereIncludeUnknownStatusAlterations"/>
+                    )
+                </trim>
+            </trim>
+        </if>
+    </sql>
+
+    <sql id="whereIncludeDriver">
+        <if test="includeDriver">
+            OR LOWER(alteration_driver_annotation.DRIVER_FILTER) = 'putative_driver'
+        </if>
+    </sql>
+
+    <sql id="whereIncludeVUS">
+        <if test="includeVUS">
+            OR LOWER(alteration_driver_annotation.DRIVER_FILTER) = 'putative_passenger'
+        </if>
+    </sql>
+
+    <sql id="whereIncludeUnknownOncogenicity">
+        <if test="includeUnknownOncogenicity">
+            OR alteration_driver_annotation.DRIVER_FILTER IS NULL
+            OR LOWER(alteration_driver_annotation.DRIVER_FILTER) IN ('unknown', 'na', '')
+        </if>
+    </sql>
+        
+    <sql id="whereIncludeTiers">
+        <bind name="allTierOptionsSelected" value="(selectedTiers == null or selectedTiers.hasAll()) and includeUnknownTier" />
+        <bind name="noTierOptionsSelected" value="(selectedTiers != null and selectedTiers.hasNone()) and not includeUnknownTier" />
+        <if test="not allTierOptionsSelected and not noTierOptionsSelected">
+            <trim prefix="AND (" prefixOverrides="OR">    
+                <if test="selectedTiers != null and selectedTiers.hasValues()">
+                    OR alteration_driver_annotation.DRIVER_TIERS_FILTER IN
+                    <foreach item="item" collection="selectedTiers" open="(" separator="," close=")">
+                        #{item}
+                    </foreach>
+                </if>
+                <if test="includeUnknownTier">
+                    OR alteration_driver_annotation.DRIVER_TIERS_FILTER IS NULL
+                    OR LOWER(alteration_driver_annotation.DRIVER_TIERS_FILTER) IN ('', 'na', 'unknown')
+                </if>
+            </trim>
+            )
+        </if>
+    </sql>
+
+    <sql id="whereIncludeGermlineAlterations">
+        <if test="includeGermline">
+            OR
+            LOWER(mutation.MUTATION_STATUS) = 'germline'
+        </if>
+    </sql>
+    
+    <sql id="whereIncludeSomaticAlterations">
+        <if test="includeSomatic">
+            OR
+            LOWER(mutation.MUTATION_STATUS) = 'somatic'
+        </if>
+    </sql>
+    
+    <sql id="whereIncludeUnknownStatusAlterations">
+        <if test="includeUnknownStatus">
+            OR
+            LOWER(mutation.MUTATION_STATUS) IN ('unknown', '')
+        </if>
+    </sql>
 
     <sql id="whereSearchFusions">
         <if test="searchFusions.name() == 'ACTIVE'">
@@ -177,6 +288,7 @@
         INNER JOIN genetic_profile ON mutation.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
         INNER JOIN patient ON patient.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID
         INNER JOIN sample ON sample.PATIENT_ID = patient.INTERNAL_ID AND sample.INTERNAL_ID = mutation.SAMPLE_ID
+        <include refid="fromIncludeCustomAnnotationsMutation"/>
         <where>
             <choose>
                 <when test="mutationTypes.hasNone()">NULL</when>
@@ -204,6 +316,8 @@
                     <include refid="whereSearchFusions" />
                 </when>
             </choose>
+            <include refid="whereCustomAnnotations"/>
+            <include refid="whereMutationStatus"/>
             <include refid="caseFilter">
                 <property name="identifiers" value="mutationMolecularProfileCaseIdentifiers"/>
                 <property name="geneticProfileIdentifier" value="genetic_profile.STABLE_ID" />
@@ -227,6 +341,7 @@
         INNER JOIN cancer_study ON cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID
         INNER JOIN reference_genome_gene ON reference_genome_gene.ENTREZ_GENE_ID = cna_event.ENTREZ_GENE_ID
         AND reference_genome_gene.reference_genome_id = cancer_study.reference_genome_id
+        <include refid="fromIncludeCustomAnnotationsCna"/>
         <where>
             <choose>
                 <when test="cnaTypes.hasNone()">NULL</when>
@@ -237,12 +352,12 @@
                     </foreach>
                 </when>
             </choose>
+            <include refid="whereCustomAnnotations"/>
             <include refid="caseFilter">
                 <property name="identifiers" value="cnaMolecularProfileCaseIdentifiers" />
                 <property name="geneticProfileIdentifier" value="genetic_profile.STABLE_ID" />
                 <property name="caseStableIdentifier" value="caseStableIdentifier" />
             </include>
-
         </where>
     </sql>
     

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/AlterationDriverAnnotationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/AlterationDriverAnnotationMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.cbioportal.persistence.mybatis.AlterationDriverAnnotationMapper">
+
+    <select id="getAlterationDriverAnnotations" resultType="org.cbioportal.model.AlterationDriverAnnotation">
+        SELECT
+            alteration_driver_annotation.ALTERATION_EVENT_ID as alterationEventId,
+            alteration_driver_annotation.GENETIC_PROFILE_ID as geneticProfileId,
+            alteration_driver_annotation.SAMPLE_ID as sampleId,
+            alteration_driver_annotation.DRIVER_FILTER as driverFilter,
+            alteration_driver_annotation.DRIVER_FILTER_ANNOTATION as driverFilterAnnotation,
+            alteration_driver_annotation.DRIVER_TIERS_FILTER as driverTiersFilter,
+            alteration_driver_annotation.DRIVER_TIERS_FILTER_ANNOTATION as driverTiersFilterAnnotation
+        FROM alteration_driver_annotation
+        INNER JOIN genetic_profile ON
+        genetic_profile.GENETIC_PROFILE_ID = alteration_driver_annotation.GENETIC_PROFILE_ID
+        <where>
+            <if test="molecularProfileIds != null and !molecularProfileIds.isEmpty()">
+                genetic_profile.STABLE_ID IN
+                <foreach item="id" collection="molecularProfileIds" open="(" separator="," close=")">
+                    #{id}
+                </foreach>
+            </if>
+        </where>
+    </select>
+
+</mapper>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMapper.xml
@@ -2,14 +2,13 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.DiscreteCopyNumberMapper">
-    
 
     <sql id="select">
+        cna_event.ENTREZ_GENE_ID as entrezGeneId,
+        cna_event.ALTERATION AS alteration,
         genetic_profile.STABLE_ID AS molecularProfileId,
         sample.STABLE_ID AS sampleId,
         patient.STABLE_ID AS patientId,
-        cna_event.ENTREZ_GENE_ID as entrezGeneId,
-        cna_event.ALTERATION AS alteration,
         cancer_study.CANCER_STUDY_IDENTIFIER AS studyId,
         alteration_driver_annotation.DRIVER_FILTER AS driverFilter,
         alteration_driver_annotation.DRIVER_FILTER_ANNOTATION AS driverFilterAnnotation,
@@ -100,19 +99,61 @@
                     (#{sampleIds[${i}]}, #{molecularProfileIds[${i}]})
                 </foreach>
             </if>
-            <if test="entrezGeneIds != null and !entrezGeneIds.isEmpty()">
+            <if test="_parameter.containsKey('entrezGeneIds') and entrezGeneIds != null and !entrezGeneIds.isEmpty()">
                 AND cna_event.ENTREZ_GENE_ID IN
                 <foreach item="item" collection="entrezGeneIds" open="(" separator="," close=")">
                     #{item}
                 </foreach>
             </if>
-            <if test="alterationTypes != null and !alterationTypes.isEmpty()">
+            <if test="_parameter.containsKey('alterationTypes') and alterationTypes != null and !alterationTypes.isEmpty()">
                 AND cna_event.ALTERATION IN
                 <foreach item="item" collection="alterationTypes" open="(" separator="," close=")">
                     #{item}
                 </foreach>
             </if>
+            <include refid="whereWithGeneQueries"/>
         </where>
+    </sql>
+
+    <sql id="whereWithGeneQueries">
+        <if test="(_parameter.containsKey('geneQueries') and geneQueries != null and !geneQueries.isEmpty())">
+            AND
+            <foreach item="geneFilterQuery" collection="geneQueries" open="(" separator=" OR " close=")">
+                ( cna_event.ENTREZ_GENE_ID = '${geneFilterQuery.getEntrezGeneId()}'
+                <if test="geneFilterQuery.getIncludeDriver() or geneFilterQuery.getIncludeVUS() or geneFilterQuery.getIncludeUnknownOncogenicity()">
+                    <trim prefix="AND (" prefixOverrides="OR">
+                        <if test="geneFilterQuery.getIncludeDriver()">
+                            OR LOWER(alteration_driver_annotation.DRIVER_FILTER) = 'putative_driver'
+                        </if>
+                        <if test="geneFilterQuery.getIncludeVUS()">
+                            OR LOWER(alteration_driver_annotation.DRIVER_FILTER) = 'putative_passenger'
+                        </if>
+                        <if test="geneFilterQuery.getIncludeUnknownOncogenicity()">
+                            OR alteration_driver_annotation.DRIVER_FILTER IS NULL
+                            OR LOWER(alteration_driver_annotation.DRIVER_FILTER) IN ('unknown', 'na', '')
+                        </if>
+                    </trim>
+                    )
+                </if>
+                <bind name="allTierOptionsSelected" value="geneFilterQuery.getSelectedTiers() == null or geneFilterQuery.getSelectedTiers().hasAll() and geneFilterQuery.getIncludeUnknownTier()" />
+                <bind name="noTierOptionsSelected" value="(geneFilterQuery.getSelectedTiers() != null and geneFilterQuery.getSelectedTiers().hasNone()) and not geneFilterQuery.getIncludeUnknownTier()" />
+                <if test="not allTierOptionsSelected and not noTierOptionsSelected">
+                    <trim prefix="AND (" prefixOverrides="OR">
+                        <if test="geneFilterQuery.getSelectedTiers() != null and geneFilterQuery.getSelectedTiers().hasValues()">
+                            <foreach item="tier" collection="geneFilterQuery.getSelectedTiers()" open="" separator="" close="">
+                                OR alteration_driver_annotation.DRIVER_TIERS_FILTER = #{tier}
+                            </foreach>
+                        </if>
+                        <if test="geneFilterQuery.getIncludeUnknownTier()">
+                            OR alteration_driver_annotation.DRIVER_TIERS_FILTER IS NULL
+                            OR LOWER(alteration_driver_annotation.DRIVER_TIERS_FILTER) IN ('', 'na', 'unknown')
+                        </if>
+                    </trim>
+                    )
+                </if>
+                )
+            </foreach>
+        </if>
     </sql>
 
     <select id="getDiscreteCopyNumbersBySampleListId" resultType="org.cbioportal.model.DiscreteCopyNumberData">
@@ -143,6 +184,16 @@
     </select>
 
     <select id="getDiscreteCopyNumbersInMultipleMolecularProfiles" resultType="org.cbioportal.model.DiscreteCopyNumberData">
+        SELECT
+        <include refid="select"/>
+        <include refid="from"/>
+        <if test="projection == 'DETAILED'">
+            INNER JOIN gene ON cna_event.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
+        </if>
+        <include refid="whereInMultipleMolecularProfiles"/>
+    </select>
+
+    <select id="getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries" resultType="org.cbioportal.model.DiscreteCopyNumberData">
         SELECT
         <include refid="select"/>
         <include refid="from"/>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.cbioportal.persistence.mybatis.MolecularDataMapper">
-    
 
     <sql id="whereInMultipleMolecularProfiles">
         <where>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularProfileMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularProfileMapper.xml
@@ -145,5 +145,4 @@
                          genetic_profile.STABLE_ID = #{referredMolecularProfileId}
                        )
     </select>
-    
 </mapper>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
@@ -145,7 +145,7 @@
                     #{item}
                 </foreach>
             </if>
-            <if test="entrezGeneIds != null and !entrezGeneIds.isEmpty()">
+            <if test="_parameter.containsKey('entrezGeneIds') and entrezGeneIds != null and !entrezGeneIds.isEmpty()">
                 AND mutation.ENTREZ_GENE_ID IN
                 <foreach item="item" collection="entrezGeneIds" open="(" separator="," close=")">
                     #{item}
@@ -222,8 +222,7 @@
             </foreach>
         </if>
     </sql>
-
-
+    
     <sql id="getAlleleSpecificCopyNumber">
         allele_specific_copy_number.ASCN_INTEGER_COPY_NUMBER AS "${prefix}ascnIntegerCopyNumber",
         allele_specific_copy_number.ASCN_METHOD AS "${prefix}ascnMethod",

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
@@ -155,8 +155,74 @@
                 AND mutation_event.REFERENCE_ALLELE IN ('A','T','C','G')
                 AND mutation_event.TUMOR_SEQ_ALLELE IN ('A','T','C','G')
             </if>
+            <if test="(_parameter.containsKey('searchFusions')">
+                <if test="searchFusions">
+                    AND
+                    mutation_event.MUTATION_TYPE = 'Fusion'
+                </if>
+                <if test="not searchFusions">
+                    AND
+                    mutation_event.MUTATION_TYPE != 'Fusion'
+                </if>
+            </if>
         </where>
     </sql>
+
+    <sql id="whereWithGeneQueries">
+        <if test="(_parameter.containsKey('geneQueries') and geneQueries != null and !geneQueries.isEmpty())">
+            AND
+            <foreach item="geneFilterQuery" collection="geneQueries" open="(" separator=" OR " close=")">
+                ( mutation.ENTREZ_GENE_ID = '${geneFilterQuery.getEntrezGeneId()}'
+                <if test="geneFilterQuery.getIncludeDriver() or geneFilterQuery.getIncludeVUS() or geneFilterQuery.getIncludeUnknownOncogenicity()">
+                    <trim prefix="AND (" prefixOverrides="OR">
+                        <if test="geneFilterQuery.getIncludeDriver()">
+                            OR LOWER(alteration_driver_annotation.DRIVER_FILTER) = 'putative_driver'
+                        </if>
+                        <if test="geneFilterQuery.getIncludeVUS()">
+                            OR LOWER(alteration_driver_annotation.DRIVER_FILTER) = 'putative_passenger'
+                        </if>
+                        <if test="geneFilterQuery.getIncludeUnknownOncogenicity()">
+                            OR alteration_driver_annotation.DRIVER_FILTER IS NULL
+                            OR LOWER(alteration_driver_annotation.DRIVER_FILTER) IN ('unknown', 'na', '')
+                        </if>
+                    </trim>
+                    )
+                </if>
+                <if test="geneFilterQuery.getIncludeGermline() or geneFilterQuery.getIncludeSomatic() or geneFilterQuery.getIncludeUnknownStatus()">
+                    <trim prefix="AND (" prefixOverrides="OR">
+                        <if test="geneFilterQuery.getIncludeGermline()">
+                            OR LOWER(mutation.MUTATION_STATUS) = 'germline'
+                        </if>
+                        <if test="geneFilterQuery.getIncludeSomatic()">
+                            OR LOWER(mutation.MUTATION_STATUS) = 'somatic'
+                        </if>
+                        <if test="geneFilterQuery.getIncludeUnknownStatus()">
+                            OR LOWER(mutation.MUTATION_STATUS) IN ('unknown', '')
+                        </if>
+                    </trim>
+                    )
+                </if>
+                <bind name="allTierOptionsSelected" value="geneFilterQuery.getSelectedTiers() == null or geneFilterQuery.getSelectedTiers().hasAll() and geneFilterQuery.getIncludeUnknownTier()" />
+                <bind name="noTierOptionsSelected" value="(geneFilterQuery.getSelectedTiers() != null and geneFilterQuery.getSelectedTiers().hasNone()) and not geneFilterQuery.getIncludeUnknownTier()" />
+                <if test="not allTierOptionsSelected and not noTierOptionsSelected">
+                    <trim prefix="AND (" prefixOverrides="OR">
+                        <if test="geneFilterQuery.getSelectedTiers() != null and geneFilterQuery.getSelectedTiers().hasValues()">
+                            <foreach item="tier" collection="geneFilterQuery.getSelectedTiers()" open="" separator="" close="">
+                                OR alteration_driver_annotation.DRIVER_TIERS_FILTER = #{tier}
+                            </foreach>
+                        </if>
+                        <if test="geneFilterQuery.getIncludeUnknownTier()">
+                            OR alteration_driver_annotation.DRIVER_TIERS_FILTER IS NULL
+                            OR LOWER(alteration_driver_annotation.DRIVER_TIERS_FILTER) IN ('', 'na', 'unknown')
+                        </if>
+                    </trim>
+                    )
+                </if>
+                )
+            </foreach>
+        </if>
+    </sql>
+
 
     <sql id="getAlleleSpecificCopyNumber">
         allele_specific_copy_number.ASCN_INTEGER_COPY_NUMBER AS "${prefix}ascnIntegerCopyNumber",
@@ -232,7 +298,7 @@
             LIMIT #{limit} OFFSET #{offset}
         </if>
     </select>
-    
+
     <!-- TODO: Remove once fusions are removed from mutation table -->
     <select id="getFusionsInMultipleMolecularProfiles" resultType="org.cbioportal.model.Mutation">
         SELECT
@@ -255,6 +321,28 @@
         </if>
     </select>
     <!-- TODO: Remove once fusions are removed from mutation table -->
+
+    <select id="getMutationsInMultipleMolecularProfilesByGeneQueries" resultType="org.cbioportal.model.Mutation">
+        SELECT
+        <include refid="select"/>
+        <include refid="from"/>
+        <!-- TODO: Remove once fusions are removed from mutation table -->
+        INNER JOIN mutation_event ON mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID AND mutation_event.MUTATION_TYPE != 'Fusion'
+        <if test="projection == 'DETAILED'">
+            INNER JOIN gene ON mutation.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
+            <include refid="includeAlleleSpecificCopyNumber"/>
+        </if>
+        <include refid="whereInMultipleMolecularProfiles"/>
+        <if test="sortBy != null and projection != 'ID'">
+            ORDER BY ${sortBy} ${direction}
+        </if>
+        <if test="projection == 'ID'">
+            ORDER BY genetic_profile.STABLE_ID ASC, sample.STABLE_ID ASC, mutation.ENTREZ_GENE_ID ASC
+        </if>
+        <if test="limit != null and limit != 0">
+            LIMIT #{limit} OFFSET #{offset}
+        </if>
+    </select>
 
     <select id="getMetaMutationsInMultipleMolecularProfiles" resultType="org.cbioportal.model.meta.MutationMeta">
         SELECT
@@ -332,4 +420,5 @@
         <!-- TODO: Remove once fusions are removed from mutation table -->
         AND mutation_event.MUTATION_TYPE != 'Fusion'
     </select>
+
 </mapper>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MutationMapper.xml
@@ -53,6 +53,18 @@
             </include>
         </if>
     </sql>
+    
+    <sql id="projectionAndLimitFilter">
+        <if test="sortBy != null and projection != 'ID'">
+            ORDER BY ${sortBy} ${direction}
+        </if>
+        <if test="projection == 'ID'">
+            ORDER BY genetic_profile.STABLE_ID ASC, sample.STABLE_ID ASC, mutation.ENTREZ_GENE_ID ASC
+        </if>
+        <if test="limit != null and limit != 0">
+            LIMIT #{limit} OFFSET #{offset}
+        </if>
+    </sql>
 
     <sql id="from">
         FROM mutation
@@ -75,11 +87,24 @@
                     #{item}
                 </foreach>
             </if>
-            <if test="entrezGeneIds != null and !entrezGeneIds.isEmpty()">
+            <if test="_parameter.containsKey('entrezGeneIds') and entrezGeneIds != null and !entrezGeneIds.isEmpty()">
                 AND mutation.ENTREZ_GENE_ID IN
                 <foreach item="item" collection="entrezGeneIds" open="(" separator="," close=")">
                     #{item}
                 </foreach>
+            </if>
+            <if test="_parameter.containsKey('geneQueries') and geneQueries != null and !geneQueries.isEmpty()">
+                <include refid="whereWithGeneQueries"/>
+            </if>
+            <if test="_parameter.containsKey('searchFusions')">
+                <if test="searchFusions">
+                    AND
+                    mutation_event.MUTATION_TYPE = 'Fusion'
+                </if>
+                <if test="not searchFusions">
+                    AND
+                    mutation_event.MUTATION_TYPE != 'Fusion'
+                </if>
             </if>
             <if test="snpOnly != null and snpOnly == true">
                 AND mutation_event.REFERENCE_ALLELE IN ('A','T','C','G')
@@ -151,11 +176,10 @@
                     #{item}
                 </foreach>
             </if>
-            <if test="snpOnly != null and snpOnly == true">
-                AND mutation_event.REFERENCE_ALLELE IN ('A','T','C','G')
-                AND mutation_event.TUMOR_SEQ_ALLELE IN ('A','T','C','G')
+            <if test="_parameter.containsKey('geneQueries') and geneQueries != null and !geneQueries.isEmpty()">
+                <include refid="whereWithGeneQueries"/>
             </if>
-            <if test="(_parameter.containsKey('searchFusions')">
+            <if test="_parameter.containsKey('searchFusions')">
                 <if test="searchFusions">
                     AND
                     mutation_event.MUTATION_TYPE = 'Fusion'
@@ -165,62 +189,64 @@
                     mutation_event.MUTATION_TYPE != 'Fusion'
                 </if>
             </if>
+            <if test="snpOnly != null and snpOnly == true">
+                AND mutation_event.REFERENCE_ALLELE IN ('A','T','C','G')
+                AND mutation_event.TUMOR_SEQ_ALLELE IN ('A','T','C','G')
+            </if>
         </where>
     </sql>
 
     <sql id="whereWithGeneQueries">
-        <if test="(_parameter.containsKey('geneQueries') and geneQueries != null and !geneQueries.isEmpty())">
-            AND
-            <foreach item="geneFilterQuery" collection="geneQueries" open="(" separator=" OR " close=")">
-                ( mutation.ENTREZ_GENE_ID = '${geneFilterQuery.getEntrezGeneId()}'
-                <if test="geneFilterQuery.getIncludeDriver() or geneFilterQuery.getIncludeVUS() or geneFilterQuery.getIncludeUnknownOncogenicity()">
-                    <trim prefix="AND (" prefixOverrides="OR">
-                        <if test="geneFilterQuery.getIncludeDriver()">
-                            OR LOWER(alteration_driver_annotation.DRIVER_FILTER) = 'putative_driver'
-                        </if>
-                        <if test="geneFilterQuery.getIncludeVUS()">
-                            OR LOWER(alteration_driver_annotation.DRIVER_FILTER) = 'putative_passenger'
-                        </if>
-                        <if test="geneFilterQuery.getIncludeUnknownOncogenicity()">
-                            OR alteration_driver_annotation.DRIVER_FILTER IS NULL
-                            OR LOWER(alteration_driver_annotation.DRIVER_FILTER) IN ('unknown', 'na', '')
-                        </if>
-                    </trim>
-                    )
-                </if>
-                <if test="geneFilterQuery.getIncludeGermline() or geneFilterQuery.getIncludeSomatic() or geneFilterQuery.getIncludeUnknownStatus()">
-                    <trim prefix="AND (" prefixOverrides="OR">
-                        <if test="geneFilterQuery.getIncludeGermline()">
-                            OR LOWER(mutation.MUTATION_STATUS) = 'germline'
-                        </if>
-                        <if test="geneFilterQuery.getIncludeSomatic()">
-                            OR LOWER(mutation.MUTATION_STATUS) = 'somatic'
-                        </if>
-                        <if test="geneFilterQuery.getIncludeUnknownStatus()">
-                            OR LOWER(mutation.MUTATION_STATUS) IN ('unknown', '')
-                        </if>
-                    </trim>
-                    )
-                </if>
-                <bind name="allTierOptionsSelected" value="geneFilterQuery.getSelectedTiers() == null or geneFilterQuery.getSelectedTiers().hasAll() and geneFilterQuery.getIncludeUnknownTier()" />
-                <bind name="noTierOptionsSelected" value="(geneFilterQuery.getSelectedTiers() != null and geneFilterQuery.getSelectedTiers().hasNone()) and not geneFilterQuery.getIncludeUnknownTier()" />
-                <if test="not allTierOptionsSelected and not noTierOptionsSelected">
-                    <trim prefix="AND (" prefixOverrides="OR">
-                        <if test="geneFilterQuery.getSelectedTiers() != null and geneFilterQuery.getSelectedTiers().hasValues()">
-                            <foreach item="tier" collection="geneFilterQuery.getSelectedTiers()" open="" separator="" close="">
-                                OR alteration_driver_annotation.DRIVER_TIERS_FILTER = #{tier}
-                            </foreach>
-                        </if>
-                        <if test="geneFilterQuery.getIncludeUnknownTier()">
-                            OR alteration_driver_annotation.DRIVER_TIERS_FILTER IS NULL
-                            OR LOWER(alteration_driver_annotation.DRIVER_TIERS_FILTER) IN ('', 'na', 'unknown')
-                        </if>
-                    </trim>
-                    )
-                </if>
+        AND
+        <foreach item="geneFilterQuery" collection="geneQueries" open="(" separator=" OR " close=")">
+            ( mutation.ENTREZ_GENE_ID = '${geneFilterQuery.getEntrezGeneId()}'
+            <if test="geneFilterQuery.getIncludeDriver() or geneFilterQuery.getIncludeVUS() or geneFilterQuery.getIncludeUnknownOncogenicity()">
+                <trim prefix="AND (" prefixOverrides="OR">
+                    <if test="geneFilterQuery.getIncludeDriver()">
+                        OR LOWER(alteration_driver_annotation.DRIVER_FILTER) = 'putative_driver'
+                    </if>
+                    <if test="geneFilterQuery.getIncludeVUS()">
+                        OR LOWER(alteration_driver_annotation.DRIVER_FILTER) = 'putative_passenger'
+                    </if>
+                    <if test="geneFilterQuery.getIncludeUnknownOncogenicity()">
+                        OR alteration_driver_annotation.DRIVER_FILTER IS NULL
+                        OR LOWER(alteration_driver_annotation.DRIVER_FILTER) IN ('unknown', 'na', '')
+                    </if>
+                </trim>
                 )
-            </foreach>
-        </if>
+            </if>
+            <if test="geneFilterQuery.getIncludeGermline() or geneFilterQuery.getIncludeSomatic() or geneFilterQuery.getIncludeUnknownStatus()">
+                <trim prefix="AND (" prefixOverrides="OR">
+                    <if test="geneFilterQuery.getIncludeGermline()">
+                        OR LOWER(mutation.MUTATION_STATUS) = 'germline'
+                    </if>
+                    <if test="geneFilterQuery.getIncludeSomatic()">
+                        OR LOWER(mutation.MUTATION_STATUS) = 'somatic'
+                    </if>
+                    <if test="geneFilterQuery.getIncludeUnknownStatus()">
+                        OR LOWER(mutation.MUTATION_STATUS) IN ('unknown', '')
+                    </if>
+                </trim>
+                )
+            </if>
+            <bind name="allTierOptionsSelected" value="geneFilterQuery.getSelectedTiers() == null or geneFilterQuery.getSelectedTiers().hasAll() and geneFilterQuery.getIncludeUnknownTier()" />
+            <bind name="noTierOptionsSelected" value="(geneFilterQuery.getSelectedTiers() != null and geneFilterQuery.getSelectedTiers().hasNone()) and not geneFilterQuery.getIncludeUnknownTier()" />
+            <if test="not allTierOptionsSelected and not noTierOptionsSelected">
+                <trim prefix="AND (" prefixOverrides="OR">
+                    <if test="geneFilterQuery.getSelectedTiers() != null and geneFilterQuery.getSelectedTiers().hasValues()">
+                        <foreach item="tier" collection="geneFilterQuery.getSelectedTiers()" open="" separator="" close="">
+                            OR alteration_driver_annotation.DRIVER_TIERS_FILTER = #{tier}
+                        </foreach>
+                    </if>
+                    <if test="geneFilterQuery.getIncludeUnknownTier()">
+                        OR alteration_driver_annotation.DRIVER_TIERS_FILTER IS NULL
+                        OR LOWER(alteration_driver_annotation.DRIVER_TIERS_FILTER) IN ('', 'na', 'unknown')
+                    </if>
+                </trim>
+                )
+            </if>
+            )
+        </foreach>
     </sql>
     
     <sql id="getAlleleSpecificCopyNumber">
@@ -276,71 +302,28 @@
         SELECT
         <include refid="select"/>
         <include refid="from"/>
-        <!-- Revert back to this once fusions are removed from mutation table -->
-        <!-- <if test="projection == 'SUMMARY' || projection == 'DETAILED'">
-            INNER JOIN mutation_event ON mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID
-        </if> -->
         <!-- TODO: Remove once fusions are removed from mutation table -->
-        INNER JOIN mutation_event ON mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID AND mutation_event.MUTATION_TYPE != 'Fusion'
+        INNER JOIN mutation_event ON mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID
         <if test="projection == 'DETAILED'">
             INNER JOIN gene ON mutation.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
             <include refid="includeAlleleSpecificCopyNumber"/>
         </if>
         <include refid="whereInMultipleMolecularProfiles"/>
-        <if test="sortBy != null and projection != 'ID'">
-            ORDER BY ${sortBy} ${direction}
-        </if>
-        <if test="projection == 'ID'">
-            ORDER BY genetic_profile.STABLE_ID ASC, sample.STABLE_ID ASC, mutation.ENTREZ_GENE_ID ASC
-        </if>
-        <if test="limit != null and limit != 0">
-            LIMIT #{limit} OFFSET #{offset}
-        </if>
+        <include refid="projectionAndLimitFilter"/>
     </select>
-
-    <!-- TODO: Remove once fusions are removed from mutation table -->
-    <select id="getFusionsInMultipleMolecularProfiles" resultType="org.cbioportal.model.Mutation">
-        SELECT
-        <include refid="select"/>
-        <include refid="from"/>
-        INNER JOIN mutation_event ON mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID AND mutation_event.MUTATION_TYPE = 'Fusion'
-        <if test="projection == 'DETAILED'">
-            INNER JOIN gene ON mutation.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
-            <include refid="includeAlleleSpecificCopyNumber"/>
-        </if>
-        <include refid="whereInMultipleMolecularProfiles"/>
-        <if test="sortBy != null and projection != 'ID'">
-            ORDER BY ${sortBy} ${direction}
-        </if>
-        <if test="projection == 'ID'">
-            ORDER BY genetic_profile.STABLE_ID ASC, sample.STABLE_ID ASC, mutation.ENTREZ_GENE_ID ASC
-        </if>
-        <if test="limit != null and limit != 0">
-            LIMIT #{limit} OFFSET #{offset}
-        </if>
-    </select>
-    <!-- TODO: Remove once fusions are removed from mutation table -->
 
     <select id="getMutationsInMultipleMolecularProfilesByGeneQueries" resultType="org.cbioportal.model.Mutation">
         SELECT
         <include refid="select"/>
         <include refid="from"/>
         <!-- TODO: Remove once fusions are removed from mutation table -->
-        INNER JOIN mutation_event ON mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID AND mutation_event.MUTATION_TYPE != 'Fusion'
+        INNER JOIN mutation_event ON mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID
         <if test="projection == 'DETAILED'">
             INNER JOIN gene ON mutation.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
             <include refid="includeAlleleSpecificCopyNumber"/>
         </if>
         <include refid="whereInMultipleMolecularProfiles"/>
-        <if test="sortBy != null and projection != 'ID'">
-            ORDER BY ${sortBy} ${direction}
-        </if>
-        <if test="projection == 'ID'">
-            ORDER BY genetic_profile.STABLE_ID ASC, sample.STABLE_ID ASC, mutation.ENTREZ_GENE_ID ASC
-        </if>
-        <if test="limit != null and limit != 0">
-            LIMIT #{limit} OFFSET #{offset}
-        </if>
+        <include refid="projectionAndLimitFilter"/>
     </select>
 
     <select id="getMetaMutationsInMultipleMolecularProfiles" resultType="org.cbioportal.model.meta.MutationMeta">
@@ -351,32 +334,6 @@
         <!-- TODO: Remove once fusions are removed from mutation table -->
         INNER JOIN mutation_event ON mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID AND mutation_event.MUTATION_TYPE != 'Fusion'
         <include refid="whereInMultipleMolecularProfiles"/>
-    </select>
-
-    <select id="getMutationsBySampleIds" resultType="org.cbioportal.model.Mutation">
-        SELECT
-        <include refid="select"/>
-        <include refid="from"/>
-        <!-- Revert back to this once fusions are removed from mutation table -->
-        <!-- <if test="projection == 'SUMMARY' || projection == 'DETAILED'">
-            INNER JOIN mutation_event ON mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID
-        </if> -->
-        <!-- TODO: Remove once fusions are removed from mutation table -->
-        INNER JOIN mutation_event ON mutation.MUTATION_EVENT_ID = mutation_event.MUTATION_EVENT_ID AND mutation_event.MUTATION_TYPE != 'Fusion'
-        <if test="projection == 'DETAILED'">
-            INNER JOIN gene ON mutation.ENTREZ_GENE_ID = gene.ENTREZ_GENE_ID
-            <include refid="includeAlleleSpecificCopyNumber"/>
-        </if>
-        <include refid="where"/>
-        <if test="sortBy != null and projection != 'ID'">
-            ORDER BY ${sortBy} ${direction}
-        </if>
-        <if test="projection == 'ID'">
-            ORDER BY genetic_profile.STABLE_ID ASC, sample.STABLE_ID ASC, mutation.ENTREZ_GENE_ID ASC
-        </if>
-        <if test="limit != null and limit != 0">
-            LIMIT #{limit} OFFSET #{offset}
-        </if>
     </select>
 
     <select id="getMetaMutationsBySampleIds" resultType="org.cbioportal.model.meta.MutationMeta">
@@ -419,5 +376,4 @@
         <!-- TODO: Remove once fusions are removed from mutation table -->
         AND mutation_event.MUTATION_TYPE != 'Fusion'
     </select>
-
 </mapper>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StructuralVariantMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StructuralVariantMapper.xml
@@ -49,6 +49,61 @@
         alteration_driver_annotation.DRIVER_TIERS_FILTER_ANNOTATION AS "${prefix}driverTiersFilterAnn"
     </sql>
 
+    <sql id="whereWithGeneQueries">
+        AND
+        <foreach item="geneFilterQuery" collection="geneQueries" open="(" separator=" OR " close=")">
+            (( structural_variant.SITE1_ENTREZ_GENE_ID = '${geneFilterQuery.getEntrezGeneId()}'
+               OR structural_variant.SITE2_ENTREZ_GENE_ID = '${geneFilterQuery.getEntrezGeneId()}')
+            <if test="geneFilterQuery.getIncludeDriver() or geneFilterQuery.getIncludeVUS() or geneFilterQuery.getIncludeUnknownOncogenicity()">
+                <trim prefix="AND (" prefixOverrides="OR">
+                    <if test="geneFilterQuery.getIncludeDriver()">
+                        OR LOWER(alteration_driver_annotation.DRIVER_FILTER) = 'putative_driver'
+                    </if>
+                    <if test="geneFilterQuery.getIncludeVUS()">
+                        OR LOWER(alteration_driver_annotation.DRIVER_FILTER) = 'putative_passenger'
+                    </if>
+                    <if test="geneFilterQuery.getIncludeUnknownOncogenicity()">
+                        OR alteration_driver_annotation.DRIVER_FILTER IS NULL
+                        OR LOWER(alteration_driver_annotation.DRIVER_FILTER) IN ('unknown', 'na', '')
+                    </if>
+                </trim>
+                )
+            </if>
+            <!--             TODO what to with struct vars and mutation status? Ignore parameter?  -->
+            <!--            <if test="geneFilterQuery.getIncludeGermline() or geneFilterQuery.getIncludeSomatic() or geneFilterQuery.getIncludeUnknownStatus()">-->
+<!--                <trim prefix="AND (" prefixOverrides="OR">-->
+<!--                    <if test="geneFilterQuery.getIncludeGermline()">-->
+<!--                        OR LOWER(mutation.MUTATION_STATUS) = 'germline'-->
+<!--                    </if>-->
+<!--                    <if test="geneFilterQuery.getIncludeSomatic()">-->
+<!--                        OR LOWER(mutation.MUTATION_STATUS) = 'somatic'-->
+<!--                    </if>-->
+<!--                    <if test="geneFilterQuery.getIncludeUnknownStatus()">-->
+<!--                        OR LOWER(mutation.MUTATION_STATUS) IN ('unknown', '')-->
+<!--                    </if>-->
+<!--                </trim>-->
+<!--                )-->
+<!--            </if>-->
+            <bind name="allTierOptionsSelected" value="geneFilterQuery.getSelectedTiers() == null or geneFilterQuery.getSelectedTiers().hasAll() and geneFilterQuery.getIncludeUnknownTier()" />
+            <bind name="noTierOptionsSelected" value="(geneFilterQuery.getSelectedTiers() != null and geneFilterQuery.getSelectedTiers().hasNone()) and not geneFilterQuery.getIncludeUnknownTier()" />
+            <if test="not allTierOptionsSelected and not noTierOptionsSelected">
+                <trim prefix="AND (" prefixOverrides="OR">
+                    <if test="geneFilterQuery.getSelectedTiers() != null and geneFilterQuery.getSelectedTiers().hasValues()">
+                        <foreach item="tier" collection="geneFilterQuery.getSelectedTiers()" open="" separator="" close="">
+                            OR alteration_driver_annotation.DRIVER_TIERS_FILTER = #{tier}
+                        </foreach>
+                    </if>
+                    <if test="geneFilterQuery.getIncludeUnknownTier()">
+                        OR alteration_driver_annotation.DRIVER_TIERS_FILTER IS NULL
+                        OR LOWER(alteration_driver_annotation.DRIVER_TIERS_FILTER) IN ('', 'na', 'unknown')
+                    </if>
+                </trim>
+                )
+            </if>
+            )
+        </foreach>
+    </sql>
+    
     <select id="fetchStructuralVariants" resultType="org.cbioportal.model.StructuralVariant">
         SELECT 
         <include refid="select">
@@ -82,6 +137,39 @@
 	            </foreach>
 	            )
             </if>
+            <if test="molecularProfileIds.size() > 0 and sampleIds.size() > 0">
+                AND (genetic_profile.STABLE_ID, sample.STABLE_ID) IN
+                <foreach index="i" collection="sampleIds" open="(" separator="," close=")"> 
+                    (#{molecularProfileIds[${i}]}, #{sampleIds[${i}]}) 
+                </foreach>
+            </if>
+        </where>
+        ORDER BY gene1.HUGO_GENE_SYMBOL, gene2.HUGO_GENE_SYMBOL
+    </select>
+    
+    <select id="fetchStructuralVariantsByGeneQueries" resultType="org.cbioportal.model.StructuralVariant">
+        SELECT 
+        <include refid="select">
+            <property name="prefix" value=""/>
+        </include> 
+        FROM structural_variant
+        JOIN genetic_profile ON structural_variant.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
+        JOIN gene gene1 ON structural_variant.SITE1_ENTREZ_GENE_ID = gene1.ENTREZ_GENE_ID
+        JOIN gene gene2 ON structural_variant.SITE2_ENTREZ_GENE_ID = gene2.ENTREZ_GENE_ID
+        JOIN sample ON structural_variant.SAMPLE_ID = sample.INTERNAL_ID
+        JOIN patient ON sample.PATIENT_ID = patient.INTERNAL_ID
+        JOIN cancer_study ON patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID AND genetic_profile.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
+        LEFT JOIN alteration_driver_annotation ON
+                structural_variant.GENETIC_PROFILE_ID = alteration_driver_annotation.GENETIC_PROFILE_ID
+            and structural_variant.SAMPLE_ID = alteration_driver_annotation.SAMPLE_ID
+            and structural_variant.INTERNAL_ID = alteration_driver_annotation.ALTERATION_EVENT_ID
+            
+        <where>
+            genetic_profile.STABLE_ID IN 
+            <foreach item="item" collection="molecularProfileIds" open="(" separator="," close=")">
+                #{item}
+            </foreach>
+            <include refid="whereWithGeneQueries" />
             <if test="molecularProfileIds.size() > 0 and sampleIds.size() > 0">
                 AND (genetic_profile.STABLE_ID, sample.STABLE_ID) IN
                 <foreach index="i" collection="sampleIds" open="(" separator="," close=")"> 

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/AlterationDriverAnnotationMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/AlterationDriverAnnotationMyBatisRepositoryTest.java
@@ -1,0 +1,52 @@
+package org.cbioportal.persistence.mybatis;
+
+import org.cbioportal.model.AlterationDriverAnnotation;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/testContextDatabase.xml")
+@Configurable
+public class AlterationDriverAnnotationMyBatisRepositoryTest {
+
+    @Autowired
+    private AlterationDriverAnnotationMyBatisRepository alterationDriverAnnotationMyBatisRepository;
+
+    @Test
+    public void getAlterationDriverAnnotationsCna() {
+        List<String> molecularProfileIds = Arrays.asList("study_tcga_pub_gistic");
+        List<AlterationDriverAnnotation> annotations = alterationDriverAnnotationMyBatisRepository.getAlterationDriverAnnotations(molecularProfileIds);
+        Assert.assertEquals(2, annotations.size());
+    }
+
+    @Test
+    public void getAlterationDriverAnnotationsMutations() {
+        List<String> molecularProfileIds = Arrays.asList("study_tcga_pub_mutations");
+        List<AlterationDriverAnnotation> annotations = alterationDriverAnnotationMyBatisRepository.getAlterationDriverAnnotations(molecularProfileIds);
+        Assert.assertEquals(8, annotations.size());
+    }
+
+    @Test
+    public void getAlterationDriverAnnotationsAll() {
+        List<String> molecularProfileIds = Arrays.asList("study_tcga_pub_gistic", "study_tcga_pub_mutations");
+        List<AlterationDriverAnnotation> annotations = alterationDriverAnnotationMyBatisRepository.getAlterationDriverAnnotations(molecularProfileIds);
+        Assert.assertEquals(10, annotations.size());
+    }
+
+    @Test
+    public void getAlterationDriverAnnotationsNull() {
+        List<AlterationDriverAnnotation> annotations = alterationDriverAnnotationMyBatisRepository.getAlterationDriverAnnotations(null);
+        Assert.assertEquals(0, annotations.size());
+    }
+    
+}

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/AlterationMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/AlterationMyBatisRepositoryTest.java
@@ -1,6 +1,7 @@
 package org.cbioportal.persistence.mybatis;
 
 import org.cbioportal.model.*;
+import org.cbioportal.model.QueryElement;
 import org.cbioportal.model.util.Select;
 import org.junit.Assert;
 import org.junit.Before;
@@ -20,19 +21,19 @@ import java.util.List;
 @Configurable
 public class AlterationMyBatisRepositoryTest {
 
-//    mutation and cna events in testSql.sql
-//        SAMPLE_ID, ENTREZ_GENE_ID, HUGO_GENE_SYMBOL, GENETIC_PROFILE_ID, MUTATION_TYPE, DRIVER_FILTER, DRIVER_TIERS_FILTER, PATIENT_ID
-//        1	    207	AKT1	2	-2	                Putative_Driver	    Tier 1  TCGA-A1-A0SB
-//        2	    207	AKT1	2	2	                Putative_Passenger	Tier 2  TCGA-A1-A0SD
-//        1	    207	AKT1	6	Nonsense_Mutation	Putative_Driver	    Tier 1  TCGA-A1-A0SB
-//        2	    207	AKT1	6	Missense_Mutation	Putative_Passenger	Tier 2  TCGA-A1-A0SD
-//        1	    208	AKT2	2	2		            <null>              <null>  TCGA-A1-A0SB
-//        3	    208	AKT2	6	Splice_Site	        Putative_Passenger	Tier 1  TCGA-A1-A0SE
-//        6	    672	BRCA1	6	Missense_Mutation	Putative_Passenger	Tier 2  TCGA-A1-A0SH
-//        6	    672	BRCA1	6	Nonsense_Mutation	Putative_Driver	    Tier 1  TCGA-A1-A0SH
-//        7	    672	BRCA1	6	Nonsense_Mutation	Putative_Driver	    Tier 2  TCGA-A1-A0SI
-//        12	672	BRCA1	6	Splice_Site	        Putative_Passenger	Tier 1  TCGA-A1-A0SO
-//        13	672	BRCA1	6	Splice_Site	        Putative_Driver	    Tier 1  TCGA-A1-A0SP
+    //    mutation and cna events in testSql.sql
+    //        SAMPLE_ID, ENTREZ_GENE_ID, HUGO_GENE_SYMBOL, GENETIC_PROFILE_ID, TYPE, MUTATION_TYPE, DRIVER_FILTER, DRIVER_TIERS_FILTER, PATIENT_ID, MUTATION_TYPE
+    //        1	    207	AKT1	2	CNA         -2	                Putative_Driver	    Tier 1  TCGA-A1-A0SB    germline
+    //        2	    207	AKT1	2	CNA         2	                Putative_Passenger	Tier 2  TCGA-A1-A0SD    germline
+    //        1	    207	AKT1	6	MUTATION    Nonsense_Mutation	Putative_Driver	    Tier 1  TCGA-A1-A0SB    germline
+    //        2	    207	AKT1	6	MUTATION    Missense_Mutation	Putative_Passenger	Tier 2  TCGA-A1-A0SD    germline
+    //        1	    208	AKT2	2	CNA         2		            <null>              <null>  TCGA-A1-A0SB    germline
+    //        3	    208	AKT2	6	MUTATION    Splice_Site	        Putative_Passenger	Tier 1  TCGA-A1-A0SE    germline
+    //        6	    672	BRCA1	6	MUTATION    Missense_Mutation	Putative_Passenger	Tier 2  TCGA-A1-A0SH    germline
+    //        6	    672	BRCA1	6	MUTATION    Nonsense_Mutation	Putative_Driver	    Tier 1  TCGA-A1-A0SH    germline
+    //        7	    672	BRCA1	6	MUTATION    Nonsense_Mutation	Putative_Driver	    Tier 2  TCGA-A1-A0SI    germline
+    //        12	672	BRCA1	6	MUTATION    Splice_Site	        Putative_Passenger	Tier 1  TCGA-A1-A0SO    germline
+    //        13	672	BRCA1	6	MUTATION    Splice_Site	        Putative_Driver	    Tier 1  TCGA-A1-A0SP    germline
 
     @Autowired
     private AlterationMyBatisRepository alterationMyBatisRepository;
@@ -48,6 +49,8 @@ public class AlterationMyBatisRepositoryTest {
     ));
     List<MolecularProfileCaseIdentifier> sampleIdToProfileId = new ArrayList<>();
     List<MolecularProfileCaseIdentifier> patientIdToProfileId = new ArrayList<>();
+    AlterationFilter alterationFilter;
+    
     Select<Integer> entrezGeneIds;
 
     @Before
@@ -74,14 +77,35 @@ public class AlterationMyBatisRepositoryTest {
         patientIdToProfileId.add(new MolecularProfileCaseIdentifier("TCGA-A1-A0SD", "study_tcga_pub_gistic"));
 
         entrezGeneIds = Select.byValues(Arrays.asList(207, 208, 672));
+        alterationFilter = new AlterationFilter(
+            mutationEventTypes,
+            cnaEventTypes,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            Select.none(),
+            false
+        );
     }
 
     @Test
     public void getSampleMutationCount() throws Exception {
 
-        cnaEventTypes = Select.none();
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        alterationFilter.setIncludeGermline(true);
+        alterationFilter.setIncludeSomatic(true);
+        alterationFilter.setIncludeUnknownStatus(true);
+        alterationFilter.setCnaTypeSelect(Select.none());
         List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
-            sampleIdToProfileId, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
 
         Assert.assertEquals(3, result.size());
         AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
@@ -98,9 +122,18 @@ public class AlterationMyBatisRepositoryTest {
     @Test
     public void getSampleCnaCount() throws Exception {
 
-        mutationEventTypes = Select.none();
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        alterationFilter.setIncludeGermline(true);
+        alterationFilter.setIncludeSomatic(true);
+        alterationFilter.setIncludeUnknownStatus(true);
+        alterationFilter.setSelectedMutationTypes(Select.none());
         List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
-            sampleIdToProfileId, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
 
         Assert.assertEquals(2, result.size());
         AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
@@ -114,8 +147,17 @@ public class AlterationMyBatisRepositoryTest {
     @Test
     public void getSampleMutationAndCnaCount() throws Exception {
 
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        alterationFilter.setIncludeGermline(true);
+        alterationFilter.setIncludeSomatic(true);
+        alterationFilter.setIncludeUnknownStatus(true);
         List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
-            sampleIdToProfileId, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
 
         Assert.assertEquals(3, result.size());
         AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
@@ -136,17 +178,49 @@ public class AlterationMyBatisRepositoryTest {
         // Sample is not profiled for mutations and not cna
         sampleIdToProfileId.add(new MolecularProfileCaseIdentifier("TCGA-A1-A0SE-01", "study_tcga_pub_gistic"));
 
-        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(sampleIdToProfileId, entrezGeneIds,
-                mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+        Assert.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void getSampleMutationCountFilterFusions() throws Exception {
+
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        alterationFilter.setIncludeGermline(true);
+        alterationFilter.setIncludeSomatic(true);
+        alterationFilter.setIncludeUnknownStatus(true);
+        alterationFilter.setCnaTypeSelect(Select.none());
+        alterationFilter.setSelectedMutationTypes(Select.all());
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.ACTIVE,
+            alterationFilter);
+        // there are no fusion mutations in the test db
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getPatientMutationCount() throws Exception {
 
-        cnaEventTypes = Select.none();
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        alterationFilter.setIncludeGermline(true);
+        alterationFilter.setIncludeSomatic(true);
+        alterationFilter.setIncludeUnknownStatus(true);
+        alterationFilter.setCnaTypeSelect(Select.none());
         List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
-            patientIdToProfileId, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            patientIdToProfileId,
+            entrezGeneIds,    
+            QueryElement.PASS,
+            alterationFilter);
 
         // For testSql.sql there are no more samples per patient for the investigated genes.
         // Therefore, patient level counts are the same as the sample level counts.
@@ -165,9 +239,15 @@ public class AlterationMyBatisRepositoryTest {
     @Test
     public void getPatientCnaCount() throws Exception {
 
-        mutationEventTypes = Select.none();
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        alterationFilter.setSelectedMutationTypes(Select.none());
         List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
-            patientIdToProfileId, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            patientIdToProfileId,
+            entrezGeneIds,    
+            QueryElement.PASS,
+            alterationFilter);
 
         // For testSql.sql there are no more samples per patient for the investigated genes.
         // Therefore, patient level counts are the same as the sample level counts.
@@ -181,34 +261,19 @@ public class AlterationMyBatisRepositoryTest {
     }
 
     @Test
-    public void getPatientMutationAndCnaCount() throws Exception {
-
-        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
-            patientIdToProfileId, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.PASS);
-
-        // For testSql.sql there are no more samples per patient for the investigated genes.
-        // Therefore, patient level counts are the same as the sample level counts.
-        Assert.assertEquals(3, result.size());
-        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
-        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
-        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
-        Assert.assertEquals((Integer) 5, result672.getTotalCount());
-        Assert.assertEquals((Integer) 4, result672.getNumberOfAlteredCases());
-        Assert.assertEquals((Integer) 4, result207.getTotalCount());
-        Assert.assertEquals((Integer) 2, result207.getNumberOfAlteredCases());
-        Assert.assertEquals((Integer) 2, result208.getTotalCount());
-        Assert.assertEquals((Integer) 2, result208.getNumberOfAlteredCases());
-    }
-
-    @Test
     public void getSampleCnaCountLegacy() throws Exception {
 
         // FIXME: the CnaCountLegacy endpoint is different from the AlterationCount endpoint
         // because it returns a single additional value 'cytoband'. It would make sense to 
         // harmonize these endpoints (both or none return 'cytoband') and use the AlterationCount
         // endpoint for all counts. Let's discuss...
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
         List<CopyNumberCountByGene> result = alterationMyBatisRepository.getSampleCnaCounts(
-            sampleIdToProfileId, entrezGeneIds, cnaEventTypes);
+            sampleIdToProfileId, 
+            entrezGeneIds,
+            alterationFilter);
 
         Assert.assertEquals(3, result.size());
         AlterationCountByGene result207up = result.stream().filter(r -> r.getEntrezGeneId() == 207 && r.getAlteration() == 2).findFirst().get();
@@ -226,8 +291,13 @@ public class AlterationMyBatisRepositoryTest {
         // because it returns a single additional value 'cytoband'. It would make sense to 
         // harmonize these endpoints (both or none return 'cytoband') and use the AlterationCount
         // endpoint for all counts. Let's discuss...
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
         List<CopyNumberCountByGene> result = alterationMyBatisRepository.getPatientCnaCounts(
-            patientIdToProfileId, entrezGeneIds, cnaEventTypes);
+            patientIdToProfileId,
+            entrezGeneIds,
+            alterationFilter);
 
         // For testSql.sql there are no more samples per patient for the investigated genes.
         // Therefore, patient level counts are the same as the sample level counts.
@@ -243,10 +313,19 @@ public class AlterationMyBatisRepositoryTest {
     @Test
     public void getSampleAlterationCountsReturnsZeroForMutationsAndCnaSelectorsInNone() {
 
-        mutationEventTypes = Select.none();
-        cnaEventTypes = Select.none();
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        alterationFilter.setIncludeGermline(true);
+        alterationFilter.setIncludeSomatic(true);
+        alterationFilter.setIncludeUnknownStatus(true);
+        alterationFilter.setCnaTypeSelect(Select.none());
+        alterationFilter.setSelectedMutationTypes(Select.none());
         List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
-            sampleIdToProfileId, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
 
         Assert.assertEquals(0, result.size());
     }
@@ -254,10 +333,19 @@ public class AlterationMyBatisRepositoryTest {
     @Test
     public void getSampleAlterationCountsReturnsAllForMutationsAndCnaSelectorsInAll() {
 
-        mutationEventTypes = Select.all();
-        cnaEventTypes = Select.all();
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        alterationFilter.setIncludeGermline(true);
+        alterationFilter.setIncludeSomatic(true);
+        alterationFilter.setIncludeUnknownStatus(true);
+        alterationFilter.setCnaTypeSelect(Select.all());
+        alterationFilter.setSelectedMutationTypes(Select.all());
         List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
-            sampleIdToProfileId, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
 
         Assert.assertEquals(3, result.size());
     }
@@ -265,178 +353,630 @@ public class AlterationMyBatisRepositoryTest {
     @Test(expected = IllegalArgumentException.class)
     public void disallowMutationTypesAndFusionSearchSamples() throws Exception {
         alterationMyBatisRepository.getSampleAlterationCounts(
-            sampleIdToProfileId, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.ACTIVE);
+            sampleIdToProfileId, entrezGeneIds, QueryElement.ACTIVE,
+            alterationFilter);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void disallowMutationTypesAndMutationSearchSamples() throws Exception {
         alterationMyBatisRepository.getSampleAlterationCounts(
-            sampleIdToProfileId, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.INACTIVE);
+            sampleIdToProfileId, entrezGeneIds, QueryElement.INACTIVE, alterationFilter);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void disallowMutationTypesAndFusionSearchPatients() throws Exception {
         alterationMyBatisRepository.getPatientAlterationCounts(
-            sampleIdToProfileId, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.ACTIVE);
+            sampleIdToProfileId, entrezGeneIds, QueryElement.ACTIVE, alterationFilter);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void disallowMutationTypesAndMutationSearchPatients() throws Exception {
         alterationMyBatisRepository.getPatientAlterationCounts(
-            sampleIdToProfileId, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.INACTIVE);
+            sampleIdToProfileId, entrezGeneIds, QueryElement.INACTIVE, alterationFilter);
     }
 
     @Test
     public void getSampleCountNullIds() throws Exception {
         List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
-            null, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            null, entrezGeneIds, QueryElement.PASS, new AlterationFilter());
         Assert.assertEquals(0, result.size());
-    }
-
-    @Test
-    public void getSampleCountNullMutations() throws Exception {
-        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
-            sampleIdToProfileId, entrezGeneIds, null, cnaEventTypes, QueryElement.PASS);
-        Assert.assertEquals(2, result.size());
-    }
-
-    @Test
-    public void getSampleCountNullCnas() throws Exception {
-        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
-            sampleIdToProfileId, entrezGeneIds, mutationEventTypes, null, QueryElement.PASS);
-        Assert.assertEquals(3, result.size());
     }
 
     @Test
     public void getPatientCountNullIds() throws Exception {
         List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
-            null, entrezGeneIds, mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            null, entrezGeneIds, QueryElement.PASS, new AlterationFilter());
         Assert.assertEquals(0, result.size());
-    }
-
-    @Test
-    public void getPatientCountNullMutations() throws Exception {
-        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
-            patientIdToProfileId, entrezGeneIds, null, cnaEventTypes, QueryElement.PASS);
-        Assert.assertEquals(2, result.size());
-    }
-
-    @Test
-    public void getPatientCountNullCnas() throws Exception {
-        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
-            patientIdToProfileId, entrezGeneIds, mutationEventTypes, null, QueryElement.PASS);
-        Assert.assertEquals(3, result.size());
     }
 
     @Test
     public void getSampleCnaCountNullIds() throws Exception {
         List<CopyNumberCountByGene> result = alterationMyBatisRepository.getSampleCnaCounts(
-            null, entrezGeneIds, cnaEventTypes);
+            null, entrezGeneIds, new AlterationFilter());
         Assert.assertEquals(0, result.size());
     }
 
     @Test
-    public void getSampleCnaCountNullCnas() throws Exception {
-        List<CopyNumberCountByGene> result = alterationMyBatisRepository.getSampleCnaCounts(
-            sampleIdToProfileId, entrezGeneIds, null);
+    public void getSampleCountIncludeOnlyDriver() throws Exception {
+
+        alterationFilter.setIncludeDriver(true);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(2, result.size());
+        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        Assert.assertEquals((Integer) 3, result672.getTotalCount());
+        Assert.assertEquals((Integer) 3, result672.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 2, result207.getTotalCount());
+        Assert.assertEquals((Integer) 1, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getSampleCountIncludeOnlyVus() throws Exception {
+
+        alterationFilter.setIncludeVUS(true);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(3, result.size());
+        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 2, result672.getTotalCount());
+        Assert.assertEquals((Integer) 2, result672.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 2, result207.getTotalCount());
+        Assert.assertEquals((Integer) 1, result207.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 1, result208.getTotalCount());
+        Assert.assertEquals((Integer) 1, result208.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getSampleCountIncludeOnlyUnknownOncogenicity() throws Exception {
+
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 1, result208.getTotalCount());
+        Assert.assertEquals((Integer) 1, result208.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getSampleCountIncludeAnyAndUnknownAnnotation() throws Exception {
+
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(3, result.size());
+        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 5, result672.getTotalCount());
+        Assert.assertEquals((Integer) 4, result672.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 2, result208.getTotalCount());
+        Assert.assertEquals((Integer) 2, result208.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 4, result207.getTotalCount());
+        Assert.assertEquals((Integer) 2, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getSampleCountIncludeOnlyTiers() throws Exception {
+
+        // All 'Tier 2' tiers are forced to be interpreted as driver events
+        alterationFilter.setSelectedTiers(Select.byValues(Arrays.asList("Tier 2")));
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(2, result.size());
+        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        Assert.assertEquals((Integer) 2, result672.getTotalCount());
+        Assert.assertEquals((Integer) 2, result672.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 2, result207.getTotalCount());
+        Assert.assertEquals((Integer) 1, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getSampleCountIncludeAnyAndUnknownTiers() throws Exception {
+
+        alterationFilter.setSelectedTiers(Select.all());
+        alterationFilter.setIncludeUnknownTier(true);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(3, result.size());
+        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 5, result672.getTotalCount());
+        Assert.assertEquals((Integer) 4, result672.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 2, result208.getTotalCount());
+        Assert.assertEquals((Integer) 2, result208.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 4, result207.getTotalCount());
+        Assert.assertEquals((Integer) 2, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getSampleCountIncludeAllTiers() throws Exception {
+
+        alterationFilter.setSelectedTiers(Select.all());
+        alterationFilter.setIncludeUnknownTier(true);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(3, result.size());
+        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 5, result672.getTotalCount());
+        Assert.assertEquals((Integer) 4, result672.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 2, result208.getTotalCount());
+        Assert.assertEquals((Integer) 2, result208.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 4, result207.getTotalCount());
+        Assert.assertEquals((Integer) 2, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getSampleCountIncludeUnknownTier() throws Exception {
+
+        alterationFilter.setIncludeUnknownTier(true);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
+            sampleIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 1, result208.getTotalCount());
+        Assert.assertEquals((Integer) 1, result208.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getPatientMutationAndCnaCount() throws Exception {
+
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        alterationFilter.setIncludeGermline(true);
+        alterationFilter.setIncludeSomatic(true);
+        alterationFilter.setIncludeUnknownStatus(true);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
+            patientIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        // For testSql.sql there are no more samples per patient for the investigated genes.
+        // Therefore, patient level counts are the same as the sample level counts.
+        Assert.assertEquals(3, result.size());
+        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 5, result672.getTotalCount());
+        Assert.assertEquals((Integer) 4, result672.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 4, result207.getTotalCount());
+        Assert.assertEquals((Integer) 2, result207.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 2, result208.getTotalCount());
+        Assert.assertEquals((Integer) 2, result208.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getPatientMutationCountIncludeOnlyGermline() throws Exception {
+
+        alterationFilter.setIncludeGermline(true);
+        alterationFilter.setCnaTypeSelect(Select.none());
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
+            patientIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+        // all mutations in testSql.sql are Germline mutations
+        Assert.assertEquals(3, result.size());
+        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 5, result672.getTotalCount());
+        Assert.assertEquals((Integer) 4, result672.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 2, result207.getTotalCount());
+        Assert.assertEquals((Integer) 2, result207.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 1, result208.getTotalCount());
+        Assert.assertEquals((Integer) 1, result208.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getPatientMutationCountIncludeOnlySomatic() throws Exception {
+
+        alterationFilter.setIncludeSomatic(true);
+        alterationFilter.setCnaTypeSelect(Select.none());
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
+            patientIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+        // all mutations in testSql.sql are Germline mutations
         Assert.assertEquals(0, result.size());
     }
+
+    @Test
+    public void getPatientMutationCountIncludeOnlyUnknownStatus() throws Exception {
+
+        alterationFilter.setIncludeUnknownStatus(true);
+        alterationFilter.setCnaTypeSelect(Select.none());
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
+            patientIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+        // all mutations in testSql.sql are Germline mutations
+        Assert.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void getPatientCountIncludeAnyAndUnknowStatus() throws Exception {
+
+        alterationFilter.setIncludeGermline(true);
+        alterationFilter.setIncludeSomatic(true);
+        alterationFilter.setIncludeUnknownStatus(true);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
+            patientIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(3, result.size());
+        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 5, result672.getTotalCount());
+        Assert.assertEquals((Integer) 4, result672.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 2, result208.getTotalCount());
+        Assert.assertEquals((Integer) 2, result208.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 4, result207.getTotalCount());
+        Assert.assertEquals((Integer) 2, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getPatientMutationCountFilterFusions() throws Exception {
+
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        alterationFilter.setIncludeGermline(true);
+        alterationFilter.setIncludeSomatic(true);
+        alterationFilter.setIncludeUnknownStatus(true);
+        alterationFilter.setCnaTypeSelect(Select.none());
+        alterationFilter.setSelectedMutationTypes(Select.all());
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
+            patientIdToProfileId,
+            entrezGeneIds,
+            QueryElement.ACTIVE,
+            alterationFilter);
+        // there are no fusion mutations in the test db
+        Assert.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void getPatientCountIncludeOnlyDriver() throws Exception {
+
+        alterationFilter.setIncludeDriver(true);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
+            patientIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(2, result.size());
+        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        Assert.assertEquals((Integer) 3, result672.getTotalCount());
+        Assert.assertEquals((Integer) 3, result672.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 2, result207.getTotalCount());
+        Assert.assertEquals((Integer) 1, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getPatientCountIncludeOnlyVUS() throws Exception {
+
+        alterationFilter.setIncludeVUS(true);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
+            patientIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(3, result.size());
+        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 2, result672.getTotalCount());
+        Assert.assertEquals((Integer) 2, result672.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 2, result207.getTotalCount());
+        Assert.assertEquals((Integer) 1, result207.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 1, result208.getTotalCount());
+        Assert.assertEquals((Integer) 1, result208.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getPatientCountIncludeOnlyTiers() throws Exception {
+
+        // All 'Tier 2' tiers are forced to be interpreted as driver events
+        alterationFilter.setSelectedTiers( Select.byValues(Arrays.asList("Tier 2")));
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
+            patientIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(2, result.size());
+        AlterationCountByGene result672 = result.stream().filter(r -> r.getEntrezGeneId() == 672).findFirst().get();
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        Assert.assertEquals((Integer) 2, result672.getTotalCount());
+        Assert.assertEquals((Integer) 2, result672.getNumberOfAlteredCases());
+        Assert.assertEquals((Integer) 2, result207.getTotalCount());
+        Assert.assertEquals((Integer) 1, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getPatientCountIncludeUnknownTier() throws Exception {
+
+        alterationFilter.setIncludeUnknownTier(true);
+        List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
+            patientIdToProfileId,
+            entrezGeneIds,
+            QueryElement.PASS,
+            alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 1, result208.getTotalCount());
+        Assert.assertEquals((Integer) 1, result208.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getSampleCnaCountLegacyOnlyDriver() throws Exception {
+
+        alterationFilter.setIncludeDriver(true);
+        List<CopyNumberCountByGene> result = alterationMyBatisRepository.getSampleCnaCounts(sampleIdToProfileId, entrezGeneIds, alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        Assert.assertEquals((Integer) 1, result207.getTotalCount());
+        Assert.assertEquals((Integer) 1, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getSampleCnaCountLegacyOnlyVUS() throws Exception {
+
+        alterationFilter.setIncludeVUS(true);
+        List<CopyNumberCountByGene> result = alterationMyBatisRepository.getSampleCnaCounts(sampleIdToProfileId, entrezGeneIds, alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        Assert.assertEquals((Integer) 1, result207.getTotalCount());
+        Assert.assertEquals((Integer) 1, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getSampleCnaCountLegacyOnlyUnknownOncogenicity() throws Exception {
+
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        List<CopyNumberCountByGene> result = alterationMyBatisRepository.getSampleCnaCounts(
+            sampleIdToProfileId, entrezGeneIds, alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 1, result208.getTotalCount());
+        Assert.assertEquals((Integer) 1, result208.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getSampleCnaCountLegacyOnlyUnknownTier() throws Exception {
+
+        alterationFilter.setIncludeUnknownTier(true);
+        List<CopyNumberCountByGene> result = alterationMyBatisRepository.getSampleCnaCounts(
+            sampleIdToProfileId, entrezGeneIds, alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 1, result208.getTotalCount());
+        Assert.assertEquals((Integer) 1, result208.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getSampleCnaCountLegacyOnlyTier2() throws Exception {
+
+        alterationFilter.setSelectedTiers( Select.byValues(Arrays.asList("Tier 2")));
+        List<CopyNumberCountByGene> result = alterationMyBatisRepository.getSampleCnaCounts(
+            sampleIdToProfileId, entrezGeneIds, alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        Assert.assertEquals((Integer) 1, result207.getTotalCount());
+        Assert.assertEquals((Integer) 1, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getPatientCnaCountLegacyOnlyDriver() throws Exception {
+
+        alterationFilter.setIncludeDriver(true);
+        List<CopyNumberCountByGene> result = alterationMyBatisRepository.getPatientCnaCounts(
+            patientIdToProfileId, entrezGeneIds, alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        Assert.assertEquals((Integer) 1, result207.getTotalCount());
+        Assert.assertEquals((Integer) 1, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getPatientCnaCountLegacyOnlyVUS() throws Exception {
+
+        alterationFilter.setIncludeVUS(true);
+        List<CopyNumberCountByGene> result = alterationMyBatisRepository.getPatientCnaCounts(
+            patientIdToProfileId, entrezGeneIds, alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        Assert.assertEquals((Integer) 1, result207.getTotalCount());
+        Assert.assertEquals((Integer) 1, result207.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getPatientCnaCountLegacyOnlyUnknownOncogenicity() throws Exception {
+
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        List<CopyNumberCountByGene> result = alterationMyBatisRepository.getPatientCnaCounts(
+            patientIdToProfileId, entrezGeneIds, alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 1, result208.getTotalCount());
+        Assert.assertEquals((Integer) 1, result208.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getPatientCnaCountLegacyOnlyUnknownTier() throws Exception {
+
+        alterationFilter.setIncludeUnknownTier(true);
+        List<CopyNumberCountByGene> result = alterationMyBatisRepository.getPatientCnaCounts(
+            patientIdToProfileId, entrezGeneIds, alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result208 = result.stream().filter(r -> r.getEntrezGeneId() == 208).findFirst().get();
+        Assert.assertEquals((Integer) 1, result208.getTotalCount());
+        Assert.assertEquals((Integer) 1, result208.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getPatientCnaCountLegacyOnlyTier2() throws Exception {
+
+        alterationFilter.setSelectedTiers( Select.byValues(Arrays.asList("Tier 2")));
+        List<CopyNumberCountByGene> result = alterationMyBatisRepository.getPatientCnaCounts(
+            patientIdToProfileId, entrezGeneIds, alterationFilter);
+
+        Assert.assertEquals(1, result.size());
+        AlterationCountByGene result207 = result.stream().filter(r -> r.getEntrezGeneId() == 207).findFirst().get();
+        Assert.assertEquals((Integer) 1, result207.getTotalCount());
+        Assert.assertEquals((Integer) 1, result207.getNumberOfAlteredCases());
+    }
+
 
     @Test
     public void getPatientCnaCountNullIds() throws Exception {
         List<CopyNumberCountByGene> result = alterationMyBatisRepository.getPatientCnaCounts(
-            null, entrezGeneIds, cnaEventTypes);
-        Assert.assertEquals(0, result.size());
-    }
-
-    @Test
-    public void getPatientCnaCountNullCnas() throws Exception {
-        List<CopyNumberCountByGene> result = alterationMyBatisRepository.getPatientCnaCounts(
-            patientIdToProfileId, entrezGeneIds, null);
+            null, entrezGeneIds, new AlterationFilter());
         Assert.assertEquals(0, result.size());
     }
     
     @Test
     public void getSampleCountNullEntrezGeneIds() throws Exception {
         List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
-            sampleIdToProfileId, null, mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            sampleIdToProfileId, null, QueryElement.PASS, new AlterationFilter());
         Assert.assertEquals(0, result.size());
     }
     
     @Test
     public void getSampleCountEmptyEntrezGeneIds() throws Exception {
         List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
-            sampleIdToProfileId, Select.none(), mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            sampleIdToProfileId, Select.none(), QueryElement.PASS, new AlterationFilter());
         Assert.assertEquals(0, result.size());
     }
     
     @Test
     public void getSampleCountAllEntrezGeneIds() throws Exception {
         List<AlterationCountByGene> result = alterationMyBatisRepository.getSampleAlterationCounts(
-            sampleIdToProfileId, Select.all(), mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            sampleIdToProfileId, Select.all(), QueryElement.PASS, new AlterationFilter());
         Assert.assertEquals(3, result.size());
     }
 
     @Test
     public void getPatientCountNullEntrezGeneIds() throws Exception {
         List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
-            patientIdToProfileId, null, mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            patientIdToProfileId, null, QueryElement.PASS, new AlterationFilter());
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getPatientCountEmptyEntrezGeneIds() throws Exception {
         List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
-            patientIdToProfileId, Select.none(), mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            patientIdToProfileId, Select.none(), QueryElement.PASS, new AlterationFilter());
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getPatientCountAllEntrezGeneIds() throws Exception {
         List<AlterationCountByGene> result = alterationMyBatisRepository.getPatientAlterationCounts(
-            patientIdToProfileId, Select.all(), mutationEventTypes, cnaEventTypes, QueryElement.PASS);
+            patientIdToProfileId, Select.all(), QueryElement.PASS, new AlterationFilter());
         Assert.assertEquals(3, result.size());
     }
 
     @Test
     public void getSampleCnaCountNullEntrezGeneIds() throws Exception {
         List<CopyNumberCountByGene> result = alterationMyBatisRepository.getSampleCnaCounts(
-            sampleIdToProfileId, null, cnaEventTypes);
+            sampleIdToProfileId, null, new AlterationFilter());
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getSampleCnaCountEmptyEntrezGeneIds() throws Exception {
         List<CopyNumberCountByGene> result = alterationMyBatisRepository.getSampleCnaCounts(
-            sampleIdToProfileId, Select.none(), cnaEventTypes);
+            sampleIdToProfileId, Select.none(), new AlterationFilter());
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getSampleCnaCountAllEntrezGeneIds() throws Exception {
         List<CopyNumberCountByGene> result = alterationMyBatisRepository.getSampleCnaCounts(
-            sampleIdToProfileId, Select.all(), cnaEventTypes);
+            sampleIdToProfileId, Select.all(), new AlterationFilter());
         Assert.assertEquals(3, result.size());
     }
 
     @Test
     public void getPatientCnaCountNullEntrezGeneIds() throws Exception {
         List<CopyNumberCountByGene> result = alterationMyBatisRepository.getPatientCnaCounts(
-            patientIdToProfileId, null, cnaEventTypes);
+            patientIdToProfileId, null, new AlterationFilter());
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getPatientCnaCountEmptyEntrezGeneIds() throws Exception {
         List<CopyNumberCountByGene> result = alterationMyBatisRepository.getPatientCnaCounts(
-            patientIdToProfileId, Select.none(), cnaEventTypes);
+            patientIdToProfileId, Select.none(), new AlterationFilter());
         Assert.assertEquals(0, result.size());
     }
 
     @Test
     public void getPatientCnaCountAllEntrezGeneIds() throws Exception {
         List<CopyNumberCountByGene> result = alterationMyBatisRepository.getPatientCnaCounts(
-            patientIdToProfileId, Select.all(), cnaEventTypes);
+            patientIdToProfileId, Select.all(), new AlterationFilter());
         Assert.assertEquals(3, result.size());
     }
     

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/DiscreteCopyNumberMyBatisRepositoryTest.java
@@ -1,11 +1,15 @@
 package org.cbioportal.persistence.mybatis;
 
+import org.cbioportal.model.CNA;
 import org.cbioportal.model.CopyNumberCountByGene;
 import org.cbioportal.model.DiscreteCopyNumberData;
 import org.cbioportal.model.Gene;
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.ReferenceGenomeGene;
 import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.model.util.Select;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,18 +17,63 @@ import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/testContextDatabase.xml")
 @Configurable
 public class DiscreteCopyNumberMyBatisRepositoryTest {
 
+    //    mutation and cna events in testSql.sql
+    //        SAMPLE_ID, ENTREZ_GENE_ID, HUGO_GENE_SYMBOL, GENETIC_PROFILE_ID, TYPE, MUTATION_TYPE, DRIVER_FILTER, DRIVER_TIERS_FILTER, PATIENT_ID, MUTATION_TYPE
+    //        1	    207	AKT1	2	CNA         -2	                Putative_Driver	    Tier 1  TCGA-A1-A0SB    germline
+    //        2	    207	AKT1	2	CNA         2	                Putative_Passenger	Tier 2  TCGA-A1-A0SD    germline
+    //        1	    207	AKT1	6	MUTATION    Nonsense_Mutation	Putative_Driver	    Tier 1  TCGA-A1-A0SB    germline
+    //        2	    207	AKT1	6	MUTATION    Missense_Mutation	Putative_Passenger	Tier 2  TCGA-A1-A0SD    germline
+    //        1	    208	AKT2	2	CNA         2		            <null>              <null>  TCGA-A1-A0SB    germline
+    //        3	    208	AKT2	6	MUTATION    Splice_Site	        Putative_Passenger	Tier 1  TCGA-A1-A0SE    germline
+    //        6	    672	BRCA1	6	MUTATION    Missense_Mutation	Putative_Passenger	Tier 2  TCGA-A1-A0SH    germline
+    //        6	    672	BRCA1	6	MUTATION    Nonsense_Mutation	Putative_Driver	    Tier 1  TCGA-A1-A0SH    germline
+    //        7	    672	BRCA1	6	MUTATION    Nonsense_Mutation	Putative_Driver	    Tier 2  TCGA-A1-A0SI    germline
+    //        12	672	BRCA1	6	MUTATION    Splice_Site	        Putative_Passenger	Tier 1  TCGA-A1-A0SO    germline
+    //        13	672	BRCA1	6	MUTATION    Splice_Site	        Putative_Driver	    Tier 1  TCGA-A1-A0SP    germline
+
     @Autowired
     private DiscreteCopyNumberMyBatisRepository discreteCopyNumberMyBatisRepository;
     
     @Autowired
     private ReferenceGenomeGeneMyBatisRepository refGeneMyBatisRepository;
+
+    @Before
+    public void init() {
+        molecularProfileIds = new ArrayList<>();
+        molecularProfileIds.add("study_tcga_pub_gistic");
+        molecularProfileIds.add("study_tcga_pub_gistic");
+        sampleIds = new ArrayList<>();
+        sampleIds.add("TCGA-A1-A0SB-01");
+        sampleIds.add("TCGA-A1-A0SD-01");
+        tiers = Select.none();
+        includeUnknownTier = false;
+        includeDriver = false;
+        includeVUS = false;
+        includeUnknownOncogenicity = false;
+        includeGermline = false;
+        includeSomatic = false;
+        
+    }
+
+    List<String> molecularProfileIds = new ArrayList<>();
+    List<String> sampleIds = new ArrayList<>();
+    Select<String> tiers = Select.none();
+    boolean includeUnknownTier = false;
+    boolean includeDriver = false;
+    boolean includeVUS = false;
+    boolean includeUnknownOncogenicity = false;
+    boolean includeGermline = false;
+    boolean includeSomatic = false;
     
     @Test
     public void getDiscreteCopyNumbersInMolecularProfileBySampleListIdSummaryProjection() throws Exception {
@@ -197,6 +246,190 @@ public class DiscreteCopyNumberMyBatisRepositoryTest {
         Assert.assertEquals((Integer) 208, copyNumberSampleCountByGene2.getEntrezGeneId());
         Assert.assertEquals((Integer) (2), copyNumberSampleCountByGene2.getAlteration());
         Assert.assertEquals((Integer) 1, copyNumberSampleCountByGene2.getNumberOfAlteredCases());
+    }
+
+    @Test
+    public void getDiscreteCopyNumbersInMultipleMolecularProfiles() throws Exception {
+
+        List<String> molecularProfileIds = new ArrayList<>();
+        molecularProfileIds.add("study_tcga_pub_gistic");
+
+        List<String> sampleIds = new ArrayList<>();
+        sampleIds.add("TCGA-A1-A0SB-01");
+        sampleIds.add("TCGA-A1-A0SD-01");
+
+        List<Integer> alterationTypes = Arrays.asList(new Integer[]{2, -2});
+
+        List<DiscreteCopyNumberData> result = discreteCopyNumberMyBatisRepository.getDiscreteCopyNumbersInMultipleMolecularProfiles(
+            molecularProfileIds, sampleIds, null, alterationTypes, "SUMMARY");
+
+        Assert.assertEquals(3, result.size());
+        DiscreteCopyNumberData cna1 = result.get(0);
+        Assert.assertEquals("study_tcga_pub_gistic", cna1.getMolecularProfileId());
+        Assert.assertEquals("TCGA-A1-A0SB-01", cna1.getSampleId());
+        DiscreteCopyNumberData cna2 = result.get(1);
+        Assert.assertEquals("study_tcga_pub_gistic", cna2.getMolecularProfileId());
+        Assert.assertEquals("TCGA-A1-A0SB-01", cna2.getSampleId());
+        DiscreteCopyNumberData cna3 = result.get(2);
+        Assert.assertEquals("study_tcga_pub_gistic", cna3.getMolecularProfileId());
+        Assert.assertEquals("TCGA-A1-A0SD-01", cna3.getSampleId());
+    }
+    
+    @Test
+    public void getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries() throws Exception {
+
+        boolean includeDriver = true;
+        boolean includeVUS = true;
+        boolean includeUnknownOncogenicity = true;
+        List<CNA> cnas = Arrays.asList(CNA.AMP, CNA.HETLOSS);
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("AKT1", 207, cnas, includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT2", 208, cnas, includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2);
+        
+        List<DiscreteCopyNumberData> result = discreteCopyNumberMyBatisRepository.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
+            molecularProfileIds, sampleIds, geneQueries,"SUMMARY");
+
+        Assert.assertEquals(3, result.size());
+        assert(result.stream().allMatch(r -> r.getMolecularProfileId().equals("study_tcga_pub_gistic")));
+        List<String> expectedSampleIds = Arrays.asList("TCGA-A1-A0SB-01", "TCGA-A1-A0SD-01");
+        assert(result.stream().allMatch(r -> expectedSampleIds.contains(r.getSampleId())));
+    }
+    
+    @Test
+    public void getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueriesInlcudeOnlyDriver() throws Exception {
+
+        boolean includeDriver = true;
+        List<CNA> cnas = Arrays.asList(CNA.AMP, CNA.HETLOSS);
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("AKT1", 207, cnas, includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT2", 208, cnas, includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2);
+
+        List<DiscreteCopyNumberData> result = discreteCopyNumberMyBatisRepository.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
+            molecularProfileIds, sampleIds, geneQueries,"SUMMARY");
+
+        Assert.assertEquals(1, result.size());
+        assert(result.stream().allMatch(r -> r.getMolecularProfileId().equals("study_tcga_pub_gistic")));
+        List<String> expectedSampleIds = Arrays.asList("TCGA-A1-A0SB-01");
+        assert(result.stream().allMatch(r -> expectedSampleIds.contains(r.getSampleId())));
+    }
+    
+    @Test
+    public void getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueriesInlcudeOnlyVus() throws Exception {
+
+        boolean includeVUS = true;
+        List<CNA> cnas = Arrays.asList(CNA.AMP, CNA.HETLOSS);
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("AKT1", 207, cnas, includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT2", 208, cnas, includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2);
+
+        List<DiscreteCopyNumberData> result = discreteCopyNumberMyBatisRepository.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
+            molecularProfileIds, sampleIds, geneQueries,"SUMMARY");
+
+        Assert.assertEquals(1, result.size());
+        assert(result.stream().allMatch(r -> r.getMolecularProfileId().equals("study_tcga_pub_gistic")));
+        List<String> expectedSampleIds = Arrays.asList("TCGA-A1-A0SD-01");
+        assert(result.stream().allMatch(r -> expectedSampleIds.contains(r.getSampleId())));
+    }
+    
+    @Test
+    public void getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueriesInlcudeOnlyUnknownOncogenicity() throws Exception {
+
+        boolean includeUnknownOncogenicity = true;
+        List<CNA> cnas = Arrays.asList(CNA.AMP, CNA.HETLOSS);
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("AKT1", 207, cnas, includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT2", 208, cnas, includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2);
+
+        List<DiscreteCopyNumberData> result = discreteCopyNumberMyBatisRepository.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
+            molecularProfileIds, sampleIds, geneQueries,"SUMMARY");
+
+        Assert.assertEquals(1, result.size());
+        assert(result.stream().allMatch(r -> r.getMolecularProfileId().equals("study_tcga_pub_gistic")));
+        List<String> expectedSampleIds = Arrays.asList("TCGA-A1-A0SB-01");
+        assert(result.stream().allMatch(r -> expectedSampleIds.contains(r.getSampleId())));
+    }
+
+    @Test
+    public void getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueriesIncludeAnyAnnotation() throws Exception {
+
+        boolean includeDriver = true;
+        boolean includeVUS = true;
+        boolean includeUnknownOncogenicity = true;
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<DiscreteCopyNumberData> result = discreteCopyNumberMyBatisRepository.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY");
+
+        Assert.assertEquals(3, result.size());
+    }
+
+    @Test
+    public void getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueriesFilterTiers() throws Exception {
+        
+        Select<String> tiers = Select.byValues(Arrays.asList("Tier 2"));
+        List<CNA> cnas = Arrays.asList(CNA.AMP, CNA.HETLOSS);
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("AKT1", 207, cnas, includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT2", 208, cnas, includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2);
+
+        List<DiscreteCopyNumberData> result = discreteCopyNumberMyBatisRepository.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
+            molecularProfileIds, sampleIds, geneQueries,"SUMMARY");
+
+        Assert.assertEquals(1, result.size());
+        assert(result.stream().allMatch(r -> r.getMolecularProfileId().equals("study_tcga_pub_gistic")));
+        List<String> expectedSampleIds = Arrays.asList("TCGA-A1-A0SD-01");
+        assert(result.stream().allMatch(r -> expectedSampleIds.contains(r.getSampleId())));
+    }
+
+    @Test
+    public void getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueriesFilterUnknownTier() throws Exception {
+
+        includeUnknownTier = true;
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, false, false, false);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<DiscreteCopyNumberData> result = discreteCopyNumberMyBatisRepository.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY");
+
+        Assert.assertEquals(1, result.size());
+        List<String> expectedSampleIds = Arrays.asList("TCGA-A1-A0SB-01");
+        assert(result.stream().allMatch(r -> expectedSampleIds.contains(r.getSampleId())));
+    }
+
+    @Test
+    public void getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueriesMixed() throws Exception {
+
+        List<CNA> cnas = Arrays.asList(CNA.AMP, CNA.HETLOSS);
+        Select<String> tiers = Select.byValues(Arrays.asList("Tier 2"));
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("AKT1", 207, cnas, false, false, false, tiers, false, false, false, false);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT2", 208, cnas, false, false, true, Select.none(), false, false, false, false);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2);
+
+        List<DiscreteCopyNumberData> result = discreteCopyNumberMyBatisRepository.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
+            molecularProfileIds, sampleIds, geneQueries,"SUMMARY");
+
+        Assert.assertEquals(2, result.size());
+        assert(result.stream().allMatch(r -> r.getMolecularProfileId().equals("study_tcga_pub_gistic")));
+        List<String> expectedSampleIds = Arrays.asList("TCGA-A1-A0SB-01", "TCGA-A1-A0SD-01");
+        assert(result.stream().allMatch(r -> expectedSampleIds.contains(r.getSampleId())));
     }
 
 }

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepositoryTest.java
@@ -1,9 +1,10 @@
 package org.cbioportal.persistence.mybatis;
 
 import org.cbioportal.model.*;
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.meta.MutationMeta;
-import org.junit.Assert;
-import org.junit.Test;
+import org.cbioportal.model.util.Select;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
@@ -19,8 +20,63 @@ import java.util.List;
 @Configurable
 public class MutationMyBatisRepositoryTest {
 
+    //    mutation and cna events in testSql.sql
+    //        SAMPLE_ID, ENTREZ_GENE_ID, HUGO_GENE_SYMBOL, GENETIC_PROFILE_ID, TYPE, MUTATION_TYPE, DRIVER_FILTER, DRIVER_TIERS_FILTER, PATIENT_ID, MUTATION_TYPE
+    //        1	    207	AKT1	2	CNA         -2	                Putative_Driver	    Tier 1  TCGA-A1-A0SB    germline
+    //        2	    207	AKT1	2	CNA         2	                Putative_Passenger	Tier 2  TCGA-A1-A0SD    germline
+    //        1	    207	AKT1	6	MUTATION    Nonsense_Mutation	Putative_Driver	    Tier 1  TCGA-A1-A0SB    germline
+    //        2	    207	AKT1	6	MUTATION    Missense_Mutation	Putative_Passenger	Tier 2  TCGA-A1-A0SD    germline
+    //        1	    208	AKT2	2	CNA         2		            <null>              <null>  TCGA-A1-A0SB    germline
+    //        3	    208	AKT2	6	MUTATION    Splice_Site	        Putative_Passenger	Tier 1  TCGA-A1-A0SE    germline
+    //        6	    672	BRCA1	6	MUTATION    Missense_Mutation	Putative_Passenger	Tier 2  TCGA-A1-A0SH    germline
+    //        6	    672	BRCA1	6	MUTATION    Nonsense_Mutation	Putative_Driver	    Tier 1  TCGA-A1-A0SH    germline
+    //        7	    672	BRCA1	6	MUTATION    Nonsense_Mutation	Putative_Driver	    Tier 2  TCGA-A1-A0SI    germline
+    //        12	672	BRCA1	6	MUTATION    Splice_Site	        Putative_Passenger	Tier 1  TCGA-A1-A0SO    germline
+    //        13	672	BRCA1	6	MUTATION    Splice_Site	        Putative_Driver	    Tier 1  TCGA-A1-A0SP    germline
+        
     @Autowired
     private MutationMyBatisRepository mutationMyBatisRepository;
+
+    @Before
+    public void init() {
+        molecularProfileIds = new ArrayList<>();
+        molecularProfileIds.add("study_tcga_pub_mutations");
+        molecularProfileIds.add("study_tcga_pub_mutations");
+        molecularProfileIds.add("study_tcga_pub_mutations");
+        molecularProfileIds.add("study_tcga_pub_mutations");
+        molecularProfileIds.add("study_tcga_pub_mutations");
+        molecularProfileIds.add("study_tcga_pub_mutations");
+        molecularProfileIds.add("study_tcga_pub_mutations");
+        molecularProfileIds.add("study_tcga_pub_mutations");
+        sampleIds = new ArrayList<>();
+        sampleIds.add("TCGA-A1-B0SO-01");
+        sampleIds.add("TCGA-A1-A0SB-01");
+        sampleIds.add("TCGA-A1-A0SD-01");
+        sampleIds.add("TCGA-A1-A0SE-01");
+        sampleIds.add("TCGA-A1-A0SH-01");
+        sampleIds.add("TCGA-A1-A0SI-01");
+        sampleIds.add("TCGA-A1-A0SO-01");
+        sampleIds.add("TCGA-A1-A0SP-01");
+        tiers = Select.none();
+        includeUnknownTier = false;
+        includeDriver = false;
+        includeVUS = false;
+        includeUnknownOncogenicity = false;
+        includeGermline = false;
+        includeSomatic = false;
+        includeUnknownOncogenicity = false;
+    }
+
+    List<String> molecularProfileIds = new ArrayList<>();
+    List<String> sampleIds = new ArrayList<>();
+    Select<String> tiers = Select.none();
+    boolean includeUnknownTier = false;
+    boolean includeDriver = false;
+    boolean includeVUS = false;
+    boolean includeUnknownOncogenicity = false;
+    boolean includeGermline = false;
+    boolean includeSomatic = false;
+    boolean includeUnknownStatus = false;
 
     @Test
     public void getMutationsInMolecularProfileBySampleListIdIdProjection() throws Exception {
@@ -239,6 +295,248 @@ public class MutationMyBatisRepositoryTest {
         Mutation mutation3 = result.get(0);
         Assert.assertEquals("acc_tcga_mutations", mutation3.getMolecularProfileId());
         Assert.assertEquals("TCGA-A1-B0SO-01", mutation3.getSampleId());
+    }
+    
+    @Test
+    public void getMutationsInMultipleMolecularProfilesByGeneQueries() throws Exception {
+
+        boolean includeDriver = true;
+        boolean includeVUS = true;
+        boolean includeUnknownOncogenicity = true;
+        boolean includeGermline = true;
+        boolean includeSomatic = true;
+        boolean includeUnknownStatus = true;
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<Mutation> result = mutationMyBatisRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY", null, null, null, null);
+
+        Assert.assertEquals(8, result.size());
+    }
+
+    @Test
+    public void getMutationsInMultipleMolecularProfilesByGeneQueriesIncludeOnlyGermline() throws Exception {
+
+        boolean includeGermline = true;
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<Mutation> result = mutationMyBatisRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY", null, null, null, null);
+        
+        Assert.assertEquals(8, result.size());
+    }
+    
+    @Test
+    public void getMutationsInMultipleMolecularProfilesByGeneQueriesIncludeOnlySomatic() throws Exception {
+
+        boolean includeSomatic = true;
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<Mutation> result = mutationMyBatisRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY", null, null, null, null);
+        
+        Assert.assertEquals(0, result.size());
+    }
+    
+    @Test
+    public void getMutationsInMultipleMolecularProfilesByGeneQueriesIncludeOnlyUnknownStatus() throws Exception {
+
+        boolean includeUnknownStatus = true;
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<Mutation> result = mutationMyBatisRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY", null, null, null, null);
+        
+        Assert.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void getMutationsInMultipleMolecularProfilesByGeneQueriesIncludeAnyStatus() throws Exception {
+
+        boolean includeGermline = true;
+        boolean includeSomatic = true;
+        boolean includeUnknownStatus = true;
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<Mutation> result = mutationMyBatisRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY", null, null, null, null);
+
+        Assert.assertEquals(8, result.size());
+    }
+
+    @Test
+    public void getMutationsInMultipleMolecularProfilesByGeneQueriesIncludeOnlyDriver() throws Exception {
+        
+        boolean includeDriver = true;
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<Mutation> result = mutationMyBatisRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY", null, null, null, null);
+
+        Assert.assertEquals(4, result.size());
+        List<String> expectedSampleIds = Arrays.asList("TCGA-A1-A0SB-01", "TCGA-A1-A0SH-01", "TCGA-A1-A0SI-01", "TCGA-A1-A0SP-01");
+        assert(result.stream().allMatch(r -> expectedSampleIds.contains(r.getSampleId())));
+    }
+
+    @Test
+    public void getMutationsInMultipleMolecularProfilesByGeneQueriesIncludeOnlyVUS() throws Exception {
+
+        boolean includeVUS = true;
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<Mutation> result = mutationMyBatisRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY", null, null, null, null);
+
+        Assert.assertEquals(4, result.size());
+        List<String> expectedSampleIds = Arrays.asList("TCGA-A1-A0SD-01", "TCGA-A1-A0SE-01", "TCGA-A1-A0SH-01", "TCGA-A1-A0SO-01");
+        assert(result.stream().allMatch(r -> expectedSampleIds.contains(r.getSampleId())));
+    }
+    
+    @Test
+    public void getMutationsInMultipleMolecularProfilesByGeneQueriesIncludeOnlyUnknownOncogenicity() throws Exception {
+
+        boolean includeUnknownOncogenicity = true;
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<Mutation> result = mutationMyBatisRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY", null, null, null, null);
+
+        Assert.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void getMutationsInMultipleMolecularProfilesByGeneQueriesIncludeAnyAnnotation() throws Exception {
+
+        boolean includeDriver = true;
+        boolean includeVUS = true;
+        boolean includeUnknownOncogenicity = true;
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<Mutation> result = mutationMyBatisRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY", null, null, null, null);
+
+        Assert.assertEquals(8, result.size());
+    }
+
+    @Test
+    public void getMutationsInMultipleMolecularProfilesByGeneQueriesFilterTiers() throws Exception {
+
+        Select<String> tiers = Select.byValues(Arrays.asList("Tier 2"));
+        
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<Mutation> result = mutationMyBatisRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY", null, null, null, null);
+
+        Assert.assertEquals(3, result.size());
+        List<String> expectedSampleIds = Arrays.asList("TCGA-A1-A0SD-01", "TCGA-A1-A0SH-01", "TCGA-A1-A0SI-01");
+        assert(result.stream().allMatch(r -> expectedSampleIds.contains(r.getSampleId())));
+    }
+
+    @Test
+    public void getMutationsInMultipleMolecularProfilesByGeneQueriesMixed() throws Exception {
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("BRCA1", 672, null,
+            false, true, false, Select.none(), false, false, false, false);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("AKT1", 207, null,
+            false, false, false, Select.byValues(Arrays.asList("Tier 1")), false, false, false, false);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("AKT2", 208, null,
+            true, false, false, Select.none(), false, false, false, false);
+        List<GeneFilterQuery> geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+
+        List<Mutation> result = mutationMyBatisRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds,
+            sampleIds, geneQueries, "SUMMARY", null, null, null, null);
+
+        Assert.assertEquals(3, result.size());
+        List<String> expectedSampleIds = Arrays.asList("TCGA-A1-A0SB-01", "TCGA-A1-A0SH-01", "TCGA-A1-A0SO-01");
+        assert(result.stream().allMatch(r -> expectedSampleIds.contains(r.getSampleId())));
+    }
+
+    @Test
+    public void getFusionsInMultipleMolecularProfiles() throws Exception {
+
+        List<String> molecularProfileIds = new ArrayList<>();
+        molecularProfileIds.add("acc_tcga_mutations");
+        molecularProfileIds.add("study_tcga_pub_mutations");
+
+        List<String> sampleIds = new ArrayList<>();
+        sampleIds.add("TCGA-A1-B0SO-01");
+        sampleIds.add("TCGA-A1-A0SH-01");
+        
+        List<String> tiers = new ArrayList<>();
+        List<Mutation> result = mutationMyBatisRepository.getFusionsInMultipleMolecularProfiles(molecularProfileIds,
+            sampleIds, null, "SUMMARY", null, null, null, null);
+
+        // TODO: cleanup once fusion/structural data is fixed in database
+        // This test should correctly return entries from the structural_variant table (7 records)
+        Assert.assertEquals(0, result.size());
     }
 
     @Test

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MutationMyBatisRepositoryTest.java
@@ -1,10 +1,15 @@
 package org.cbioportal.persistence.mybatis;
 
-import org.cbioportal.model.*;
+import org.cbioportal.model.AlleleSpecificCopyNumber;
+import org.cbioportal.model.Gene;
 import org.cbioportal.model.GeneFilterQuery;
+import org.cbioportal.model.Mutation;
+import org.cbioportal.model.MutationCountByPosition;
 import org.cbioportal.model.meta.MutationMeta;
 import org.cbioportal.model.util.Select;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
@@ -13,6 +18,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/StructuralVariantMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/StructuralVariantMyBatisRepositoryTest.java
@@ -202,4 +202,6 @@ public class StructuralVariantMyBatisRepositoryTest {
         Assert.assertEquals((String) "TCGA-A1-A0SB", structuralVariantSecondResult.getPatientId());
         Assert.assertEquals((String) "study_tcga_pub", structuralVariantSecondResult.getStudyId());
     }
+    
+    // TODO add tests for 'ByGeneQueries'
 }

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/StructuralVariantMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/StructuralVariantMyBatisRepositoryTest.java
@@ -23,8 +23,11 @@
 
 package org.cbioportal.persistence.mybatis;
 
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.StructuralVariant;
+import org.cbioportal.model.util.Select;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,8 +35,10 @@ import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.util.List;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/testContextDatabase.xml")
@@ -42,7 +47,46 @@ public class StructuralVariantMyBatisRepositoryTest {
 
     @Autowired
     StructuralVariantMyBatisRepository structuralVariantMyBatisRepository;
-    
+
+    @Before
+    public void init() {
+        molecularProfileIds = new ArrayList<>();
+        molecularProfileIds.add("study_tcga_pub_sv");
+        molecularProfileIds.add("acc_tcga_mutations");
+        sampleIds = new ArrayList<>();
+        sampleIds.add("TCGA-A1-A0SB-01");
+        sampleIds.add("TCGA-A1-B0SO-01");
+        tiers = Select.none();
+        includeUnknownTier = false;
+        includeDriver = false;
+        includeVUS = false;
+        includeUnknownOncogenicity = false;
+        includeGermline = false;
+        includeSomatic = false;
+        includeUnknownOncogenicity = false;
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("KIAA1549", 57670, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("RET", 5979, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        GeneFilterQuery geneFilterQuery3 = new GeneFilterQuery("TMPRSS2", 7113, null,
+            includeDriver, includeVUS, includeUnknownOncogenicity, tiers, includeUnknownTier, includeGermline, includeSomatic, includeUnknownStatus);
+        geneQueries =  Arrays.asList(geneFilterQuery1, geneFilterQuery2, geneFilterQuery3);
+        
+    }
+
+    List<String> molecularProfileIds = new ArrayList<>();
+    List<String> sampleIds = new ArrayList<>();
+    Select<String> tiers = Select.none();
+    boolean includeUnknownTier = false;
+    boolean includeDriver = false;
+    boolean includeVUS = false;
+    boolean includeUnknownOncogenicity = false;
+    boolean includeGermline = false;
+    boolean includeSomatic = false;
+    boolean includeUnknownStatus = false;
+    private List<GeneFilterQuery> geneQueries;
+
     @Test
     public void fetchStructuralVariantsNoSampleIdentifiers() throws Exception {
 
@@ -202,6 +246,185 @@ public class StructuralVariantMyBatisRepositoryTest {
         Assert.assertEquals((String) "TCGA-A1-A0SB", structuralVariantSecondResult.getPatientId());
         Assert.assertEquals((String) "study_tcga_pub", structuralVariantSecondResult.getStudyId());
     }
+
+    @Test
+    public void fetchStructuralVariantsMultiStudyByGeneQueriesWithSampleIdentifiers() throws Exception {
+
+        geneQueries.stream().forEach(
+            q -> {
+                q.setIncludeDriver(true);
+                q.setIncludeVUS(true);
+                q.setIncludeUnknownOncogenicity(true);
+            }
+        );
+
+        List<StructuralVariant> result =
+            structuralVariantMyBatisRepository.fetchStructuralVariantsByGeneQueries(molecularProfileIds,
+                geneQueries, sampleIds);
+
+        Assert.assertEquals(5,  result.size());
+
+        List<String> resultTcgaPubVariants = result.stream()
+            .filter(s -> "study_tcga_pub_sv".equals(s.getMolecularProfileId()))
+            .map(StructuralVariant::getAnnotation)
+            .collect(Collectors.toList());
+        List<String> resultTcgaVariants = result.stream()
+            .filter(s -> "acc_tcga_mutations".equals(s.getMolecularProfileId()))
+            .map(StructuralVariant::getAnnotation)
+            .collect(Collectors.toList());
+        
+        Assert.assertArrayEquals(new String[] {"KIAA1549-BRAF.K16B10.COSF509", "NCOA4-RET.N7R1", "TMPRSS2-ERG.T1E2.COSF23.1"}, resultTcgaPubVariants.toArray());
+        Assert.assertArrayEquals(new String[] {"KIAA1549-BRAF.K16B10.COSF509", "NCOA4-RET.N7R1"}, resultTcgaVariants.toArray());
+    }
+
+    @Test
+    public void fetchStructuralVariantsMultiStudyByGeneQueriesWithSampleIdentifiersExcludePassenger() throws Exception {
+        
+        // There is one passenger event in 'study_tcga_pub_sv', the rest is unannotated
+        geneQueries.stream().forEach(
+            q -> {
+                q.setIncludeDriver(true);
+                q.setIncludeVUS(false);
+                q.setIncludeUnknownOncogenicity(true);
+            }
+        );
+
+        List<StructuralVariant> result =
+            structuralVariantMyBatisRepository.fetchStructuralVariantsByGeneQueries(molecularProfileIds,
+                geneQueries, sampleIds);
+
+        Assert.assertEquals(4,  result.size());
+
+        List<String> resultTcgaPubVariants = result.stream()
+            .filter(s -> "study_tcga_pub_sv".equals(s.getMolecularProfileId()))
+            .map(StructuralVariant::getAnnotation)
+            .collect(Collectors.toList());
+        List<String> resultTcgaVariants = result.stream()
+            .filter(s -> "acc_tcga_mutations".equals(s.getMolecularProfileId()))
+            .map(StructuralVariant::getAnnotation)
+            .collect(Collectors.toList());
+
+        Assert.assertArrayEquals(new String[] {"NCOA4-RET.N7R1", "TMPRSS2-ERG.T1E2.COSF23.1"}, resultTcgaPubVariants.toArray());
+        Assert.assertArrayEquals(new String[] {"KIAA1549-BRAF.K16B10.COSF509", "NCOA4-RET.N7R1"}, resultTcgaVariants.toArray());
+    }
+
+    @Test
+    public void fetchStructuralVariantsMultiStudyByGeneQueriesWithSampleIdentifiersExcludePassengerDriver() throws Exception {
+
+        // There is one passenger event in 'study_tcga_pub_sv', the rest is unannotated
+        geneQueries.stream().forEach(
+            q -> {
+                q.setIncludeDriver(false);
+                q.setIncludeVUS(false);
+                q.setIncludeUnknownOncogenicity(true);
+            }
+        );
+
+        List<StructuralVariant> result =
+            structuralVariantMyBatisRepository.fetchStructuralVariantsByGeneQueries(molecularProfileIds,
+                geneQueries, sampleIds);
+
+        Assert.assertEquals(4,  result.size());
+
+        List<String> resultTcgaPubVariants = result.stream()
+            .filter(s -> "study_tcga_pub_sv".equals(s.getMolecularProfileId()))
+            .map(StructuralVariant::getAnnotation)
+            .collect(Collectors.toList());
+        List<String> resultTcgaVariants = result.stream()
+            .filter(s -> "acc_tcga_mutations".equals(s.getMolecularProfileId()))
+            .map(StructuralVariant::getAnnotation)
+            .collect(Collectors.toList());
+
+        Assert.assertArrayEquals(new String[] {"NCOA4-RET.N7R1", "TMPRSS2-ERG.T1E2.COSF23.1"}, resultTcgaPubVariants.toArray());
+        Assert.assertArrayEquals(new String[] {"KIAA1549-BRAF.K16B10.COSF509", "NCOA4-RET.N7R1"}, resultTcgaVariants.toArray());
+    }
+
+    @Test
+    public void fetchStructuralVariantsMultiStudyByGeneQueriesWithSampleIdentifiersExcludeUnknownOncogenicity() throws Exception {
+
+        // There is one passenger event in 'study_tcga_pub_sv', the rest is unannotated
+
+        geneQueries.stream().forEach(
+            q -> {
+                q.setIncludeDriver(false);
+                q.setIncludeVUS(true);
+                q.setIncludeUnknownOncogenicity(false);
+            }
+        );
+
+        List<StructuralVariant> result =
+            structuralVariantMyBatisRepository.fetchStructuralVariantsByGeneQueries(molecularProfileIds,
+                geneQueries, sampleIds);
+
+        Assert.assertEquals(1,  result.size());
+
+        List<String> resultTcgaPubVariants = result.stream()
+            .filter(s -> "study_tcga_pub_sv".equals(s.getMolecularProfileId()))
+            .map(StructuralVariant::getAnnotation)
+            .collect(Collectors.toList());
+
+        Assert.assertArrayEquals(new String[] {"KIAA1549-BRAF.K16B10.COSF509"}, resultTcgaPubVariants.toArray());
+    }
+
+    @Test
+    public void fetchStructuralVariantsMultiStudyByGeneQueriesWithSampleIdentifiersIncludeTier() throws Exception {
+
+        // There is one passenger event that is 'Tier 1 annotated' in 'study_tcga_pub_sv', the rest is unannotated
+        geneQueries.stream().forEach(
+            q -> {
+                q.setIncludeDriver(false);
+                q.setIncludeVUS(false);
+                q.setIncludeUnknownOncogenicity(false);
+                q.setSelectedTiers(Select.byValues(Arrays.asList("Tier 1")));
+            }
+        );
+
+        List<StructuralVariant> result =
+            structuralVariantMyBatisRepository.fetchStructuralVariantsByGeneQueries(molecularProfileIds,
+                geneQueries, sampleIds);
+
+        Assert.assertEquals(1,  result.size());
+
+        List<String> resultTcgaPubVariants = result.stream()
+            .filter(s -> "study_tcga_pub_sv".equals(s.getMolecularProfileId()))
+            .map(StructuralVariant::getAnnotation)
+            .collect(Collectors.toList());
+
+        Assert.assertArrayEquals(new String[] {"KIAA1549-BRAF.K16B10.COSF509"}, resultTcgaPubVariants.toArray());
+    }
+
+    @Test
+    public void fetchStructuralVariantsMultiStudyByGeneQueriesWithSampleIdentifiersAllTiers() throws Exception {
+
+        // There is one passenger event that is 'Tier 1 annotated' in 'study_tcga_pub_sv', the rest is unannotated
+
+        geneQueries.stream().forEach(
+            q -> {
+                q.setIncludeDriver(false);
+                q.setIncludeVUS(false);
+                q.setIncludeUnknownOncogenicity(false);
+                q.setSelectedTiers(Select.all());
+                q.setIncludeUnknownTier(true);
+            }
+        );
+        
+        List<StructuralVariant> result =
+            structuralVariantMyBatisRepository.fetchStructuralVariantsByGeneQueries(molecularProfileIds,
+                geneQueries, sampleIds);
+
+        Assert.assertEquals(5,  result.size());
+
+        List<String> resultTcgaPubVariants = result.stream()
+            .filter(s -> "study_tcga_pub_sv".equals(s.getMolecularProfileId()))
+            .map(StructuralVariant::getAnnotation)
+            .collect(Collectors.toList());
+        List<String> resultTcgaVariants = result.stream()
+            .filter(s -> "acc_tcga_mutations".equals(s.getMolecularProfileId()))
+            .map(StructuralVariant::getAnnotation)
+            .collect(Collectors.toList());
+
+        Assert.assertArrayEquals(new String[] {"KIAA1549-BRAF.K16B10.COSF509", "NCOA4-RET.N7R1", "TMPRSS2-ERG.T1E2.COSF23.1"}, resultTcgaPubVariants.toArray());
+        Assert.assertArrayEquals(new String[] {"KIAA1549-BRAF.K16B10.COSF509", "NCOA4-RET.N7R1"}, resultTcgaVariants.toArray());
+    }
     
-    // TODO add tests for 'ByGeneQueries'
 }

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -101,6 +101,7 @@
             "skin.show_tweet_button",
             "skin.patientview.filter_genes_profiled_all_samples",
             "skin.patientview.show_mskcc_slide_viewer",
+            "skin.show_settings_menu",
             "quick_search.enabled",
             "default_cross_cancer_study_session_id",
             "default_cross_cancer_study_list",

--- a/service/src/main/java/org/cbioportal/service/AlterationCountService.java
+++ b/service/src/main/java/org/cbioportal/service/AlterationCountService.java
@@ -13,64 +13,64 @@ public interface AlterationCountService {
                                                                       Select<Integer> entrezGeneIds,
                                                                       boolean includeFrequency,
                                                                       boolean includeMissingAlterationsFromGenePanel,
-                                                                      Select<MutationEventType> mutationEventTypes,
-                                                                      Select<CNA> cnaEventTypes,
-                                                                      QueryElement searchFusions);
+                                                                      QueryElement searchFusions,
+                                                                      AlterationFilter alterationFilter);
 
     Pair<List<AlterationCountByGene>, Long> getPatientAlterationCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
-                                                                       Select<Integer> entrezGeneIds,
-                                                                       boolean includeFrequency,
-                                                                       boolean includeMissingAlterationsFromGenePanel,
-                                                                       Select<MutationEventType> mutationEventTypes,
-                                                                       Select<CNA> cnaEventTypes,
-                                                                       QueryElement searchFusions);
+                                                           Select<Integer> entrezGeneIds,
+                                                           boolean includeFrequency,
+                                                           boolean includeMissingAlterationsFromGenePanel,
+                                                           QueryElement searchFusions,
+                                                           AlterationFilter alterationFilter);
 
     Pair<List<AlterationCountByGene>, Long> getSampleMutationCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
-                                                                    Select<Integer> entrezGeneIds,
-                                                                    boolean includeFrequency,
-                                                                    boolean includeMissingAlterationsFromGenePanel,
-                                                                    Select<MutationEventType> mutationEventTypes);
+                                                        Select<Integer> entrezGeneIds,
+                                                        boolean includeFrequency,
+                                                        boolean includeMissingAlterationsFromGenePanel,
+                                                        AlterationFilter alterationFilter);
 
     Pair<List<AlterationCountByGene>, Long> getPatientMutationCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
-                                                                     Select<Integer> entrezGeneIds,
-                                                                     boolean includeFrequency,
-                                                                     boolean includeMissingAlterationsFromGenePanel,
-                                                                     Select<MutationEventType> mutationEventTypes);
+                                                         Select<Integer> entrezGeneIds,
+                                                         boolean includeFrequency,
+                                                         boolean includeMissingAlterationsFromGenePanel,
+                                                         AlterationFilter alterationFilter);
 
     Pair<List<AlterationCountByGene>, Long> getSampleStructuralVariantCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                       Select<Integer> entrezGeneIds,
                                                       boolean includeFrequency,
-                                                      boolean includeMissingAlterationsFromGenePanel);
+                                                      boolean includeMissingAlterationsFromGenePanel,
+                                                      AlterationFilter alterationFilter);
 
     Pair<List<AlterationCountByGene>, Long> getPatientStructuralVariantCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                        Select<Integer> entrezGeneIds,
                                                        boolean includeFrequency,
-                                                       boolean includeMissingAlterationsFromGenePanel);
+                                                       boolean includeMissingAlterationsFromGenePanel,
+                                                       AlterationFilter alterationFilter);
 
 // Should be restored when old CNA count endpoint is retired
-//    List<AlterationCountByGene> getSampleCnaCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
+//    Pair<List<AlterationCountByGene>, Long> getSampleCnaCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
 //                                                   Select<Integer> entrezGeneIds,
 //                                                   boolean includeFrequency,
 //                                                   boolean includeMissingAlterationsFromGenePanel,
-//                                                   List<CNA> cnaEventTypes);
+//                                                   AlterationFilter alterationFilter);
 //
-//    List<AlterationCountByGene> getPatientCnaCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
+//    Pair<List<AlterationCountByGene>, Long> getPatientCnaCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
 //                                                    Select<Integer> entrezGeneIds,
 //                                                    boolean includeFrequency,
 //                                                    boolean includeMissingAlterationsFromGenePanel,
-//                                                    List<CNA> cnaEventTypes);
-    
-// Should be removed when old CNA count endpoint is retired
+//                                                   AlterationFilter alterationFilter);
+
+    // Should be removed when old CNA count endpoint is retired
     Pair<List<CopyNumberCountByGene>, Long> getSampleCnaCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
-                                                               Select<Integer> entrezGeneIds,
-                                                               boolean includeFrequency,
-                                                               boolean includeMissingAlterationsFromGenePanel,
-                                                               Select<CNA> cnaEventTypes);
+                                                   Select<Integer> entrezGeneIds,
+                                                   boolean includeFrequency,
+                                                   boolean includeMissingAlterationsFromGenePanel,
+                                                   AlterationFilter alterationFilter);
 
     Pair<List<CopyNumberCountByGene>, Long> getPatientCnaCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
-                                                                Select<Integer> entrezGeneIds,
-                                                                boolean includeFrequency,
-                                                                boolean includeMissingAlterationsFromGenePanel,
-                                                                Select<CNA> cnaEventTypes);
+                                                    Select<Integer> entrezGeneIds,
+                                                    boolean includeFrequency,
+                                                    boolean includeMissingAlterationsFromGenePanel,
+                                                    AlterationFilter alterationFilter);
     
 }

--- a/service/src/main/java/org/cbioportal/service/AlterationDriverAnnotationService.java
+++ b/service/src/main/java/org/cbioportal/service/AlterationDriverAnnotationService.java
@@ -1,0 +1,9 @@
+package org.cbioportal.service;
+
+import org.cbioportal.model.CustomDriverAnnotationReport;
+
+import java.util.List;
+
+public interface AlterationDriverAnnotationService {
+    CustomDriverAnnotationReport getCustomDriverAnnotationProps(List<String> molecularProfileIds);
+}

--- a/service/src/main/java/org/cbioportal/service/AlterationEnrichmentService.java
+++ b/service/src/main/java/org/cbioportal/service/AlterationEnrichmentService.java
@@ -1,7 +1,9 @@
 package org.cbioportal.service;
 
-import org.cbioportal.model.*;
-import org.cbioportal.model.util.Select;
+import org.cbioportal.model.AlterationEnrichment;
+import org.cbioportal.model.AlterationFilter;
+import org.cbioportal.model.EnrichmentType;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 
 import java.util.List;
@@ -11,8 +13,7 @@ public interface AlterationEnrichmentService {
 
     List<AlterationEnrichment> getAlterationEnrichments(
         Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets,
-        final Select<MutationEventType> mutationEventTypes,
-        final Select<CNA> cnaEventTypes,
-        EnrichmentType enrichmentType)
+        EnrichmentType enrichmentType,
+        AlterationFilter alterationFilter)
         throws MolecularProfileNotFoundException;
 }

--- a/service/src/main/java/org/cbioportal/service/CopyNumberEnrichmentService.java
+++ b/service/src/main/java/org/cbioportal/service/CopyNumberEnrichmentService.java
@@ -1,14 +1,18 @@
 package org.cbioportal.service;
 
-import org.cbioportal.model.*;
+import org.cbioportal.model.AlterationEnrichment;
+import org.cbioportal.model.AlterationFilter;
+import org.cbioportal.model.EnrichmentType;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 
 import java.util.List;
 import java.util.Map;
 
 public interface CopyNumberEnrichmentService {
-
-    List<AlterationEnrichment> getCopyNumberEnrichments(Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets,
-                                                        CNA copyNumberEventType,
-                                                        EnrichmentType enrichmentType) throws MolecularProfileNotFoundException;
+    List<AlterationEnrichment> getCopyNumberEnrichments(
+        Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets,
+        EnrichmentType enrichmentType,
+        AlterationFilter alterationFilter
+    ) throws MolecularProfileNotFoundException;
 }

--- a/service/src/main/java/org/cbioportal/service/DiscreteCopyNumberService.java
+++ b/service/src/main/java/org/cbioportal/service/DiscreteCopyNumberService.java
@@ -33,6 +33,11 @@ public interface DiscreteCopyNumberService {
                                                                                    List<Integer> alterationTypes, 
                                                                                    String projection);
 
+    List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
+                                                                                                List<String> sampleIds,
+                                                                                                List<GeneFilterQuery> geneQueries,
+                                                                                                String projection);
+
     BaseMeta fetchMetaDiscreteCopyNumbersInMolecularProfile(String molecularProfileId, List<String> sampleIds,
                                                             List<Integer> entrezGeneIds, List<Integer> alterationTypes)
         throws MolecularProfileNotFoundException;

--- a/service/src/main/java/org/cbioportal/service/MolecularDataService.java
+++ b/service/src/main/java/org/cbioportal/service/MolecularDataService.java
@@ -1,5 +1,6 @@
 package org.cbioportal.service;
 
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GeneMolecularData;
 import org.cbioportal.model.meta.BaseMeta;
@@ -29,9 +30,15 @@ public interface MolecularDataService {
     Integer getNumberOfSamplesInMolecularProfile(String molecularProfileId);
 
     List<GeneMolecularData> getMolecularDataInMultipleMolecularProfiles(List<String> molecularProfileIds,
-                                                                        List<String> sampleIds, List<Integer> entrezGeneIds,
+                                                                        List<String> sampleIds,
+                                                                        List<Integer> entrezGeneIds,
                                                                         String projection);
+
+    List<GeneMolecularData> getMolecularDataInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
+                                                                                     List<String> sampleIds, List<GeneFilterQuery> geneQueries,
+                                                                                     String projection);
 
 	BaseMeta getMetaMolecularDataInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
 		                                                     List<Integer> entrezGeneIds);
+
 }

--- a/service/src/main/java/org/cbioportal/service/MolecularDataService.java
+++ b/service/src/main/java/org/cbioportal/service/MolecularDataService.java
@@ -35,7 +35,8 @@ public interface MolecularDataService {
                                                                         String projection);
 
     List<GeneMolecularData> getMolecularDataInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
-                                                                                     List<String> sampleIds, List<GeneFilterQuery> geneQueries,
+                                                                                     List<String> sampleIds,
+                                                                                     List<GeneFilterQuery> geneQueries,
                                                                                      String projection);
 
 	BaseMeta getMetaMolecularDataInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,

--- a/service/src/main/java/org/cbioportal/service/MutationEnrichmentService.java
+++ b/service/src/main/java/org/cbioportal/service/MutationEnrichmentService.java
@@ -1,6 +1,7 @@
 package org.cbioportal.service;
 
 import org.cbioportal.model.AlterationEnrichment;
+import org.cbioportal.model.AlterationFilter;
 import org.cbioportal.model.EnrichmentType;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
@@ -12,6 +13,7 @@ public interface MutationEnrichmentService {
 
     List<AlterationEnrichment> getMutationEnrichments(
         Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets,
-        EnrichmentType enrichmentType)
+        EnrichmentType enrichmentType,
+        AlterationFilter alterationFilter)
         throws MolecularProfileNotFoundException;
 }

--- a/service/src/main/java/org/cbioportal/service/MutationService.java
+++ b/service/src/main/java/org/cbioportal/service/MutationService.java
@@ -1,6 +1,8 @@
 package org.cbioportal.service;
 
-import org.cbioportal.model.*;
+import org.cbioportal.model.GeneFilterQuery;
+import org.cbioportal.model.Mutation;
+import org.cbioportal.model.MutationCountByPosition;
 import org.cbioportal.model.meta.MutationMeta;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 
@@ -23,6 +25,11 @@ public interface MutationService {
                                                            Integer pageSize, Integer pageNumber,
                                                            String sortBy, String direction);
 
+    List<Mutation> getMutationsInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds, List<String> sampleIds,
+                                                                      List<GeneFilterQuery> geneQueries,
+                                                                      String projection, Integer pageSize, Integer pageNumber,
+                                                                      String sortBy, String direction);
+
     MutationMeta getMetaMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
                                                              List<Integer> entrezGeneIds);
 
@@ -44,5 +51,11 @@ public interface MutationService {
     List<Mutation> getFusionsInMultipleMolecularProfiles(List<String> molecularProfileIds, List<String> sampleIds,
                                                          List<Integer> entrezGeneIds, String projection, Integer pageSize, Integer pageNumber, String sortBy,
                                                          String direction);
+
+    List<Mutation> getFusionsInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds, List<String> sampleIds,
+                                                                      List<GeneFilterQuery> geneQueries,
+                                                                      String projection, Integer pageSize, Integer pageNumber,
+                                                                      String sortBy, String direction);
+
     // TODO: cleanup once fusion/structural data is fixed in database
 }

--- a/service/src/main/java/org/cbioportal/service/StructuralVariantService.java
+++ b/service/src/main/java/org/cbioportal/service/StructuralVariantService.java
@@ -23,13 +23,17 @@
 
 package org.cbioportal.service;
 
-import java.util.List;
-
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.StructuralVariant;
+
+import java.util.List;
 
 public interface StructuralVariantService {
 
     List<StructuralVariant> fetchStructuralVariants(List<String> molecularProfileIds, List<Integer> entrezGeneIds,
+            List<String> sampleIds);
+    
+    List<StructuralVariant> fetchStructuralVariantsByGeneQueries(List<String> molecularProfileIds, List<GeneFilterQuery> geneQueries,
             List<String> sampleIds);
 
 }

--- a/service/src/main/java/org/cbioportal/service/impl/AlterationCountServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/AlterationCountServiceImpl.java
@@ -1,8 +1,10 @@
 package org.cbioportal.service.impl;
 
 import org.apache.commons.math3.util.Pair;
-
-import org.cbioportal.model.*;
+import org.cbioportal.model.AlterationCountByGene;
+import org.cbioportal.model.AlterationFilter;
+import org.cbioportal.model.CopyNumberCountByGene;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.model.QueryElement;
 import org.cbioportal.model.util.Select;
 import org.cbioportal.persistence.AlterationRepository;
@@ -13,7 +15,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,10 +32,9 @@ public class AlterationCountServiceImpl implements AlterationCountService {
                                                                              Select<Integer> entrezGeneIds,
                                                                              boolean includeFrequency,
                                                                              boolean includeMissingAlterationsFromGenePanel,
-                                                                             Select<MutationEventType> mutationEventTypes,
-                                                                             Select<CNA> cnaEventTypes,
-                                                                             QueryElement searchFusions) {
-
+                                                                             QueryElement searchFusions,
+                                                                             AlterationFilter alterationFilter) {
+        
         List<AlterationCountByGene> alterationCountByGenes;
         Long profiledCasesCount = 0L;
         if (molecularProfileCaseIdentifiers.isEmpty()) {
@@ -51,9 +51,8 @@ public class AlterationCountServiceImpl implements AlterationCountService {
             alterationCountByGenes = alterationRepository.getSampleAlterationCounts(
                 updatedProfileCaseIdentifiers,
                 entrezGeneIds,
-                mutationEventTypes,
-                cnaEventTypes,
-                searchFusions);
+                searchFusions,
+                alterationFilter);
             if (includeFrequency) {
                 profiledCasesCount = alterationEnrichmentUtil.includeFrequencyForSamples(updatedProfileCaseIdentifiers,
                     alterationCountByGenes,
@@ -68,10 +67,9 @@ public class AlterationCountServiceImpl implements AlterationCountService {
                                                                               Select<Integer> entrezGeneIds,
                                                                               boolean includeFrequency,
                                                                               boolean includeMissingAlterationsFromGenePanel,
-                                                                              Select<MutationEventType> mutationEventTypes,
-                                                                              Select<CNA> cnaEventTypes,
-                                                                              QueryElement searchFusions) {
-
+                                                                              QueryElement searchFusions,
+                                                                              AlterationFilter alterationFilter) {
+        
         List<AlterationCountByGene> alterationCountByGenes;
         Long profiledCasesCount = 0L;
         if (molecularProfileCaseIdentifiers.isEmpty()) {
@@ -88,9 +86,8 @@ public class AlterationCountServiceImpl implements AlterationCountService {
             alterationCountByGenes = alterationRepository.getPatientAlterationCounts(
                 updatedProfileCaseIdentifiers,
                 entrezGeneIds,
-                mutationEventTypes,
-                cnaEventTypes,
-                searchFusions);
+                searchFusions,
+                alterationFilter);
             if (includeFrequency) {
                 profiledCasesCount = alterationEnrichmentUtil.includeFrequencyForPatients(updatedProfileCaseIdentifiers, alterationCountByGenes, includeMissingAlterationsFromGenePanel);
             }
@@ -103,14 +100,13 @@ public class AlterationCountServiceImpl implements AlterationCountService {
                                                                            Select<Integer> entrezGeneIds,
                                                                            boolean includeFrequency,
                                                                            boolean includeMissingAlterationsFromGenePanel,
-                                                                           Select<MutationEventType> mutationEventTypes) {
+                                                                           AlterationFilter alterationFilter) {
         return getSampleAlterationCounts(molecularProfileCaseIdentifiers,
             entrezGeneIds,
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
-            mutationEventTypes,
-            Select.none(),
-            QueryElement.INACTIVE
+            QueryElement.INACTIVE,
+            alterationFilter
         );
     }
 
@@ -119,29 +115,27 @@ public class AlterationCountServiceImpl implements AlterationCountService {
                                                                             Select<Integer> entrezGeneIds,
                                                                             boolean includeFrequency,
                                                                             boolean includeMissingAlterationsFromGenePanel,
-                                                                            Select<MutationEventType> mutationEventTypes) {
+                                                                            AlterationFilter alterationFilter) {
         return getPatientAlterationCounts(molecularProfileCaseIdentifiers,
             entrezGeneIds,
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
-            mutationEventTypes,
-            Select.none(),
-            QueryElement.INACTIVE
-        );
+            QueryElement.INACTIVE,
+            alterationFilter);
     }
 
     @Override
     public Pair<List<AlterationCountByGene>, Long>  getSampleStructuralVariantCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                              Select<Integer> entrezGeneIds,
                                                              boolean includeFrequency,
-                                                             boolean includeMissingAlterationsFromGenePanel) {
+                                                             boolean includeMissingAlterationsFromGenePanel,
+                                                             AlterationFilter alterationFilter) {
         return getSampleAlterationCounts(molecularProfileCaseIdentifiers,
             entrezGeneIds,
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
-            Select.all(),
-            Select.none(),
-            QueryElement.ACTIVE
+            QueryElement.ACTIVE,
+            alterationFilter
         );
     }
 
@@ -149,14 +143,14 @@ public class AlterationCountServiceImpl implements AlterationCountService {
     public Pair<List<AlterationCountByGene>, Long>  getPatientStructuralVariantCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                               Select<Integer> entrezGeneIds,
                                                               boolean includeFrequency,
-                                                              boolean includeMissingAlterationsFromGenePanel) {
+                                                              boolean includeMissingAlterationsFromGenePanel,
+                                                              AlterationFilter alterationFilter) {
         return getPatientAlterationCounts(molecularProfileCaseIdentifiers,
             entrezGeneIds,
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
-            Select.all(),
-            Select.none(),
-            QueryElement.ACTIVE
+            QueryElement.ACTIVE,
+            alterationFilter
             );    
         }
             
@@ -166,14 +160,13 @@ public class AlterationCountServiceImpl implements AlterationCountService {
 //                                                          Select<Integer> entrezGeneIds,
 //                                                          boolean includeFrequency,
 //                                                          boolean includeMissingAlterationsFromGenePanel,
-//                                                          List<CNA> cnaEventTypes) {
+//                                                          AlterationFilter alterationFilter) {
 //        return getSampleAlterationCounts(molecularProfileCaseIdentifiers,
 //            entrezGeneIds,
 //            includeFrequency,
 //            includeMissingAlterationsFromGenePanel,
 //            new ArrayList<>(),
-//            cnaEventTypes,
-//            false);
+//            alterationFilter);
 //    }
 //
 //    @Override
@@ -181,14 +174,13 @@ public class AlterationCountServiceImpl implements AlterationCountService {
 //                                                           List<Integer> entrezGeneIds,
 //                                                           boolean includeFrequency,
 //                                                           boolean includeMissingAlterationsFromGenePanel,
-//                                                           List<CNA> cnaEventTypes) {
+//                                                           AlterationFilter alterationFilter) {
 //        return getPatientAlterationCounts(molecularProfileCaseIdentifiers,
 //            entrezGeneIds,
 //            includeFrequency,
 //            includeMissingAlterationsFromGenePanel,
 //            new ArrayList<>(),
-//            cnaEventTypes,
-//            false);
+//            alterationFilter);
 //    }
     
     @Override
@@ -196,7 +188,7 @@ public class AlterationCountServiceImpl implements AlterationCountService {
                                                                       Select<Integer> entrezGeneIds,
                                                                       boolean includeFrequency,
                                                                       boolean includeMissingAlterationsFromGenePanel,
-                                                                      Select<CNA> cnaEventTypes) {
+                                                                      AlterationFilter alterationFilter) {
         List<CopyNumberCountByGene> alterationCountByGenes;
         Long profiledCasesCount = 0L;
         if (molecularProfileCaseIdentifiers.isEmpty()) {
@@ -205,7 +197,7 @@ public class AlterationCountServiceImpl implements AlterationCountService {
             alterationCountByGenes = alterationRepository.getSampleCnaCounts(
                 molecularProfileCaseIdentifiers,
                 entrezGeneIds,
-                cnaEventTypes);
+                alterationFilter);
             if (includeFrequency) {
                 profiledCasesCount = alterationEnrichmentUtilCna.includeFrequencyForSamples(molecularProfileCaseIdentifiers, alterationCountByGenes, includeMissingAlterationsFromGenePanel);
             }
@@ -219,7 +211,7 @@ public class AlterationCountServiceImpl implements AlterationCountService {
                                                                        Select<Integer> entrezGeneIds,
                                                                        boolean includeFrequency,
                                                                        boolean includeMissingAlterationsFromGenePanel,
-                                                                       Select<CNA> cnaEventTypes) {
+                                                                       AlterationFilter alterationFilter) {
         List<CopyNumberCountByGene> alterationCountByGenes;
         Long profiledCasesCount = 0L;
         if (molecularProfileCaseIdentifiers.isEmpty()) {
@@ -228,7 +220,7 @@ public class AlterationCountServiceImpl implements AlterationCountService {
             alterationCountByGenes = alterationRepository.getPatientCnaCounts(
                 molecularProfileCaseIdentifiers,
                 entrezGeneIds,
-                cnaEventTypes);
+                alterationFilter);
             if (includeFrequency) {
                 profiledCasesCount = alterationEnrichmentUtilCna.includeFrequencyForPatients(molecularProfileCaseIdentifiers, alterationCountByGenes, includeMissingAlterationsFromGenePanel);
             }

--- a/service/src/main/java/org/cbioportal/service/impl/AlterationDriverAnnotationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/AlterationDriverAnnotationServiceImpl.java
@@ -1,0 +1,35 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.model.AlterationDriverAnnotation;
+import org.cbioportal.model.CustomDriverAnnotationReport;
+import org.cbioportal.persistence.AlterationDriverAnnotationRepository;
+import org.cbioportal.service.AlterationDriverAnnotationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class AlterationDriverAnnotationServiceImpl implements AlterationDriverAnnotationService {
+    
+    @Autowired
+    private AlterationDriverAnnotationRepository alterationDriverAnnotationRepository;
+    private final Set<String> NO_DATA_TIERS = new HashSet<>(Arrays.asList(null, "", "NA"));
+    
+    public CustomDriverAnnotationReport getCustomDriverAnnotationProps(List<String> molecularProfileIds) {
+        
+        List<AlterationDriverAnnotation> rows = alterationDriverAnnotationRepository
+            .getAlterationDriverAnnotations(molecularProfileIds);
+        
+        Set<String> tiers = rows.stream()
+            .map(AlterationDriverAnnotation::getDriverTiersFilter)
+            .filter(driverTiersFilter -> !NO_DATA_TIERS.contains(driverTiersFilter))
+            .collect(Collectors.toCollection(TreeSet::new));
+        boolean hasBinary = rows.stream().anyMatch(d ->
+            "Putative_Driver".equals(d.getDriverFilter()) ||
+                "Putative_Passenger".equals(d.getDriverFilter()));
+        
+        return new CustomDriverAnnotationReport(hasBinary, tiers);
+    }
+}

--- a/service/src/main/java/org/cbioportal/service/impl/AlterationEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/AlterationEnrichmentServiceImpl.java
@@ -24,20 +24,20 @@ public class AlterationEnrichmentServiceImpl implements AlterationEnrichmentServ
 
     @Override
     public List<AlterationEnrichment> getAlterationEnrichments(
-        Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets, final Select<MutationEventType> mutationEventTypes,
-        final Select<CNA> cnaEventTypes, EnrichmentType enrichmentType) {
+        Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets,
+        EnrichmentType enrichmentType,
+        AlterationFilter alterationFilter) {
 
         Map<String, Pair<List<AlterationCountByGene>, Long>> alterationCountsbyEntrezGeneIdAndGroup = getAlterationCountsbyEntrezGeneIdAndGroup(
-            molecularProfileCaseSets, mutationEventTypes, cnaEventTypes, enrichmentType);
+            molecularProfileCaseSets, enrichmentType, alterationFilter);
 
         return alterationEnrichmentUtil.createAlterationEnrichments(alterationCountsbyEntrezGeneIdAndGroup);
     }
 
     public Map<String, Pair<List<AlterationCountByGene>, Long>> getAlterationCountsbyEntrezGeneIdAndGroup(
         Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets,
-        Select<MutationEventType> mutationEventTypes,
-        Select<CNA> cnaEventTypes,
-        EnrichmentType enrichmentType) {
+        EnrichmentType enrichmentType,
+        AlterationFilter alterationFilter) {
         return molecularProfileCaseSets
             .entrySet()
             .stream()
@@ -47,14 +47,13 @@ public class AlterationEnrichmentServiceImpl implements AlterationEnrichmentServ
 
                     if (enrichmentType.equals(EnrichmentType.SAMPLE)) {
                         return alterationCountService
-                                .getSampleAlterationCounts(
+                            .getSampleAlterationCounts(
                                 entry.getValue(),
                                 Select.all(),
                                 true,
                                 true,
-                                mutationEventTypes,
-                                cnaEventTypes,
-                                QueryElement.PASS);
+                                QueryElement.PASS,
+                                alterationFilter);
                     } else {
                         return alterationCountService
                             .getPatientAlterationCounts(
@@ -62,9 +61,8 @@ public class AlterationEnrichmentServiceImpl implements AlterationEnrichmentServ
                                 Select.all(),
                                 true,
                                 true,
-                                mutationEventTypes,
-                                cnaEventTypes,
-                                QueryElement.PASS);
+                                QueryElement.PASS,
+                                alterationFilter);
                     }
                 }));
     }

--- a/service/src/main/java/org/cbioportal/service/impl/CopyNumberEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CopyNumberEnrichmentServiceImpl.java
@@ -10,7 +10,6 @@ import org.cbioportal.service.util.AlterationEnrichmentUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -26,21 +25,21 @@ public class CopyNumberEnrichmentServiceImpl implements CopyNumberEnrichmentServ
     @Override
     public List<AlterationEnrichment> getCopyNumberEnrichments(
         Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets,
-        CNA copyNumberEventType,
-        EnrichmentType enrichmentType) throws MolecularProfileNotFoundException {
+        EnrichmentType enrichmentType,
+        AlterationFilter alterationFilter) throws MolecularProfileNotFoundException {
 
         Map<String, Pair<List<CopyNumberCountByGene>, Long>> copyNumberCountByGeneAndGroup = getCopyNumberCountByGeneAndGroup(
             molecularProfileCaseSets,
-            copyNumberEventType,
-            enrichmentType);
+            enrichmentType,
+            alterationFilter);
 
         return alterationEnrichmentUtil.createAlterationEnrichments(copyNumberCountByGeneAndGroup);
     }
 
     public Map<String, Pair<List<CopyNumberCountByGene>, Long>> getCopyNumberCountByGeneAndGroup(
         Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets,
-        CNA copyNumberEventType,
-        EnrichmentType enrichmentType) {
+        EnrichmentType enrichmentType,
+        AlterationFilter alterationFilter) {
         return molecularProfileCaseSets
             .entrySet()
             .stream()
@@ -48,22 +47,20 @@ public class CopyNumberEnrichmentServiceImpl implements CopyNumberEnrichmentServ
                 entry -> entry.getKey(),
                 entry -> { //set value of each group to list of CopyNumberCountByGene
 
-                    Select<CNA> cnaTypes = Select.byValues(Arrays.asList(copyNumberEventType));
-
-                    if (enrichmentType.equals(EnrichmentType.SAMPLE)) {
+                    if (enrichmentType.name().equals("SAMPLE")) {
                         return alterationCountService.getSampleCnaCounts(
                             entry.getValue(),
                             Select.all(),
                             true,
                             true,
-                            cnaTypes);
+                            alterationFilter);
                     } else {
                         return alterationCountService.getPatientCnaCounts(
                             entry.getValue(),
                             Select.all(),
                             true,
                             true,
-                            cnaTypes);
+                            alterationFilter);
                     }
                 }));
     }

--- a/service/src/main/java/org/cbioportal/service/impl/MutationEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationEnrichmentServiceImpl.java
@@ -28,21 +28,23 @@ public class MutationEnrichmentServiceImpl implements MutationEnrichmentService 
     @Override
     public List<AlterationEnrichment> getMutationEnrichments(
         Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets,
-        EnrichmentType enrichmentType) throws MolecularProfileNotFoundException {
+        EnrichmentType enrichmentType,
+        AlterationFilter alterationFilter) throws MolecularProfileNotFoundException {
 
         alterationEnrichmentUtil.validateMolecularProfiles(molecularProfileCaseSets,
                 Arrays.asList(MolecularAlterationType.MUTATION_EXTENDED, MolecularAlterationType.MUTATION_UNCALLED),
                 null);
 
         Map<String, Pair<List<AlterationCountByGene>, Long>> mutationCountsbyEntrezGeneIdAndGroup = getMutationCountsbyEntrezGeneIdAndGroup(
-            molecularProfileCaseSets, enrichmentType);
+            molecularProfileCaseSets, enrichmentType, alterationFilter);
 
         return alterationEnrichmentUtil.createAlterationEnrichments(mutationCountsbyEntrezGeneIdAndGroup);
     }
 
     public Map<String, Pair<List<AlterationCountByGene>, Long>> getMutationCountsbyEntrezGeneIdAndGroup(
         Map<String, List<MolecularProfileCaseIdentifier>> molecularProfileCaseSets,
-        EnrichmentType enrichmentType) {
+        EnrichmentType enrichmentType,
+        AlterationFilter alterationFilter) {
         return molecularProfileCaseSets
             .entrySet()
             .stream()
@@ -63,7 +65,7 @@ public class MutationEnrichmentServiceImpl implements MutationEnrichmentService 
                             Select.all(),
                             true,
                             true,
-                            Select.all());
+                            alterationFilter);
                     } else {
                         return alterationCountService
                             .getPatientMutationCounts(
@@ -71,7 +73,7 @@ public class MutationEnrichmentServiceImpl implements MutationEnrichmentService 
                                 Select.all(),
                                 true,
                                 true,
-                                Select.all());
+                                alterationFilter);
                     }
                 }));
     }

--- a/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MutationServiceImpl.java
@@ -1,5 +1,6 @@
 package org.cbioportal.service.impl;
 
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.Mutation;
 import org.cbioportal.model.MutationCountByPosition;
@@ -49,16 +50,24 @@ public class MutationServiceImpl implements MutationService {
             entrezGeneIds);
     }
 
+    public List<Mutation> getMutationsInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds, List<String> sampleIds,
+                                                                               List<GeneFilterQuery> geneQueries, String projection,
+                                                                               Integer pageSize, Integer pageNumber,
+                                                                               String sortBy, String direction) {
+
+        List<Mutation> mutationList = mutationRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(
+            molecularProfileIds, sampleIds, geneQueries, projection, pageSize, pageNumber, sortBy, direction);
+
+        return mutationList;
+    }
+
     @Override
     public List<Mutation> getMutationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
                                                                   List<String> sampleIds, List<Integer> entrezGeneIds, 
                                                                   String projection, Integer pageSize, 
                                                                   Integer pageNumber, String sortBy, String direction) {
-
-        List<Mutation> mutationList = mutationRepository.getMutationsInMultipleMolecularProfiles(molecularProfileIds,
-            sampleIds, entrezGeneIds, projection, pageSize, pageNumber, sortBy, direction);
-        
-        return mutationList;
+        return mutationRepository.getMutationsInMultipleMolecularProfiles(molecularProfileIds, sampleIds,
+            entrezGeneIds, projection, pageSize, pageNumber, sortBy, direction);
     }
 
     @Override
@@ -133,6 +142,18 @@ public class MutationServiceImpl implements MutationService {
 
         List<Mutation> mutationList = mutationRepository.getFusionsInMultipleMolecularProfiles(molecularProfileIds,
                 sampleIds, entrezGeneIds, projection, pageSize, pageNumber, sortBy, direction);
+
+        return mutationList;
+    }
+
+    @Override
+    public List<Mutation> getFusionsInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds, List<String> sampleIds,
+                                                                             List<GeneFilterQuery> geneQueries, String projection, 
+                                                                             Integer pageSize, Integer pageNumber,
+                                                                             String sortBy, String direction) {
+
+        List<Mutation> mutationList = mutationRepository.getFusionsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds, sampleIds,
+            geneQueries, projection, pageSize, pageNumber, sortBy, direction);
 
         return mutationList;
     }

--- a/service/src/main/java/org/cbioportal/service/impl/StructuralVariantServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/StructuralVariantServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.StructuralVariant;
 import org.cbioportal.persistence.MutationRepository;
 import org.cbioportal.persistence.StructuralVariantRepository;
@@ -87,6 +88,52 @@ public class StructuralVariantServiceImpl implements StructuralVariantService {
                     mutationRepository.getFusionsInMultipleMolecularProfiles(fusionVariantMolecularProfileIds,
                             fusionVariantSampleIds, entrezGeneIds, "DETAILED", null, null, null, null),
                     molecularProfileIdReplaceMap, CollectionUtils.isEmpty(entrezGeneIds));
+        }
+
+        // TODO: Remove once fusions are removed from mutation table
+
+        return Stream.concat(structuralVariants.stream(), variantsFromMutationtable.stream())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<StructuralVariant> fetchStructuralVariantsByGeneQueries(List<String> molecularProfileIds,
+                                                                        List<GeneFilterQuery> geneQueries, List<String> sampleIds) {
+
+        List<String> structuralVariantMolecularProfileIds = new ArrayList<String>();
+        List<String> structuralVariantSampleIds = new ArrayList<String>();
+
+        List<String> fusionVariantMolecularProfileIds = new ArrayList<String>();
+        List<String> fusionVariantSampleIds = new ArrayList<String>();
+        Map<String, String> molecularProfileIdReplaceMap = new HashMap<>();
+
+        // TODO: Remove once fusions are removed from mutation table
+        for (int i = 0; i < molecularProfileIds.size(); i++) {
+            String molecularProfileId = molecularProfileIds.get(i);
+            if (molecularProfileId.endsWith("_structural_variants")) {
+                structuralVariantMolecularProfileIds.add(molecularProfileId);
+                structuralVariantSampleIds.add(sampleIds.get(i));
+            } else if (molecularProfileId.endsWith("_fusion")) {
+                String mutationMolecularProfileId = molecularProfileId.replace("_fusion", "_mutations");
+                molecularProfileIdReplaceMap.put(mutationMolecularProfileId, molecularProfileId);
+                fusionVariantMolecularProfileIds.add(molecularProfileId);
+                fusionVariantSampleIds.add(sampleIds.get(i));
+            }
+        }
+
+        List<StructuralVariant> structuralVariants = new ArrayList<>();
+        List<StructuralVariant> variantsFromMutationtable = new ArrayList<>();
+
+        if (CollectionUtils.isNotEmpty(structuralVariantMolecularProfileIds)) {
+            structuralVariants = structuralVariantRepository.fetchStructuralVariantsByGeneQueries(
+                    structuralVariantMolecularProfileIds, geneQueries, structuralVariantSampleIds);
+        }
+
+        if (CollectionUtils.isNotEmpty(fusionVariantMolecularProfileIds)) {
+            variantsFromMutationtable = mutationMapperUtils.mapFusionsToStructuralVariants(
+                    mutationRepository.getFusionsInMultipleMolecularProfilesByGeneQueries(fusionVariantMolecularProfileIds,
+                            fusionVariantSampleIds, geneQueries, "DETAILED", null, null, null, null),
+                    molecularProfileIdReplaceMap, CollectionUtils.isEmpty(geneQueries));
         }
 
         // TODO: Remove once fusions are removed from mutation table

--- a/service/src/test/java/org/cbioportal/service/impl/AlterationCountServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/AlterationCountServiceImplTest.java
@@ -35,31 +35,40 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
     Select<MutationEventType> mutationEventTypes = Select.byValues(Arrays.asList(MutationEventType.missense_mutation));
     Select<CNA> cnaEventTypes = Select.byValues(Arrays.asList(CNA.AMP));
     Select<Integer> entrezGeneIds = Select.all();
-    boolean includeFrequency = false;
+    boolean includeFrequency = true;
     boolean includeMissingAlterationsFromGenePanel = false;
     List<AlterationCountByGene> expectedCountByGeneList = Arrays.asList(new AlterationCountByGene());
     List<CopyNumberCountByGene> expectedCnaCountByGeneList = Arrays.asList(new CopyNumberCountByGene());
+    AlterationFilter alterationFilter = new AlterationFilter(
+        mutationEventTypes,
+        cnaEventTypes,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+        Select.none(),
+            false
+    );
     
     @Test
     public void getSampleAlterationCounts() {
-
-        boolean includeFrequency = true;
 
         // this mock tests correct argument types
         when(alterationRepository.getSampleAlterationCounts(
             caseIdentifiers,
             entrezGeneIds,
-            mutationEventTypes,
-            cnaEventTypes, QueryElement.PASS)).thenReturn(expectedCountByGeneList);
+            QueryElement.PASS,
+            alterationFilter)).thenReturn(expectedCountByGeneList);
 
         Pair<List<AlterationCountByGene>, Long> result = alterationCountService.getSampleAlterationCounts(
             caseIdentifiers,
             entrezGeneIds,
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
-            mutationEventTypes,
-            cnaEventTypes, QueryElement.PASS
-        );
+            QueryElement.PASS,
+            alterationFilter);
         
         verify(alterationEnrichmentUtil, times(1)).includeFrequencyForSamples(anyList(), anyList(), anyBoolean());
 
@@ -68,23 +77,20 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
     @Test
     public void getPatientAlterationCounts() {
 
-        boolean includeFrequency = true;
-
         // this mock tests correct argument types
         when(alterationRepository.getPatientAlterationCounts(
             caseIdentifiers,
             entrezGeneIds,
-            mutationEventTypes,
-            cnaEventTypes, QueryElement.PASS)).thenReturn(expectedCountByGeneList);
+            QueryElement.PASS,
+            alterationFilter)).thenReturn(expectedCountByGeneList);
 
         Pair<List<AlterationCountByGene>, Long> result = alterationCountService.getPatientAlterationCounts(
             caseIdentifiers,
             entrezGeneIds,
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
-            mutationEventTypes,
-            cnaEventTypes, QueryElement.PASS
-        );
+            QueryElement.PASS,
+            alterationFilter);
 
         verify(alterationEnrichmentUtil, times(1)).includeFrequencyForPatients(anyList(), anyList(), anyBoolean());
     }
@@ -96,15 +102,15 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
         when(alterationRepository.getSampleAlterationCounts(
             caseIdentifiers,
             entrezGeneIds,
-            mutationEventTypes,
-            Select.none(), QueryElement.INACTIVE)).thenReturn(expectedCountByGeneList);
+            QueryElement.INACTIVE,
+            alterationFilter)).thenReturn(expectedCountByGeneList);
 
         Pair<List<AlterationCountByGene>, Long> result = alterationCountService.getSampleMutationCounts(
             caseIdentifiers,
             entrezGeneIds,
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
-            mutationEventTypes);
+            alterationFilter);
 
         Assert.assertEquals(expectedCountByGeneList, result.getFirst());
 
@@ -117,15 +123,15 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
         when(alterationRepository.getPatientAlterationCounts(
             caseIdentifiers,
             entrezGeneIds,
-            mutationEventTypes,
-            Select.none(), QueryElement.INACTIVE)).thenReturn(expectedCountByGeneList);
+            QueryElement.INACTIVE,
+            alterationFilter)).thenReturn(expectedCountByGeneList);
 
         Pair<List<AlterationCountByGene>, Long> result = alterationCountService.getPatientMutationCounts(
             caseIdentifiers,
             entrezGeneIds,
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
-            mutationEventTypes);
+            alterationFilter);
 
         Assert.assertEquals(expectedCountByGeneList, result.getFirst());
 
@@ -133,43 +139,45 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
 
     @Test
     public void getSampleFusionCounts() {
-        
-        boolean searchFusions = true;
+
+        QueryElement searchFusions = QueryElement.ACTIVE;
 
         // this mock tests correct argument types
         when(alterationRepository.getSampleAlterationCounts(
             caseIdentifiers,
             entrezGeneIds,
-            Select.all(),
-            Select.none(), QueryElement.ACTIVE)).thenReturn(expectedCountByGeneList);
+            searchFusions,
+            alterationFilter
+        )).thenReturn(expectedCountByGeneList);
         
         Pair<List<AlterationCountByGene>, Long> result = alterationCountService.getSampleStructuralVariantCounts(
             caseIdentifiers,
             entrezGeneIds,
             includeFrequency,
-            includeMissingAlterationsFromGenePanel);
+            includeMissingAlterationsFromGenePanel,
+            alterationFilter);
 
         Assert.assertEquals(expectedCountByGeneList, result.getFirst());
     }
 
     @Test
     public void getPatientFusionCounts() {
-        
-        boolean searchFusions = true;
+
+        QueryElement searchFusions = QueryElement.ACTIVE;
 
         // this mock tests correct argument types
         when(alterationRepository.getPatientAlterationCounts(
             caseIdentifiers,
             entrezGeneIds,
-            Select.all(),
-            Select.none(),
-            QueryElement.ACTIVE)).thenReturn(expectedCountByGeneList);
-        
+            searchFusions,
+            alterationFilter)).thenReturn(expectedCountByGeneList);
+
         Pair<List<AlterationCountByGene>, Long> result = alterationCountService.getPatientStructuralVariantCounts(
             caseIdentifiers,
             entrezGeneIds,
             includeFrequency,
-            includeMissingAlterationsFromGenePanel);
+            includeMissingAlterationsFromGenePanel,
+            alterationFilter);
 
         Assert.assertEquals(expectedCountByGeneList, result.getFirst());
     }
@@ -177,20 +185,18 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
     @Test
     public void getSampleCnaCounts() {
 
-        boolean includeFrequency = true;
-
         // this mock tests correct argument types
         when(alterationRepository.getSampleCnaCounts(
             caseIdentifiers,
             entrezGeneIds,
-            cnaEventTypes)).thenReturn(expectedCnaCountByGeneList);
+            alterationFilter)).thenReturn(expectedCnaCountByGeneList);
 
         Pair<List<CopyNumberCountByGene>, Long> result = alterationCountService.getSampleCnaCounts(
             caseIdentifiers,
             entrezGeneIds,
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
-            cnaEventTypes);
+            alterationFilter);
 
         verify(alterationEnrichmentUtilCna, times(1)).includeFrequencyForSamples(anyList(), anyList(), anyBoolean());
         Assert.assertEquals(expectedCnaCountByGeneList, result.getFirst());
@@ -200,13 +206,11 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
     @Test
     public void getPatientCnaCounts() {
 
-        boolean includeFrequency = true;
-
         // this mock tests correct argument types
         when(alterationRepository.getPatientCnaCounts(
             caseIdentifiers,
             entrezGeneIds,
-            cnaEventTypes)).thenReturn(expectedCnaCountByGeneList);
+            alterationFilter)).thenReturn(expectedCnaCountByGeneList);
 
 
         Pair<List<CopyNumberCountByGene>, Long> result = alterationCountService.getPatientCnaCounts(
@@ -214,7 +218,7 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
             entrezGeneIds,
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
-            cnaEventTypes);
+            alterationFilter);
 
         verify(alterationEnrichmentUtilCna, times(1)).includeFrequencyForPatients(anyList(), anyList(), anyBoolean());
         Assert.assertEquals(expectedCnaCountByGeneList, result.getFirst());

--- a/service/src/test/java/org/cbioportal/service/impl/AlterationDriverAnnotationServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/AlterationDriverAnnotationServiceImplTest.java
@@ -1,0 +1,141 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.model.AlterationDriverAnnotation;
+import org.cbioportal.model.CustomDriverAnnotationReport;
+import org.cbioportal.persistence.AlterationDriverAnnotationRepository;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class AlterationDriverAnnotationServiceImplTest {
+
+    @InjectMocks
+    private AlterationDriverAnnotationServiceImpl alterationDriverAnnotationService;
+    @Mock
+    private AlterationDriverAnnotationRepository alterationDriverAnnotationRepository;
+    private AlterationDriverAnnotation alterationDriverAnnotation1;
+    private AlterationDriverAnnotation alterationDriverAnnotation2;
+
+    @Before
+    public void setUp() throws Exception {
+        alterationDriverAnnotation1 = new AlterationDriverAnnotation();
+        alterationDriverAnnotation2 = new AlterationDriverAnnotation();
+    }
+
+    @Test
+    public void getCustomDriverAnnotationProps() {
+
+        alterationDriverAnnotation1.setDriverFilter("Putative_Driver");
+        alterationDriverAnnotation1.setDriverTiersFilter("Class1");
+        alterationDriverAnnotation2.setDriverFilter("Putative_Passenger");
+        alterationDriverAnnotation2.setDriverTiersFilter("Class2");
+        List<AlterationDriverAnnotation> annotationList = Arrays.asList(alterationDriverAnnotation1, alterationDriverAnnotation2);
+        when(alterationDriverAnnotationRepository.getAlterationDriverAnnotations(isNull())).thenReturn(annotationList);
+
+        CustomDriverAnnotationReport props = alterationDriverAnnotationService.getCustomDriverAnnotationProps(null);
+
+        Assert.assertTrue(props.getHasBinary());
+        Assert.assertTrue(props.getTiers().containsAll(Arrays.asList("Class1", "Class2")));
+        
+    }
+    
+    @Test
+    public void getCustomDriverAnnotationPropsNoFilter() {
+        alterationDriverAnnotation1.setDriverFilter("Filter1");
+        alterationDriverAnnotation1.setDriverTiersFilter("Class1");
+        alterationDriverAnnotation2.setDriverFilter("Filter2");
+        alterationDriverAnnotation2.setDriverTiersFilter("Class2");
+        List<AlterationDriverAnnotation> annotationList = Arrays.asList(alterationDriverAnnotation1, alterationDriverAnnotation2);
+        when(alterationDriverAnnotationRepository.getAlterationDriverAnnotations(isNull())).thenReturn(annotationList);
+
+        CustomDriverAnnotationReport props = alterationDriverAnnotationService.getCustomDriverAnnotationProps(null);
+
+        Assert.assertFalse(props.getHasBinary());
+        Assert.assertTrue(props.getTiers().containsAll(Arrays.asList("Class1", "Class2")));
+        
+    }
+    
+    @Test
+    public void getCustomDriverAnnotationPropsNoTiersFilter() {
+
+        alterationDriverAnnotation1.setDriverFilter("Putative_Driver");
+        alterationDriverAnnotation2.setDriverFilter("Putative_Passenger");
+        List<AlterationDriverAnnotation> annotationList = Arrays.asList(alterationDriverAnnotation1, alterationDriverAnnotation2);
+        when(alterationDriverAnnotationRepository.getAlterationDriverAnnotations(isNull())).thenReturn(annotationList);
+
+        CustomDriverAnnotationReport props = alterationDriverAnnotationService.getCustomDriverAnnotationProps(null);
+
+        Assert.assertTrue(props.getHasBinary());
+        Assert.assertEquals(0, props.getTiers().size());
+        
+    }
+    
+    @Test
+    public void getCustomDriverAnnotationPropsOneFilter() {
+
+        alterationDriverAnnotation1.setDriverFilter("Putative_Driver");
+        List<AlterationDriverAnnotation> annotationList = Arrays.asList(alterationDriverAnnotation1, alterationDriverAnnotation2);
+        when(alterationDriverAnnotationRepository.getAlterationDriverAnnotations(isNull())).thenReturn(annotationList);
+
+        CustomDriverAnnotationReport props = alterationDriverAnnotationService.getCustomDriverAnnotationProps(null);
+
+        Assert.assertTrue(props.getHasBinary());
+        Assert.assertEquals(0, props.getTiers().size());
+        
+    }
+    
+    @Test
+    public void getCustomDriverAnnotationPropsNoFiltersAtAll() {
+
+        List<AlterationDriverAnnotation> annotationList = Arrays.asList(alterationDriverAnnotation1, alterationDriverAnnotation2);
+        when(alterationDriverAnnotationRepository.getAlterationDriverAnnotations(isNull())).thenReturn(annotationList);
+
+        CustomDriverAnnotationReport props = alterationDriverAnnotationService.getCustomDriverAnnotationProps(null);
+
+        Assert.assertFalse(props.getHasBinary());
+        Assert.assertEquals(0, props.getTiers().size());
+        
+    }
+
+    @Test
+    public void getCustomDriverAnnotationPropsWithoutNATiers() {
+        AlterationDriverAnnotation naTierAnnotation = new AlterationDriverAnnotation();
+        naTierAnnotation.setDriverTiersFilter("NA");
+        List<String> molecularProfileIds = Arrays.asList("test_1", "test_2");
+        List<AlterationDriverAnnotation> annotationList = Arrays.asList(alterationDriverAnnotation1, naTierAnnotation);
+        when(alterationDriverAnnotationRepository.getAlterationDriverAnnotations(molecularProfileIds))
+            .thenReturn(annotationList);
+
+        CustomDriverAnnotationReport props = alterationDriverAnnotationService
+            .getCustomDriverAnnotationProps(molecularProfileIds);
+
+        Assert.assertFalse("NA has to be removed from the set of tiers", props.getTiers().contains("NA"));
+    }
+
+    @Test
+    public void getCustomDriverAnnotationPropsWithoutEmptyTiers() {
+        AlterationDriverAnnotation emptyTierAnnotation = new AlterationDriverAnnotation();
+        emptyTierAnnotation.setDriverTiersFilter("");
+        List<String> molecularProfileIds = Arrays.asList("test_1", "test_2");
+        List<AlterationDriverAnnotation> annotationList = Arrays.asList(alterationDriverAnnotation1, emptyTierAnnotation);
+        when(alterationDriverAnnotationRepository.getAlterationDriverAnnotations(molecularProfileIds))
+            .thenReturn(annotationList);
+
+        CustomDriverAnnotationReport props = alterationDriverAnnotationService
+            .getCustomDriverAnnotationProps(molecularProfileIds);
+
+        Assert.assertFalse("Empty string tier has to be removed from the set", props.getTiers().contains(""));
+    }
+}

--- a/service/src/test/java/org/cbioportal/service/impl/AlterationEnrichmentServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/AlterationEnrichmentServiceImplTest.java
@@ -1,12 +1,14 @@
 package org.cbioportal.service.impl;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.math3.util.Pair;
-import org.cbioportal.model.*;
+import org.cbioportal.model.AlterationCountByGene;
+import org.cbioportal.model.AlterationEnrichment;
+import org.cbioportal.model.AlterationFilter;
+import org.cbioportal.model.CNA;
+import org.cbioportal.model.EnrichmentType;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
+import org.cbioportal.model.MutationCountByGene;
+import org.cbioportal.model.MutationEventType;
 import org.cbioportal.model.QueryElement;
 import org.cbioportal.model.util.Select;
 import org.cbioportal.service.AlterationCountService;
@@ -18,6 +20,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class AlterationEnrichmentServiceImplTest extends BaseServiceImplTest {
@@ -59,13 +66,14 @@ public class AlterationEnrichmentServiceImplTest extends BaseServiceImplTest {
         Pair<List<AlterationCountByGene>, Long> alterationSampleCountByGeneList = new Pair<>(new ArrayList<>(), 0L);
         Select<MutationEventType> mutationTypes = Select.none();
         Select<CNA> cnaTypes = Select.none();
+        
+        AlterationFilter alterationFilter = new AlterationFilter();
 
         //  return counts for each of the two groups 
         for (String molecularProfileId : groupMolecularProfileCaseSets.keySet()) {
             Mockito.when(alterationCountService.getSampleAlterationCounts(
                 groupMolecularProfileCaseSets.get(molecularProfileId),
-                Select.all(), true, true,
-                mutationTypes, cnaTypes, QueryElement.PASS)
+                Select.all(), true, true, QueryElement.PASS, alterationFilter)
             ).thenReturn(alterationSampleCountByGeneList);
         }
 
@@ -76,9 +84,8 @@ public class AlterationEnrichmentServiceImplTest extends BaseServiceImplTest {
         List<AlterationEnrichment> result = alterationEnrichmentService
             .getAlterationEnrichments(
                 groupMolecularProfileCaseSets,
-                mutationTypes,
-                cnaTypes,
-                EnrichmentType.SAMPLE);
+                EnrichmentType.SAMPLE,
+                alterationFilter);
         Assert.assertEquals(result, expectedAlterationEnrichments);
     }
 }

--- a/service/src/test/java/org/cbioportal/service/impl/CopyNumberEnrichmentServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/CopyNumberEnrichmentServiceImplTest.java
@@ -1,13 +1,12 @@
 package org.cbioportal.service.impl;
 
 import org.apache.commons.math3.util.Pair;
-import org.cbioportal.model.CNA;
+import org.cbioportal.model.AlterationFilter;
 import org.cbioportal.model.CopyNumberCountByGene;
 import org.cbioportal.model.EnrichmentType;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.model.util.Select;
 import org.cbioportal.service.AlterationCountService;
-import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,8 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -69,7 +67,6 @@ public class CopyNumberEnrichmentServiceImplTest {
         groupMolecularProfileCaseSets.put("unaltered group", molecularProfileCaseSet);
 
         List<CopyNumberCountByGene> counts = new ArrayList<>();
-
         Pair<List<CopyNumberCountByGene>, Long> mockedData = new Pair<>(counts, 0L);
         
         when(alterationCountService.getSampleCnaCounts(
@@ -77,15 +74,19 @@ public class CopyNumberEnrichmentServiceImplTest {
             argThat(new SelectMockitoArgumentMatcher("ALL")),
             eq(true),
             eq(true),
-            argThat(new SelectMockitoArgumentMatcher("SOME")))
-        ).thenReturn(mockedData);
+            any(AlterationFilter.class)
+        )).thenReturn(mockedData);
     }
 
     Map<String, List<MolecularProfileCaseIdentifier>> groupMolecularProfileCaseSets;
 
     @Test
-    public void testGetCopyNumberCountByGeneAndGroup() throws MolecularProfileNotFoundException {
-        Map<String, Pair<List<CopyNumberCountByGene>, Long>> copyNumberCountByGeneAndGroup = cnaCountService.getCopyNumberCountByGeneAndGroup(groupMolecularProfileCaseSets, CNA.AMP, EnrichmentType.SAMPLE);
+    public void testGetCopyNumberCountByGeneAndGroup() {
+        AlterationFilter alterationFilter = new AlterationFilter();
+        Map<String, Pair<List<CopyNumberCountByGene>, Long>> copyNumberCountByGeneAndGroup = cnaCountService.getCopyNumberCountByGeneAndGroup(
+            groupMolecularProfileCaseSets,
+            EnrichmentType.SAMPLE,
+            alterationFilter);
         Assert.assertEquals(2, copyNumberCountByGeneAndGroup.keySet().size());
     }
 }

--- a/service/src/test/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/DiscreteCopyNumberServiceImplTest.java
@@ -1,11 +1,6 @@
 package org.cbioportal.service.impl;
 
-import org.cbioportal.model.CopyNumberCount;
-import org.cbioportal.model.CopyNumberCountByGene;
-import org.cbioportal.model.DiscreteCopyNumberData;
-import org.cbioportal.model.Gene;
-import org.cbioportal.model.GeneMolecularData;
-import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.*;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.DiscreteCopyNumberRepository;
 import org.cbioportal.service.MolecularDataService;
@@ -21,8 +16,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
@@ -66,7 +65,7 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
     }
 
     @Test
-    public void getDiscreteCopyNumbersInMultipleMolecularProfilesAllMutTypes() {
+    public void getDiscreteCopyNumbersInMultipleMolecularProfilesAllAlterationTypes() {
         List<GeneMolecularData> returned = Arrays.asList(
             geneMolecularData("sample1", "study1", "-2"),
             geneMolecularData("sample2", "study1", "-1"),
@@ -77,18 +76,20 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
         
         List<String> profiles = Arrays.asList("profile1", "profile2");
         List<String> samples = Arrays.asList("sample1", "sample2");
-        List<Integer> geneIds = Arrays.asList(0, 1);
-        List<Integer> alterationTypes = Arrays.asList(-2, 1, 0, -1, 2);
-        Mockito.when(molecularDataService.getMolecularDataInMultipleMolecularProfiles(
-                profiles,
-                samples,
-                geneIds,
-                PROJECTION
+        List<CNA> alterationTypes = Arrays.asList(CNA.AMP, CNA.HOMDEL, CNA.DIPLOID, CNA.GAIN, CNA.HETLOSS);
+        GeneFilterQuery query = new GeneFilterQuery();
+        query.setAlterations(alterationTypes);
+        List<GeneFilterQuery> geneQueries = Arrays.asList(query);
+        Mockito.when(molecularDataService.getMolecularDataInMultipleMolecularProfilesByGeneQueries(
+                anyList(),
+                anyList(),
+                anyList(),
+                anyString()
             ))
             .thenReturn(returned);
 
-        List<DiscreteCopyNumberData> actual = discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfiles(
-            profiles, samples, geneIds, alterationTypes, PROJECTION
+        List<DiscreteCopyNumberData> actual = discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
+            profiles, samples, geneQueries, PROJECTION
         );
         List<DiscreteCopyNumberData> expected = Arrays.asList(
             discreteCopyNumberData("sample1", "study1", -2),
@@ -99,6 +100,29 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
         );
         
         Assert.assertEquals(toStrings(expected), toStrings(actual));
+    }
+
+    @Test
+    public void getDiscreteCopyNumbersInMultipleMolecularProfilesEmptyAlterationTypes() {
+        List<GeneMolecularData> returned = Arrays.asList(
+            geneMolecularData("sample1", "study1", "-2"),
+            geneMolecularData("sample2", "study1", "-1"),
+            geneMolecularData("sample3", "study1", "0"),
+            geneMolecularData("sample4", "study1", "1"),
+            geneMolecularData("sample5", "study2", "2")
+        );
+        
+        List<String> profiles = Arrays.asList("profile1", "profile2");
+        List<String> samples = Arrays.asList("sample1", "sample2");
+        List<CNA> alterationTypes = Collections.emptyList();
+        GeneFilterQuery query = new GeneFilterQuery();
+        query.setAlterations(alterationTypes);
+        List<GeneFilterQuery> geneQueries = Arrays.asList(query);
+
+        List<DiscreteCopyNumberData> actual = discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
+            profiles, samples, geneQueries, PROJECTION
+        );
+        Assert.assertEquals(Collections.emptyList(), toStrings(actual));
     }
     
     @Test

--- a/service/src/test/java/org/cbioportal/service/impl/MolecularDataServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MolecularDataServiceImplTest.java
@@ -1,11 +1,13 @@
 package org.cbioportal.service.impl;
 
+import org.cbioportal.model.DiscreteCopyNumberData;
 import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GeneMolecularData;
 import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.MolecularProfileSamples;
 import org.cbioportal.model.Sample;
 import org.cbioportal.model.meta.BaseMeta;
+import org.cbioportal.persistence.DiscreteCopyNumberRepository;
 import org.cbioportal.persistence.MolecularDataRepository;
 import org.cbioportal.persistence.SampleListRepository;
 import org.cbioportal.service.MolecularProfileService;
@@ -15,12 +17,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MolecularDataServiceImplTest extends BaseServiceImplTest {
@@ -31,6 +36,8 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
     @Mock
     private MolecularDataRepository molecularDataRepository;
     @Mock
+    private DiscreteCopyNumberRepository discreteCopyNumberRepository;
+    @Mock
     private SampleService sampleService;
     @Mock
     private MolecularProfileService molecularProfileService;
@@ -40,27 +47,27 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
     @Test
     public void getMolecularData() throws Exception {
         
-        Mockito.when(sampleListRepository.getAllSampleIdsInSampleList(SAMPLE_LIST_ID))
+        when(sampleListRepository.getAllSampleIdsInSampleList(SAMPLE_LIST_ID))
             .thenReturn(Arrays.asList(SAMPLE_ID1));
         
         MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
         molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
         molecularProfileSamples.setCommaSeparatedSampleIds("1,2,");
         
-        Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
+        when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
             .thenReturn(molecularProfileSamples);
 
         MolecularProfile molecularProfile = new MolecularProfile();
         molecularProfile.setCancerStudyIdentifier(STUDY_ID);
         molecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.MRNA_EXPRESSION);
-        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
+        when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
         
         List<Sample> sampleList = new ArrayList<>();
         Sample sample = new Sample();
         sample.setInternalId(1);
         sample.setStableId(SAMPLE_ID1);
         sampleList.add(sample);
-        Mockito.when(sampleService.fetchSamples(Arrays.asList(STUDY_ID), Arrays.asList(SAMPLE_ID1), "ID"))
+        when(sampleService.fetchSamples(Arrays.asList(STUDY_ID), Arrays.asList(SAMPLE_ID1), "ID"))
             .thenReturn(sampleList);
 
         List<GeneMolecularAlteration> molecularAlterationList = new ArrayList<>();
@@ -71,7 +78,7 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
 
         List<Integer> entrezGeneIds = new ArrayList<>();
         entrezGeneIds.add(ENTREZ_GENE_ID_1);
-        Mockito.when(molecularDataRepository.getGeneMolecularAlterations(MOLECULAR_PROFILE_ID, entrezGeneIds, 
+        when(molecularDataRepository.getGeneMolecularAlterations(MOLECULAR_PROFILE_ID, entrezGeneIds, 
             PROJECTION)).thenReturn(molecularAlterationList);
 
         List<GeneMolecularData> result = molecularDataService.getMolecularData(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, 
@@ -88,27 +95,27 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
     @Test
     public void getMetaMolecularData() throws Exception {
 
-        Mockito.when(sampleListRepository.getAllSampleIdsInSampleList(SAMPLE_LIST_ID))
+        when(sampleListRepository.getAllSampleIdsInSampleList(SAMPLE_LIST_ID))
             .thenReturn(Arrays.asList(SAMPLE_ID1));
 
         MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
         molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
         molecularProfileSamples.setCommaSeparatedSampleIds("1,2,");
         
-        Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
+        when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
             .thenReturn(molecularProfileSamples);
 
         MolecularProfile molecularProfile = new MolecularProfile();
         molecularProfile.setCancerStudyIdentifier(STUDY_ID);
         molecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.MRNA_EXPRESSION);
-        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
+        when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
 
         List<Sample> sampleList = new ArrayList<>();
         Sample sample = new Sample();
         sample.setInternalId(1);
         sample.setStableId(SAMPLE_ID1);
         sampleList.add(sample);
-        Mockito.when(sampleService.fetchSamples(Arrays.asList(STUDY_ID), Arrays.asList(SAMPLE_ID1), "ID"))
+        when(sampleService.fetchSamples(Arrays.asList(STUDY_ID), Arrays.asList(SAMPLE_ID1), "ID"))
             .thenReturn(sampleList);
 
         List<GeneMolecularAlteration> molecularAlterationList = new ArrayList<>();
@@ -119,7 +126,7 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
 
         List<Integer> entrezGeneIds = new ArrayList<>();
         entrezGeneIds.add(ENTREZ_GENE_ID_1);
-        Mockito.when(molecularDataRepository.getGeneMolecularAlterations(MOLECULAR_PROFILE_ID, entrezGeneIds, "ID"))
+        when(molecularDataRepository.getGeneMolecularAlterations(MOLECULAR_PROFILE_ID, entrezGeneIds, "ID"))
             .thenReturn(molecularAlterationList);
 
         BaseMeta result = molecularDataService.getMetaMolecularData(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID, 
@@ -133,13 +140,13 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
 
         MolecularProfile molecularProfile = new MolecularProfile();
         molecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.MRNA_EXPRESSION);
-        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
+        when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
 
         MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
         molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
         molecularProfileSamples.setCommaSeparatedSampleIds("1,2,");
         
-        Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
+        when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
             .thenReturn(molecularProfileSamples);
 
         List<GeneMolecularAlteration> molecularAlterationList = new ArrayList<>();
@@ -150,7 +157,7 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
 
         List<Integer> entrezGeneIds = new ArrayList<>();
         entrezGeneIds.add(ENTREZ_GENE_ID_1);
-        Mockito.when(molecularDataRepository.getGeneMolecularAlterations(MOLECULAR_PROFILE_ID, entrezGeneIds, 
+        when(molecularDataRepository.getGeneMolecularAlterations(MOLECULAR_PROFILE_ID, entrezGeneIds, 
             PROJECTION)).thenReturn(molecularAlterationList);
         
         List<Integer> internalIds = new ArrayList<>();
@@ -166,7 +173,7 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
         sample2.setInternalId(2);
         sample2.setStableId("sample_id_2");
         samples.add(sample2);
-        Mockito.when(sampleService.getSamplesByInternalIds(internalIds)).thenReturn(samples);
+        when(sampleService.getSamplesByInternalIds(internalIds)).thenReturn(samples);
 
         List<GeneMolecularData> result = molecularDataService.fetchMolecularData(MOLECULAR_PROFILE_ID, null, 
             entrezGeneIds, PROJECTION);
@@ -189,13 +196,13 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
 
         MolecularProfile molecularProfile = new MolecularProfile();
         molecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.MRNA_EXPRESSION);
-        Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
+        when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID)).thenReturn(molecularProfile);
 
         MolecularProfileSamples molecularProfileSamples = new MolecularProfileSamples();
         molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
         molecularProfileSamples.setCommaSeparatedSampleIds("1,2,");
         
-        Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
+        when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
             .thenReturn(molecularProfileSamples);
 
         List<GeneMolecularAlteration> molecularAlterationList = new ArrayList<>();
@@ -206,7 +213,7 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
 
         List<Integer> entrezGeneIds = new ArrayList<>();
         entrezGeneIds.add(ENTREZ_GENE_ID_1);
-        Mockito.when(molecularDataRepository.getGeneMolecularAlterations(MOLECULAR_PROFILE_ID, entrezGeneIds, "ID"))
+        when(molecularDataRepository.getGeneMolecularAlterations(MOLECULAR_PROFILE_ID, entrezGeneIds, "ID"))
             .thenReturn(molecularAlterationList);
 
         List<Integer> internalIds = new ArrayList<>();
@@ -222,7 +229,7 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
         sample2.setInternalId(2);
         sample2.setStableId("sample_id_2");
         samples.add(sample2);
-        Mockito.when(sampleService.getSamplesByInternalIds(internalIds)).thenReturn(samples);
+        when(sampleService.getSamplesByInternalIds(internalIds)).thenReturn(samples);
 
         BaseMeta result = molecularDataService.fetchMetaMolecularData(MOLECULAR_PROFILE_ID, null, entrezGeneIds);
 
@@ -236,11 +243,51 @@ public class MolecularDataServiceImplTest extends BaseServiceImplTest {
         molecularProfileSamples.setMolecularProfileId(MOLECULAR_PROFILE_ID);
         molecularProfileSamples.setCommaSeparatedSampleIds("1,2,");
         
-        Mockito.when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
+        when(molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(MOLECULAR_PROFILE_ID))
             .thenReturn(molecularProfileSamples);
         
         Integer result = molecularDataService.getNumberOfSamplesInMolecularProfile(MOLECULAR_PROFILE_ID);
         
         Assert.assertEquals((Integer) 2, result);
+    }
+
+    @Test
+    public void getMolecularDataInMultipleMolecularProfilesByGeneQueries() {
+
+        // two record come in ..
+        List<GeneMolecularData> unfilteredData = new ArrayList<>();
+        GeneMolecularData geneMolecularData1 = new GeneMolecularData();
+        geneMolecularData1.setEntrezGeneId(1);
+        geneMolecularData1.setMolecularProfileId("profile1");
+        geneMolecularData1.setValue("-2");
+        geneMolecularData1.setSampleId("sample1");
+        GeneMolecularData geneMolecularData2 = new GeneMolecularData();
+        geneMolecularData2.setEntrezGeneId(1);
+        geneMolecularData2.setMolecularProfileId("profile1");
+        geneMolecularData2.setValue("-1");
+        geneMolecularData2.setSampleId("sample2");
+        unfilteredData.add(geneMolecularData1);
+        unfilteredData.add(geneMolecularData2);
+        
+        MolecularDataServiceImpl spy = spy(molecularDataService);
+        doReturn(unfilteredData).when(spy).getMolecularDataInMultipleMolecularProfiles(anyList(), anyList(), anyList(), anyString());
+
+        List<DiscreteCopyNumberData> selectedCnaEvents = new ArrayList<>();
+        DiscreteCopyNumberData discreteCopyNumberData1 = new DiscreteCopyNumberData();
+        discreteCopyNumberData1.setEntrezGeneId(1);
+        discreteCopyNumberData1.setMolecularProfileId("profile1");
+        discreteCopyNumberData1.setAlteration(-2);
+        discreteCopyNumberData1.setSampleId("sample1");
+        selectedCnaEvents.add(discreteCopyNumberData1);
+
+        when(discreteCopyNumberRepository.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(anyList(), anyList(), anyList(), anyString())).thenReturn(selectedCnaEvents);
+
+        List<GeneMolecularData> filteredData = spy.getMolecularDataInMultipleMolecularProfilesByGeneQueries(Arrays.asList(), Arrays.asList(), Arrays.asList(), "projection");
+        
+        // one record comes out ...
+        // so, test whether record correctly removed from result set
+        Assert.assertEquals(1, filteredData.size());
+        Assert.assertEquals("sample1", filteredData.get(0).getSampleId());
+
     }
 }

--- a/service/src/test/java/org/cbioportal/service/impl/MutationServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MutationServiceImplTest.java
@@ -1,6 +1,7 @@
 package org.cbioportal.service.impl;
 
 import org.cbioportal.model.Gene;
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.Mutation;
 import org.cbioportal.model.MutationCountByPosition;
@@ -19,6 +20,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class MutationServiceImplTest extends BaseServiceImplTest {
@@ -100,13 +105,35 @@ public class MutationServiceImplTest extends BaseServiceImplTest {
         mutation.setChr("19");
         expectedMutationList.add(mutation);
 
-        Mockito.when(mutationRepository.getMutationsInMultipleMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID), 
-            Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, 
-            DIRECTION)).thenReturn(expectedMutationList);
+        Mockito.when(mutationRepository.getMutationsInMultipleMolecularProfiles(anyList(),
+            anyList(), anyList(), eq(PROJECTION), eq(PAGE_SIZE), eq(PAGE_NUMBER), eq(SORT),
+            eq(DIRECTION))).thenReturn(expectedMutationList);
         
         List<Mutation> result = mutationService.getMutationsInMultipleMolecularProfiles(
-            Arrays.asList(MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), PROJECTION, 
-            PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+            Arrays.asList(MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1), Arrays.asList(ENTREZ_GENE_ID_1), PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
+
+        Assert.assertEquals(expectedMutationList, result);
+        Assert.assertEquals("19", result.get(0).getChr());
+    }
+
+    @Test
+    public void getMutationsInMultipleMolecularProfilesByGeneQueries() throws Exception {
+
+        List<Mutation> expectedMutationList = new ArrayList<>();
+        Mutation mutation = new Mutation();
+        Gene gene = new Gene();
+        mutation.setGene(gene);
+        mutation.setChr("19");
+        expectedMutationList.add(mutation);
+
+        GeneFilterQuery geneFilterQuery = mock(GeneFilterQuery.class);
+
+        Mockito.when(mutationRepository.getMutationsInMultipleMolecularProfilesByGeneQueries(anyList(),
+            anyList(), anyList(), eq(PROJECTION), eq(PAGE_SIZE), eq(PAGE_NUMBER), eq(SORT),
+            eq(DIRECTION))).thenReturn(expectedMutationList);
+        
+        List<Mutation> result = mutationService.getMutationsInMultipleMolecularProfilesByGeneQueries(
+            Arrays.asList(MOLECULAR_PROFILE_ID), Arrays.asList(SAMPLE_ID1), Arrays.asList(geneFilterQuery), PROJECTION, PAGE_SIZE, PAGE_NUMBER, SORT, DIRECTION);
 
         Assert.assertEquals(expectedMutationList, result);
         Assert.assertEquals("19", result.get(0).getChr());

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -81,6 +81,9 @@ skin.study_view.link_text=To build your own case set, try out our enhanced Study
 # setting controlling the default setting for filtering genes in patient view
 # skin.patientview.filter_genes_profiled_all_samples=false
 
+# settings controlling the appearance of the annotation filter menu in study view and group comparison
+# skin.show_settings_menu=false
+
 ## enable and set this property to specify a study group to be used to identify public studies for which no specific authorization entries are needed in the `authorities` table
 # always_show_study_group=
 

--- a/web/src/main/java/org/cbioportal/web/AlterationDriverAnnotationController.java
+++ b/web/src/main/java/org/cbioportal/web/AlterationDriverAnnotationController.java
@@ -1,0 +1,42 @@
+package org.cbioportal.web;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.cbioportal.model.CustomDriverAnnotationReport;
+import org.cbioportal.service.AlterationDriverAnnotationService;
+import org.cbioportal.web.config.annotation.InternalApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@InternalApi
+@RestController
+@Validated
+@Api(tags = "Custom driver annotations", description = " ")
+public class AlterationDriverAnnotationController {
+
+    @Autowired
+    private AlterationDriverAnnotationService alterationDriverAnnotationService;
+
+    @PreAuthorize("hasPermission(#molecularProfileIds, 'Collection<MolecularProfileId>', 'read')")
+    @PostMapping(value = "/custom-driver-annotation-report/fetch",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Return availability of custom driver annotations for molecular profiles")
+    public ResponseEntity<CustomDriverAnnotationReport> fetchAlterationDriverAnnotationReport(
+        @RequestParam(required = true) List<String> molecularProfileIds) {
+
+        CustomDriverAnnotationReport customDriverAnnotationReport = alterationDriverAnnotationService.getCustomDriverAnnotationProps(molecularProfileIds);
+
+        return new ResponseEntity<>(customDriverAnnotationReport, HttpStatus.OK);
+    }
+}
+

--- a/web/src/main/java/org/cbioportal/web/AlterationEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/AlterationEnrichmentController.java
@@ -42,7 +42,7 @@ public class AlterationEnrichmentController {
         // prevent reference to this attribute in the swagger-ui interface. this attribute is needed for the @PreAuthorize tag above.
         @Valid @RequestAttribute(required = false, value = "interceptedMolecularProfileCasesGroupFilters") List<MolecularProfileCasesGroupFilter> interceptedMolecularProfileCasesGroupFilters,
         @ApiIgnore
-        @Valid @RequestAttribute(required = false, value = "alterationEventTypes") AlterationFilter alterationFilter,
+        @Valid @RequestAttribute(required = false, value = "alterationFilter") AlterationFilter alterationFilter,
         @ApiParam("Type of the enrichment e.g. SAMPLE or PATIENT")
         @RequestParam(defaultValue = "SAMPLE") EnrichmentType enrichmentType,
         @ApiParam(required = true, value = "List of groups containing sample identifiers and list of Alteration Types")

--- a/web/src/main/java/org/cbioportal/web/AlterationEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/AlterationEnrichmentController.java
@@ -42,7 +42,7 @@ public class AlterationEnrichmentController {
         // prevent reference to this attribute in the swagger-ui interface. this attribute is needed for the @PreAuthorize tag above.
         @Valid @RequestAttribute(required = false, value = "interceptedMolecularProfileCasesGroupFilters") List<MolecularProfileCasesGroupFilter> interceptedMolecularProfileCasesGroupFilters,
         @ApiIgnore
-        @Valid @RequestAttribute(required = false, value = "alterationEventTypes") AlterationEventTypeFilter alterationEventTypes,
+        @Valid @RequestAttribute(required = false, value = "alterationEventTypes") AlterationFilter alterationFilter,
         @ApiParam("Type of the enrichment e.g. SAMPLE or PATIENT")
         @RequestParam(defaultValue = "SAMPLE") EnrichmentType enrichmentType,
         @ApiParam(required = true, value = "List of groups containing sample identifiers and list of Alteration Types")
@@ -54,9 +54,8 @@ public class AlterationEnrichmentController {
 
         List<AlterationEnrichment> alterationEnrichments = alterationEnrichmentService.getAlterationEnrichments(
             groupCaseIdentifierSet,
-            alterationEventTypes.getMutationTypeSelect(),
-            alterationEventTypes.getCNAEventTypeSelect(),
-            enrichmentType);
+            enrichmentType,
+            alterationFilter);
 
         return new ResponseEntity<>(alterationEnrichments, HttpStatus.OK);
     }

--- a/web/src/main/java/org/cbioportal/web/CopyNumberEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/CopyNumberEnrichmentController.java
@@ -4,9 +4,11 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.AlterationEnrichment;
+import org.cbioportal.model.AlterationFilter;
 import org.cbioportal.model.CNA;
 import org.cbioportal.model.EnrichmentType;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
+import org.cbioportal.model.util.Select;
 import org.cbioportal.service.CopyNumberEnrichmentService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.web.config.annotation.InternalApi;
@@ -17,10 +19,16 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -56,10 +64,12 @@ public class CopyNumberEnrichmentController {
                 .collect(Collectors.toMap(MolecularProfileCasesGroupFilter::getName,
                         MolecularProfileCasesGroupFilter::getMolecularProfileCaseIdentifiers));
 
+        AlterationFilter alterationFilter = new AlterationFilter();
+        alterationFilter.setSelectedMutationTypes(Select.none());
+        alterationFilter.setCnaTypeSelect(Select.byValues(Arrays.asList(copyNumberEventType)));
+        
         return new ResponseEntity<>(
             copyNumberEnrichmentService.getCopyNumberEnrichments(
-                groupCaseIdentifierSet,
-                copyNumberEventType,
-                enrichmentType), HttpStatus.OK);
+                groupCaseIdentifierSet, enrichmentType, alterationFilter), HttpStatus.OK);
     }
 }

--- a/web/src/main/java/org/cbioportal/web/MutationEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationEnrichmentController.java
@@ -4,11 +4,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.cbioportal.model.AlterationEnrichment;
+import org.cbioportal.model.AlterationFilter;
+import org.cbioportal.model.EnrichmentType;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.service.MutationEnrichmentService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.web.config.annotation.InternalApi;
-import org.cbioportal.model.EnrichmentType;
 import org.cbioportal.web.parameter.MolecularProfileCasesGroupFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -16,11 +17,18 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @InternalApi
@@ -54,6 +62,7 @@ public class MutationEnrichmentController {
         return new ResponseEntity<>(
             mutationEnrichmentService.getMutationEnrichments(
                 groupCaseIdentifierSet,
-                enrichmentType), HttpStatus.OK);
+                enrichmentType,
+                new AlterationFilter()), HttpStatus.OK);
     }
 }

--- a/web/src/main/java/org/cbioportal/web/StudyViewController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyViewController.java
@@ -42,6 +42,7 @@ import org.cbioportal.service.SignificantlyMutatedGeneService;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.service.util.ClinicalAttributeUtil;
 import org.cbioportal.web.config.annotation.InternalApi;
+import org.cbioportal.model.AlterationFilter;
 import org.cbioportal.web.parameter.ClinicalDataBinCountFilter;
 import org.cbioportal.web.parameter.ClinicalDataBinFilter;
 import org.cbioportal.web.parameter.ClinicalDataCountFilter;
@@ -324,6 +325,8 @@ public class StudyViewController {
         @ApiIgnore // prevent reference to this attribute in the swagger-ui interface. this attribute is needed for the @PreAuthorize tag above.
         @Valid @RequestAttribute(required = false, value = "interceptedStudyViewFilter") StudyViewFilter interceptedStudyViewFilter) throws StudyNotFoundException {
 
+        AlterationFilter annotationFilters = interceptedStudyViewFilter.getAlterationFilter();    
+
         List<SampleIdentifier> filteredSampleIdentifiers = studyViewFilterApplier.apply(interceptedStudyViewFilter);
         Pair<List<AlterationCountByGene>, Long> result = new Pair<>(new ArrayList<>(), 0L);
         if (!filteredSampleIdentifiers.isEmpty()) {
@@ -340,7 +343,7 @@ public class StudyViewController {
                 Select.all(),
                 true, 
                 false,
-                Select.all());
+                annotationFilters);
             result.getFirst().sort((a, b) -> b.getNumberOfAlteredCases() - a.getNumberOfAlteredCases());
             List<String> distinctStudyIds = studyIds.stream().distinct().collect(Collectors.toList());
             if (distinctStudyIds.size() == 1 && !result.getFirst().isEmpty()) {
@@ -369,6 +372,9 @@ public class StudyViewController {
         @RequestAttribute(required = false, value = "involvedCancerStudies") Collection<String> involvedCancerStudies,
         @ApiIgnore // prevent reference to this attribute in the swagger-ui interface.
         @Valid @RequestAttribute(required = false, value = "interceptedStudyViewFilter") StudyViewFilter interceptedStudyViewFilter) throws StudyNotFoundException {
+
+        AlterationFilter annotationFilters = interceptedStudyViewFilter.getAlterationFilter();
+        
         List<SampleIdentifier> filteredSampleIdentifiers = studyViewFilterApplier.apply(interceptedStudyViewFilter);
         Pair<List<AlterationCountByGene>, Long> result = new Pair<>(new ArrayList<>(), 0L);
         if (!filteredSampleIdentifiers.isEmpty()) {
@@ -385,7 +391,8 @@ public class StudyViewController {
                 caseIdentifiers,
                 Select.all(),
                 true,
-                false);
+                false,
+                annotationFilters);
             result.getFirst().sort((a, b) -> b.getNumberOfAlteredCases() - a.getNumberOfAlteredCases());
             List<String> distinctStudyIds = studyIds.stream().distinct().collect(Collectors.toList());
             if (distinctStudyIds.size() == 1 && !result.getFirst().isEmpty()) {
@@ -416,6 +423,8 @@ public class StudyViewController {
         @ApiIgnore // prevent reference to this attribute in the swagger-ui interface. this attribute is needed for the @PreAuthorize tag above.
         @Valid @RequestAttribute(required = false, value = "interceptedStudyViewFilter") StudyViewFilter interceptedStudyViewFilter) throws StudyNotFoundException {
 
+        AlterationFilter alterationFilter = interceptedStudyViewFilter.getAlterationFilter();
+
         // TODO refactor resolution of sampleids to List<MolecularProfileCaseIdentifier> and share between methods
         List<SampleIdentifier> filteredSampleIdentifiers = studyViewFilterApplier.apply(interceptedStudyViewFilter);
         Pair<List<CopyNumberCountByGene>, Long> result = new Pair<>(new ArrayList<>(), 0L);
@@ -434,7 +443,7 @@ public class StudyViewController {
                 Select.all(),
                 true,
                 false,
-                cnaTypes);
+                alterationFilter);
             result.getFirst().sort((a, b) -> b.getNumberOfAlteredCases() - a.getNumberOfAlteredCases());
             List<String> distinctStudyIds = studyIds.stream().distinct().collect(Collectors.toList());
             if (distinctStudyIds.size() == 1 && !result.getFirst().isEmpty()) {

--- a/web/src/main/java/org/cbioportal/web/parameter/MolecularProfileCasesGroupAndAlterationTypeFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/MolecularProfileCasesGroupAndAlterationTypeFilter.java
@@ -1,19 +1,18 @@
 package org.cbioportal.web.parameter;
 
 import io.swagger.annotations.ApiModelProperty;
-
-import java.util.List;
+import org.cbioportal.model.AlterationFilter;
 
 import javax.validation.constraints.Size;
+import java.util.List;
 
 public class MolecularProfileCasesGroupAndAlterationTypeFilter {
 
-
-    private AlterationEventTypeFilter alterationEventTypes;
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     @ApiModelProperty(required = true)
     private List<MolecularProfileCasesGroupFilter> molecularProfileCasesGroupFilter;
- 
+    @ApiModelProperty(required = true)
+    private AlterationFilter alterationFilter;
 
     public List<MolecularProfileCasesGroupFilter> getMolecularProfileCasesGroupFilter() {
         return this.molecularProfileCasesGroupFilter;
@@ -24,11 +23,11 @@ public class MolecularProfileCasesGroupAndAlterationTypeFilter {
                 this.molecularProfileCasesGroupFilter = molecularProfileCasesGroupFilter;
     }
 
-    public AlterationEventTypeFilter getAlterationEventTypes() {
-        return this.alterationEventTypes;
+    public AlterationFilter getAlterationFilter() {
+        return this.alterationFilter;
     }
 
-    public void setAlterationEventTypes(AlterationEventTypeFilter alterationEventTypes) {
-        this.alterationEventTypes = alterationEventTypes;
+    public void setAlterationFilter(AlterationFilter alterationFilter) {
+        this.alterationFilter = alterationFilter;
     }
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/MolecularProfileCasesGroupAndAlterationTypeFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/MolecularProfileCasesGroupAndAlterationTypeFilter.java
@@ -8,11 +8,15 @@ import java.util.List;
 
 public class MolecularProfileCasesGroupAndAlterationTypeFilter {
 
+    // TODO alterationEventTypes and alterationFilter are both 
+    // implemented because of backwards compatibility
+    // after merge of PR https://github.com/cBioPortal/cbioportal-frontend/pull/3555
+    // the alterationEventTypes param can be removed
+    private AlterationEventTypeFilter alterationEventTypes;
+    private AlterationFilter alterationFilter;
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     @ApiModelProperty(required = true)
     private List<MolecularProfileCasesGroupFilter> molecularProfileCasesGroupFilter;
-    @ApiModelProperty(required = true)
-    private AlterationFilter alterationFilter;
 
     public List<MolecularProfileCasesGroupFilter> getMolecularProfileCasesGroupFilter() {
         return this.molecularProfileCasesGroupFilter;
@@ -24,10 +28,24 @@ public class MolecularProfileCasesGroupAndAlterationTypeFilter {
     }
 
     public AlterationFilter getAlterationFilter() {
-        return this.alterationFilter;
+        if (this.alterationFilter != null)
+            return this.alterationFilter;
+        // TODO code below can be removed after merge of PR https://github.com/cBioPortal/cbioportal-frontend/pull/3555
+        AlterationFilter alterationFilter = new AlterationFilter();
+        if (this.alterationEventTypes != null) {
+            alterationFilter.setMutationBooleanMap(this.alterationEventTypes.getMutationEventTypes());
+            alterationFilter.setCnaBooleanMap(this.alterationEventTypes.getCopyNumberAlterationEventTypes());
+        }
+        return alterationFilter;
     }
 
     public void setAlterationFilter(AlterationFilter alterationFilter) {
         this.alterationFilter = alterationFilter;
     }
+
+    // TODO code below can be removed after merge of PR https://github.com/cBioPortal/cbioportal-frontend/pull/3555
+    public void setAlterationEventTypes(AlterationEventTypeFilter alterationEventTypes) {
+        this.alterationEventTypes = alterationEventTypes;
+    }
+    
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/StudyViewFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/StudyViewFilter.java
@@ -1,16 +1,18 @@
 package org.cbioportal.web.parameter;
 
-import java.io.Serializable;
-import java.util.List;
-import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.cbioportal.model.AlterationFilter;
+import org.cbioportal.model.GeneFilter;
+import org.cbioportal.web.parameter.filter.AndedPatientTreatmentFilters;
+import org.cbioportal.web.parameter.filter.AndedSampleTreatmentFilters;
 
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.cbioportal.web.parameter.filter.*;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
@@ -29,7 +31,8 @@ public class StudyViewFilter implements Serializable {
     private List<GenericAssayDataFilter> genericAssayDataFilters;
     private List<List<String>> caseLists;
     private List<ClinicalDataFilter> customDataFilters;
-
+    private AlterationFilter alterationFilter;
+    
     @AssertTrue
     private boolean isEitherSampleIdentifiersOrStudyIdsPresent() {
         return sampleIdentifiers != null ^ studyIds != null;
@@ -157,4 +160,11 @@ public class StudyViewFilter implements Serializable {
         this.customDataFilters = customDataFilters;
     }
 
+    public AlterationFilter getAlterationFilter() {
+        return alterationFilter;
+    }
+
+    public void setAlterationFilter(AlterationFilter alterationFilter) {
+        this.alterationFilter = alterationFilter;
+    }
 }

--- a/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
+++ b/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
@@ -560,6 +560,11 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
     private boolean extractAttributesFromStudyViewFilter(HttpServletRequest request) {
         try {
             StudyViewFilter studyViewFilter = objectMapper.readValue(request.getInputStream(), StudyViewFilter.class);
+            if (studyViewFilter.getAlterationFilter() == null) {
+                // For backwards compatibility an inactive filter is set
+                // when the AlterationFilter is not part of the request.
+                studyViewFilter.setAlterationFilter(new AlterationFilter());
+            }
             LOG.debug("extracted studyViewFilter: " + studyViewFilter.toString());
             LOG.debug("setting interceptedStudyViewFilter to " + studyViewFilter);
             request.setAttribute("interceptedStudyViewFilter", studyViewFilter);
@@ -602,12 +607,13 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
             LOG.debug("extracted molecularProfileCasesGroupFilters: " + molecularProfileCasesGroupFilters.toString());
             LOG.debug("setting interceptedMolecularProfileCasesGroupFilters to " + molecularProfileCasesGroupFilters);
             request.setAttribute("interceptedMolecularProfileCasesGroupFilters", molecularProfileCasesGroupFilters);
-            if (molecularProfileCasesAndAlterationTypesGroupFilters.getAlterationFilter() != null) {
-                AlterationFilter alterationEnrichmentEventTypes = molecularProfileCasesAndAlterationTypesGroupFilters.getAlterationFilter();
-                LOG.debug("extracted alterationEventTypes: " + alterationEnrichmentEventTypes.toString());
-                LOG.debug("setting alterationEventTypes to " + alterationEnrichmentEventTypes);
-                request.setAttribute("alterationEventTypes", alterationEnrichmentEventTypes);
+            AlterationFilter alterationFilter = molecularProfileCasesAndAlterationTypesGroupFilters.getAlterationFilter();
+            if (molecularProfileCasesAndAlterationTypesGroupFilters.getAlterationFilter() == null) {
+                // For backwards compatibility an inactive filter is set
+                // when the AlterationFilter is not part of the request.
+                alterationFilter = new AlterationFilter();
             }
+            request.setAttribute("alterationFilter", alterationFilter);
             if (cacheMapUtil.hasCacheEnabled()) {
                 Collection<String> cancerStudyIdCollection = extractCancerStudyIdsFromMolecularProfileCasesGroups(
                         molecularProfileCasesGroupFilters);

--- a/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
+++ b/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
@@ -38,8 +38,10 @@ import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.cbioportal.model.MolecularProfileCaseIdentifier;
+
+import org.cbioportal.model.AlterationFilter;
 import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.model.SampleList;
 import org.cbioportal.persistence.mybatis.util.CacheMapUtil;
 import org.cbioportal.web.parameter.*;
@@ -600,8 +602,8 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
             LOG.debug("extracted molecularProfileCasesGroupFilters: " + molecularProfileCasesGroupFilters.toString());
             LOG.debug("setting interceptedMolecularProfileCasesGroupFilters to " + molecularProfileCasesGroupFilters);
             request.setAttribute("interceptedMolecularProfileCasesGroupFilters", molecularProfileCasesGroupFilters);
-            if (molecularProfileCasesAndAlterationTypesGroupFilters.getAlterationEventTypes() != null) {
-                AlterationEventTypeFilter alterationEnrichmentEventTypes = molecularProfileCasesAndAlterationTypesGroupFilters.getAlterationEventTypes();
+            if (molecularProfileCasesAndAlterationTypesGroupFilters.getAlterationFilter() != null) {
+                AlterationFilter alterationEnrichmentEventTypes = molecularProfileCasesAndAlterationTypesGroupFilters.getAlterationFilter();
                 LOG.debug("extracted alterationEventTypes: " + alterationEnrichmentEventTypes.toString());
                 LOG.debug("setting alterationEventTypes to " + alterationEnrichmentEventTypes);
                 request.setAttribute("alterationEventTypes", alterationEnrichmentEventTypes);

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -34,7 +34,6 @@ import org.cbioportal.web.parameter.DataBinFilter;
 import org.cbioportal.web.parameter.DataBinMethod;
 import org.cbioportal.web.parameter.DataFilter;
 import org.cbioportal.web.parameter.DiscreteCopyNumberEventType;
-import org.cbioportal.web.parameter.GeneFilter.SingleGeneQuery;
 import org.cbioportal.web.parameter.GeneIdType;
 import org.cbioportal.web.parameter.GenericAssayDataBinCountFilter;
 import org.cbioportal.web.parameter.GenericAssayDataBinFilter;
@@ -60,6 +59,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.cbioportal.model.MolecularProfile.*;
 
 @Component
 public class StudyViewFilterApplier {
@@ -409,7 +410,7 @@ public class StudyViewFilterApplier {
                     .stream()
                     .collect(Collectors.groupingBy(MolecularProfile::getCancerStudyIdentifier));
 
-            for (List<SingleGeneQuery> geneQueries : genefilter.getGeneQueries()) {
+            for (List<GeneFilterQuery> geneQueries : genefilter.getGeneQueries()) {
                 List<String> studyIds = new ArrayList<>();
                 List<String> sampleIds = new ArrayList<>();
 
@@ -447,7 +448,7 @@ public class StudyViewFilterApplier {
                 }
 
                 sampleIdentifiers = structuralVariantService
-                        .fetchStructuralVariants(molecularProfileIds, geneQueries, sampleIds)
+                        .fetchStructuralVariantsByGeneQueries(molecularProfileIds, geneQueries, sampleIds)
                         .stream()
                         .map(m -> {
                             SampleIdentifier sampleIdentifier = new SampleIdentifier();
@@ -572,7 +573,7 @@ public class StudyViewFilterApplier {
                 if (alterationType == MolecularAlterationType.MUTATION_EXTENDED) {
                     mutatedGeneFilters.add(genefilter);
                 } else if (alterationType.equals(MolecularAlterationType.STRUCTURAL_VARIANT) ||
-                        alterationType.equals(MolecularProfile.MolecularAlterationType.FUSION)) {
+                        alterationType.equals(MolecularAlterationType.FUSION)) {
                     structuralVariantGeneFilters.add(genefilter);
                 } else if (alterationType == MolecularAlterationType.COPY_NUMBER_ALTERATION
                         && dataTypes.size() == 1 && dataTypes.iterator().next().equals("DISCRETE")) {

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -1,22 +1,65 @@
 package org.cbioportal.web.util;
 
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.map.MultiKeyMap;
-import org.cbioportal.model.*;
-import org.cbioportal.model.MolecularProfile.MolecularAlterationType;
-import org.cbioportal.service.*;
+import org.cbioportal.model.ClinicalAttribute;
+import org.cbioportal.model.ClinicalData;
+import org.cbioportal.model.DataBin;
+import org.cbioportal.model.DiscreteCopyNumberData;
+import org.cbioportal.model.Gene;
+import org.cbioportal.model.GeneFilter;
+import org.cbioportal.model.GeneFilterQuery;
+import org.cbioportal.model.GenePanelData;
+import org.cbioportal.model.GenericAssayDataBin;
+import org.cbioportal.model.GenomicDataBin;
+import org.cbioportal.model.MolecularProfile;
+import org.cbioportal.model.Sample;
+import org.cbioportal.model.SampleList;
+import org.cbioportal.service.ClinicalAttributeService;
+import org.cbioportal.service.DiscreteCopyNumberService;
+import org.cbioportal.service.GenePanelService;
+import org.cbioportal.service.GeneService;
+import org.cbioportal.service.GenericAssayService;
+import org.cbioportal.service.MolecularDataService;
+import org.cbioportal.service.MolecularProfileService;
+import org.cbioportal.service.MutationService;
+import org.cbioportal.service.SampleListService;
+import org.cbioportal.service.SampleService;
+import org.cbioportal.service.StructuralVariantService;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
-import org.cbioportal.web.parameter.*;
+import org.cbioportal.web.parameter.ClinicalDataFilter;
+import org.cbioportal.web.parameter.ClinicalDataType;
+import org.cbioportal.web.parameter.DataBinCountFilter;
+import org.cbioportal.web.parameter.DataBinFilter;
+import org.cbioportal.web.parameter.DataBinMethod;
+import org.cbioportal.web.parameter.DataFilter;
+import org.cbioportal.web.parameter.DiscreteCopyNumberEventType;
 import org.cbioportal.web.parameter.GeneFilter.SingleGeneQuery;
+import org.cbioportal.web.parameter.GeneIdType;
+import org.cbioportal.web.parameter.GenericAssayDataBinCountFilter;
+import org.cbioportal.web.parameter.GenericAssayDataBinFilter;
+import org.cbioportal.web.parameter.GenericAssayDataFilter;
+import org.cbioportal.web.parameter.GenomicDataBinCountFilter;
+import org.cbioportal.web.parameter.GenomicDataBinFilter;
+import org.cbioportal.web.parameter.GenomicDataFilter;
+import org.cbioportal.web.parameter.Projection;
+import org.cbioportal.web.parameter.SampleIdentifier;
+import org.cbioportal.web.parameter.StudyViewFilter;
 import org.cbioportal.web.util.appliers.PatientTreatmentFilterApplier;
 import org.cbioportal.web.util.appliers.SampleTreatmentFilterApplier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Component
 public class StudyViewFilterApplier {
@@ -297,21 +340,28 @@ public class StudyViewFilterApplier {
                     .stream()
                     .collect(Collectors.groupingBy(MolecularProfile::getCancerStudyIdentifier));
 
-            for (List<SingleGeneQuery> geneQueries : genefilter.getSingleGeneQueries()) {
+            for (List<GeneFilterQuery> geneQueries : genefilter.getGeneQueries()) {
                 List<String> studyIds = new ArrayList<>();
                 List<String> sampleIds = new ArrayList<>();
 
                 List<String> hugoGeneSymbols = geneQueries
                         .stream()
-                        .map(SingleGeneQuery::getHugoGeneSymbol)
+                        .map(GeneFilterQuery::getHugoGeneSymbol)
                         .collect(Collectors.toList());
 
-                List<Integer> entrezGeneIds = geneService
-                        .fetchGenes(hugoGeneSymbols, GeneIdType.HUGO_GENE_SYMBOL.name(), Projection.SUMMARY.name())
-                        .stream()
-                        .map(gene -> gene.getEntrezGeneId())
-                        .collect(Collectors.toList());
+                Map<String, Integer> symbolToEntrezGeneId = geneService
+                    .fetchGenes(new ArrayList<>(hugoGeneSymbols),
+                        GeneIdType.HUGO_GENE_SYMBOL.name(), Projection.SUMMARY.name())
+                    .stream()
+                    .collect(Collectors.toMap(Gene::getHugoGeneSymbol, Gene::getEntrezGeneId));
 
+                geneQueries.removeIf(
+                    q -> !symbolToEntrezGeneId.containsKey(q.getHugoGeneSymbol())
+                );
+
+                geneQueries.stream().forEach(
+                    q -> q.setEntrezGeneId(symbolToEntrezGeneId.get(q.getHugoGeneSymbol()))
+                );
                 studyViewFilterUtil.extractStudyAndSampleIds(sampleIdentifiers, studyIds, sampleIds);
 
                 List<String> molecularProfileIds = new ArrayList<>();
@@ -327,7 +377,7 @@ public class StudyViewFilterApplier {
                 }
 
                 sampleIdentifiers = mutationService
-                        .getMutationsInMultipleMolecularProfiles(molecularProfileIds, sampleIds, entrezGeneIds,
+                        .getMutationsInMultipleMolecularProfilesByGeneQueries(molecularProfileIds, sampleIds, geneQueries,
                                 Projection.ID.name(), null, null, null, null)
                         .stream()
                         .map(m -> {
@@ -359,21 +409,29 @@ public class StudyViewFilterApplier {
                     .stream()
                     .collect(Collectors.groupingBy(MolecularProfile::getCancerStudyIdentifier));
 
-            for (List<SingleGeneQuery> geneQueries : genefilter.getSingleGeneQueries()) {
+            for (List<SingleGeneQuery> geneQueries : genefilter.getGeneQueries()) {
                 List<String> studyIds = new ArrayList<>();
                 List<String> sampleIds = new ArrayList<>();
 
                 List<String> hugoGeneSymbols = geneQueries
-                        .stream()
-                        .map(SingleGeneQuery::getHugoGeneSymbol)
-                        .collect(Collectors.toList());
+                    .stream()
+                    .map(GeneFilterQuery::getHugoGeneSymbol)
+                    .collect(Collectors.toList());
 
-                List<Integer> entrezGeneIds = geneService
-                        .fetchGenes(hugoGeneSymbols, GeneIdType.HUGO_GENE_SYMBOL.name(), Projection.SUMMARY.name())
-                        .stream()
-                        .map(gene -> gene.getEntrezGeneId())
-                        .collect(Collectors.toList());
+                Map<String, Integer> symbolToEntrezGeneId = geneService
+                    .fetchGenes(new ArrayList<>(hugoGeneSymbols),
+                        GeneIdType.HUGO_GENE_SYMBOL.name(), Projection.SUMMARY.name())
+                    .stream()
+                    .collect(Collectors.toMap(Gene::getHugoGeneSymbol, Gene::getEntrezGeneId));
 
+                geneQueries.removeIf(
+                    q -> !symbolToEntrezGeneId.containsKey(q.getHugoGeneSymbol())
+                );
+
+                geneQueries.stream().forEach(
+                    q -> q.setEntrezGeneId(symbolToEntrezGeneId.get(q.getHugoGeneSymbol()))
+                );
+                
                 studyViewFilterUtil.extractStudyAndSampleIds(sampleIdentifiers, studyIds, sampleIds);
 
                 List<String> molecularProfileIds = new ArrayList<>();
@@ -389,7 +447,7 @@ public class StudyViewFilterApplier {
                 }
 
                 sampleIdentifiers = structuralVariantService
-                        .fetchStructuralVariants(molecularProfileIds, entrezGeneIds, sampleIds)
+                        .fetchStructuralVariants(molecularProfileIds, geneQueries, sampleIds)
                         .stream()
                         .map(m -> {
                             SampleIdentifier sampleIdentifier = new SampleIdentifier();
@@ -414,7 +472,7 @@ public class StudyViewFilterApplier {
                     .map(molecularProfileId -> molecularProfileMap.get(molecularProfileId))
                     .collect(Collectors.toList());
 
-            for (List<SingleGeneQuery> geneQueries : geneFilter.getSingleGeneQueries()) {
+            for (List<GeneFilterQuery> geneQueries : geneFilter.getGeneQueries()) {
 
                 List<String> studyIds = new ArrayList<>();
                 List<String> sampleIds = new ArrayList<>();
@@ -437,27 +495,36 @@ public class StudyViewFilterApplier {
                 List<DiscreteCopyNumberData> resultList = DiscreteCopyNumberEventType.ALL
                         .getAlterationTypes().stream().flatMap(alterationType -> {
 
-                            List<SingleGeneQuery> filteredGeneQueries = geneQueries.stream()
-                                    .filter(geneQuery -> geneQuery.getAlterations().stream()
-                                            .filter(alteration -> alteration.getCode() == alterationType)
-                                            .count() > 0)
-                                    .collect(Collectors.toList());
+                            List<GeneFilterQuery> filteredGeneQueries = geneQueries.stream()
+                                .filter(geneQuery -> geneQuery.getAlterations().stream()
+                                    .filter(alteration -> alteration.getCode() == alterationType)
+                                    .count() > 0)
+                                .collect(Collectors.toList());
 
                             List<String> hugoGeneSymbols = filteredGeneQueries.stream()
-                                    .map(SingleGeneQuery::getHugoGeneSymbol).collect(Collectors.toList());
+                                    .map(GeneFilterQuery::getHugoGeneSymbol).collect(Collectors.toList());
 
-                            List<Integer> entrezGeneIds = geneService
-                                    .fetchGenes(new ArrayList<>(hugoGeneSymbols),
-                                            GeneIdType.HUGO_GENE_SYMBOL.name(), Projection.SUMMARY.name())
-                                    .stream().map(gene -> gene.getEntrezGeneId()).collect(Collectors.toList());
+                            Map<String, Integer> symbolToEntrezGeneId = geneService
+                                .fetchGenes(new ArrayList<>(hugoGeneSymbols),
+                                    GeneIdType.HUGO_GENE_SYMBOL.name(), Projection.SUMMARY.name())
+                                .stream().collect(Collectors.toMap(x -> x.getHugoGeneSymbol(), x -> x.getEntrezGeneId()));
+
+                            filteredGeneQueries.removeIf(
+                                q -> !symbolToEntrezGeneId.containsKey(q.getHugoGeneSymbol())
+                            );
+
+                            filteredGeneQueries.stream().forEach(
+                                q -> q.setEntrezGeneId(symbolToEntrezGeneId.get(q.getHugoGeneSymbol()))
+                            );
 
                             List<DiscreteCopyNumberData> copyNumberDatas = new ArrayList<>();
-                            if (!entrezGeneIds.isEmpty()) {
+                            if (!filteredGeneQueries.isEmpty()) {
                                 copyNumberDatas = discreteCopyNumberService
-                                        .getDiscreteCopyNumbersInMultipleMolecularProfiles(molecularProfileIds,
-                                                sampleIds, entrezGeneIds, Arrays.asList(alterationType),
-                                                Projection.ID.name());
-
+                                    .getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
+                                        molecularProfileIds,
+                                        sampleIds,
+                                        filteredGeneQueries,
+                                        Projection.ID.name());
                             }
                             return copyNumberDatas.stream();
                         }).collect(Collectors.toList());

--- a/web/src/test/java/org/cbioportal/web/AlterationDriverAnnotationControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/AlterationDriverAnnotationControllerTest.java
@@ -1,0 +1,78 @@
+package org.cbioportal.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cbioportal.model.CustomDriverAnnotationReport;
+import org.cbioportal.service.AlterationDriverAnnotationService;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration("/applicationContext-web-test.xml")
+@Configuration
+public class AlterationDriverAnnotationControllerTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+    
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Autowired
+    private AlterationDriverAnnotationService alterationDriverAnnotationService;
+
+    private MockMvc mockMvc;
+
+    @Bean
+    public AlterationDriverAnnotationService alterationDriverAnnotationService() {
+        return Mockito.mock(AlterationDriverAnnotationService.class);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        Mockito.reset(alterationDriverAnnotationService);
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+    }
+
+    @Test
+    public void fetchCustomDriverAnnotationReport() throws Exception {
+        CustomDriverAnnotationReport report = new CustomDriverAnnotationReport(true, new HashSet<>(Arrays.asList("a", "b")));
+        when(alterationDriverAnnotationService.getCustomDriverAnnotationProps(
+            anyList()))
+            .thenReturn(report);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("molecularProfileIds", Arrays.asList("molecularProfileId1"));
+        mockMvc.perform(MockMvcRequestBuilders.post(
+            "/custom-driver-annotation-report/fetch")
+            .param("molecularProfileIds", "molecularProfileId1")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(body)))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.hasBinary", Matchers.equalTo(true)))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.tiers", Matchers.hasSize(2)))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.tiers[0]", Matchers.equalTo("a")))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.tiers[1]", Matchers.equalTo("b")));
+    }
+}

--- a/web/src/test/java/org/cbioportal/web/AlterationEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/AlterationEnrichmentControllerTest.java
@@ -2,15 +2,15 @@ package org.cbioportal.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cbioportal.model.AlterationEnrichment;
+import org.cbioportal.model.AlterationFilter;
 import org.cbioportal.model.CNA;
 import org.cbioportal.model.CountSummary;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.model.MutationEventType;
 import org.cbioportal.service.AlterationEnrichmentService;
-import org.cbioportal.web.parameter.AlterationEventTypeFilter;
 import org.cbioportal.web.parameter.MolecularProfileCasesGroupAndAlterationTypeFilter;
 import org.cbioportal.web.parameter.MolecularProfileCasesGroupFilter;
-import org.cbioportal.web.util.SelectMockitoArgumentMatcher;
+import org.cbioportal.web.util.AlterationFilterMockitoArgumentMatcher;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,7 +72,9 @@ public class AlterationEnrichmentControllerTest {
 
     private MockMvc mockMvc;
     private ArrayList<AlterationEnrichment> alterationEnrichments;
-    private AlterationEventTypeFilter eventTypes;
+    private AlterationFilter alterationFilter;
+    Map<MutationEventType, Boolean> mutationTypes;
+    Map<CNA, Boolean> cnaTypes;
 
     @Bean
     public AlterationEnrichmentService alterationEnrichmentService() {
@@ -145,18 +147,21 @@ public class AlterationEnrichmentControllerTest {
         filter = new MolecularProfileCasesGroupAndAlterationTypeFilter();
         filter.setMolecularProfileCasesGroupFilter(Arrays.asList(casesGroup1,casesGroup2));
 
-        eventTypes = new AlterationEventTypeFilter();
-        Map<MutationEventType, Boolean> mutationEventTypeMap = new HashMap();
-        mutationEventTypeMap.put(MutationEventType.missense_mutation, true);
-        mutationEventTypeMap.put(MutationEventType.feature_truncation, true);
-        Map<CNA, Boolean> cnaEventTypeMap = new HashMap();
-        cnaEventTypeMap.put(CNA.AMP, true);
-        cnaEventTypeMap.put(CNA.HOMDEL, true);
-        eventTypes.setMutationEventTypes(mutationEventTypeMap);
-        eventTypes.setCopyNumberAlterationEventTypes(cnaEventTypeMap);
-        filter.setAlterationEventTypes(eventTypes);
+        alterationFilter = new AlterationFilter();
+        filter.setAlterationFilter(alterationFilter);
+        alterationFilter.setIncludeDriver(true);
+        alterationFilter.setIncludeVUS(true);
+        alterationFilter.setIncludeUnknownOncogenicity(true);
+        alterationFilter.setIncludeSomatic(true);
+        alterationFilter.setIncludeGermline(true);
+        alterationFilter.setIncludeUnknownStatus(true);
+        alterationFilter.setIncludeUnknownTier(true);
+        alterationFilter.setTiersBooleanMap(new HashMap<String, Boolean>());
         
         mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+        
+        mutationTypes = new HashMap<>();
+        cnaTypes = new HashMap<>();
         
     }
 
@@ -165,10 +170,16 @@ public class AlterationEnrichmentControllerTest {
 
         when(alterationEnrichmentService.getAlterationEnrichments(
             argThat(new caseIdMatcher()),
-            argThat(new SelectMockitoArgumentMatcher("ALL")),
-            argThat(new SelectMockitoArgumentMatcher("ALL")),
-            any()))
-            .thenReturn(alterationEnrichments);
+            any(),
+            argThat(new AlterationFilterMockitoArgumentMatcher("ALL", "ALL")))).thenReturn(alterationEnrichments);
+
+        mutationTypes.put(MutationEventType.missense_mutation, true);
+        mutationTypes.put(MutationEventType.feature_truncation, true);
+        cnaTypes.put(CNA.AMP, true);
+        cnaTypes.put(CNA.HOMDEL, true);
+
+        filter.getAlterationFilter().setMutationBooleanMap(mutationTypes);
+        filter.getAlterationFilter().setCnaBooleanMap(cnaTypes);
         
         mockMvc.perform(MockMvcRequestBuilders.post(
             "/alteration-enrichments/fetch")
@@ -201,15 +212,16 @@ public class AlterationEnrichmentControllerTest {
 
         when(alterationEnrichmentService.getAlterationEnrichments(
             argThat(new caseIdMatcher()),
-            argThat(new SelectMockitoArgumentMatcher("EMPTY")),
-            argThat(new SelectMockitoArgumentMatcher("EMPTY")),
-            any()))
-            .thenReturn(alterationEnrichments);
+            any(),
+            argThat(new AlterationFilterMockitoArgumentMatcher("EMPTY", "EMPTY")))).thenReturn(alterationEnrichments);
         
-        filter.getAlterationEventTypes().getMutationEventTypes().put(MutationEventType.missense_mutation, false);
-        filter.getAlterationEventTypes().getMutationEventTypes().put(MutationEventType.feature_truncation, false);
-        filter.getAlterationEventTypes().getCopyNumberAlterationEventTypes().put(CNA.AMP, false);
-        filter.getAlterationEventTypes().getCopyNumberAlterationEventTypes().put(CNA.HOMDEL, false);
+        mutationTypes.put(MutationEventType.missense_mutation, false);
+        mutationTypes.put(MutationEventType.feature_truncation, false);
+        cnaTypes.put(CNA.AMP, false);
+        cnaTypes.put(CNA.HOMDEL, false);
+        
+        filter.getAlterationFilter().setMutationBooleanMap(mutationTypes);
+        filter.getAlterationFilter().setCnaBooleanMap(cnaTypes);
 
         mockMvc.perform(MockMvcRequestBuilders.post(
             "/alteration-enrichments/fetch")
@@ -218,21 +230,41 @@ public class AlterationEnrichmentControllerTest {
             .content(objectMapper.writeValueAsString(filter)))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)));
+            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneId").value(TEST_ENTREZ_GENE_ID_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].hugoGeneSymbol").value(TEST_HUGO_GENE_SYMBOL_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].cytoband").value(TEST_CYTOBAND_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[0].alteredCount").value(TEST_NUMBER_OF_SAMPLES_ALTERED_IN_SET_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[1].alteredCount").value(TEST_NUMBER_OF_SAMPLES_UNALTERED_IN_SET_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].pValue").value(TEST_P_VALUE_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[0].profiledCount").value(TEST_NUMBER_OF_SAMPLES_PROFILED_IN_SET_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[1].profiledCount").value(TEST_NUMBER_OF_SAMPLES_PROFILED_IN_SET_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneId").value(TEST_ENTREZ_GENE_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].hugoGeneSymbol").value(TEST_HUGO_GENE_SYMBOL_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].cytoband").value(TEST_CYTOBAND_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[0].alteredCount").value(TEST_NUMBER_OF_SAMPLES_ALTERED_IN_SET_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[1].alteredCount").value(TEST_NUMBER_OF_SAMPLES_UNALTERED_IN_SET_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].pValue").value(TEST_P_VALUE_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[0].profiledCount").value(TEST_NUMBER_OF_SAMPLES_PROFILED_IN_SET_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[1].profiledCount").value(TEST_NUMBER_OF_SAMPLES_PROFILED_IN_SET_2));
     }
 
     @Test
-    public void fetchAlterationEnrichmentsNullMutationTypes() throws Exception {
+    public void fetchAlterationEnrichmentsAllMutationTypesDeselected() throws Exception {
 
         when(alterationEnrichmentService.getAlterationEnrichments(
             argThat(new caseIdMatcher()),
-            argThat(new SelectMockitoArgumentMatcher("EMPTY")),
-            argThat(new SelectMockitoArgumentMatcher("ALL")),
-            any()))
-            .thenReturn(alterationEnrichments);
+            any(),
+            argThat(new AlterationFilterMockitoArgumentMatcher("EMPTY", "ALL"))
+        )).thenReturn(alterationEnrichments);
 
-        filter.getAlterationEventTypes().getMutationEventTypes().put(MutationEventType.missense_mutation, false);
-        filter.getAlterationEventTypes().getMutationEventTypes().put(MutationEventType.feature_truncation, false);
+        mutationTypes.put(MutationEventType.missense_mutation, false);
+        mutationTypes.put(MutationEventType.feature_truncation, false);
+        cnaTypes.put(CNA.AMP, true);
+        cnaTypes.put(CNA.HOMDEL, true);
+        
+        filter.getAlterationFilter().setMutationBooleanMap(mutationTypes);
+        filter.getAlterationFilter().setCnaBooleanMap(cnaTypes);
 
         mockMvc.perform(MockMvcRequestBuilders.post(
             "/alteration-enrichments/fetch")
@@ -241,22 +273,42 @@ public class AlterationEnrichmentControllerTest {
             .content(objectMapper.writeValueAsString(filter)))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)));
+            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneId").value(TEST_ENTREZ_GENE_ID_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].hugoGeneSymbol").value(TEST_HUGO_GENE_SYMBOL_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].cytoband").value(TEST_CYTOBAND_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[0].alteredCount").value(TEST_NUMBER_OF_SAMPLES_ALTERED_IN_SET_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[1].alteredCount").value(TEST_NUMBER_OF_SAMPLES_UNALTERED_IN_SET_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].pValue").value(TEST_P_VALUE_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[0].profiledCount").value(TEST_NUMBER_OF_SAMPLES_PROFILED_IN_SET_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[1].profiledCount").value(TEST_NUMBER_OF_SAMPLES_PROFILED_IN_SET_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneId").value(TEST_ENTREZ_GENE_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].hugoGeneSymbol").value(TEST_HUGO_GENE_SYMBOL_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].cytoband").value(TEST_CYTOBAND_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[0].alteredCount").value(TEST_NUMBER_OF_SAMPLES_ALTERED_IN_SET_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[1].alteredCount").value(TEST_NUMBER_OF_SAMPLES_UNALTERED_IN_SET_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].pValue").value(TEST_P_VALUE_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[0].profiledCount").value(TEST_NUMBER_OF_SAMPLES_PROFILED_IN_SET_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[1].profiledCount").value(TEST_NUMBER_OF_SAMPLES_PROFILED_IN_SET_2));
     }
 
     @Test
-    public void fetchAlterationEnrichmentsNullCnaTypes() throws Exception {
+    public void fetchAlterationEnrichmentsAllCnaTypesDeselected() throws Exception {
 
         when(alterationEnrichmentService.getAlterationEnrichments(
             argThat(new caseIdMatcher()),
-            argThat(new SelectMockitoArgumentMatcher("ALL")),
-            argThat(new SelectMockitoArgumentMatcher("EMPTY")),
-            any()))
-            .thenReturn(alterationEnrichments);
+            any(),
+            argThat(new AlterationFilterMockitoArgumentMatcher("ALL", "EMPTY"))
+        )).thenReturn(alterationEnrichments);
 
-        filter.getAlterationEventTypes().getCopyNumberAlterationEventTypes().put(CNA.AMP, false);
-        filter.getAlterationEventTypes().getCopyNumberAlterationEventTypes().put(CNA.HOMDEL, false);
+        mutationTypes.put(MutationEventType.missense_mutation, true);
+        mutationTypes.put(MutationEventType.feature_truncation, true);
+        cnaTypes.put(CNA.AMP, false);
+        cnaTypes.put(CNA.HOMDEL, false);
 
+        filter.getAlterationFilter().setMutationBooleanMap(mutationTypes);
+        filter.getAlterationFilter().setCnaBooleanMap(cnaTypes);
+        
         mockMvc.perform(MockMvcRequestBuilders.post(
             "/alteration-enrichments/fetch")
             .accept(MediaType.APPLICATION_JSON)
@@ -272,13 +324,16 @@ public class AlterationEnrichmentControllerTest {
 
         when(alterationEnrichmentService.getAlterationEnrichments(
             argThat(new caseIdMatcher()),
-            argThat(new SelectMockitoArgumentMatcher("SOME")),
-            argThat(new SelectMockitoArgumentMatcher("SOME")),
-            any()))
-            .thenReturn(alterationEnrichments);
+            any(),
+            argThat(new AlterationFilterMockitoArgumentMatcher("SOME", "SOME")))).thenReturn(alterationEnrichments);
 
-        filter.getAlterationEventTypes().getMutationEventTypes().put(MutationEventType.missense_mutation, false);
-        filter.getAlterationEventTypes().getCopyNumberAlterationEventTypes().put(CNA.HOMDEL, false);
+        mutationTypes.put(MutationEventType.missense_mutation, false);
+        mutationTypes.put(MutationEventType.feature_truncation, true);
+        cnaTypes.put(CNA.AMP, false);
+        cnaTypes.put(CNA.HOMDEL, true);
+
+        filter.getAlterationFilter().setMutationBooleanMap(mutationTypes);
+        filter.getAlterationFilter().setCnaBooleanMap(cnaTypes);
 
         mockMvc.perform(MockMvcRequestBuilders.post(
             "/alteration-enrichments/fetch")
@@ -287,6 +342,22 @@ public class AlterationEnrichmentControllerTest {
             .content(objectMapper.writeValueAsString(filter)))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)));
+            .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneId").value(TEST_ENTREZ_GENE_ID_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].hugoGeneSymbol").value(TEST_HUGO_GENE_SYMBOL_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].cytoband").value(TEST_CYTOBAND_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[0].alteredCount").value(TEST_NUMBER_OF_SAMPLES_ALTERED_IN_SET_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[1].alteredCount").value(TEST_NUMBER_OF_SAMPLES_UNALTERED_IN_SET_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].pValue").value(TEST_P_VALUE_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[0].profiledCount").value(TEST_NUMBER_OF_SAMPLES_PROFILED_IN_SET_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].counts[1].profiledCount").value(TEST_NUMBER_OF_SAMPLES_PROFILED_IN_SET_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneId").value(TEST_ENTREZ_GENE_ID_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].hugoGeneSymbol").value(TEST_HUGO_GENE_SYMBOL_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].cytoband").value(TEST_CYTOBAND_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[0].alteredCount").value(TEST_NUMBER_OF_SAMPLES_ALTERED_IN_SET_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[1].alteredCount").value(TEST_NUMBER_OF_SAMPLES_UNALTERED_IN_SET_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].pValue").value(TEST_P_VALUE_2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[0].profiledCount").value(TEST_NUMBER_OF_SAMPLES_PROFILED_IN_SET_1))
+            .andExpect(MockMvcResultMatchers.jsonPath("$[1].counts[1].profiledCount").value(TEST_NUMBER_OF_SAMPLES_PROFILED_IN_SET_2));
     }
 }

--- a/web/src/test/java/org/cbioportal/web/CopyNumberEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CopyNumberEnrichmentControllerTest.java
@@ -2,6 +2,7 @@ package org.cbioportal.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cbioportal.model.AlterationEnrichment;
+import org.cbioportal.model.AlterationFilter;
 import org.cbioportal.model.CountSummary;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.service.CopyNumberEnrichmentService;
@@ -113,9 +114,7 @@ public class CopyNumberEnrichmentControllerTest {
         alterationEnrichments.add(alterationEnrichment2);
 
         Mockito.when(copyNumberEnrichmentService.getCopyNumberEnrichments(
-            anyMap(),
-            any(),
-            any()))
+            anyMap(), any(), any(AlterationFilter.class)))
         .thenReturn(alterationEnrichments);
 
         MolecularProfileCaseIdentifier entity1 = new MolecularProfileCaseIdentifier();

--- a/web/src/test/java/org/cbioportal/web/MutationControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MutationControllerTest.java
@@ -5,7 +5,6 @@ import org.cbioportal.model.AlleleSpecificCopyNumber;
 import org.cbioportal.model.Gene;
 import org.cbioportal.model.Mutation;
 import org.cbioportal.model.MutationCountByPosition;
-import org.cbioportal.model.ReferenceGenomeGene;
 import org.cbioportal.model.meta.MutationMeta;
 import org.cbioportal.service.MutationService;
 import org.cbioportal.web.parameter.HeaderKeyConstants;

--- a/web/src/test/java/org/cbioportal/web/MutationEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/MutationEnrichmentControllerTest.java
@@ -2,6 +2,7 @@ package org.cbioportal.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cbioportal.model.AlterationEnrichment;
+import org.cbioportal.model.AlterationFilter;
 import org.cbioportal.model.CountSummary;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.service.MutationEnrichmentService;
@@ -107,8 +108,7 @@ public class MutationEnrichmentControllerTest {
         alterationEnrichments.add(alterationEnrichment2);
 
         Mockito.when(mutationEnrichmentService.getMutationEnrichments(
-            anyMap(),
-            any()))
+            anyMap(), any(), any(AlterationFilter.class)))
             .thenReturn(alterationEnrichments);
 
         MolecularProfileCaseIdentifier entity1 = new MolecularProfileCaseIdentifier();

--- a/web/src/test/java/org/cbioportal/web/SampleControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/SampleControllerTest.java
@@ -14,7 +14,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
@@ -27,7 +26,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/web/src/test/java/org/cbioportal/web/StudyViewControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StudyViewControllerTest.java
@@ -3,6 +3,7 @@ package org.cbioportal.web;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.math3.util.Pair;
 import org.cbioportal.model.AlterationCountByGene;
+import org.cbioportal.model.AlterationFilter;
 import org.cbioportal.model.ClinicalAttribute;
 import org.cbioportal.model.ClinicalData;
 import org.cbioportal.model.ClinicalDataCount;
@@ -11,7 +12,6 @@ import org.cbioportal.model.CopyNumberCountByGene;
 import org.cbioportal.model.GenePanelData;
 import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.Sample;
-import org.cbioportal.model.util.Select;
 import org.cbioportal.persistence.AlterationRepository;
 import org.cbioportal.service.AlterationCountService;
 import org.cbioportal.service.ClinicalAttributeService;
@@ -309,10 +309,11 @@ public class StudyViewControllerTest {
             argThat(new SelectMockitoArgumentMatcher("ALL")),
             anyBoolean(),
             anyBoolean(),
-            any(Select.class))).thenReturn(mutationCountsMockedData);
+            any(AlterationFilter.class))).thenReturn(mutationCountsMockedData);
 
         StudyViewFilter studyViewFilter = new StudyViewFilter();
         studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
+        studyViewFilter.setAlterationFilter(new AlterationFilter());
 
         mockMvc.perform(MockMvcRequestBuilders.post("/mutated-genes/fetch")
             .accept(MediaType.APPLICATION_JSON)
@@ -357,17 +358,19 @@ public class StudyViewControllerTest {
         fusionCount2.setNumberOfAlteredCases(2);
         fusionCount2.setTotalCount(2);
         fusionCounts.add(fusionCount2);
-        
+
         Pair<List<AlterationCountByGene>, Long> fusionCountsMockedData = new Pair<>(fusionCounts, 0L);
 
         Mockito.when(alterationCountService.getSampleStructuralVariantCounts(
             anyList(),
             argThat(new SelectMockitoArgumentMatcher("ALL")),
             anyBoolean(),
-            anyBoolean())).thenReturn(fusionCountsMockedData);
+            anyBoolean(),
+            any(AlterationFilter.class))).thenReturn(fusionCountsMockedData);
 
         StudyViewFilter studyViewFilter = new StudyViewFilter();
         studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
+        studyViewFilter.setAlterationFilter(new AlterationFilter());
 
         mockMvc.perform(MockMvcRequestBuilders.post("/structuralvariant-genes/fetch")
             .accept(MediaType.APPLICATION_JSON)
@@ -423,10 +426,11 @@ public class StudyViewControllerTest {
             argThat(new SelectMockitoArgumentMatcher("ALL")),
             anyBoolean(),
             anyBoolean(),
-            any(Select.class))).thenReturn(cnaCountsMockedData);
+            any(AlterationFilter.class))).thenReturn(cnaCountsMockedData);
 
         StudyViewFilter studyViewFilter = new StudyViewFilter();
         studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
+        studyViewFilter.setAlterationFilter(new AlterationFilter());
 
         mockMvc.perform(MockMvcRequestBuilders.post("/cna-genes/fetch")
             .accept(MediaType.APPLICATION_JSON)
@@ -622,6 +626,7 @@ public class StudyViewControllerTest {
 
         StudyViewFilter studyViewFilter = new StudyViewFilter();
         studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
+        studyViewFilter.setAlterationFilter(new AlterationFilter());
 
         mockMvc.perform(MockMvcRequestBuilders.post("/clinical-data-density-plot/fetch")
             .accept(MediaType.APPLICATION_JSON)

--- a/web/src/test/java/org/cbioportal/web/util/AlterationFilterMockitoArgumentMatcher.java
+++ b/web/src/test/java/org/cbioportal/web/util/AlterationFilterMockitoArgumentMatcher.java
@@ -1,0 +1,47 @@
+package org.cbioportal.web.util;
+
+import org.cbioportal.model.AlterationFilter;
+import org.mockito.ArgumentMatcher;
+
+public class AlterationFilterMockitoArgumentMatcher implements ArgumentMatcher<AlterationFilter> {
+    private String checkWhatMutation;
+    private String checkWhatCna;
+
+    public AlterationFilterMockitoArgumentMatcher(String checkWhatMutation, String checkWhatCna) {
+        this.checkWhatMutation = checkWhatMutation;
+        this.checkWhatCna = checkWhatCna;
+    }
+
+    @Override
+    public boolean matches(AlterationFilter filter) {
+        boolean correctMutation;
+        boolean correctCna;
+        switch (checkWhatMutation) {
+            case "ALL":
+                correctMutation = filter.getSelectedMutationTypes().hasAll();
+                break;
+            case "EMPTY":
+                correctMutation = filter.getSelectedMutationTypes().hasNone();
+                break;
+            case "SOME":
+                correctMutation = filter.getSelectedMutationTypes().hasValues();
+                break;
+            default:
+                correctMutation = false;
+        }
+        switch (checkWhatCna) {
+            case "ALL":
+                correctCna = filter.getSelectedCnaTypes().hasAll();
+                break;
+            case "EMPTY":
+                correctCna = filter.getSelectedCnaTypes().hasNone();
+                break;
+            case "SOME":
+                correctCna = filter.getSelectedCnaTypes().hasValues();
+                break;
+            default:
+                correctCna = false;
+        }
+        return correctMutation && correctCna;
+    }
+}

--- a/web/src/test/java/org/cbioportal/web/util/StudyViewFilterApplierTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/StudyViewFilterApplierTest.java
@@ -1,14 +1,18 @@
 package org.cbioportal.web.util;
 
+import org.cbioportal.model.CNA;
 import org.cbioportal.model.ClinicalAttribute;
 import org.cbioportal.model.ClinicalData;
 import org.cbioportal.model.DiscreteCopyNumberData;
 import org.cbioportal.model.Gene;
+import org.cbioportal.model.GeneFilter;
+import org.cbioportal.model.GeneFilterQuery;
 import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.MolecularProfile.MolecularAlterationType;
 import org.cbioportal.model.Mutation;
 import org.cbioportal.model.Patient;
 import org.cbioportal.model.Sample;
+import org.cbioportal.model.util.Select;
 import org.cbioportal.service.ClinicalAttributeService;
 import org.cbioportal.service.ClinicalDataService;
 import org.cbioportal.service.DiscreteCopyNumberService;
@@ -24,7 +28,6 @@ import org.cbioportal.service.SampleService;
 import org.cbioportal.service.StructuralVariantService;
 import org.cbioportal.web.parameter.ClinicalDataFilter;
 import org.cbioportal.web.parameter.DataFilterValue;
-import org.cbioportal.web.parameter.GeneFilter;
 import org.cbioportal.web.parameter.GeneIdType;
 import org.cbioportal.web.parameter.Projection;
 import org.cbioportal.web.parameter.SampleIdentifier;
@@ -46,6 +49,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class StudyViewFilterApplierTest {
@@ -69,7 +74,7 @@ public class StudyViewFilterApplierTest {
     public static final String HUGO_GENE_SYMBOL_2 = "HUGO_GENE_SYMBOL_2";
     public static final String MOLECULAR_PROFILE_ID_1 = "molecular_profile_id1";
     public static final String MOLECULAR_PROFILE_ID_2 = "molecular_profile_id2";
-
+        
     @InjectMocks
     private StudyViewFilterApplier studyViewFilterApplier;
 
@@ -178,15 +183,41 @@ public class StudyViewFilterApplierTest {
         clinicalDataEqualityFilter2.setValues(Arrays.asList(filterValue1, filterValue2));
         clinicalDataEqualityFilters.add(clinicalDataEqualityFilter2);
         studyViewFilter.setClinicalDataFilters(clinicalDataEqualityFilters);
+
+        boolean includeDriver = true;
+        boolean includeVUS = true;
+        boolean includeUnknownOncogenicity = true;
+        boolean includeGermline = true;
+        boolean includeSomatic = true;
+        boolean includeUnknownStatus = true;
+        Select<String> selectedTiers = Select.none();
+        boolean includeUnknownTier = true;
         List<GeneFilter> geneFilters = new ArrayList<>();
+        
         GeneFilter mutationGeneFilter = new GeneFilter();
-        mutationGeneFilter.setGeneQueries(Arrays.asList(Arrays.asList(HUGO_GENE_SYMBOL_1)));
-        mutationGeneFilter.setMolecularProfileIds(new HashSet<>(Arrays.asList(MOLECULAR_PROFILE_ID_1, "FILTERED_OUT_PROFILE_ID")));
-        geneFilters.add(mutationGeneFilter);
+        mutationGeneFilter.setMolecularProfileIds(new HashSet<>(Arrays.asList(MOLECULAR_PROFILE_ID_1)));
+
+        GeneFilterQuery geneFilterQuery1 = new GeneFilterQuery("HUGO_GENE_SYMBOL_1", null,
+            null, includeDriver, includeVUS, includeUnknownOncogenicity,  selectedTiers, includeUnknownTier,
+            includeGermline, includeSomatic, includeUnknownStatus);
+        List<List<GeneFilterQuery>> q1 = new ArrayList<>();
+        List<GeneFilterQuery> q2 = new ArrayList<>();
+        q2.add(geneFilterQuery1);
+        q1.add(q2);
+        mutationGeneFilter.setGeneQueries(q1);
 
         GeneFilter copyNumberGeneFilter = new GeneFilter();
-        copyNumberGeneFilter.setGeneQueries(Arrays.asList(Arrays.asList(HUGO_GENE_SYMBOL_2 + ":HOMDEL")));
         copyNumberGeneFilter.setMolecularProfileIds(new HashSet<>(Arrays.asList(MOLECULAR_PROFILE_ID_2)));
+        GeneFilterQuery geneFilterQuery2 = new GeneFilterQuery("HUGO_GENE_SYMBOL_2", null,
+            Arrays.asList(CNA.HOMDEL), includeDriver, includeVUS, includeUnknownOncogenicity,  selectedTiers,
+            includeUnknownTier,includeGermline, includeSomatic, includeUnknownStatus);
+        List<List<GeneFilterQuery>> q3 = new ArrayList<>();
+        List<GeneFilterQuery> q4 = new ArrayList<>();
+        q4.add(geneFilterQuery2);
+        q3.add(q4);
+        copyNumberGeneFilter.setGeneQueries(q3);
+
+        geneFilters.add(mutationGeneFilter);
         geneFilters.add(copyNumberGeneFilter);
         studyViewFilter.setGeneFilters(geneFilters);
 
@@ -377,13 +408,11 @@ public class StudyViewFilterApplierTest {
 
         Gene gene1 = new Gene();
         gene1.setEntrezGeneId(ENTREZ_GENE_ID_1);
+        gene1.setHugoGeneSymbol(HUGO_GENE_SYMBOL_1);
         Mockito.when(geneService.fetchGenes(Arrays.asList(HUGO_GENE_SYMBOL_1), GeneIdType.HUGO_GENE_SYMBOL.name(),
                 Projection.SUMMARY.name())).thenReturn(Arrays.asList(gene1));
-
-        Mockito.when(mutationService.getMutationsInMultipleMolecularProfiles(
-                Arrays.asList(MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1,
-                        MOLECULAR_PROFILE_ID_1),
-                updatedSampleIds, Arrays.asList(ENTREZ_GENE_ID_1), "ID", null, null, null, null)).thenReturn(mutations);
+        Mockito.when(mutationService.getMutationsInMultipleMolecularProfilesByGeneQueries(
+            anyList(), anyList(), anyList(), anyString(), isNull(), isNull(), isNull(), isNull())).thenReturn(mutations);
 
         updatedSampleIds = new ArrayList<>();
         updatedSampleIds.add(SAMPLE_ID1);
@@ -391,8 +420,8 @@ public class StudyViewFilterApplierTest {
         updatedSampleIds.add(SAMPLE_ID4);
 
         Mockito.when(molecularProfileService.getFirstDiscreteCNAProfileIds(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID),
-                updatedSampleIds))
-                .thenReturn(Arrays.asList(MOLECULAR_PROFILE_ID_2, MOLECULAR_PROFILE_ID_2, MOLECULAR_PROFILE_ID_2));
+            updatedSampleIds))
+            .thenReturn(Arrays.asList(MOLECULAR_PROFILE_ID_2, MOLECULAR_PROFILE_ID_2, MOLECULAR_PROFILE_ID_2));
 
         List<DiscreteCopyNumberData> discreteCopyNumberDataList = new ArrayList<>();
         DiscreteCopyNumberData discreteCopyNumberData1 = new DiscreteCopyNumberData();
@@ -410,12 +439,12 @@ public class StudyViewFilterApplierTest {
 
         Gene gene2 = new Gene();
         gene2.setEntrezGeneId(ENTREZ_GENE_ID_2);
+        gene2.setHugoGeneSymbol(HUGO_GENE_SYMBOL_2);
         Mockito.when(geneService.fetchGenes(Arrays.asList(HUGO_GENE_SYMBOL_2), GeneIdType.HUGO_GENE_SYMBOL.name(),
-                Projection.SUMMARY.name())).thenReturn(Arrays.asList(gene2));
+            Projection.SUMMARY.name())).thenReturn(Arrays.asList(gene2));
 
-        Mockito.when(discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfiles(
-                Arrays.asList(MOLECULAR_PROFILE_ID_2, MOLECULAR_PROFILE_ID_2, MOLECULAR_PROFILE_ID_2), updatedSampleIds,
-                Arrays.asList(ENTREZ_GENE_ID_2), Arrays.asList(-2), "ID")).thenReturn(discreteCopyNumberDataList);
+        Mockito.when(discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
+            anyList(), anyList(), anyList(), anyString())).thenReturn(discreteCopyNumberDataList);
 
         List<ClinicalAttribute> clinicalAttributeList = new ArrayList<>();
         ClinicalAttribute clinicalAttribute1 = new ClinicalAttribute();


### PR DESCRIPTION
# Implement annotation and mutation status filtering for Study View and enrichment/count endpoints

:warning: This PR should be merged together with the corresponding frontend branch.

This PR is covered by RFC56 sections [Annotation menu in Study View](https://docs.google.com/document/d/1TLRIOurdRK1HE7nDPqk6d4zhfjpgchBd9tU6PQpbwxw/edit#heading=h.ttnh4ne6gi59) and [Annotation menu in Group Comparison view](https://docs.google.com/document/d/1TLRIOurdRK1HE7nDPqk6d4zhfjpgchBd9tU6PQpbwxw/edit#heading=h.fen51cq7gucp). See [this doc](https://docs.google.com/document/d/1TLRIOurdRK1HE7nDPqk6d4zhfjpgchBd9tU6PQpbwxw/edit?usp=sharing)

This PR will:
- Add driver annotation, driver tiers and mutation status filtering to _/filtered-samples/fetch_, _/mutated-genes/fetch_, _/fusion-genes/fetch_, _/cna-genes/fetch_, _/alteration-enrichments/fetch_, _/copy-number-enrichments/fetch_ and _/mutation-enrichments/fetch_ endpoints.
- Add database indexes for different fields used for queries.
