### PR TITLE
Gene panel data api updates

### DIFF
--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenePanelMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenePanelMapper.xml
@@ -14,15 +14,12 @@
     </sql>
 
     <sql id="selectGenePanelData">
-	    gene_panel.STABLE_ID AS genePanelId,
-	    sample.STABLE_ID AS sampleId,
-	    patient.STABLE_ID AS patientId,
-	    cancer_study.CANCER_STUDY_IDENTIFIER AS studyId,
-	    genetic_profile.STABLE_ID AS molecularProfileId,
-        CASE
-            WHEN sample_profile.GENETIC_PROFILE_ID IS NOT NULL THEN TRUE
-            ELSE FALSE
-        END AS profiled
+        gene_panel.STABLE_ID AS genePanelId,
+        sample.STABLE_ID AS sampleId,
+        patient.STABLE_ID AS patientId,
+        cancer_study.CANCER_STUDY_IDENTIFIER AS studyId,
+        genetic_profile.STABLE_ID AS molecularProfileId,
+        sample_profile.GENETIC_PROFILE_ID IS NOT NULL AS profiled
     </sql>
 
     <sql id="fromGenePanelData">

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenePanelMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenePanelMapper.xml
@@ -19,15 +19,18 @@
 	    patient.STABLE_ID AS patientId,
 	    cancer_study.CANCER_STUDY_IDENTIFIER AS studyId,
 	    genetic_profile.STABLE_ID AS molecularProfileId,
-        true as profiled
+        CASE
+            WHEN sample_profile.GENETIC_PROFILE_ID IS NOT NULL THEN TRUE
+            ELSE FALSE
+        END AS profiled
     </sql>
 
     <sql id="fromGenePanelData">
-        FROM sample_profile
-        INNER JOIN genetic_profile ON sample_profile.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
-        INNER JOIN sample ON sample_profile.SAMPLE_ID = sample.INTERNAL_ID
+        FROM sample
         INNER JOIN patient ON sample.PATIENT_ID = patient.INTERNAL_ID
         INNER JOIN cancer_study ON patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
+        LEFT JOIN genetic_profile ON cancer_study.CANCER_STUDY_ID = genetic_profile.CANCER_STUDY_ID
+        LEFT JOIN sample_profile ON sample_profile.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID AND sample.INTERNAL_ID = sample_profile.SAMPLE_ID
         LEFT JOIN gene_panel ON sample_profile.PANEL_ID = gene_panel.INTERNAL_ID
     </sql>
     

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/GenePanelMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/GenePanelMyBatisRepositoryTest.java
@@ -80,7 +80,7 @@ public class GenePanelMyBatisRepositoryTest {
         List<GenePanelData> result = genePanelMyBatisRepository.getGenePanelDataBySampleListId("study_tcga_pub_mrna", 
             "study_tcga_pub_all");
         
-        Assert.assertEquals(9, result.size());
+        Assert.assertEquals(14, result.size());
         GenePanelData genePanelData = result.get(0);
         Assert.assertEquals("study_tcga_pub_mrna", genePanelData.getMolecularProfileId());
         Assert.assertEquals("TESTPANEL1", genePanelData.getGenePanelId());

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
   </profiles>
 
   <properties>
-    <frontend.version>581f2fd48dd33cba9711aa411035c197c650dcdb</frontend.version>
+    <frontend.version>af55a52bf01990bd5e6838b99293cd1ec75047e1</frontend.version>
     <frontend.groupId>com.github.cbioportal</frontend.groupId>
     <spring.version>5.2.6.RELEASE</spring.version>
     <spring.integration.version>5.3.0.RELEASE</spring.integration.version>

--- a/service/src/main/java/org/cbioportal/service/impl/AlterationCountServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/AlterationCountServiceImpl.java
@@ -8,6 +8,7 @@ import org.cbioportal.model.util.Select;
 import org.cbioportal.persistence.AlterationRepository;
 import org.cbioportal.service.AlterationCountService;
 import org.cbioportal.service.util.AlterationEnrichmentUtil;
+import org.cbioportal.service.util.MolecularProfileUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -25,6 +26,8 @@ public class AlterationCountServiceImpl implements AlterationCountService {
     private AlterationEnrichmentUtil<AlterationCountByGene> alterationEnrichmentUtil;
     @Autowired
     private AlterationEnrichmentUtil<CopyNumberCountByGene> alterationEnrichmentUtilCna;
+    @Autowired
+    private MolecularProfileUtil molecularProfileUtil;
 
     @Override
     public Pair<List<AlterationCountByGene>, Long> getSampleAlterationCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
@@ -43,7 +46,7 @@ public class AlterationCountServiceImpl implements AlterationCountService {
             List<MolecularProfileCaseIdentifier> updatedProfileCaseIdentifiers = molecularProfileCaseIdentifiers
                 .stream()
                 .map(molecularProfileCaseIdentifier -> {
-                    molecularProfileCaseIdentifier.setMolecularProfileId(molecularProfileCaseIdentifier.getMolecularProfileId().replace("_fusion", "_mutations"));
+                    molecularProfileCaseIdentifier.setMolecularProfileId(molecularProfileUtil.replaceFusionProfileWithMutationProfile(molecularProfileCaseIdentifier.getMolecularProfileId()));
                     return molecularProfileCaseIdentifier;
                 })
                 .distinct()
@@ -80,7 +83,7 @@ public class AlterationCountServiceImpl implements AlterationCountService {
             List<MolecularProfileCaseIdentifier> updatedProfileCaseIdentifiers = molecularProfileCaseIdentifiers
                 .stream()
                 .map(molecularProfileCaseIdentifier -> {
-                    molecularProfileCaseIdentifier.setMolecularProfileId(molecularProfileCaseIdentifier.getMolecularProfileId().replace("_fusion", "_mutations"));
+                    molecularProfileCaseIdentifier.setMolecularProfileId(molecularProfileUtil.replaceFusionProfileWithMutationProfile(molecularProfileCaseIdentifier.getMolecularProfileId()));
                     return molecularProfileCaseIdentifier;
                 })
                 .distinct()

--- a/service/src/main/java/org/cbioportal/service/impl/StructuralVariantServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/StructuralVariantServiceImpl.java
@@ -35,6 +35,7 @@ import org.cbioportal.model.StructuralVariant;
 import org.cbioportal.persistence.MutationRepository;
 import org.cbioportal.persistence.StructuralVariantRepository;
 import org.cbioportal.service.StructuralVariantService;
+import org.cbioportal.service.util.MolecularProfileUtil;
 import org.cbioportal.service.util.MutationMapperUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -48,6 +49,8 @@ public class StructuralVariantServiceImpl implements StructuralVariantService {
     private MutationRepository mutationRepository;
     @Autowired
     private MutationMapperUtils mutationMapperUtils;
+    @Autowired
+    private MolecularProfileUtil molecularProfileUtil;
 
     @Override
     public List<StructuralVariant> fetchStructuralVariants(List<String> molecularProfileIds,
@@ -63,11 +66,11 @@ public class StructuralVariantServiceImpl implements StructuralVariantService {
         // TODO: Remove once fusions are removed from mutation table
         for (int i = 0; i < molecularProfileIds.size(); i++) {
             String molecularProfileId = molecularProfileIds.get(i);
-            if (molecularProfileId.endsWith("_structural_variants")) {
+            if (molecularProfileId.endsWith(molecularProfileUtil.STRUCTURAL_VARIANT_PROFILE_SUFFIX)) {
                 structuralVariantMolecularProfileIds.add(molecularProfileId);
                 structuralVariantSampleIds.add(sampleIds.get(i));
-            } else if (molecularProfileId.endsWith("_fusion")) {
-                String mutationMolecularProfileId = molecularProfileId.replace("_fusion", "_mutations");
+            } else if (molecularProfileId.endsWith(molecularProfileUtil.FUSION_PROFILE_SUFFIX)) {
+                String mutationMolecularProfileId = molecularProfileUtil.replaceFusionProfileWithMutationProfile(molecularProfileId);
                 molecularProfileIdReplaceMap.put(mutationMolecularProfileId, molecularProfileId);
                 fusionVariantMolecularProfileIds.add(molecularProfileId);
                 fusionVariantSampleIds.add(sampleIds.get(i));

--- a/service/src/main/java/org/cbioportal/service/util/MolecularProfileUtil.java
+++ b/service/src/main/java/org/cbioportal/service/util/MolecularProfileUtil.java
@@ -15,6 +15,10 @@ import java.util.stream.Stream;
 @Component
 public class MolecularProfileUtil {
 
+    public final String MUTATION_PROFILE_SUFFIX = "_mutations";
+    public final String FUSION_PROFILE_SUFFIX = "_fusion";
+    public final String STRUCTURAL_VARIANT_PROFILE_SUFFIX = "_structural_variants";
+
     public Predicate<MolecularProfile> isStructuralVariantMolecularProfile =
         m -> m.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.FUSION) ||
             m.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.STRUCTURAL_VARIANT);
@@ -98,6 +102,10 @@ public class MolecularProfileUtil {
                     return profilesToReturn;
                 }));
         return studyMolecularProfilesSet;
+    }
+
+    public String replaceFusionProfileWithMutationProfile(String profileId) {
+        return profileId.replace(FUSION_PROFILE_SUFFIX, MUTATION_PROFILE_SUFFIX);
     }
 
 }

--- a/service/src/test/java/org/cbioportal/service/impl/AlterationCountServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/AlterationCountServiceImplTest.java
@@ -7,11 +7,13 @@ import org.cbioportal.model.util.Select;
 import org.cbioportal.persistence.AlterationRepository;
 import org.cbioportal.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.service.util.AlterationEnrichmentUtil;
+import org.cbioportal.service.util.MolecularProfileUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
@@ -30,6 +32,9 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
     private AlterationEnrichmentUtil<AlterationCountByGene> alterationEnrichmentUtil;
     @Mock
     private AlterationEnrichmentUtil<CopyNumberCountByGene> alterationEnrichmentUtilCna;
+    @Spy
+    @InjectMocks
+    private MolecularProfileUtil molecularProfileUtil;
 
     List<MolecularProfileCaseIdentifier> caseIdentifiers = Arrays.asList(new MolecularProfileCaseIdentifier("A", MOLECULAR_PROFILE_ID));
     Select<MutationEventType> mutationEventTypes = Select.byValues(Arrays.asList(MutationEventType.missense_mutation));

--- a/service/src/test/java/org/cbioportal/service/impl/GenePanelServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenePanelServiceImplTest.java
@@ -6,15 +6,16 @@ import java.util.stream.Collectors;
 import org.cbioportal.model.*;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.GenePanelRepository;
-import org.cbioportal.persistence.MolecularProfileRepository;
-import org.cbioportal.persistence.StudyRepository;
+import org.cbioportal.service.MolecularProfileService;
 import org.cbioportal.service.exception.GenePanelNotFoundException;
+import org.cbioportal.service.util.MolecularProfileUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
@@ -26,9 +27,10 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
     @Mock
     private GenePanelRepository genePanelRepository;
     @Mock
-    private MolecularProfileRepository molecularProfileRepository;
-    @Mock
-    private StudyRepository studyRepository;
+    private MolecularProfileService molecularProfileService;
+    @Spy
+    @InjectMocks
+    private MolecularProfileUtil molecularProfileUtil;
     
     @Test
     public void getAllGenePanelsSummaryProjection() throws Exception {
@@ -132,6 +134,15 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
         genePanelData2.setProfiled(false);
         genePanelDataList.add(genePanelData2);
 
+        MolecularProfile molecularProfile = new MolecularProfile();
+        molecularProfile.setStableId(MOLECULAR_PROFILE_ID);
+        molecularProfile.setCancerStudyIdentifier(STUDY_ID);
+        molecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.COPY_NUMBER_ALTERATION);
+
+        Mockito.when(molecularProfileService
+            .getMolecularProfile(MOLECULAR_PROFILE_ID))
+            .thenReturn(molecularProfile);
+
         Mockito.when(genePanelRepository.getGenePanelDataBySampleListId(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID))
             .thenReturn(genePanelDataList);
         
@@ -156,6 +167,15 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
 
     @Test
     public void getGenePanelDataInvalidSampleListId() throws Exception {
+
+        MolecularProfile molecularProfile = new MolecularProfile();
+        molecularProfile.setStableId(MOLECULAR_PROFILE_ID);
+        molecularProfile.setCancerStudyIdentifier(STUDY_ID);
+        molecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.COPY_NUMBER_ALTERATION);
+
+        Mockito.when(molecularProfileService
+            .getMolecularProfile(MOLECULAR_PROFILE_ID))
+            .thenReturn(molecularProfile);
         
         List<GenePanelData> result = genePanelService.getGenePanelData(MOLECULAR_PROFILE_ID, SAMPLE_LIST_ID);
         
@@ -174,6 +194,15 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
         genePanelData.setStudyId(STUDY_ID);
         genePanelData.setProfiled(true);
         genePanelDataList.add(genePanelData);
+
+        MolecularProfile molecularProfile = new MolecularProfile();
+        molecularProfile.setStableId(MOLECULAR_PROFILE_ID);
+        molecularProfile.setCancerStudyIdentifier(STUDY_ID);
+        molecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.COPY_NUMBER_ALTERATION);
+
+        Mockito.when(molecularProfileService
+            .getMolecularProfiles(Arrays.asList(MOLECULAR_PROFILE_ID), "SUMMARY"))
+            .thenReturn(Arrays.asList(molecularProfile));
 
         Mockito.when(genePanelRepository
             .fetchGenePanelDataByMolecularProfileId(MOLECULAR_PROFILE_ID))
@@ -236,17 +265,12 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
         Set<String> molecularProfileIds = molecularProfileSampleIdentifiers.stream().map(MolecularProfileCaseIdentifier::getMolecularProfileId).collect(Collectors.toSet());
 
         MolecularProfile molecularProfile = new MolecularProfile();
+        molecularProfile.setStableId(MOLECULAR_PROFILE_ID);
         molecularProfile.setCancerStudyIdentifier(STUDY_ID);
         molecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.COPY_NUMBER_ALTERATION);
         
-        Mockito.when(molecularProfileRepository.getMolecularProfiles(new ArrayList<>(molecularProfileIds), "SUMMARY"))
+        Mockito.when(molecularProfileService.getMolecularProfiles(new ArrayList<>(molecularProfileIds), "SUMMARY"))
             .thenReturn(Arrays.asList(molecularProfile));
-        
-        CancerStudy cancerStudy = new CancerStudy();
-        cancerStudy.setAllSampleCount(10);
-        
-        Mockito.when(studyRepository.fetchStudies(Arrays.asList(STUDY_ID), "SUMMARY"))
-            .thenReturn(Arrays.asList(cancerStudy));
 
         List<GenePanelData> result = genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(new ArrayList<>(molecularProfileSampleIdentifiers));
 

--- a/service/src/test/java/org/cbioportal/service/impl/GenePanelServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenePanelServiceImplTest.java
@@ -175,7 +175,8 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
         genePanelData.setProfiled(true);
         genePanelDataList.add(genePanelData);
 
-        Mockito.when(genePanelRepository.fetchGenePanelData(MOLECULAR_PROFILE_ID, Arrays.asList(SAMPLE_ID1, SAMPLE_ID2)))
+        Mockito.when(genePanelRepository
+            .fetchGenePanelDataByMolecularProfileId(MOLECULAR_PROFILE_ID))
             .thenReturn(genePanelDataList);
 
         List<GenePanelData> result = genePanelService.fetchGenePanelData(MOLECULAR_PROFILE_ID, 
@@ -229,12 +230,14 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
         profileCaseIdentifier3.setCaseId(SAMPLE_ID3);
         molecularProfileSampleIdentifiers.add(profileCaseIdentifier3);
 
-        Mockito.when(genePanelRepository.fetchGenePanelDataInMultipleMolecularProfiles(new ArrayList<>(molecularProfileSampleIdentifiers)))
+        Mockito.when(genePanelRepository
+            .fetchGenePanelDataByMolecularProfileId(MOLECULAR_PROFILE_ID))
             .thenReturn(genePanelDataList);
         Set<String> molecularProfileIds = molecularProfileSampleIdentifiers.stream().map(MolecularProfileCaseIdentifier::getMolecularProfileId).collect(Collectors.toSet());
 
         MolecularProfile molecularProfile = new MolecularProfile();
         molecularProfile.setCancerStudyIdentifier(STUDY_ID);
+        molecularProfile.setMolecularAlterationType(MolecularProfile.MolecularAlterationType.COPY_NUMBER_ALTERATION);
         
         Mockito.when(molecularProfileRepository.getMolecularProfiles(new ArrayList<>(molecularProfileIds), "SUMMARY"))
             .thenReturn(Arrays.asList(molecularProfile));

--- a/service/src/test/java/org/cbioportal/service/impl/StructuralVariantServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/StructuralVariantServiceImplTest.java
@@ -28,12 +28,14 @@ import java.util.List;
 
 import org.cbioportal.model.StructuralVariant;
 import org.cbioportal.persistence.StructuralVariantRepository;
+import org.cbioportal.service.util.MolecularProfileUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -44,6 +46,9 @@ public class StructuralVariantServiceImplTest extends BaseServiceImplTest {
 
     @Mock
     private StructuralVariantRepository structuralVariantRepository;
+    @Spy
+    @InjectMocks
+    private MolecularProfileUtil molecularProfileUtil;
 
     @Test
     public void getStructuralVariants() throws Exception {


### PR DESCRIPTION
- See if samples are present in sequenced sample list while fetching for gene panel data for mutation/fusion profiles

- Always fetch gene-panel data for all samples for given profiles and then filter the response -> this has better performance than querying database with samples/patient ids. Also data would be cached for each gene-panel molecular profile query.