### PR TITLE
Converted AlterationMyBatisRepository.java unique collections to sets

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
@@ -2,6 +2,7 @@ package org.cbioportal.persistence;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.cbioportal.model.GeneMolecularAlteration;
 import org.cbioportal.model.GenericAssayMolecularAlteration;
@@ -15,7 +16,7 @@ public interface MolecularDataRepository {
     MolecularProfileSamples getCommaSeparatedSampleIdsOfMolecularProfile(String molecularProfileId);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
-    Map<String, MolecularProfileSamples> commaSeparatedSampleIdsOfMolecularProfilesMap(List<String> molecularProfileIds);
+    Map<String, MolecularProfileSamples> commaSeparatedSampleIdsOfMolecularProfilesMap(Set<String> molecularProfileIds);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
@@ -25,7 +26,7 @@ public interface MolecularDataRepository {
                                                                           String projection);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
-    List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(List<String> molecularProfileIds,
+    List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(Set<String> molecularProfileIds,
                                                                                          List<Integer> entrezGeneIds,
                                                                                          String projection);
 

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularProfileRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularProfileRepository.java
@@ -6,6 +6,7 @@ import org.cbioportal.model.meta.BaseMeta;
 import org.springframework.cache.annotation.Cacheable;
 
 import java.util.List;
+import java.util.Set;
 
 public interface MolecularProfileRepository {
 
@@ -20,10 +21,10 @@ public interface MolecularProfileRepository {
     MolecularProfile getMolecularProfile(String molecularProfileId);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
-    List<MolecularProfile> getMolecularProfiles(List<String> molecularProfileIds, String projection);
+    List<MolecularProfile> getMolecularProfiles(Set<String> molecularProfileIds, String projection);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
-    BaseMeta getMetaMolecularProfiles(List<String> molecularProfileIds);
+    BaseMeta getMetaMolecularProfiles(Set<String> molecularProfileIds);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<MolecularProfile> getAllMolecularProfilesInStudy(String studyId, String projection, Integer pageSize,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationMyBatisRepository.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -44,8 +45,9 @@ public class AlterationMyBatisRepository implements AlterationRepository {
             return Collections.emptyList();
         }
 
-        List<String> molecularProfileIds = molecularProfileCaseIdentifiers.stream()
-                .map(MolecularProfileCaseIdentifier::getMolecularProfileId).distinct().collect(Collectors.toList());
+        Set<String> molecularProfileIds = molecularProfileCaseIdentifiers.stream()
+                .map(MolecularProfileCaseIdentifier::getMolecularProfileId)
+                .collect(Collectors.toSet());
 
         Map<String, MolecularAlterationType> profileTypeByProfileId = molecularProfileRepository
                 .getMolecularProfiles(molecularProfileIds, "SUMMARY").stream()
@@ -81,8 +83,9 @@ public class AlterationMyBatisRepository implements AlterationRepository {
             return Collections.emptyList();
         }
 
-        List<String> molecularProfileIds = molecularProfileCaseIdentifiers.stream()
-                .map(MolecularProfileCaseIdentifier::getMolecularProfileId).distinct().collect(Collectors.toList());
+        Set<String> molecularProfileIds = molecularProfileCaseIdentifiers.stream()
+                .map(MolecularProfileCaseIdentifier::getMolecularProfileId)
+                .collect(Collectors.toSet());
 
         Map<String, MolecularAlterationType> profileTypeByProfileId = molecularProfileRepository
                 .getMolecularProfiles(molecularProfileIds, "SUMMARY").stream()

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
@@ -7,11 +7,13 @@ import org.cbioportal.model.GenesetMolecularAlteration;
 import org.cbioportal.model.MolecularProfileSamples;
 
 import java.util.List;
+import java.util.Set;
+
 import org.apache.ibatis.cursor.Cursor;
 
 public interface MolecularDataMapper {
 
-    List<MolecularProfileSamples> getCommaSeparatedSampleIdsOfMolecularProfiles(List<String> molecularProfileIds);
+    List<MolecularProfileSamples> getCommaSeparatedSampleIdsOfMolecularProfiles(Set<String> molecularProfileIds);
 
     List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
                                                               String projection);
@@ -19,7 +21,7 @@ public interface MolecularDataMapper {
     Cursor<GeneMolecularAlteration> getGeneMolecularAlterationsIter(String molecularProfileId, List<Integer> entrezGeneIds,
                                                                     String projection);
 
-    List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
+    List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(Set<String> molecularProfileIds, 
                                                                                          List<Integer> entrezGeneIds, String projection);
 
     List<GenesetMolecularAlteration> getGenesetMolecularAlterations(String molecularProfileId, List<String> genesetIds,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
@@ -22,14 +22,14 @@ public class MolecularDataMyBatisRepository implements MolecularDataRepository {
     public MolecularProfileSamples getCommaSeparatedSampleIdsOfMolecularProfile(String molecularProfileId) {
         try {
             return molecularDataMapper.getCommaSeparatedSampleIdsOfMolecularProfiles(
-                Arrays.asList(molecularProfileId)).get(0);
+                Collections.singleton(molecularProfileId)).get(0);
         } catch (IndexOutOfBoundsException e) {
             return null;
         }
     }
 
     @Override
-    public Map<String, MolecularProfileSamples> commaSeparatedSampleIdsOfMolecularProfilesMap(List<String> molecularProfileIds) {
+    public Map<String, MolecularProfileSamples> commaSeparatedSampleIdsOfMolecularProfilesMap(Set<String> molecularProfileIds) {
 
         return molecularDataMapper.getCommaSeparatedSampleIdsOfMolecularProfiles(molecularProfileIds)
                 .stream()
@@ -54,7 +54,7 @@ public class MolecularDataMyBatisRepository implements MolecularDataRepository {
     }
 
     @Override
-    public List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(List<String> molecularProfileIds, 
+    public List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(Set<String> molecularProfileIds, 
                                                                                                 List<Integer> entrezGeneIds, 
                                                                                                 String projection) {
 

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularProfileMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularProfileMapper.java
@@ -4,6 +4,7 @@ import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.meta.BaseMeta;
 
 import java.util.List;
+import java.util.Set;
 
 public interface MolecularProfileMapper {
 
@@ -14,9 +15,9 @@ public interface MolecularProfileMapper {
 
     MolecularProfile getMolecularProfile(String molecularProfileId, String projection);
 
-    List<MolecularProfile> getMolecularProfiles(List<String> molecularProfileIds, String projection);
+    List<MolecularProfile> getMolecularProfiles(Set<String> molecularProfileIds, String projection);
 
-    BaseMeta getMetaMolecularProfiles(List<String> molecularProfileIds);
+    BaseMeta getMetaMolecularProfiles(Set<String> molecularProfileIds);
 
 	List<MolecularProfile> getMolecularProfilesReferredBy(String referringMolecularProfileId, String projection);
 

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularProfileMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularProfileMyBatisRepository.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 @Repository
 public class MolecularProfileMyBatisRepository implements MolecularProfileRepository {
@@ -38,13 +39,13 @@ public class MolecularProfileMyBatisRepository implements MolecularProfileReposi
     }
 
     @Override
-	public List<MolecularProfile> getMolecularProfiles(List<String> molecularProfileIds, String projection) {
+	public List<MolecularProfile> getMolecularProfiles(Set<String> molecularProfileIds, String projection) {
         
         return molecularProfileMapper.getMolecularProfiles(molecularProfileIds, projection);
     }
     
     @Override
-	public BaseMeta getMetaMolecularProfiles(List<String> molecularProfileIds) {
+	public BaseMeta getMetaMolecularProfiles(Set<String> molecularProfileIds) {
         
         return molecularProfileMapper.getMetaMolecularProfiles(molecularProfileIds);
 	}

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
@@ -28,9 +28,9 @@
         FROM genetic_profile_samples
         INNER JOIN genetic_profile ON genetic_profile_samples.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
         <where>
-            <if test="list != null and !list.isEmpty()">
+            <if test="molecularProfileIds != null and !molecularProfileIds.isEmpty()">
                 genetic_profile.STABLE_ID IN
-                <foreach item="item" collection="list" open="(" separator="," close=")">
+                <foreach item="item" collection="molecularProfileIds" open="(" separator="," close=")">
                     #{item}
                 </foreach>
             </if>

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularProfileMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularProfileMapper.xml
@@ -101,9 +101,9 @@
         COUNT(*) AS totalCount
         FROM genetic_profile
         <where>
-            <if test="list != null and !list.isEmpty()">
+            <if test="molecularProfileIds != null and !molecularProfileIds.isEmpty()">
                 genetic_profile.STABLE_ID IN
-                <foreach item="item" collection="list" open="(" separator="," close=")">
+                <foreach item="item" collection="molecularProfileIds" open="(" separator="," close=")">
                     #{item}
                 </foreach>
             </if>

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepositoryTest.java
@@ -12,10 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/testContextDatabase.xml")
@@ -38,7 +37,8 @@ public class MolecularDataMyBatisRepositoryTest {
     public void getCommaSeparatedSampleIdsOfMolecularProfiles() throws Exception {
 
         Map<String, MolecularProfileSamples> result = molecularDataMyBatisRepository
-            .commaSeparatedSampleIdsOfMolecularProfilesMap(Arrays.asList("study_tcga_pub_mrna", "study_tcga_pub_m_na"));
+            .commaSeparatedSampleIdsOfMolecularProfilesMap(Stream.of("study_tcga_pub_mrna", "study_tcga_pub_m_na")
+                                                            .collect(Collectors.toSet()));
 
         Assert.assertEquals(2, result.size());
         Assert.assertEquals("1,2,3,4,5,6,7,8,9,10,11,", result.get("study_tcga_pub_m_na").getCommaSeparatedSampleIds());
@@ -99,7 +99,7 @@ public class MolecularDataMyBatisRepositoryTest {
         entrezGeneIds.add(208);
 
         List<GeneMolecularAlteration> result = molecularDataMyBatisRepository
-            .getGeneMolecularAlterationsInMultipleMolecularProfiles(Arrays.asList("study_tcga_pub_gistic", "study_tcga_pub_mrna"),
+            .getGeneMolecularAlterationsInMultipleMolecularProfiles(Stream.of("study_tcga_pub_gistic", "study_tcga_pub_mrna").collect(Collectors.toSet()),
             entrezGeneIds, "SUMMARY");
 
         Assert.assertEquals(3, result.size());

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularProfileMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/MolecularProfileMyBatisRepositoryTest.java
@@ -13,6 +13,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/testContextDatabase.xml")
@@ -175,8 +178,8 @@ public class MolecularProfileMyBatisRepositoryTest {
     @Test
     public void getMolecularProfiles() throws Exception {
 
-        List<MolecularProfile> result = molecularProfileMyBatisRepository.getMolecularProfiles(Arrays.asList(
-            "study_tcga_pub_gistic", "study_tcga_pub_mrna"), "SUMMARY");
+        List<MolecularProfile> result = molecularProfileMyBatisRepository.getMolecularProfiles(Stream.of(
+            "study_tcga_pub_gistic", "study_tcga_pub_mrna").collect(Collectors.toSet()), "SUMMARY");
 
         Assert.assertEquals(2, result.size());
         Assert.assertEquals("study_tcga_pub_gistic", result.get(0).getStableId());
@@ -186,8 +189,8 @@ public class MolecularProfileMyBatisRepositoryTest {
     @Test
     public void getMetaMolecularProfilesById() throws Exception {
 
-        BaseMeta result = molecularProfileMyBatisRepository.getMetaMolecularProfiles(Arrays.asList(
-            "study_tcga_pub_gistic", "study_tcga_pub_mrna"));
+        BaseMeta result = molecularProfileMyBatisRepository.getMetaMolecularProfiles(Stream.of(
+            "study_tcga_pub_gistic", "study_tcga_pub_mrna").collect(Collectors.toSet()));
 
         Assert.assertEquals((Integer) 2, result.getTotalCount());
     }

--- a/service/src/main/java/org/cbioportal/service/MolecularProfileService.java
+++ b/service/src/main/java/org/cbioportal/service/MolecularProfileService.java
@@ -6,6 +6,7 @@ import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 
 import java.util.List;
+import java.util.Set;
 
 public interface MolecularProfileService {
 
@@ -16,9 +17,9 @@ public interface MolecularProfileService {
 
     MolecularProfile getMolecularProfile(String molecularProfileId) throws MolecularProfileNotFoundException;
 
-    List<MolecularProfile> getMolecularProfiles(List<String> molecularProfileIds, String projection);
+    List<MolecularProfile> getMolecularProfiles(Set<String> molecularProfileIds, String projection);
 
-    BaseMeta getMetaMolecularProfiles(List<String> molecularProfileIds);
+    BaseMeta getMetaMolecularProfiles(Set<String> molecularProfileIds);
 
     List<MolecularProfile> getAllMolecularProfilesInStudy(String studyId, String projection, Integer pageSize,
                                                           Integer pageNumber, String sortBy, String direction) 

--- a/service/src/main/java/org/cbioportal/service/impl/GenericAssayServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/GenericAssayServiceImpl.java
@@ -1,13 +1,6 @@
 package org.cbioportal.service.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -110,7 +103,7 @@ public class GenericAssayServiceImpl implements GenericAssayService {
     List<String> sampleIds, List<String> genericAssayStableIds, String projection) throws MolecularProfileNotFoundException {
         List<GenericAssayData> result = new ArrayList<>();
 
-        List<String> distinctMolecularProfileIds = molecularProfileIds.stream().distinct().sorted().collect(Collectors.toList());
+        SortedSet<String> distinctMolecularProfileIds = new TreeSet<>(molecularProfileIds);
 
         Map<String, MolecularProfileSamples> commaSeparatedSampleIdsOfMolecularProfilesMap = molecularDataRepository
                 .commaSeparatedSampleIdsOfMolecularProfilesMap(distinctMolecularProfileIds);
@@ -118,8 +111,7 @@ public class GenericAssayServiceImpl implements GenericAssayService {
         Map<String, Map<Integer, Integer>> internalSampleIdsMap = new HashMap<>();
         List<Integer> allInternalSampleIds = new ArrayList<>();
 
-        for (int i = 0; i < distinctMolecularProfileIds.size(); i++) {
-            String molecularProfileId = distinctMolecularProfileIds.get(i);
+        for (String molecularProfileId : distinctMolecularProfileIds) {
             List<Integer> internalSampleIds = Arrays
                     .stream(commaSeparatedSampleIdsOfMolecularProfilesMap.get(molecularProfileId).getSplitSampleIds())
                     .mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());

--- a/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
@@ -143,7 +143,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
             List<String> sampleIds, List<Integer> entrezGeneIds, String projection) {
 
         List<GeneMolecularData> molecularDataList = new ArrayList<>();
-        List<String> distinctMolecularProfileIds = molecularProfileIds.stream().distinct().sorted().collect(Collectors.toList());
+        SortedSet<String> distinctMolecularProfileIds = new TreeSet<>(molecularProfileIds);
 
         Map<String, MolecularProfileSamples> commaSeparatedSampleIdsOfMolecularProfilesMap =  molecularDataRepository
                 .commaSeparatedSampleIdsOfMolecularProfilesMap(distinctMolecularProfileIds);
@@ -151,8 +151,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
         Map<String, Map<Integer, Integer>> internalSampleIdsMap = new HashMap<>();
         List<Integer> allInternalSampleIds = new ArrayList<>();
 
-        for (int i = 0; i < distinctMolecularProfileIds.size(); i++) {
-            String molecularProfileId = distinctMolecularProfileIds.get(i);
+        for (String molecularProfileId : distinctMolecularProfileIds) {
             List<Integer> internalSampleIds = Arrays
                     .stream(commaSeparatedSampleIdsOfMolecularProfilesMap.get(molecularProfileId).getSplitSampleIds())
                     .mapToInt(Integer::parseInt).boxed().collect(Collectors.toList());

--- a/service/src/main/java/org/cbioportal/service/impl/MolecularProfileServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularProfileServiceImpl.java
@@ -12,11 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
-import java.util.ArrayList;
-import java.util.HashMap;
 
 @Service
 public class MolecularProfileServiceImpl implements MolecularProfileService {
@@ -56,13 +53,13 @@ public class MolecularProfileServiceImpl implements MolecularProfileService {
     }
 
     @Override
-	public List<MolecularProfile> getMolecularProfiles(List<String> molecularProfileIds, String projection) {
+	public List<MolecularProfile> getMolecularProfiles(Set<String> molecularProfileIds, String projection) {
         
         return molecularProfileRepository.getMolecularProfiles(molecularProfileIds, projection);
     }
     
     @Override
-	public BaseMeta getMetaMolecularProfiles(List<String> molecularProfileIds) {
+	public BaseMeta getMetaMolecularProfiles(Set<String> molecularProfileIds) {
         
         return molecularProfileRepository.getMetaMolecularProfiles(molecularProfileIds);
 	}

--- a/service/src/main/java/org/cbioportal/service/util/AlterationEnrichmentUtil.java
+++ b/service/src/main/java/org/cbioportal/service/util/AlterationEnrichmentUtil.java
@@ -225,7 +225,7 @@ public class AlterationEnrichmentUtil<T extends AlterationCountByGene> {
             .collect(Collectors.toSet());
 
         List<MolecularProfile> molecularProfiles = molecularProfileService
-            .getMolecularProfiles(new ArrayList<>(molecularProfileIds), "SUMMARY");
+            .getMolecularProfiles(molecularProfileIds, "SUMMARY");
 
         if (molecularProfileIds.size() != molecularProfiles.size()) {
             Map<String, MolecularProfile> molecularProfileMap = molecularProfiles.stream()

--- a/service/src/test/java/org/cbioportal/service/impl/GenericAssayServiceImpTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenericAssayServiceImpTest.java
@@ -1,11 +1,9 @@
 
 package org.cbioportal.service.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.cbioportal.model.GenericAssayAdditionalProperty;
 import org.cbioportal.model.GenericAssayData;
@@ -93,10 +91,10 @@ public class GenericAssayServiceImpTest extends BaseServiceImplTest {
 
         // stub for samples
         Mockito.when(geneticDataRepository
-                .commaSeparatedSampleIdsOfMolecularProfilesMap(Arrays.asList(MOLECULAR_PROFILE_ID_1)))
+                .commaSeparatedSampleIdsOfMolecularProfilesMap(Collections.singleton(MOLECULAR_PROFILE_ID_1)))
                 .thenReturn(commaSeparatedSampleIdsOfMolecularProfilesMap1);
         Mockito.when(geneticDataRepository.commaSeparatedSampleIdsOfMolecularProfilesMap(
-                Arrays.asList(MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_2)))
+                Stream.of(MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_2).collect(Collectors.toSet())))
                 .thenReturn(commaSeparatedSampleIdsOfMolecularProfilesMap2);
 
         List<Sample> sampleList1 = new ArrayList<>();
@@ -132,8 +130,10 @@ public class GenericAssayServiceImpTest extends BaseServiceImplTest {
         geneticProfiles.add(geneticProfile2);
 
         Mockito.when(geneticProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID_1)).thenReturn(geneticProfile1);
-        Mockito.when(geneticProfileService.getMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID_1), "SUMMARY")).thenReturn(Arrays.asList(geneticProfile1));
-        Mockito.when(geneticProfileService.getMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_2), "SUMMARY")).thenReturn(geneticProfiles);
+        Mockito.when(geneticProfileService.getMolecularProfiles(Collections.singleton(MOLECULAR_PROFILE_ID_1), "SUMMARY"))
+            .thenReturn(Arrays.asList(geneticProfile1));
+        Mockito.when(geneticProfileService.getMolecularProfiles(Stream.of(MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_2)
+            .collect(Collectors.toSet()), "SUMMARY")).thenReturn(geneticProfiles);
 
         //stub for repository data
         List<GenericAssayMolecularAlteration> genericAssayMolecularAlterationList1 = new ArrayList<>();

--- a/service/src/test/java/org/cbioportal/service/impl/MolecularProfileServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/MolecularProfileServiceImplTest.java
@@ -16,9 +16,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MolecularProfileServiceImplTest extends BaseServiceImplTest {
@@ -90,10 +88,10 @@ public class MolecularProfileServiceImplTest extends BaseServiceImplTest {
 
         List<MolecularProfile> expectedMolecularProfiles = new ArrayList<>();
 
-        Mockito.when(molecularProfileRepository.getMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID), PROJECTION))
+        Mockito.when(molecularProfileRepository.getMolecularProfiles(Collections.singleton(MOLECULAR_PROFILE_ID), PROJECTION))
             .thenReturn(expectedMolecularProfiles);
 
-        List<MolecularProfile> result = molecularProfileService.getMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID), PROJECTION);
+        List<MolecularProfile> result = molecularProfileService.getMolecularProfiles(Collections.singleton(MOLECULAR_PROFILE_ID), PROJECTION);
 
         Assert.assertEquals(expectedMolecularProfiles, result);
     }
@@ -103,10 +101,10 @@ public class MolecularProfileServiceImplTest extends BaseServiceImplTest {
 
         BaseMeta expectedBaseMeta = new BaseMeta();
 
-        Mockito.when(molecularProfileRepository.getMetaMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID)))
+        Mockito.when(molecularProfileRepository.getMetaMolecularProfiles(Collections.singleton(MOLECULAR_PROFILE_ID)))
             .thenReturn(expectedBaseMeta);
 
-        BaseMeta result = molecularProfileService.getMetaMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID));
+        BaseMeta result = molecularProfileService.getMetaMolecularProfiles(Collections.singleton(MOLECULAR_PROFILE_ID));
 
         Assert.assertEquals(expectedBaseMeta, result);
     }

--- a/web/src/main/java/org/cbioportal/web/parameter/MolecularProfileFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/MolecularProfileFilter.java
@@ -4,13 +4,14 @@ import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Size;
 import java.util.List;
 import java.io.Serializable;
+import java.util.Set;
 
 public class MolecularProfileFilter implements Serializable {
 
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> studyIds;
     @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
-    private List<String> molecularProfileIds;
+    private Set<String> molecularProfileIds;
 
     @AssertTrue
     private boolean isEitherStudyIdsOrMolecularProfileIdsPresent() {
@@ -25,11 +26,11 @@ public class MolecularProfileFilter implements Serializable {
         this.studyIds = studyIds;
     }
 
-    public List<String> getMolecularProfileIds() {
+    public Set<String> getMolecularProfileIds() {
         return molecularProfileIds;
     }
 
-    public void setMolecularProfileIds(List<String> molecularProfileIds) {
+    public void setMolecularProfileIds(Set<String> molecularProfileIds) {
         this.molecularProfileIds = molecularProfileIds;
     }
 }


### PR DESCRIPTION
Fix cBioPortal#8623:
Converted `molecularProfileIds` from `List<String>` to `Set<String>` in `AlterationMyBatisRespository.java` and made corresponding changes to rest of the codebase. (`SortedSet` was used instead of `Set` where applicable.)