### PR TITLE
Optimize coexpression endpoint

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MolecularDataRepository.java
@@ -18,12 +18,18 @@ public interface MolecularDataRepository {
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     Map<String, MolecularProfileSamples> commaSeparatedSampleIdsOfMolecularProfilesMap(Set<String> molecularProfileIds);
 
-    @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
+    // Not caching when entrezGeneIds is null or empty because the large response size sometimes crashes the cache
+    @Cacheable(cacheResolver = "generalRepositoryCacheResolver",
+               condition = "@cacheEnabledConfig.getEnabled() && #entrezGeneIds != null && #entrezGeneIds.size() != 0")
     List<GeneMolecularAlteration> getGeneMolecularAlterations(String molecularProfileId, List<Integer> entrezGeneIds,
                                                               String projection);
 
     Iterable<GeneMolecularAlteration> getGeneMolecularAlterationsIterable(String molecularProfileId, List<Integer> entrezGeneIds,
                                                                           String projection);
+
+    // Same as getGeneMolecularAlterationsIterable above, except assumes that
+    // entrezGeneIds is null or empty AND projection is "SUMMARY"
+    Iterable<GeneMolecularAlteration> getGeneMolecularAlterationsIterableFast(String molecularProfileId);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(Set<String> molecularProfileIds,

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMapper.java
@@ -21,6 +21,10 @@ public interface MolecularDataMapper {
     Cursor<GeneMolecularAlteration> getGeneMolecularAlterationsIter(String molecularProfileId, List<Integer> entrezGeneIds,
                                                                     String projection);
 
+    // Same as getGeneMolecularAlterationsIter above, except assumes that
+    // entrezGeneIds is null or empty AND projection is "SUMMARY"
+    Cursor<GeneMolecularAlteration> getGeneMolecularAlterationsIterFast(String molecularProfileId);
+
     List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(Set<String> molecularProfileIds, 
                                                                                          List<Integer> entrezGeneIds, String projection);
 

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/MolecularDataMyBatisRepository.java
@@ -51,6 +51,12 @@ public class MolecularDataMyBatisRepository implements MolecularDataRepository {
     }
 
     @Override
+    public Iterable<GeneMolecularAlteration> getGeneMolecularAlterationsIterableFast(String molecularProfileId) {
+
+        return molecularDataMapper.getGeneMolecularAlterationsIterFast(molecularProfileId);
+    }
+
+    @Override
     public List<GeneMolecularAlteration> getGeneMolecularAlterationsInMultipleMolecularProfiles(Set<String> molecularProfileIds, 
                                                                                                 List<Integer> entrezGeneIds, 
                                                                                                 String projection) {

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularDataMapper.xml
@@ -91,6 +91,19 @@
         </where>
     </select>
 
+    <!-- This routine is an abbreviated copy of getGeneMolecularAlterationsIter above. The two should be kept in sync. -->
+    <select id="getGeneMolecularAlterationsIterFast" resultType="org.cbioportal.model.GeneMolecularAlteration">
+        SELECT
+        gene.ENTREZ_GENE_ID AS entrezGeneId,
+        genetic_alteration.VALUES AS "values"
+        FROM genetic_alteration
+        INNER JOIN genetic_profile ON genetic_alteration.GENETIC_PROFILE_ID = genetic_profile.GENETIC_PROFILE_ID
+        INNER JOIN gene ON genetic_alteration.GENETIC_ENTITY_ID = gene.GENETIC_ENTITY_ID
+        <where>
+            genetic_profile.STABLE_ID = #{molecularProfileId}
+        </where>
+    </select>
+
     <select id="getGeneMolecularAlterationsInMultipleMolecularProfiles" resultType="org.cbioportal.model.GeneMolecularAlteration">
         SELECT
         gene.ENTREZ_GENE_ID AS entrezGeneId,

--- a/service/src/main/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImpl.java
@@ -64,7 +64,7 @@ public class ExpressionEnrichmentServiceImpl implements ExpressionEnrichmentServ
         validateMolecularProfile(molecularProfile, validGenomicMolecularAlterationTypes);
 
         Iterable<GeneMolecularAlteration> maItr = molecularDataRepository
-                .getGeneMolecularAlterationsIterable(molecularProfile.getStableId(), null, "SUMMARY");
+                .getGeneMolecularAlterationsIterableFast(molecularProfile.getStableId());
 
         List<GenomicEnrichment> expressionEnrichments = expressionEnrichmentUtil.getEnrichments(molecularProfile,
                 molecularProfileCaseSets, enrichmentType, maItr);

--- a/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
@@ -126,6 +126,9 @@ public class MolecularDataServiceImpl implements MolecularDataService {
         throws MolecularProfileNotFoundException {
 
         validateMolecularProfile(molecularProfileId);
+        if ((entrezGeneIds == null || entrezGeneIds.isEmpty()) && projection == "SUMMARY") {
+            return molecularDataRepository.getGeneMolecularAlterationsIterableFast(molecularProfileId);
+        }
         return molecularDataRepository.getGeneMolecularAlterationsIterable(molecularProfileId, entrezGeneIds, projection);
     }
 

--- a/service/src/main/java/org/cbioportal/service/util/AppConfig.java
+++ b/service/src/main/java/org/cbioportal/service/util/AppConfig.java
@@ -1,0 +1,31 @@
+package org.cbioportal.service.util;
+
+import org.springframework.core.env.Environment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.lang.Runtime;
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AppConfig implements AsyncConfigurer {
+
+    @Autowired
+    private Environment env;
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        int corePoolSize = env.getProperty("multithread.core_pool_size", int.class, Runtime.getRuntime().availableProcessors());
+        executor.setCorePoolSize(corePoolSize);
+        executor.setThreadNamePrefix("ThreadPoolTaskExecutor-");
+        executor.initialize();
+        return executor;
+    }
+
+}
+

--- a/service/src/main/java/org/cbioportal/service/util/CoExpressionAsyncMethods.java
+++ b/service/src/main/java/org/cbioportal/service/util/CoExpressionAsyncMethods.java
@@ -1,0 +1,64 @@
+package org.cbioportal.service.util;
+
+import org.springframework.stereotype.Component;
+import org.springframework.scheduling.annotation.Async;
+import org.cbioportal.model.CoExpression;
+import org.cbioportal.service.exception.GeneNotFoundException;
+import org.cbioportal.service.exception.GenesetNotFoundException;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.math3.linear.Array2DRowRealMatrix;
+import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.stat.correlation.SpearmansCorrelation;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.math.BigDecimal;
+import java.util.concurrent.CompletableFuture;
+
+@Component
+public class CoExpressionAsyncMethods {
+
+    @Async
+    public CompletableFuture<CoExpression> computeCoExpression(String entityId, List<String> valuesA, List<String> valuesB, Double threshold) {
+
+        List<String> valuesACopy = new ArrayList<>(valuesA);
+        List<String> valuesBCopy = new ArrayList<>(valuesB);
+
+        Iterator<String> itA = valuesACopy.listIterator();
+        Iterator<String> itB = valuesBCopy.listIterator();
+        while (itA.hasNext() && itB.hasNext()) {
+            if (!NumberUtils.isCreatable(itA.next()) | !NumberUtils.isCreatable(itB.next())) {
+                itA.remove();
+                itB.remove();
+            }
+        }
+
+        CoExpression coExpression = new CoExpression();
+        coExpression.setGeneticEntityId(entityId);
+
+        double[] valuesBNumber = valuesBCopy.stream().mapToDouble(Double::parseDouble).toArray();
+        double[] valuesANumber = valuesACopy.stream().mapToDouble(Double::parseDouble).toArray();
+
+        if (valuesANumber.length <= 2) {
+            return null;
+        }
+
+        double[][] arrays = new double[2][valuesANumber.length];
+        arrays[0] = valuesBNumber;
+        arrays[1] = valuesANumber;
+        SpearmansCorrelation spearmansCorrelation = new SpearmansCorrelation((new Array2DRowRealMatrix(arrays, false)).transpose());
+
+        double spearmansValue = spearmansCorrelation.correlation(valuesBNumber, valuesANumber);
+        if (Double.isNaN(spearmansValue) || Math.abs(spearmansValue) < threshold) {
+            return null;
+        }
+        coExpression.setSpearmansCorrelation(BigDecimal.valueOf(spearmansValue));
+
+        RealMatrix resultMatrix = spearmansCorrelation.getRankCorrelation().getCorrelationPValues();
+        coExpression.setpValue(BigDecimal.valueOf(resultMatrix.getEntry(0, 1)));
+
+        return CompletableFuture.supplyAsync(() -> coExpression);
+    }
+
+}

--- a/service/src/test/java/org/cbioportal/service/impl/CoExpressionServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/CoExpressionServiceImplTest.java
@@ -13,6 +13,7 @@ import org.cbioportal.service.GenesetService;
 import org.cbioportal.service.MolecularDataService;
 import org.cbioportal.service.GenesetDataService;
 import org.cbioportal.service.MolecularProfileService;
+import org.cbioportal.service.util.CoExpressionAsyncMethods;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +26,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class CoExpressionServiceImplTest extends BaseServiceImplTest {
@@ -34,6 +36,8 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
     @InjectMocks
     private CoExpressionServiceImpl coExpressionService;
     
+    @Mock
+    private CoExpressionAsyncMethods asyncMethods;
     @Mock
     private MolecularDataService molecularDataService;
     @Mock 
@@ -73,7 +77,18 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
             .thenReturn(geneMolecularProfile);
         Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID_B))
             .thenReturn(geneMolecularProfile);
-        
+
+        List<List<String>> allValuesA = createAllValuesA();
+        List<String> valuesB = createValuesB();
+        List<CompletableFuture<CoExpression>> coExpressions = createCoExpressions();
+
+        Mockito.when(asyncMethods.computeCoExpression("2", allValuesA.get(0), valuesB, THRESHOLD))
+            .thenReturn(coExpressions.get(0));
+        Mockito.when(asyncMethods.computeCoExpression("3", allValuesA.get(1), valuesB, THRESHOLD))
+            .thenReturn(coExpressions.get(1));
+        Mockito.when(asyncMethods.computeCoExpression("4", allValuesA.get(2), valuesB, THRESHOLD))
+            .thenReturn(CompletableFuture.supplyAsync(() -> null));
+
         List<CoExpression> result = coExpressionService.getCoExpressions("1", EntityType.GENE, 
         SAMPLE_LIST_ID, MOLECULAR_PROFILE_ID_A, MOLECULAR_PROFILE_ID_B, THRESHOLD);
 
@@ -115,6 +130,17 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
         Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID_B))
             .thenReturn(geneMolecularProfile);
 
+        List<List<String>> allValuesA = createAllValuesA();
+        List<String> valuesB = createValuesB();
+        List<CompletableFuture<CoExpression>> coExpressions = createCoExpressions();
+
+        Mockito.when(asyncMethods.computeCoExpression("2", allValuesA.get(0), valuesB, THRESHOLD))
+            .thenReturn(coExpressions.get(0));
+        Mockito.when(asyncMethods.computeCoExpression("3", allValuesA.get(1), valuesB, THRESHOLD))
+            .thenReturn(coExpressions.get(1));
+        Mockito.when(asyncMethods.computeCoExpression("4", allValuesA.get(2), valuesB, THRESHOLD))
+            .thenReturn(CompletableFuture.supplyAsync(() -> null));
+
         List<CoExpression> result = coExpressionService.fetchCoExpressions("1", EntityType.GENE,
             Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), MOLECULAR_PROFILE_ID_A, MOLECULAR_PROFILE_ID_B, THRESHOLD);
 
@@ -155,6 +181,17 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
             .thenReturn(genesetMolecularProfile);
         Mockito.when(molecularProfileService.getMolecularProfile("profile_id_gsva_scores_b"))
             .thenReturn(genesetMolecularProfile);
+
+        List<List<String>> allValuesA = createAllValuesA();
+        List<String> valuesB = createValuesB();
+        List<CompletableFuture<CoExpression>> coExpressions = createCoExpressions();
+
+        Mockito.when(asyncMethods.computeCoExpression("BIOCARTA_ASBCELL_PATHWAY", allValuesA.get(0), valuesB, THRESHOLD))
+            .thenReturn(coExpressions.get(2));
+        Mockito.when(asyncMethods.computeCoExpression("KEGG_DNA_REPLICATION", allValuesA.get(1), valuesB, THRESHOLD))
+            .thenReturn(coExpressions.get(3));
+        Mockito.when(asyncMethods.computeCoExpression("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE", allValuesA.get(2), valuesB, THRESHOLD))
+            .thenReturn(CompletableFuture.supplyAsync(() -> null));
 
         List<CoExpression> result = coExpressionService.getCoExpressions("GENESET_ID_TEST", EntityType.GENESET, 
         SAMPLE_LIST_ID, "profile_id_gsva_scores_a", "profile_id_gsva_scores_b", THRESHOLD);
@@ -199,6 +236,17 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
             .thenReturn(genesetMolecularProfile);
         Mockito.when(genesetDataService.fetchGenesetData("profile_id_gsva_scores_b", Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), 
             null)).thenReturn(molecularDataList);
+
+        List<List<String>> allValuesA = createAllValuesA();
+        List<String> valuesB = createValuesB();
+        List<CompletableFuture<CoExpression>> coExpressions = createCoExpressions();
+
+        Mockito.when(asyncMethods.computeCoExpression("BIOCARTA_ASBCELL_PATHWAY", allValuesA.get(0), valuesB, THRESHOLD))
+            .thenReturn(coExpressions.get(2));
+        Mockito.when(asyncMethods.computeCoExpression("KEGG_DNA_REPLICATION", allValuesA.get(1), valuesB, THRESHOLD))
+            .thenReturn(coExpressions.get(3));
+        Mockito.when(asyncMethods.computeCoExpression("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE", allValuesA.get(2), valuesB, THRESHOLD))
+            .thenReturn(CompletableFuture.supplyAsync(() -> null));
 
         List<CoExpression> result = coExpressionService.fetchCoExpressions("GENESET_ID_TEST", EntityType.GENESET,
             Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), "profile_id_gsva_scores_a", "profile_id_gsva_scores_b", THRESHOLD);
@@ -379,6 +427,49 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
         geneset3.setName("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE");
         genesets.add(geneset3);
         return genesets;
+    }
+
+    private List<List<String>> createAllValuesA() {
+        List<List<String>> allValuesA = new ArrayList<>();
+        List<String> valuesA1 = new ArrayList<>();
+        valuesA1.add("2"); valuesA1.add("3"); valuesA1.add("2");
+        allValuesA.add(valuesA1);
+        List<String> valuesA2 = new ArrayList<>();
+        valuesA2.add("1.1"); valuesA2.add("5"); valuesA2.add("3");
+        allValuesA.add(valuesA2);
+        List<String> valuesA3 = new ArrayList<>();
+        valuesA3.add("1"); valuesA3.add("4"); valuesA3.add("0");
+        allValuesA.add(valuesA3);
+        return allValuesA;
+    }
+
+    private List<String> createValuesB() {
+        return new ArrayList<>(Arrays.asList("2.1", "3", "3"));
+    }
+
+    private List<CompletableFuture<CoExpression>> createCoExpressions() {
+        List<CompletableFuture<CoExpression>> coExpressions = new ArrayList<>();
+        CoExpression coExpression1 = new CoExpression();
+        coExpression1.setGeneticEntityId("2");
+        coExpression1.setSpearmansCorrelation(new BigDecimal("0.5"));
+        coExpression1.setpValue(new BigDecimal("0.6666666666666667"));
+        coExpressions.add(CompletableFuture.supplyAsync(() -> coExpression1));
+        CoExpression coExpression2 = new CoExpression();
+        coExpression2.setGeneticEntityId("3");
+        coExpression2.setSpearmansCorrelation(new BigDecimal("0.8660254037844386"));
+        coExpression2.setpValue(new BigDecimal("0.3333333333333333"));
+        coExpressions.add(CompletableFuture.supplyAsync(() -> coExpression2));
+        CoExpression coExpression3 = new CoExpression();
+        coExpression3.setGeneticEntityId("BIOCARTA_ASBCELL_PATHWAY");
+        coExpression3.setSpearmansCorrelation(new BigDecimal("0.5"));
+        coExpression3.setpValue(new BigDecimal("0.6666666666666667"));
+        coExpressions.add(CompletableFuture.supplyAsync(() -> coExpression3));
+        CoExpression coExpression4 = new CoExpression();
+        coExpression4.setGeneticEntityId("KEGG_DNA_REPLICATION");
+        coExpression4.setSpearmansCorrelation(new BigDecimal("0.8660254037844386"));
+        coExpression4.setpValue(new BigDecimal("0.3333333333333333"));
+        coExpressions.add(CompletableFuture.supplyAsync(() -> coExpression4));
+        return coExpressions;
     }
 
     private MolecularProfile createGeneMolecularProfile() {

--- a/service/src/test/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ExpressionEnrichmentServiceImplTest.java
@@ -148,7 +148,7 @@ public class ExpressionEnrichmentServiceImplTest extends BaseServiceImplTest {
         geneMolecularAlteration2.setEntrezGeneId(ENTREZ_GENE_ID_3);
         geneMolecularAlteration2.setValues("1.1,5,2.3,3");
         molecularDataList.add(geneMolecularAlteration2);
-        Mockito.when(molecularDataRepository.getGeneMolecularAlterationsIterable(MOLECULAR_PROFILE_ID, null, "SUMMARY"))
+        Mockito.when(molecularDataRepository.getGeneMolecularAlterationsIterableFast(MOLECULAR_PROFILE_ID))
                 .thenReturn(molecularDataList);
 
         List<Gene> expectedGeneList = new ArrayList<>();

--- a/service/src/test/java/org/cbioportal/service/util/CoExpressionAsyncMethodsTest.java
+++ b/service/src/test/java/org/cbioportal/service/util/CoExpressionAsyncMethodsTest.java
@@ -1,0 +1,102 @@
+package org.cbioportal.service.util;
+
+import org.cbioportal.model.CoExpression;
+import org.cbioportal.service.util.CoExpressionAsyncMethods;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.concurrent.CompletableFuture;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CoExpressionAsyncMethodsTest {
+
+    private static final double THRESHOLD = 0.3;
+
+    @InjectMocks
+    private CoExpressionAsyncMethods asyncMethods;
+
+    @Test
+    public void TEST_NAME_1() throws Exception {
+
+        List<CompletableFuture<CoExpression>> futures = new ArrayList<>();
+        List<List<String>> allValuesA = createAllValuesA();
+        List<String> valuesB = createValuesB();
+
+        CompletableFuture<CoExpression> future1 = asyncMethods
+            .computeCoExpression("2", allValuesA.get(0), valuesB, THRESHOLD);
+        CompletableFuture<CoExpression> future2 = asyncMethods
+            .computeCoExpression("3", allValuesA.get(1), valuesB, THRESHOLD);
+        CompletableFuture<CoExpression> future3 = asyncMethods
+            .computeCoExpression("4", allValuesA.get(2), valuesB, THRESHOLD);
+
+        futures.add(future1); futures.add(future2); futures.add(future3);
+        List<CoExpression> result = futures
+            .stream().filter(Objects::nonNull).map(CompletableFuture::join).collect(Collectors.toList());
+
+        Assert.assertEquals(2, result.size());
+        CoExpression coExpression1 = result.get(0);
+        Assert.assertEquals("2", coExpression1.getGeneticEntityId());
+        Assert.assertEquals(new BigDecimal("0.5"), coExpression1.getSpearmansCorrelation());
+        Assert.assertEquals(new BigDecimal("0.6666666666666667"), coExpression1.getpValue());
+        CoExpression coExpression2 = result.get(1);
+        Assert.assertEquals("3", coExpression2.getGeneticEntityId());
+        Assert.assertEquals(new BigDecimal("0.8660254037844386"), coExpression2.getSpearmansCorrelation());
+        Assert.assertEquals(new BigDecimal("0.3333333333333333"), coExpression2.getpValue());
+    }
+
+    @Test
+    public void TEST_NAME_2() throws Exception {
+
+        List<CompletableFuture<CoExpression>> futures = new ArrayList<>();
+        List<List<String>> allValuesA = createAllValuesA();
+        List<String> valuesB = createValuesB();
+
+        CompletableFuture<CoExpression> future1 = asyncMethods
+            .computeCoExpression("KEGG_DNA_REPLICATION", allValuesA.get(1), valuesB, THRESHOLD);
+        CompletableFuture<CoExpression> future2 = asyncMethods
+            .computeCoExpression("BIOCARTA_ASBCELL_PATHWAY", allValuesA.get(0), valuesB, THRESHOLD);
+        CompletableFuture<CoExpression> future3 = asyncMethods
+            .computeCoExpression("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE", allValuesA.get(2), valuesB, THRESHOLD);
+
+        futures.add(future1); futures.add(future2); futures.add(future3);
+        List<CoExpression> result = futures
+            .stream().filter(Objects::nonNull).map(CompletableFuture::join).collect(Collectors.toList());
+
+        Assert.assertEquals(2, result.size());
+        CoExpression coExpression1 = result.get(0);
+        Assert.assertEquals("KEGG_DNA_REPLICATION", coExpression1.getGeneticEntityId());
+        Assert.assertEquals(new BigDecimal("0.8660254037844386"), coExpression1.getSpearmansCorrelation());
+        Assert.assertEquals(new BigDecimal("0.3333333333333333"), coExpression1.getpValue());
+        CoExpression coExpression2 = result.get(1);
+        Assert.assertEquals("BIOCARTA_ASBCELL_PATHWAY", coExpression2.getGeneticEntityId());
+        Assert.assertEquals(new BigDecimal("0.5"), coExpression2.getSpearmansCorrelation());
+        Assert.assertEquals(new BigDecimal("0.6666666666666667"), coExpression2.getpValue());
+    }
+
+    private List<List<String>> createAllValuesA() {
+        List<List<String>> allValuesA = new ArrayList<>();
+        List<String> valuesA1 = new ArrayList<>();
+        valuesA1.add("2"); valuesA1.add("3"); valuesA1.add("2");
+        allValuesA.add(valuesA1);
+        List<String> valuesA2 = new ArrayList<>();
+        valuesA2.add("1.1"); valuesA2.add("5"); valuesA2.add("3");
+        allValuesA.add(valuesA2);
+        List<String> valuesA3 = new ArrayList<>();
+        valuesA3.add("1"); valuesA3.add("4"); valuesA3.add("0");
+        allValuesA.add(valuesA3);
+        return allValuesA;
+    }
+
+    private List<String> createValuesB() {
+        return new ArrayList<>(Arrays.asList("2.1", "3", "3"));
+    }
+}

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -147,6 +147,9 @@ dat.jwt.secret_key=
 #dat.oauth2.redirectUri=<cbioportal-url>/.../api/data-access-token/oauth2
 #dat.oauth2.jwtRolesPath=resource_access::cbioportal::roles
 
+# multithreading configuration
+multithread.core_pool_size=16
+
 # study view settings
 # always show studies with this group
 always_show_study_group=


### PR DESCRIPTION
Fix #8775

Speedup `CoExpressionService` endpoint via multithreading and faster SQL logic. The multithreading capability is accessible throughout the service layer simply by adding an `@Async` annotation to some method and ensuring that it is called from somewhere outside its own class.

Unit tests and the portal configuration property `multithreading.core_pool_size` (with default value 16) have also been added.

Rates of speedup vary across queries but generally hover somewhere around a 2x improvement.