### PR TITLE
Workaround for fusions structural variant genes imported as mutations

### DIFF
--- a/service/src/main/java/org/cbioportal/service/util/MolecularProfileUtil.java
+++ b/service/src/main/java/org/cbioportal/service/util/MolecularProfileUtil.java
@@ -3,7 +3,6 @@ package org.cbioportal.service.util;
 import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.springframework.stereotype.Component;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -18,10 +17,14 @@ public class MolecularProfileUtil {
     public final String MUTATION_PROFILE_SUFFIX = "_mutations";
     public final String FUSION_PROFILE_SUFFIX = "_fusion";
     public final String STRUCTURAL_VARIANT_PROFILE_SUFFIX = "_structural_variants";
+    public final String FUSIONS_AS_MUTATIONS_DATATYPE = "FUSION";
 
+    // TODO: Remove once fusions are removed from mutation table
     public Predicate<MolecularProfile> isStructuralVariantMolecularProfile =
         m -> m.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.FUSION) ||
-            m.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.STRUCTURAL_VARIANT);
+            m.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.STRUCTURAL_VARIANT) || 
+                (m.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.MUTATION_EXTENDED) 
+                        && m.getDatatype().equals(FUSIONS_AS_MUTATIONS_DATATYPE));
 
     public Predicate<MolecularProfile> isDiscreteCNAMolecularProfile =
         m -> m.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.COPY_NUMBER_ALTERATION) && 


### PR DESCRIPTION
**Related issue:**
- https://github.com/knowledgesystems/pipelines-scrum/issues/620

FIXES:
- [x] expand def'n of what genomic profiles fall under types of "structural variant" data
- [x] identify other areas of code that affect population of study view "Genomic Profile Sample Counts: Molecular Profiles" table and "Structural Variant" genes tables // ONCOPRINT does not use the same endpoint. This table is rendering fine for the MSKARCHER study fusions imported as "_mutations"
- [x] fix oncoprint rendering - samples are not showing up with genomic alterations for genes which have structural variants
- [x] fix mutation table rendering - genomic alteration events are not rendering in table for genes which have structural variants

**Describe changes proposed in this pull request:**

**Implement workaround for populating Structural Variant Genes table in Study View page**
- Pull structural variant genes for genomic profiles of genetic alteration type (molecular alteration type)= "MUTATION_EXTENDED" and datatype = "FUSION"
  - Endpoints affected: 
    - `/structuralvariants-genes/fetch`
    - `/filtered-samples/fetch`

**Structural Variant Genes table renders now for this type of scenario**
![image](https://user-images.githubusercontent.com/15623749/126648556-9b96e04c-28cd-42e6-9268-41fdb123c668.png)

**Implement workaround for populating OncoPrint fusion events that are imported as a "_mutations" profile w/genetic alteration type "STRUCTURAL_VARIANT" and datatype "FUSION"**

_Note: This is a necessary change to accommodate `mskarcher` which has a single genomic profile (fusions) being imported as "_mutations" so that they show up in the mutation table and are linked to the appropriate gene panel._

If you are really curious as to all the steps taken during debugging/troubleshooting this issue then please refer to the attachment `mskarcher_debugging.txt`. It is literally just a log of trials and errors so it's messy but contains all of my notes.
[mskarcher_debugging.txt](https://github.com/cBioPortal/cbioportal/files/6865407/mskarcher_debugging.txt)


Fixed OncoPrint screen shot:
![image](https://user-images.githubusercontent.com/15623749/126713987-1bc7d491-abf4-4941-8d84-79cea1cce82d.png)

  - Endpoints affected:
    - `/structural-variants/fetch`


Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
