### PR TITLE
Add `no-transaction` argument to migrate_db.py

### DIFF
--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -254,7 +254,10 @@ def run_migration(db_version, sql_filename, connection, cursor):
 
 def run_statements(statements, connection, cursor):
     try:
-        cursor.execute('SET autocommit=0;')
+        if parser.no_transaction:
+            cursor.execute('SET autocommit=1;')
+        else:
+            cursor.execute('SET autocommit=0;')
     except MySQLdb.Error as msg:
         print(msg, file=ERROR_FILE)
         sys.exit(1)
@@ -299,6 +302,9 @@ def main():
     parser.add_argument('-s', '--sql', type=str, required=True,
                         help='Path to official migration.sql script.')
     parser.add_argument('-f', '--force', default=False, action='store_true', help='Force to run database migration')
+    parser.add_argument('--no-transaction', default=False, action='store_true', help="""
+        Do not run migration in a single transaction. Only use this when you known what you are doing!!!
+    """)
     parser = parser.parse_args()
 
     properties_filename = parser.properties_file

--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -207,7 +207,7 @@ def strip_trailing_comment_from_line(line):
     line_parts = re.split("--\s",line)
     return line_parts[0]
 
-def run_migration(db_version, sql_filename, connection, cursor):
+def run_migration(db_version, sql_filename, connection, cursor, no_transaction):
     """
         Goes through the sql and runs lines based on the version numbers. SQL version should be stated as follows:
 
@@ -248,13 +248,13 @@ def run_migration(db_version, sql_filename, connection, cursor):
                     statements[sql_version].append(statement)
                 statement = ''
     if len(statements) > 0:
-        run_statements(statements, connection, cursor)
+        run_statements(statements, connection, cursor, no_transaction)
     else:
         print('Everything up to date, nothing to migrate.', file=OUTPUT_FILE)
 
-def run_statements(statements, connection, cursor):
+def run_statements(statements, connection, cursor, no_transaction):
     try:
-        if parser.no_transaction:
+        if no_transaction:
             cursor.execute('SET autocommit=1;')
         else:
             cursor.execute('SET autocommit=0;')
@@ -342,7 +342,7 @@ def main():
         if is_version_larger(MULTI_REFERENCE_GENOME_SUPPORT_MIGRATION_STEP, db_version):
             #retrieve reference genomes from database
             check_reference_genome(portal_properties, cursor, parser.force)
-        run_migration(db_version, sql_filename, connection, cursor)
+        run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction)
     print('Finished.', file=OUTPUT_FILE)
 
 # do main


### PR DESCRIPTION
# Problem
Migration of the cBioPortal database on Google Cloud SQL fails with error:


>Temporary tables.  CREATE TEMPORARY TABLE and DROP TEMPORARY TABLE statements are not supported inside transactions, procedures, functions, and triggers when using GTIDs (that is, when the enforce_gtid_consistency system variable is set to ON). It is possible to use these statements with GTIDs enabled, but only outside of any transaction, and only with autocommit=1.

The reason for this is that Google Cloud SQL uses GTID-based replication (see [MySQL docs](https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-restrictions.html) for more information).

The _migrate_db.py_ script runs the migration in a single transaction which is incompatible with the replication strategy:

```
cursor.execute('SET autocommit=0;')
```

# Solution
In this PR we add a `--no-transaction` flag to the _migrate_db.py_ script which will suppress running migration as a single transaction. The default value for this parameter is `False`. This means that this change is backward compatible.

# Remark
We are aware that running migration outside of a transaction is dangerous and should only be performed in cases where it is absolutely necessary. All user session should be terminated before migrating with the `--no-transaction` flag.