### PR TITLE
Impl. skin.hide_logout_button property

### DIFF
--- a/docs/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/Customizing-your-instance-of-cBioPortal.md
@@ -223,6 +223,12 @@ Below you can find the complete list of all the available skin properties.
             <td>false</td>
             <td>true / false</td>
         </tr>
+        <tr>
+            <td>skin.hide_logout_button</td>
+            <td>controls the appearance the logout button on a portal with user authentication.</td>
+            <td>false</td>
+            <td>true / false</td>
+        </tr>
       <tr>
             <td>google_analytics_profile_id</td>
             <td>enables google analaytics tracking on your site</td>

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -177,6 +177,15 @@ in these sections. This menu will only appear, when setting the property _skin.s
 skin.show_settings_menu=
 ```
 
+## Hide logout button
+When the user is logged-in, a button with logout and data access token options is shown at the right side of the header section.
+This button can be hidden by setting the property _skin.hide_logout_button to _true_ (default is _false_). Hiding the logout button will remove
+the ability to perform a manual logout and download data access tokens by the user.
+
+```
+skin.hide_logout_button=
+```
+
 
 ## Hide p- and q-values in survival types table
 ```

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -104,6 +104,7 @@
             "skin.patientview.filter_genes_profiled_all_samples",
             "skin.patientview.show_mskcc_slide_viewer",
             "skin.show_settings_menu",
+            "skin.hide_logout_button",
             "quick_search.enabled",
             "default_cross_cancer_study_session_id",
             "default_cross_cancer_study_list",

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -87,6 +87,9 @@ skin.study_view.link_text=To build your own case set, try out our enhanced Study
 # settings controlling the appearance of the annotation filter menu in study view and group comparison
 # skin.show_settings_menu=false
 
+# controls the appearance the logout button on a portal with user authentication
+# skin.hide_logout_button=false
+
 ## enable and set this property to specify a study group to be used to identify public studies for which no specific authorization entries are needed in the `authorities` table
 # always_show_study_group=
 


### PR DESCRIPTION
This PR implements a property used to hide the logout button in the cBioPortal header. It is related to front-end PR [#3879](https://github.com/cBioPortal/cbioportal-frontend/pull/3879).