### PR TITLE
Remove NA value from Generic Assay Data endpoints

### DIFF
--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -2777,14 +2777,7 @@ class GenericAssayCategoricalTestCase(PostClinicalDataFileTestCase):
                             extra_meta_fields={
                                 'generic_entity_meta_properties': 'name,description,url'})
 
-        self.assertEqual(len(record_list), 2)
-        record_iterator = iter(record_list)
-        record = next(record_iterator)
-        self.assertEqual(record.levelno, logging.ERROR)
-        self.assertIn('Blank cell found in column', record.getMessage())
-        record = next(record_iterator)
-        self.assertEqual(record.levelno, logging.ERROR)
-        self.assertIn('Cell is empty. A categorical value is expected.', record.getMessage())
+        self.assertEqual(len(record_list), 0)
 
 class GenericAssayBinaryTestCase(PostClinicalDataFileTestCase):
     def test_generic_assay_with_with_valid_binary_data(self):

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -1435,7 +1435,7 @@ All generic assay data is registered to be of the type of `genetic_alteration_ty
 - ***CATEGORICAL (under development)***: This datatype is intended to be used for any categorical data set with similar structure (entities measured in samples). Any text is allowed in `CATEGORICAL` except blank.
 - ***BINARY (under development)***: This datatype is intended to be used for any binary data set with similar structure (entities measured in samples). The `BINARY` is validated to contain only reserved text (`true`, `false`, `yes`, `no`).
 
-If the value for the generic entity in the respective sample could not (or was not) be measured (or detected), the value should be 'NA'.
+If the value for the generic entity in the respective sample could not (or was not) be measured (or detected), the value should be 'NA' or leave that cell blank.
 
 ### Generic Assay data file
 The data file will be a simple tab separated format, similar to the expression data file: each sample is a column, each generic entity is a row, each cell contains values for that generic entity x sample combination.

--- a/web/src/main/java/org/cbioportal/web/GenericAssayController.java
+++ b/web/src/main/java/org/cbioportal/web/GenericAssayController.java
@@ -3,11 +3,13 @@ package org.cbioportal.web;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.apache.commons.lang3.StringUtils;
 import springfox.documentation.annotations.ApiIgnore;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.validation.Valid;
 
@@ -88,11 +90,11 @@ public class GenericAssayController {
 
         List<GenericAssayData> result;
         if (genericAssayDataFilter.getSampleListId() != null) {
-            result = genericAssayService.getGenericAssayData(molecularProfileId,
-                genericAssayDataFilter.getSampleListId(), genericAssayDataFilter.getGenericAssayStableIds(), projection.name());
+            result = filterEmptyGenericAssayData(genericAssayService.getGenericAssayData(molecularProfileId,
+                genericAssayDataFilter.getSampleListId(), genericAssayDataFilter.getGenericAssayStableIds(), projection.name()));
         } else {
-            result = genericAssayService.fetchGenericAssayData(molecularProfileId,
-                genericAssayDataFilter.getSampleIds(), genericAssayDataFilter.getGenericAssayStableIds(), projection.name());
+            result = filterEmptyGenericAssayData(genericAssayService.fetchGenericAssayData(molecularProfileId,
+                genericAssayDataFilter.getSampleIds(), genericAssayDataFilter.getGenericAssayStableIds(), projection.name()));
         }
 
         if (projection == Projection.META) {
@@ -121,16 +123,16 @@ public class GenericAssayController {
 
         List<GenericAssayData> result;
         if (interceptedGenericAssayDataMultipleStudyFilter.getMolecularProfileIds() != null) {
-            result = genericAssayService.fetchGenericAssayData(
+            result = filterEmptyGenericAssayData(genericAssayService.fetchGenericAssayData(
                 interceptedGenericAssayDataMultipleStudyFilter.getMolecularProfileIds(), null,
-                interceptedGenericAssayDataMultipleStudyFilter.getGenericAssayStableIds(), projection.name());
+                interceptedGenericAssayDataMultipleStudyFilter.getGenericAssayStableIds(), projection.name()));
         } else {
 
             List<String> molecularProfileIds = new ArrayList<>();
             List<String> sampleIds = new ArrayList<>();
             extractMolecularProfileAndSampleIds(interceptedGenericAssayDataMultipleStudyFilter, molecularProfileIds, sampleIds);
-            result = genericAssayService.fetchGenericAssayData(molecularProfileIds,
-                sampleIds, interceptedGenericAssayDataMultipleStudyFilter.getGenericAssayStableIds(), projection.name());
+            result = filterEmptyGenericAssayData(genericAssayService.fetchGenericAssayData(molecularProfileIds,
+                sampleIds, interceptedGenericAssayDataMultipleStudyFilter.getGenericAssayStableIds(), projection.name()));
         }
 
         if (projection == Projection.META) {
@@ -147,5 +149,11 @@ public class GenericAssayController {
             molecularProfileIds.add(sampleMolecularIdentifier.getMolecularProfileId());
             sampleIds.add(sampleMolecularIdentifier.getSampleId());
         }
+    }
+
+    private List<GenericAssayData> filterEmptyGenericAssayData(List<GenericAssayData> genericAssayDataList) {
+        return genericAssayDataList.stream()
+            .filter(g -> StringUtils.isNotEmpty(g.getValue()) && !g.getValue().equals("NA"))
+            .collect(Collectors.toList());
     }
 }

--- a/web/src/test/java/org/cbioportal/web/GenericAssayControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GenericAssayControllerTest.java
@@ -42,9 +42,13 @@ public class GenericAssayControllerTest {
     private static final String ENTITY_TYPE = "test_type";
     public static final String GENERIC_ASSAY_STABLE_ID_1 = "genericAssayStableId1";
     public static final String GENERIC_ASSAY_STABLE_ID_2 = "genericAssayStableId2";
+    public static final String GENERIC_ASSAY_STABLE_ID_3 = "genericAssayStableId3";
+    public static final String GENERIC_ASSAY_STABLE_ID_4 = "genericAssayStableId4";
     private static final String SAMPLE_ID = "test_sample_stable_id_1";
     private static final String VALUE_1 = "0.25";
     private static final String VALUE_2 = "-0.75";
+    private static final String VALUE_3 = "";
+    private static final String VALUE_4 = "NA";
     private static final String TEST_NAME = "name";
     private static final String TEST_NAME_VALUE = "test_name";
     private static final String TEST_DESCRIPTION = "description";
@@ -83,7 +87,7 @@ public class GenericAssayControllerTest {
 
         GenericAssayFilter genericAssayDataFilter = new GenericAssayFilter();	
         genericAssayDataFilter.setSampleIds(Arrays.asList(SAMPLE_ID));	
-        genericAssayDataFilter.setGenericAssayStableIds(Arrays.asList(GENERIC_ASSAY_STABLE_ID_1, GENERIC_ASSAY_STABLE_ID_2));	
+        genericAssayDataFilter.setGenericAssayStableIds(Arrays.asList(GENERIC_ASSAY_STABLE_ID_1, GENERIC_ASSAY_STABLE_ID_2, GENERIC_ASSAY_STABLE_ID_3, GENERIC_ASSAY_STABLE_ID_4));	
 
         mockMvc.perform(MockMvcRequestBuilders.post("/generic_assay_data/" + PROF_ID + "/fetch")	
                 .accept(MediaType.APPLICATION_JSON)	
@@ -185,6 +189,22 @@ public class GenericAssayControllerTest {
         item2.setValue(VALUE_2);
         genericAssayDataItems.add(item2);
 
+        // This item should be filtered out in api result
+        GenericAssayData item3 = new GenericAssayData();
+        item3.setGenericAssayStableId(GENERIC_ASSAY_STABLE_ID_3);
+        item3.setMolecularProfileId(PROF_ID);
+        item3.setSampleId(SAMPLE_ID);
+        item3.setValue(VALUE_3);
+        genericAssayDataItems.add(item3);
+
+        // This item should be filtered out in api result
+        GenericAssayData item4 = new GenericAssayData();
+        item4.setGenericAssayStableId(GENERIC_ASSAY_STABLE_ID_4);
+        item4.setMolecularProfileId(PROF_ID);
+        item4.setSampleId(SAMPLE_ID);
+        item4.setValue(VALUE_4);
+        genericAssayDataItems.add(item4);
+
         return genericAssayDataItems;
     }
 
@@ -198,9 +218,19 @@ public class GenericAssayControllerTest {
         sampleMolecularIdentifiers.add(identifier1);
 
         SampleMolecularIdentifier identifier2 = new SampleMolecularIdentifier();
-        identifier1.setSampleId(SAMPLE_ID);
-        identifier1.setMolecularProfileId(GENERIC_ASSAY_STABLE_ID_2);
+        identifier2.setSampleId(SAMPLE_ID);
+        identifier2.setMolecularProfileId(GENERIC_ASSAY_STABLE_ID_2);
         sampleMolecularIdentifiers.add(identifier2);
+
+        SampleMolecularIdentifier identifier3 = new SampleMolecularIdentifier();
+        identifier3.setSampleId(SAMPLE_ID);
+        identifier3.setMolecularProfileId(GENERIC_ASSAY_STABLE_ID_3);
+        sampleMolecularIdentifiers.add(identifier3);
+
+        SampleMolecularIdentifier identifier4 = new SampleMolecularIdentifier();
+        identifier4.setSampleId(SAMPLE_ID);
+        identifier4.setMolecularProfileId(GENERIC_ASSAY_STABLE_ID_4);
+        sampleMolecularIdentifiers.add(identifier4);
 
         return sampleMolecularIdentifiers;
     }


### PR DESCRIPTION
Fix https://github.com/cbioportal/cbioportal/issues/8695

Currently, if data is not available, we require to put a NA in the data file, leave it blank is not allowed. However we should allow it to be blank since we won't expose those data anyway. So the task is:

- [x] Validator: Allow blank (empty) cell
- [x] Controller: Filter out blank (empty) values before send response
- [x] Documentation: Update documentation