### PR TITLE
Fix Redis activation in official cBioPortal Docker hub images

### DIFF
--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -103,6 +103,7 @@
           <warName>${final.war.name}</warName>
           <webappDirectory>${project.build.directory}/portal</webappDirectory>
           <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
+          <escapeString>\</escapeString>
           <webResources>
             <resource>
               <directory>${project.parent.basedir}/persistence/persistence-connections/src/main/resources</directory>

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -24,11 +24,11 @@
     <!-- dbcp profile is defined here to prevent exceptions during war deployment -->
     <context-param>
         <param-name>spring.profiles.active</param-name>
-        <param-value>${dbconnector:dbcp},${authenticate},${google.analytics.tracking:ga-api-tracking-disabled}</param-value>
+        <param-value>\${dbconnector:dbcp},\${authenticate},\${google.analytics.tracking:ga-api-tracking-disabled}</param-value>
     </context-param>
     <context-param>
         <param-name>spring.liveBeansView.mbeanDomain</param-name>
-        <param-value>${dbconnector:dbcp},${authenticate}</param-value>
+        <param-value>\${dbconnector:dbcp},\${authenticate}</param-value>
     </context-param>
     
     <context-param>
@@ -38,7 +38,7 @@
 
     <context-param>
         <param-name>webAppRootKey</param-name>
-        <param-value>${app.name}.${timestamp}</param-value>
+        <param-value>\${app.name}.${timestamp}</param-value>
     </context-param>
 
     <context-param>


### PR DESCRIPTION
# Problem

The official cBioPortal docker hub images have a hard-coded `no-cache` in the web.xml active profiles section:

```
    <context-param>
        <param-name>spring.profiles.active</param-name>
        <param-value>${dbconnector:dbcp},${authenticate},${google.analytics.tracking:ga-api-tracking-disabled},no-cache</param-value>
    </context-param>
```

Since the `no-cache` replaces the original `${persistence.cache_type}` placeholder, this prevents activation of any caching strategy activated via application properties when using the official Docker images (`no-cache` is hard-coded).

# Cause

The cause of this replacement is the filter (=replace) option in the _maven-war-plugin_.  The `${...}` are recognized by both the war-plugin (replace variables for system properties at build time) and Spring (replace variables with application properties at runtime). I logically conclude that somehow during the MSK docker image build process `persistence.cache_type=no-cache` is available as a system property and the `${persistence.cache_type}` is replaced by `no-cache` by maven.

# Solution

Placeholder that should be ignored by _maven-war-plugin_ can be escaped with a character (see changes to pom.xml). The placeholders will be removed by the _maven-war-plugin_ when finished. In web.xml only the `${timestamp}` placeholder refers to a system argument and is left un-escaped. 