### PR TITLE
Remove the need to restart Tomcat after data loading via cache-clearing endpoint

### DIFF
--- a/docs/Deploying.md
+++ b/docs/Deploying.md
@@ -158,7 +158,9 @@ Lastly, open a browser and go to:
 
 - Each time you modify any java code, you must recompile and redeploy the app.
 - Each time you modify any properties (see customization options), you must restart the app
-- Each time you add new data, you must restart the app
+- Each time you add new data, you must restart the app or call the `/api/cache` endpoint 
+  with a `DELETE` http-request (see [here](portal.properties-Reference.md#flush-caches-with-the-_apicache_-endpoint)
+  for more information).
 
 
 [Next Step: Loading a Sample Study](Load-Sample-Cancer-Study.md)

--- a/docs/Import-Gene-Panels.md
+++ b/docs/Import-Gene-Panels.md
@@ -29,7 +29,9 @@ cd <cbioportal_source_folder>/core/src/main/scripts
 ./importGenePanel.pl --data ../../test/scripts/test_data/study_es_0/data_gene_panel_testpanel2.txt
 ```
 
-After loading gene panels into the database, please restart Tomcat so that the validator can retrieve gene panel information from the cBioPortal API. 
+After loading gene panels into the database, please restart Tomcat or call the `/api/cache` endpoint with a `DELETE` http-request
+(see [here](portal.properties-Reference.md#flush-caches-with-the-_apicache_-endpoint) for more information) so that the
+validator can retrieve gene panel information from the cBioPortal API. 
 
 #### Update existing gene panel
 

--- a/docs/Import-Gene-Sets.md
+++ b/docs/Import-Gene-Sets.md
@@ -43,7 +43,9 @@ Note: This removes existing gene set, gene set hierarchy and gene set genetic pr
 	--data ../../test/resources/genesets/study_es_0_tree.yaml
 ```
 
-4. Restart Tomcat if you have it running.
+4. Restart Tomcat if you have it running or call the `/api/cache` endpoint with a `DELETE` http-request
+   (see [here](portal.properties-Reference.md#flush-caches-with-the-_apicache_-endpoint) for more information).
+
 
 5. Import study (replace argument after `-u` with local cBioPortal and `-html` with preferred location for html report):
 

--- a/docs/Import-Study-Using-Docker.md
+++ b/docs/Import-Study-Using-Docker.md
@@ -1,6 +1,7 @@
 # Import Study Using Docker
 
-:warning: Please make sure to restart tomcat every time you add/remove/overwrite a study
+:warning: Every time you add/remove/overwrite a study please restart tomcat (or the Docker container), or 
+call the `/api/cache` endpoint with a `DELETE` http-request (see [here](portal.properties-Reference.md#flush-caches-with-the-_apicache_-endpoint) for more information).
 
 ## Adding a Study
 

--- a/docs/Load-Sample-Cancer-Study.md
+++ b/docs/Load-Sample-Cancer-Study.md
@@ -31,7 +31,9 @@ cd <your_cbioportal_dir>/core/src/main/scripts
 ./importGenePanel.pl --data ../../test/scripts/test_data/study_es_0/data_gene_panel_testpanel2.txt
 ```
 
-After loading gene panels into the database, please restart Tomcat so that the validator can retrieve gene panel information from the cBioPortal API.
+After loading gene panels into the database, please restart Tomcat or call the `/api/cache` endpoint with a `DELETE` http-request
+(see [here](portal.properties-Reference.md#flush-caches-with-the-_apicache_-endpoint) for more information)
+so that the validator can retrieve gene panel information from the cBioPortal API.
 
 More details to load your own gene panel and gene set data can be found here: [Import Gene Panels](Import-Gene-Panels.md).
 
@@ -78,6 +80,7 @@ Done.
 Total time:  7742 ms
 ```
 
-After loading the study data, please restart the app.
+After loading the study data, please restart the app  or call the `/api/cache` endpoint with a `DELETE` http-request
+(see [here](portal.properties-Reference.md#flush-caches-with-the-_apicache_-endpoint) for more information).
 
 [Steps Complete: Return Home](README.md)

--- a/docs/Updating-gene-and-gene_alias-tables.md
+++ b/docs/Updating-gene-and-gene_alias-tables.md
@@ -37,7 +37,9 @@ ALTER TABLE `geneset_hierarchy_node` AUTO_INCREMENT = 1;
 ALTER TABLE `geneset` AUTO_INCREMENT = 1;
 ```
 
-4- Restart cBioPortal (restart webserver) to clean-up any cached gene lists.
+4- Restart cBioPortal (restart webserver)  or call the `/api/cache` endpoint with a `DELETE` http-request
+(see [here](portal.properties-Reference.md#flush-caches-with-the-_apicache_-endpoint) for more information)
+to clean-up any cached gene lists.
 
 5- To import gene data type the following commands when in the folder `<cbioportal_source_folder>/core/src/main/scripts`:
 ```

--- a/docs/Updating-your-cBioPortal-installation.md
+++ b/docs/Updating-your-cBioPortal-installation.md
@@ -69,4 +69,5 @@ Running statments for version: 1.1.0
 etc
 ```
 
-**Final step:** Restart your webserver. 
+**Final step:** Restart your webserver or call the `/api/cache` endpoint with a `DELETE` http-request
+(see [here](portal.properties-Reference.md#flush-caches-with-the-_apicache_-endpoint) for more information).

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -98,7 +98,13 @@ This will import the [lgg_ucsf_2014 study](https://www.cbioportal.org/patient?st
 docker-compose restart cbioportal
 ```
 
-You can visit http://localhost:8080 again and you should be able to see the new study.
+or call the `/api/cache` endpoint with a `DELETE` http-request (see [here](portal.properties-Reference.md#flush-caches-with-the-_apicache_-endpoint) for more information):
+
+```
+curl -x DELETE -H "X-API-KEY: 7d70fecb-cda8-490f-9ea2-ef874b6512f4" http://localhost:8080/api/cache
+```
+
+where the value of the API key is configured in the _portal.properties_ file. You can visit http://localhost:8080 again and you should be able to see the new study.
 
 All public studies can be downloaded from https://www.cbioportal.org/datasets, or https://github.com/cBioPortal/datahub/. You can add any of them to the `./study` folder and import them. There's also a script (`./study/init.sh`) to download multiple studies. You can set `DATAHUB_STUDIES` to any public study id (e.g. `lgg_ucsf_2014`) and run `./init.sh`.
 

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -444,6 +444,24 @@ ehcache.static_repository_cache_one.max_mega_bytes_local_disk=
 
 For more information on Ehcache, refer to the official documentation [here](https://www.ehcache.org/documentation/3.7/index.html)
 
+# Flush caches with the _/api/cache_ endpoint
+
+`DELETE` http requests to the `/api/cache` endpoint will flush the cBioPortal caches, and serves as an alternative to restarting
+the cBioPortal application.
+
+By default the endpoint is enabled. The endpoint can be disabled by setting:
+
+```
+cache.endpoint.enable=false
+```
+
+Access to the endpoint is not regulated by the configured user authorization mechanism. Instead, an API key should be passed
+with the `X-API-KEY` header. The accepted value for the API key can be configured by setting (for example):
+
+```
+cache.endpoint.api-key=7d70fecb-cda8-490f-9ea2-ef874b6512f4
+```
+
 # Enable GSVA functionality
 
 [GSVA functionality](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#gene-set-data) can be enabled by uncommenting this line (and making sure it is set to `true`):

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/CacheMapUtil.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/CacheMapUtil.java
@@ -67,10 +67,10 @@ public class CacheMapUtil {
     private static final int REPOSITORY_RESULT_OFFSET = 0; // retrieve all entries (do not skip any)
 
     // maps used to cache required relationships - in all maps stable ids are key
-    private Map<String, MolecularProfile> molecularProfileCache;
-    private Map<String, SampleList> sampleListCache;
-    private Map<String, CancerStudy> cancerStudyCache;
-    private Map<String, String> genericAssayStableIdToMolecularProfileIdCache;
+    private static Map<String, MolecularProfile> molecularProfileCache;
+    private static Map<String, SampleList> sampleListCache;
+    private static Map<String, CancerStudy> cancerStudyCache;
+    private static Map<String, String> genericAssayStableIdToMolecularProfileIdCache;
 
     public Map<String, MolecularProfile> getMolecularProfileMap() {
         return molecularProfileCache;
@@ -89,11 +89,17 @@ public class CacheMapUtil {
     }
 
     @PostConstruct
-    private void initializeCacheMemory() {
+    private void init() {
+        initializeCacheMemory();
+    }
+
+    public void initializeCacheMemory() {
+        
         // CHANGES TO THIS LIST MUST BE PROPAGATED TO 'GlobalProperties'
         this.cacheEnabled = (!authenticate.isEmpty() 
                 && !authenticate.equals("false") 
                 && !authenticate.contains("social_auth"));
+        
         if (cacheEnabled) {
             LOG.debug("creating cache maps for authorization");
             populateMolecularProfileMap();

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/CacheMapUtil.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/CacheMapUtil.java
@@ -162,7 +162,7 @@ public class CacheMapUtil {
             null,
             "ASC")) {
             // Only select GENERIC_ASSAY profiles
-            if (mp.getMolecularAlterationType().toString() == EntityType.GENERIC_ASSAY.toString()) {
+            if (EntityType.GENERIC_ASSAY.toString().equals(mp.getMolecularAlterationType().toString())) {
                 List<String> molecularId = new ArrayList<String>();
                 molecularId.add(mp.getStableId());
                 List<String> stableIds = genericAssayRepository.getGenericAssayStableIdsByMolecularIds(molecularId);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/CacheMapUtil.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/CacheMapUtil.java
@@ -97,7 +97,7 @@ public class CacheMapUtil {
         initializeCacheMemory();
     }
 
-    public void initializeCacheMemory() {
+    public synchronized void initializeCacheMemory() {
         
         // CHANGES TO THIS LIST MUST BE PROPAGATED TO 'GlobalProperties'
         this.cacheEnabled = (!authenticate.isEmpty() 
@@ -114,9 +114,7 @@ public class CacheMapUtil {
     }
 
     private void populateMolecularProfileMap() {
-        if (molecularProfileCache == null) {
-            molecularProfileCache = new HashMap<String, MolecularProfile>();
-        }
+        molecularProfileCache = new HashMap<String, MolecularProfile>();
         for (MolecularProfile mp : molecularProfileRepository.getAllMolecularProfiles(
                 "SUMMARY",
                 REPOSITORY_RESULT_LIMIT,
@@ -129,9 +127,7 @@ public class CacheMapUtil {
     }
 
     private void populateSampleListMap() {
-        if (sampleListCache == null) {
-            sampleListCache = new HashMap<String, SampleList>();
-        }
+        sampleListCache = new HashMap<String, SampleList>();
         for (SampleList sl : sampleListRepository.getAllSampleLists(
                 "SUMMARY",
                 REPOSITORY_RESULT_LIMIT,
@@ -144,9 +140,7 @@ public class CacheMapUtil {
     }
 
     private void populateCancerStudyMap() {
-        if (cancerStudyCache == null) {
-            cancerStudyCache = new HashMap<String, CancerStudy>();
-        }
+        cancerStudyCache = new HashMap<String, CancerStudy>();
         for (CancerStudy cs : studyRepository.getAllStudies(
                 null,
                 "SUMMARY",
@@ -160,9 +154,7 @@ public class CacheMapUtil {
     }
 
     private void populateGenericAssayStableIdToMolecularProfileIdMap() {
-        if (genericAssayStableIdToMolecularProfileIdCache == null) {
-            genericAssayStableIdToMolecularProfileIdCache = new HashMap<String, String>();
-        }
+        genericAssayStableIdToMolecularProfileIdCache = new HashMap<String, String>();
         for (MolecularProfile mp : molecularProfileRepository.getAllMolecularProfiles(
             "SUMMARY",
             REPOSITORY_RESULT_LIMIT,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/CacheMapUtil.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/util/CacheMapUtil.java
@@ -33,6 +33,7 @@
 package org.cbioportal.persistence.mybatis.util;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.PostConstruct;
 import org.cbioportal.model.*;
 import org.cbioportal.persistence.*;
@@ -67,6 +68,9 @@ public class CacheMapUtil {
     private static final int REPOSITORY_RESULT_OFFSET = 0; // retrieve all entries (do not skip any)
 
     // maps used to cache required relationships - in all maps stable ids are key
+    // Fields are static because the proxying mechanism of the CancerStudyPermissionEvaluator
+    // appears to perturb the Singleton scope of the CacheMapUtils bean. When debugging
+    // two version appeared to exist in context. A mechanism with bean injection did not work here.
     private static Map<String, MolecularProfile> molecularProfileCache;
     private static Map<String, SampleList> sampleListCache;
     private static Map<String, CancerStudy> cancerStudyCache;

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -262,6 +262,7 @@
         <servlet-name>api</servlet-name>
         <url-pattern>/api/*</url-pattern>
         <url-pattern>/health</url-pattern>
+        <url-pattern>/cache</url-pattern>
     </servlet-mapping>
 
     <servlet>

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -87,6 +87,7 @@
     <http pattern="/api/swagger-resources/**" security="none"/>
     <http pattern="/api/swagger-ui.html" security="none"/>
     <http pattern="/api/health" security="none"/>
+    <http pattern="/api/cache" security="none"/>
 
     <!-- This must come before the default entry point which will capture everything not matched by pattern -->
     <http use-expressions="true" pattern="/api/**" entry-point-ref="restAuthenticationEntryPoint" create-session="never">

--- a/service/src/main/java/org/cbioportal/service/CacheService.java
+++ b/service/src/main/java/org/cbioportal/service/CacheService.java
@@ -1,0 +1,5 @@
+package org.cbioportal.service;
+
+public interface CacheService {
+    public void evictAllCaches();
+}

--- a/service/src/main/java/org/cbioportal/service/CacheService.java
+++ b/service/src/main/java/org/cbioportal/service/CacheService.java
@@ -1,5 +1,5 @@
 package org.cbioportal.service;
 
 public interface CacheService {
-    public void evictAllCaches();
+    public void clearCaches(boolean springManagedCache);
 }

--- a/service/src/main/java/org/cbioportal/service/impl/CacheServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CacheServiceImpl.java
@@ -1,0 +1,34 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.persistence.mybatis.util.CacheMapUtil;
+import org.cbioportal.service.CacheService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CacheServiceImpl implements CacheService {
+
+    @Autowired(required = false)
+    private CacheManager cacheManager;
+
+    @Autowired
+    private CacheMapUtil cacheMapUtil;
+
+    @Override
+    public void evictAllCaches() {
+        
+        // Flush Spring-managed caches (only when cache strategy has been defined).
+        if (cacheManager != null)
+            cacheManager.getCacheNames().stream()
+                .forEach(cacheName -> cacheManager.getCache(cacheName).clear());
+        
+        // Flush cache used for user permission evaluation.
+        cacheMapUtil.initializeCacheMemory();
+        
+        // Note: DAO classes in package org.mskcc.cbio.portal.dao do have their own
+        // caching strategy. Since these classes are only used by the deprecated old
+        // version of the r-library and may result in problems in the running instance
+        // when flushing the cashes, we do not handle these caches in this service.
+    }
+}

--- a/service/src/main/java/org/cbioportal/service/impl/CacheServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CacheServiceImpl.java
@@ -16,10 +16,10 @@ public class CacheServiceImpl implements CacheService {
     private CacheMapUtil cacheMapUtil;
 
     @Override
-    public void evictAllCaches() {
+    public void clearCaches(boolean clearSpringManagedCache) {
         
         // Flush Spring-managed caches (only when cache strategy has been defined).
-        if (cacheManager != null)
+        if (cacheManager != null && clearSpringManagedCache)
             cacheManager.getCacheNames().stream()
                 .forEach(cacheName -> cacheManager.getCache(cacheName).clear());
         

--- a/service/src/test/java/org/cbioportal/service/impl/CacheServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/CacheServiceImplTest.java
@@ -1,0 +1,53 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.persistence.mybatis.util.CacheMapUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CacheServiceImplTest {
+
+    @InjectMocks
+    private CacheServiceImpl cachingService;
+
+    @Mock
+    private CacheManager cacheManager;
+
+    @Mock
+    private CacheMapUtil cacheMapUtil;
+    private Cache mockCache;
+
+    @Before
+    public void init() {
+        mockCache = mock(Cache.class);
+        when(cacheManager.getCacheNames()).thenReturn(Arrays.asList(new String[]{"name_1", "name_2"}));
+        when(cacheManager.getCache(anyString())).thenReturn(mockCache);
+    }
+
+    @Test
+    public void evictAllCachesSuccess() {
+        cachingService.evictAllCaches();
+        verify(mockCache, times(2)).clear();
+        verify(cacheMapUtil, times(1)).initializeCacheMemory();
+    }
+
+    @Test
+    public void evictAllCachesNullManager() {
+        ReflectionTestUtils.setField(cachingService, "cacheManager", null);
+        cachingService.evictAllCaches();
+        verify(mockCache, never()).clear();
+        verify(cacheMapUtil, times(1)).initializeCacheMemory();
+        ReflectionTestUtils.setField(cachingService, "cacheManager", cacheManager);
+    }
+}

--- a/service/src/test/java/org/cbioportal/service/impl/CacheServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/CacheServiceImplTest.java
@@ -37,7 +37,7 @@ public class CacheServiceImplTest {
 
     @Test
     public void evictAllCachesSuccess() {
-        cachingService.evictAllCaches();
+        cachingService.clearCaches(true);
         verify(mockCache, times(2)).clear();
         verify(cacheMapUtil, times(1)).initializeCacheMemory();
     }
@@ -45,9 +45,17 @@ public class CacheServiceImplTest {
     @Test
     public void evictAllCachesNullManager() {
         ReflectionTestUtils.setField(cachingService, "cacheManager", null);
-        cachingService.evictAllCaches();
+        cachingService.clearCaches(true);
         verify(mockCache, never()).clear();
         verify(cacheMapUtil, times(1)).initializeCacheMemory();
         ReflectionTestUtils.setField(cachingService, "cacheManager", cacheManager);
     }
+    
+    @Test
+    public void evictAllCachesSkipSpringManagedCache() {
+        cachingService.clearCaches(false);
+        verify(mockCache, never()).clear();
+        verify(cacheMapUtil, times(1)).initializeCacheMemory();
+    }
+    
 }

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -335,7 +335,7 @@ persistence.cache_type=no-cache
 # If blank or commented out, no map will be shown and that page will be hidden.
 # installation_map_url=https://installationmap.netlify.app/
 
-# Turn cache management endpoint on (default) or off
-# cache.endpoint.enabled=false
+# Turn cache management endpoint on or off (default)
+# cache.endpoint.enabled=true
 # API key for access to cache management endpoint
 # cache.endpoint.api-key=fd15f1ae-66f2-4b8a-8d54-fb899b03557e

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -334,3 +334,8 @@ persistence.cache_type=no-cache
 # Installation map URL for installation map iframes. 
 # If blank or commented out, no map will be shown and that page will be hidden.
 # installation_map_url=https://installationmap.netlify.app/
+
+# Turn cache management endpoint on (default) or off
+# cache.endpoint.enabled=false
+# API key for access to cache management endpoint
+# cache.endpoint.api-key=fd15f1ae-66f2-4b8a-8d54-fb899b03557e

--- a/web/src/main/java/org/cbioportal/web/CacheController.java
+++ b/web/src/main/java/org/cbioportal/web/CacheController.java
@@ -2,7 +2,9 @@ package org.cbioportal.web;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import org.cbioportal.service.CacheService;
+import org.cbioportal.web.config.annotation.InternalApi;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -12,13 +14,13 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @Validated
-@ApiIgnore
-@Api(tags = "Cache", description = "")
+@InternalApi
+@Api(tags = "Cache")
 public class CacheController {
 
     @Autowired
@@ -27,17 +29,21 @@ public class CacheController {
     @Value("${cache.endpoint.api-key:not set}")
     private String requiredApiKey;
     
-    @Value("${cache.endpoint.enabled:true}")
+    @Value("${cache.endpoint.enabled:false}")
     private boolean cacheEndpointEnabled;
 
     @RequestMapping(value = "/cache", method = RequestMethod.DELETE, produces = MediaType.TEXT_PLAIN_VALUE)
-    @ApiOperation("Flush and reinitialize caches")
-    public ResponseEntity<String> clearAllCaches(@RequestHeader("X-API-KEY") String providedApiKey) {
+    @ApiOperation("Clear and reinitialize caches")
+    public ResponseEntity<String> clearAllCaches(
+        @ApiParam("Secret API key passed in HTTP header. The key is configured in portal.properties of the portal instance.")
+        @RequestHeader(value = "X-API-KEY") String providedApiKey,
+        @ApiParam("Clear Spring-managed caches")
+        @RequestParam(defaultValue = "true", required = false) final boolean springManagedCache) {
         if (!cacheEndpointEnabled)
             return new ResponseEntity<>("Cache endpoint is disabled for this instance.", HttpStatus.NOT_FOUND);
         if ("not set".equals(requiredApiKey) || ! requiredApiKey.equals(providedApiKey))
             return new ResponseEntity<>("", HttpStatus.UNAUTHORIZED);
-        cacheService.evictAllCaches();
+        cacheService.clearCaches(springManagedCache);
         return new ResponseEntity<>("Flushed all caches!!!", HttpStatus.OK);
     }
 }

--- a/web/src/main/java/org/cbioportal/web/CacheController.java
+++ b/web/src/main/java/org/cbioportal/web/CacheController.java
@@ -1,0 +1,43 @@
+package org.cbioportal.web;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.cbioportal.service.CacheService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+@RestController
+@Validated
+@ApiIgnore
+@Api(tags = "Cache", description = "")
+public class CacheController {
+
+    @Autowired
+    private CacheService cacheService;
+    
+    @Value("${cache.endpoint.api-key:not set}")
+    private String requiredApiKey;
+    
+    @Value("${cache.endpoint.enabled:true}")
+    private boolean cacheEndpointEnabled;
+
+    @RequestMapping(value = "/cache", method = RequestMethod.DELETE, produces = MediaType.TEXT_PLAIN_VALUE)
+    @ApiOperation("Flush and reinitialize caches")
+    public ResponseEntity<String> clearAllCaches(@RequestHeader("X-API-KEY") String providedApiKey) {
+        if (!cacheEndpointEnabled)
+            return new ResponseEntity<>("Cache endpoint is disabled for this instance.", HttpStatus.NOT_FOUND);
+        if ("not set".equals(requiredApiKey) || ! requiredApiKey.equals(providedApiKey))
+            return new ResponseEntity<>("", HttpStatus.UNAUTHORIZED);
+        cacheService.evictAllCaches();
+        return new ResponseEntity<>("Flushed all caches!!!", HttpStatus.OK);
+    }
+}

--- a/web/src/main/java/org/cbioportal/web/CacheController.java
+++ b/web/src/main/java/org/cbioportal/web/CacheController.java
@@ -39,10 +39,12 @@ public class CacheController {
         @RequestHeader(value = "X-API-KEY") String providedApiKey,
         @ApiParam("Clear Spring-managed caches")
         @RequestParam(defaultValue = "true", required = false) final boolean springManagedCache) {
-        if (!cacheEndpointEnabled)
+        if (!cacheEndpointEnabled) {
             return new ResponseEntity<>("Cache endpoint is disabled for this instance.", HttpStatus.NOT_FOUND);
-        if ("not set".equals(requiredApiKey) || ! requiredApiKey.equals(providedApiKey))
+        }
+        if ("not set".equals(requiredApiKey) || ! requiredApiKey.equals(providedApiKey)) {
             return new ResponseEntity<>("", HttpStatus.UNAUTHORIZED);
+        }
         cacheService.clearCaches(springManagedCache);
         return new ResponseEntity<>("Flushed all caches!!!", HttpStatus.OK);
     }

--- a/web/src/test/java/org/cbioportal/web/CacheControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CacheControllerTest.java
@@ -1,0 +1,97 @@
+package org.cbioportal.web;
+
+import org.cbioportal.service.CacheService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration("/applicationContext-web-test.xml")
+@TestPropertySource(
+    properties = {
+        // -- needed for the PropertySourcesPlaceholderConfigurer
+        "PORTAL_HOME=fake",
+        "google.analytics.tracking.code.api=",
+        "google.analytics.application.client.id=1"
+        // --
+    }
+)
+@Configuration
+public class CacheControllerTest {
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CacheService cacheService;
+
+    @Autowired
+    private CacheController cacheController;
+    
+    @Bean
+    public CacheService cacheService() {
+        return mock(CacheService.class);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();
+    }
+
+    @Test
+    public void clearAllCachesNoKeyProvided() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/cache"))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        verify(cacheService, never()).evictAllCaches();
+    }
+
+    @Test
+    public void clearAllCachesUnauthorized() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/cache")
+            .header("X-API-KEY", "incorrect-key"))
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+            .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN_VALUE));
+        verify(cacheService, never()).evictAllCaches();
+    }
+
+    @Test
+    public void clearAllCachesSuccess() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/cache")
+            .header("X-API-KEY", "correct-key"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN_VALUE));
+        verify(cacheService, times(1)).evictAllCaches();
+    }
+
+    @Test
+    public void clearAllCachesDisabled() throws Exception {
+        ReflectionTestUtils.setField(cacheController, "cacheEndpointEnabled", false);
+        mockMvc.perform(MockMvcRequestBuilders.delete("/cache")
+            .header("X-API-KEY", "correct-key"))
+            .andExpect(MockMvcResultMatchers.status().isNotFound())
+            .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN_VALUE));
+        verify(cacheService, never()).evictAllCaches();
+        ReflectionTestUtils.setField(cacheController, "cacheEndpointEnabled", true);
+    }
+
+}

--- a/web/src/test/resources/applicationContext-web-test.xml
+++ b/web/src/test/resources/applicationContext-web-test.xml
@@ -14,6 +14,16 @@
     <!-- load beans from shared test configuration -->
     <bean class="org.cbioportal.web.config.CacheMapUtilConfig"/>
 
+    <bean
+        class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <list>
+                <value>classpath:test.properties</value>
+            </list>
+        </property>
+        <property name="ignoreUnresolvablePlaceholders" value="true" />
+    </bean>
+    
     <!-- load the beans from the prodution configuration xml file -->
     <import resource="classpath:applicationContext-web.xml" />
 </beans>

--- a/web/src/test/resources/test.properties
+++ b/web/src/test/resources/test.properties
@@ -1,1 +1,2 @@
+cache.endpoint.enabled=true
 cache.endpoint.api-key=correct-key

--- a/web/src/test/resources/test.properties
+++ b/web/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+cache.endpoint.api-key=correct-key


### PR DESCRIPTION
# Problem
When loading a new study the cBioPortal tomcat server needs to be restarted. This breaks the user experience of users logged in the running portal instance. The need to restart comes from the need to flush two levels of caching used by cBioPortal. The first is by the _CacheManager_ used by Spring (can be MyBatis/EHcache or redis). The second is by the _CacheMapUtils_ class that references lists of studies, samples and profiles for fast lookup during evaluation of user permissions.

# Solution
This PR adds a new endpoint `/api/cache` that triggers flushing of the Spring-managed and CacheMapUtils caches when a DELETE http-request is received. The CacheMapUtils cache is re-initialized for handling of user permissions. Calling this endpoint removes the need to restart the cBioPortal tomcat server/docker service after loading of a new study (or other data).

## Rationale for choosing endpoint over script 'local' script
I opted for an endpoint over a mechanism that involved calling a local script for flushing the caches because in certain deployment environments (e.g., kubernetes) triggering scripts in a running instance is not/less convenient. A REST endpoint can be easily called on all running instances in a system irrespective of the deployment method. I consider the ability to turn off the endpoint in _portal.properties_  and the use of a secret API key to sufficiently cover the added security risk. 

## Access to the endpoint
The endpoint is not handled by the user authN/authZ method. Flushing of the caches can only be performed when passing an API key configured in the _portal.properties_ in the `X-API-KEY` header. When a API key is not provided the endpoint returns a BAD REQUEST response. When the wrong API key is passed, the endpoint returns an UNAUTHORIZED response. 

## Additions to _portal.properties_
These properties are added:

```
# Turn cache management endpoint on or off (default)
# cache.endpoint.enabled=false

# API key for access to cache management endpoint
# cache.endpoint.api-key=fd15f1ae-66f2-4b8a-8d54-fb899b03557e
```

## Tests
Unit tests for the controller and service classes were added.

## Documentation
Where applicable, instructions to restart the cBioPortal tomcat server or restart of the docker container were amended with instructions to call the `/api/cache` endpoint.