### PR TITLE
Add modal to HTML report to visualize all error/warning values

### DIFF
--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -554,8 +554,16 @@ class CollapsingLogMessageHandler(logging.handlers.MemoryHandler):
                                  record.getMessage())
             if identifying_tuple not in grouping_dict:
                 grouping_dict[identifying_tuple] = []
-            grouping_dict[identifying_tuple].append(record)
 
+            # add a tuple that keeps the relation between the line number,
+            # the column number and the cause for the HTML report
+            record.__dict__['value'] = (
+                getattr(record, 'line_number', None),
+                getattr(record, 'column_number', None),
+                getattr(record, 'cause', None))
+
+            grouping_dict[identifying_tuple].append(record)
+        
         aggregated_buffer = []
         # for each list of same-message records
         for record_list in list(grouping_dict.values()):

--- a/core/src/main/scripts/importer/metaImport.py
+++ b/core/src/main/scripts/importer/metaImport.py
@@ -93,13 +93,6 @@ def interface():
                         action='store_true', default=False,
                         help='Option to enable strict mode for validator when '
                              'validating mutation data')
-    parser.add_argument('-a', '--max_reported_values', required=False,
-                        type=int, default=3,
-                        help='Cutoff in report for the maximum number of line numbers '
-                             'and values encountered to report for each message in the HTML '
-                             'report. For example, set this to a high number to '
-                             'report all genes that could not be loaded, instead '
-                             'of reporting "(GeneA, GeneB, GeneC, 213 more)".')
     parser.add_argument('-update', '--update_generic_assay_entity', type=str, required=False, default="False",
                         help='Set as True to update the existing generic assay entities, set as False to keep the existing generic assay entities for generic assay')
     parser.add_argument('-oncokb', '--import_oncokb', action='store_true',

--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -182,11 +182,10 @@ class Jinja2HtmlHandler(logging.handlers.BufferingHandler):
 
     """Logging handler that formats aggregated HTML reports using Jinja2."""
 
-    def __init__(self, study_dir, output_filename, max_reported_values, *args, **kwargs):
+    def __init__(self, study_dir, output_filename, *args, **kwargs):
         """Set study directory name, output filename and buffer size."""
         self.study_dir = study_dir
         self.output_filename = output_filename
-        self.max_reported_values = max_reported_values
         self.max_level = logging.NOTSET
         self.closed = False
         # get the directory name of the currently running script,
@@ -231,7 +230,6 @@ class Jinja2HtmlHandler(logging.handlers.BufferingHandler):
         template = j_env.get_template('validation_report_template.html.jinja')
         doc = template.render(
             study_dir=self.study_dir,
-            max_reported_values=self.max_reported_values,
             record_list=self.buffer,
             max_level=logging.getLevelName(self.max_level),
             **kwargs)
@@ -5286,14 +5284,6 @@ def interface(args=None):
                         action='store_true', default=False,
                         help='Option to enable strict mode for validator when '
                              'validating mutation data')
-    parser.add_argument('-a', '--max_reported_values', required=False,
-                        type=int, default=3,
-                        help='Cutoff in HTML report for the maximum number of line numbers '
-                             'and values encountered to report for each message. '
-                             'For example, set this to a high number to '
-                             'report all genes that could not be loaded, instead '
-                             'of reporting "GeneA, GeneB, GeneC, 213 more"')
-
     parser = parser.parse_args(args)
     return parser
 
@@ -5538,7 +5528,6 @@ def main_validate(args):
     html_output_filename = args.html_table
     relaxed_mode = args.relaxed_clinical_definitions
     strict_maf_checks = args.strict_maf_checks
-    max_reported_values = args.max_reported_values
 
     # determine the log level for terminal and html output
     output_loglevel = logging.INFO
@@ -5571,7 +5560,6 @@ def main_validate(args):
         html_handler = Jinja2HtmlHandler(
             study_dir,
             html_output_filename,
-            max_reported_values=max_reported_values,
             capacity=1e5)
         # TODO extend CollapsingLogMessageHandler to flush to multiple targets,
         # and get rid of the duplicated buffering of messages here

--- a/core/src/main/scripts/importer/validateStudies.py
+++ b/core/src/main/scripts/importer/validateStudies.py
@@ -83,10 +83,6 @@ def main(args):
         if args.strict_maf_checks is not False:
             validator_args.append('-m')
 
-        # Append argument for maximum reported line numbers and encountered values in HTML
-        if args.max_reported_values != 3:
-            validator_args.append('-a %s' % args.max_reported_values)
-
         # When HTML file is required, create html file name and add to arguments for validateData
         if output_folder is not None:
             try:
@@ -180,13 +176,6 @@ def interface(args=None):
                         action='store_true', default=False,
                         help='Option to enable strict mode for validator when '
                              'validating mutation data')
-    parser.add_argument('-a', '--max_reported_values', required=False,
-                        type=int, default = 3,
-                        help='Cutoff in HTML report for the maximum number of line numbers '
-                             'and values encountered to report for each message. '
-                             'For example, set this to a high number to '
-                             'report all genes that could not be loaded, instead '
-                             'of reporting "GeneA, GeneB, GeneC, 213 more"')
 
     args = parser.parse_args(args)
 

--- a/core/src/main/scripts/importer/validation_report_template.html.jinja
+++ b/core/src/main/scripts/importer/validation_report_template.html.jinja
@@ -128,6 +128,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -144,11 +145,8 @@
               <tr class="{{ record_class }}">
                 {% macro format_aggregated(record, attr_name) %}
                     {% if record[attr_name + '_list'] is defined -%}
-                      {% if (record['show_all_values'] is not defined or record['show_all_values'] == False) and (record[attr_name + '_list']|length) > max_reported_values -%}
-                              {{ (record[attr_name + '_list'][:max_reported_values]|join(', ') +
-                                  ', (' +
-                                  record[attr_name + '_list'][max_reported_values:]|length|string +
-                                  ' more)')|e }}
+                      {% if (record['show_all_values'] is not defined or record['show_all_values'] == False) and (record[attr_name + '_list']|length) > 3 -%}
+                              {{ record[attr_name + '_list'][:3]|join(', ')|e }}{{ '&hellip;' }}
                           {%- else -%}
                                   {{ (record[attr_name + '_list']|join(', '))|e }}
                           {%- endif %}	          
@@ -167,6 +165,48 @@
                 {% endif %}
                 <td>{{ record.getMessage()|e }}</td>
                 <td>{{ format_aggregated(record, 'cause') }}</td>
+                {% macro create_modal(filename, record, attr_name, num_record) %}
+                    {% if record[attr_name + '_list'] is defined -%}
+                      {% if (record['show_all_values'] is not defined or record['show_all_values'] == False) and (record[attr_name + '_list']|length) > 3 -%}
+                        <!-- Trigger/Open The Modal -->
+                        {% set num_values = record[attr_name + '_list']|length|string %}
+                        {% set modal_name = "modal" + filename.rsplit('.', 1)[0] + num_record + attr_name %}
+                        <a href="#showValues" data-toggle="modal" data-backdrop="false" data-target=".{{ modal_name }}">See all {{ num_values }} values </a>
+
+                        <div class="modal fade {{ modal_name }}" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
+                          <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                              <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="gridSystemModalLabel">Listing all values for the message: {{ record.getMessage()|e }}</h4>
+                              </div>
+                              <div class="modal-body">
+                                <table class="table">
+                                  <thead>
+                                    <tr>
+                                      <th>Line Number</th>
+                                      <th>Column Number</th>
+                                      <th>Value Encountered</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                    {% for value in record[attr_name + '_list'] %}
+                                      <tr>
+                                        <td>{{ value[0]|e if  value[0] is not none else '&ndash;' }}</td>
+                                        <td>{{ value[1]|e if  value[1] is not none else '&ndash;' }}</td>
+                                        <td>{{ value[2]|e if  value[2] is not none else '&ndash;' }}</td>
+                                      </tr>
+                                    {% endfor %}
+                                  </tbody>
+                                </table>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      {%- endif %}
+                    {%- endif %}
+                {% endmacro %}
+                <td>{{ create_modal(filename, record, 'value', loop.index|string) }}</td>
               </tr>
               {% endfor %}
             </tbody>

--- a/core/src/test/scripts/test_data/study_es_0/result_report.html
+++ b/core/src/test/scripts/test_data/study_es_0/result_report.html
@@ -86,6 +86,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -95,6 +96,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/cancer-types.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -102,6 +104,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/genes.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -109,6 +112,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/genesets.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -116,6 +120,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/genesets_version.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -123,6 +128,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/gene-panels.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -130,6 +136,7 @@
                 <td>&ndash;</td>
                 <td>Retrieving chromosome lengths from &#39;/cbioportal/core/src/main/scripts/importer/chromosome_sizes.json&#39;</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -137,6 +144,7 @@
                 <td>&ndash;</td>
                 <td>Retrieving chromosome lengths from &#39;/cbioportal/core/src/main/scripts/importer/chromosome_sizes.json&#39;</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -144,6 +152,7 @@
                 <td>&ndash;</td>
                 <td>Study Tag file found. It will be validated.</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -151,6 +160,7 @@
                 <td>&ndash;</td>
                 <td>Validating case lists</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -158,6 +168,7 @@
                 <td>&ndash;</td>
                 <td>Validation of case list folder complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -165,6 +176,7 @@
                 <td>&ndash;</td>
                 <td>Validation complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -196,6 +208,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -205,6 +218,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -212,6 +226,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -242,6 +257,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -251,6 +267,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -258,6 +275,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -288,6 +306,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -297,6 +316,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -304,6 +324,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -334,6 +355,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -343,6 +365,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -350,6 +373,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -380,6 +404,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -389,6 +414,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -396,6 +422,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -426,6 +453,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -435,6 +463,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -442,6 +471,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -449,6 +479,7 @@
                 <td>&ndash;</td>
                 <td>Read 1 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -479,6 +510,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -488,6 +520,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -495,6 +528,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -502,6 +536,7 @@
                 <td>&ndash;</td>
                 <td>Read 845 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -532,6 +567,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -541,6 +577,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -548,6 +585,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -555,6 +593,7 @@
                 <td>&ndash;</td>
                 <td>Read 847 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -585,6 +624,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -594,6 +634,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -601,6 +642,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -608,6 +650,7 @@
                 <td>&ndash;</td>
                 <td>Read 9 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -638,6 +681,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -647,6 +691,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -654,6 +699,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -661,6 +707,7 @@
                 <td>&ndash;</td>
                 <td>Read 10 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -691,6 +738,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -700,6 +748,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -707,6 +756,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -714,6 +764,7 @@
                 <td>&ndash;</td>
                 <td>Read 8 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -744,6 +795,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -753,13 +805,60 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
-                <td>2, 3, 6, (1 more)</td>
+                <td>2, 3, 6&hellip; </td>
                 <td>4</td>
                 <td>Values contained in the column cbp_driver_tiers that will appear in the &#34;Mutation Color&#34; menu of the Oncoprint</td>
                 <td>Class 2, Class 1</td>
+                <td><!-- Trigger/Open The Modal -->
+                        <a href="#showValues" data-toggle="modal" data-backdrop="false" data-target=".modaldata_cna_pd_annotations2value">See all 4 values </a>
+
+                        <div class="modal fade modaldata_cna_pd_annotations2value" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
+                          <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                              <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="gridSystemModalLabel">Listing all values for the message: Values contained in the column cbp_driver_tiers that will appear in the "Mutation Color" menu of the Oncoprint</h4>
+                              </div>
+                              <div class="modal-body">
+                                <table class="table">
+                                  <thead>
+                                    <tr>
+                                      <th>Line Number</th>
+                                      <th>Column Number</th>
+                                      <th>Value Encountered</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                      <tr>
+                                        <td>2</td>
+                                        <td>4</td>
+                                        <td>Class 2</td>
+                                      </tr>
+                                      <tr>
+                                        <td>3</td>
+                                        <td>4</td>
+                                        <td>Class 1</td>
+                                      </tr>
+                                      <tr>
+                                        <td>6</td>
+                                        <td>4</td>
+                                        <td>Class 2</td>
+                                      </tr>
+                                      <tr>
+                                        <td>7</td>
+                                        <td>4</td>
+                                        <td>Class 1</td>
+                                      </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+                            </div>
+                          </div>
+                        </div></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -767,6 +866,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -774,6 +874,7 @@
                 <td>&ndash;</td>
                 <td>Read 8 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -804,6 +905,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -813,6 +915,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -820,6 +923,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -827,6 +931,7 @@
                 <td>&ndash;</td>
                 <td>Read 7 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -857,6 +962,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -866,6 +972,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -873,6 +980,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -880,6 +988,7 @@
                 <td>&ndash;</td>
                 <td>Read 6 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -910,6 +1019,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -919,6 +1029,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -926,6 +1037,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -933,6 +1045,7 @@
                 <td>&ndash;</td>
                 <td>Read 6 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -963,6 +1076,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -972,6 +1086,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -979,6 +1094,7 @@
                 <td>&ndash;</td>
                 <td>This column can be replaced by a &#39;gene_panel&#39; property in the respective meta file</td>
                 <td>gistic</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -986,6 +1102,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -993,6 +1110,7 @@
                 <td>&ndash;</td>
                 <td>Read 21 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1023,6 +1141,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1032,6 +1151,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1039,6 +1159,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1046,6 +1167,7 @@
                 <td>&ndash;</td>
                 <td>Read 3 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1076,6 +1198,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1085,6 +1208,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1092,6 +1216,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1099,6 +1224,7 @@
                 <td>&ndash;</td>
                 <td>Read 13 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1129,6 +1255,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1138,6 +1265,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1145,6 +1273,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1152,6 +1281,7 @@
                 <td>&ndash;</td>
                 <td>Read 8 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1182,6 +1312,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1191,6 +1322,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1198,6 +1330,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1205,6 +1338,7 @@
                 <td>&ndash;</td>
                 <td>Read 8 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1235,6 +1369,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1244,6 +1379,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1251,6 +1387,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1258,6 +1395,7 @@
                 <td>&ndash;</td>
                 <td>Read 9 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1288,6 +1426,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1297,6 +1436,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1304,6 +1444,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1311,6 +1452,7 @@
                 <td>&ndash;</td>
                 <td>Read 61 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1341,6 +1483,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1350,13 +1493,80 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
-                <td>4, 5, 6, (5 more)</td>
+                <td>4, 5, 6&hellip; </td>
                 <td>164</td>
                 <td>Values contained in the column cbp_driver_tiers that will appear in the &#34;Mutation Color&#34; menu of the Oncoprint</td>
-                <td>Class 2, Class 1, Class 4, (1 more)</td>
+                <td>Class 2, Class 1, Class 4&hellip; </td>
+                <td><!-- Trigger/Open The Modal -->
+                        <a href="#showValues" data-toggle="modal" data-backdrop="false" data-target=".modaldata_mutations_extended2value">See all 8 values </a>
+
+                        <div class="modal fade modaldata_mutations_extended2value" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
+                          <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                              <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="gridSystemModalLabel">Listing all values for the message: Values contained in the column cbp_driver_tiers that will appear in the "Mutation Color" menu of the Oncoprint</h4>
+                              </div>
+                              <div class="modal-body">
+                                <table class="table">
+                                  <thead>
+                                    <tr>
+                                      <th>Line Number</th>
+                                      <th>Column Number</th>
+                                      <th>Value Encountered</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                      <tr>
+                                        <td>4</td>
+                                        <td>164</td>
+                                        <td>Class 2</td>
+                                      </tr>
+                                      <tr>
+                                        <td>5</td>
+                                        <td>164</td>
+                                        <td>Class 1</td>
+                                      </tr>
+                                      <tr>
+                                        <td>6</td>
+                                        <td>164</td>
+                                        <td>Class 4</td>
+                                      </tr>
+                                      <tr>
+                                        <td>7</td>
+                                        <td>164</td>
+                                        <td>Class 4</td>
+                                      </tr>
+                                      <tr>
+                                        <td>8</td>
+                                        <td>164</td>
+                                        <td>Class 1</td>
+                                      </tr>
+                                      <tr>
+                                        <td>9</td>
+                                        <td>164</td>
+                                        <td>Class 1</td>
+                                      </tr>
+                                      <tr>
+                                        <td>10</td>
+                                        <td>164</td>
+                                        <td>Class 3</td>
+                                      </tr>
+                                      <tr>
+                                        <td>12</td>
+                                        <td>164</td>
+                                        <td>Class 3</td>
+                                      </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+                            </div>
+                          </div>
+                        </div></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1364,6 +1574,7 @@
                 <td>&ndash;</td>
                 <td>Line will not be loaded due to the variant classification filter. Filtered types: [Silent, Intron, 3&#39;UTR, 3&#39;Flank, 5&#39;UTR, 5&#39;Flank, IGR, RNA]</td>
                 <td>Silent</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1371,6 +1582,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1378,6 +1590,7 @@
                 <td>&ndash;</td>
                 <td>Read 35 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1408,6 +1621,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1417,6 +1631,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1424,6 +1639,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1431,6 +1647,7 @@
                 <td>&ndash;</td>
                 <td>Read 4 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1461,6 +1678,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1470,6 +1688,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1477,6 +1696,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1484,6 +1704,7 @@
                 <td>&ndash;</td>
                 <td>Read 4 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1514,6 +1735,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1523,6 +1745,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1530,6 +1753,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1537,6 +1761,7 @@
                 <td>&ndash;</td>
                 <td>Read 4 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1567,6 +1792,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1576,6 +1802,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1583,6 +1810,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1590,6 +1818,7 @@
                 <td>&ndash;</td>
                 <td>Read 2 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1620,6 +1849,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1629,6 +1859,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1636,6 +1867,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1643,6 +1875,7 @@
                 <td>&ndash;</td>
                 <td>Read 46 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1673,6 +1906,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1682,6 +1916,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1689,6 +1924,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1696,6 +1932,7 @@
                 <td>&ndash;</td>
                 <td>Read 11 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1726,6 +1963,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1735,6 +1973,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1742,6 +1981,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1749,6 +1989,7 @@
                 <td>&ndash;</td>
                 <td>Read 11 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1779,6 +2020,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1788,6 +2030,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1795,6 +2038,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1825,6 +2069,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1834,6 +2079,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1841,6 +2087,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1871,6 +2118,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1880,6 +2128,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1887,6 +2136,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1917,6 +2167,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1926,6 +2177,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1933,6 +2185,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -1963,6 +2216,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1972,6 +2226,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -1979,6 +2234,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2009,6 +2265,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2018,6 +2275,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2025,6 +2283,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2055,6 +2314,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2064,6 +2324,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2071,6 +2332,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2101,6 +2363,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2110,6 +2373,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2117,6 +2381,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2147,6 +2412,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2156,6 +2422,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2163,6 +2430,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2193,6 +2461,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2202,6 +2471,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2209,6 +2479,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2239,6 +2510,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2248,6 +2520,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2255,6 +2528,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2285,6 +2559,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2294,6 +2569,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2301,6 +2577,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2331,6 +2608,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2340,6 +2618,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2347,6 +2626,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2377,6 +2657,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2386,6 +2667,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2393,6 +2675,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2423,6 +2706,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2432,6 +2716,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2439,6 +2724,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2469,6 +2755,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2478,6 +2765,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2485,6 +2773,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2515,6 +2804,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2524,6 +2814,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2531,6 +2822,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2561,6 +2853,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2570,6 +2863,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2577,6 +2871,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2607,6 +2902,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2616,6 +2912,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2623,6 +2920,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2653,6 +2951,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2662,6 +2961,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2669,6 +2969,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2699,6 +3000,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2708,6 +3010,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2715,6 +3018,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2745,6 +3049,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2754,6 +3059,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2761,6 +3067,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2791,6 +3098,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2800,6 +3108,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2807,6 +3116,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2837,6 +3147,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2846,6 +3157,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2853,6 +3165,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2883,6 +3196,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2892,6 +3206,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2899,6 +3214,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -2929,6 +3245,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -2938,6 +3255,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of study tags file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -2945,6 +3263,7 @@
                 <td>&ndash;</td>
                 <td>Validation of study tags file complete.</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>

--- a/core/src/test/scripts/test_data/study_quotes/result_report.html
+++ b/core/src/test/scripts/test_data/study_quotes/result_report.html
@@ -86,6 +86,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -95,6 +96,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/cancer-types.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -102,6 +104,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/genes.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -109,6 +112,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/genesets.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -116,6 +120,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/genesets_version.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -123,6 +128,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/gene-panels.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -130,6 +136,7 @@
                 <td>&ndash;</td>
                 <td>Validating case lists</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -137,6 +144,7 @@
                 <td>&ndash;</td>
                 <td>Validation of case list folder complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -144,6 +152,7 @@
                 <td>&ndash;</td>
                 <td>Validation complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -175,6 +184,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -184,6 +194,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="warning">
                 <td><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning</span></td>
@@ -191,6 +202,7 @@
                 <td>&ndash;</td>
                 <td>Found quotation marks around field(s) in the first rows of the file. Fields and values surrounded by quotation marks might be incorrectly loaded (i.e. with the quotation marks included as part of the value)</td>
                 <td>quotation marks of type: [&#34;] </td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -198,6 +210,7 @@
                 <td>6</td>
                 <td>The end position of this variant is not an integer</td>
                 <td>&#34;46707888, &#34;116247760&#34;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -205,6 +218,7 @@
                 <td>&ndash;</td>
                 <td>Line will not be loaded due to the variant classification filter. Filtered types: [Silent, Intron, 3&#39;UTR, 3&#39;Flank, 5&#39;UTR, 5&#39;Flank, IGR, RNA]</td>
                 <td>Silent</td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -212,6 +226,7 @@
                 <td>&ndash;</td>
                 <td>The specified reference genome does not correspond with the reference genome found in the MAF.</td>
                 <td>GRCh37&#34;</td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -219,6 +234,7 @@
                 <td>4</td>
                 <td>Value in column &#39;NCBI_Build&#39; is invalid</td>
                 <td>GRCh37&#34;</td>
+                <td></td>
               </tr>
               <tr class="warning">
                 <td><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning</span></td>
@@ -226,6 +242,7 @@
                 <td>&ndash;</td>
                 <td>Value in &#39;Verification_Status&#39; not in MAF format</td>
                 <td>&#34;Unknown</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -233,6 +250,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -240,6 +258,7 @@
                 <td>&ndash;</td>
                 <td>Read 15 lines. Lines with warning: 1. Lines with error: 3</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -270,6 +289,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -279,6 +299,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -286,6 +307,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -316,6 +338,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -325,6 +348,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -332,6 +356,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -362,6 +387,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -371,6 +397,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -378,6 +405,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -385,6 +413,7 @@
                 <td>&ndash;</td>
                 <td>Sample ID not defined in clinical file</td>
                 <td>&#34;TCGA-A1-A0SE-01&#34;, &#34;TCGA-A1-A0SF-01, TCGA-AR-A1AR-01</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -415,6 +444,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -424,6 +454,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -431,6 +462,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -461,6 +493,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -470,6 +503,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="warning">
                 <td><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning</span></td>
@@ -477,6 +511,7 @@
                 <td>&ndash;</td>
                 <td>Found quotation marks around field(s) in the first rows of the file. Fields and values surrounded by quotation marks might be incorrectly loaded (i.e. with the quotation marks included as part of the value)</td>
                 <td>quotation marks of type: [&#34;] </td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -484,6 +519,7 @@
                 <td>315</td>
                 <td>Sample ID not defined in clinical file</td>
                 <td>TCGA-AR-A1AR-01</td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -491,6 +527,7 @@
                 <td>&ndash;</td>
                 <td>Invalid column header, file cannot be parsed</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -521,6 +558,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -530,6 +568,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -537,6 +576,7 @@
                 <td>3, 5 <br/>Column names: OS_MONTHS, DFS_MONTHS</td>
                 <td>Value of numeric attribute is not a real number</td>
                 <td>&#34;8.77&#34;, &#34;12.25, 12.25&#34;</td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -544,6 +584,7 @@
                 <td>1</td>
                 <td>PATIENT_ID and SAMPLE_ID can only contain letters, numbers, points, underscores and/or hyphens</td>
                 <td>&#34;TCGA-BH-A0HW&#34;</td>
+                <td></td>
               </tr>
               <tr class="warning">
                 <td><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning</span></td>
@@ -551,6 +592,7 @@
                 <td>1</td>
                 <td>Clinical data defined for a patient with no samples</td>
                 <td>&#34;TCGA-BH-A0HW&#34;</td>
+                <td></td>
               </tr>
               <tr class="warning">
                 <td><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning</span></td>
@@ -558,6 +600,7 @@
                 <td>&ndash;</td>
                 <td>Missing clinical data for a patient associated with samples</td>
                 <td>TCGA-BH-A0HW</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -565,6 +608,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -572,6 +616,7 @@
                 <td>&ndash;</td>
                 <td>Read 830 lines. Lines with warning: 1. Lines with error: 3</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -602,6 +647,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -611,6 +657,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="warning">
                 <td><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning</span></td>
@@ -618,6 +665,7 @@
                 <td>&ndash;</td>
                 <td>Found quotation marks around field(s) in the first rows of the file. Fields and values surrounded by quotation marks might be incorrectly loaded (i.e. with the quotation marks included as part of the value)</td>
                 <td>quotation marks of type: [&#34;] </td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -625,6 +673,7 @@
                 <td>2</td>
                 <td>PATIENT_ID and SAMPLE_ID can only contain letters, numbers, points, underscores and/or hyphens</td>
                 <td>&#34;TCGA-AR-A1AR-01&#34;, &#34;TCGA-B6-A0I6-01</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -632,6 +681,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -639,6 +689,7 @@
                 <td>&ndash;</td>
                 <td>Read 831 lines. Lines with warning: 0. Lines with error: 2</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -669,6 +720,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -678,6 +730,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -685,6 +738,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -715,6 +769,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -724,6 +779,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -731,6 +787,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -761,6 +818,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -770,6 +828,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -777,6 +836,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -807,6 +867,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -816,6 +877,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -823,6 +885,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -853,6 +916,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -862,6 +926,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -869,6 +934,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -876,6 +942,7 @@
                 <td>&ndash;</td>
                 <td>No reference genome specified -- using default (hg19)</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>

--- a/core/src/test/scripts/test_data/study_various_issues/result_report.html
+++ b/core/src/test/scripts/test_data/study_various_issues/result_report.html
@@ -86,6 +86,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -95,6 +96,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/cancer-types.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -102,6 +104,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/genes.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -109,6 +112,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/genesets.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -116,6 +120,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/genesets_version.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -123,6 +128,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/gene-panels.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -130,6 +136,7 @@
                 <td>&ndash;</td>
                 <td>Validating case lists</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -137,6 +144,7 @@
                 <td>&ndash;</td>
                 <td>Validation of case list folder complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -144,6 +152,7 @@
                 <td>&ndash;</td>
                 <td>No case list found with stable_id &#39;brca_tcga_pub_all&#39;, consider adding &#39;add_global_case_list: true&#39; to the meta_study.txt file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -151,6 +160,7 @@
                 <td>&ndash;</td>
                 <td>Validation complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -182,6 +192,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -191,27 +202,216 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="warning">
                 <td><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning</span></td>
-                <td>2, 3, 5, (5 more)</td>
+                <td>2, 3, 5&hellip; </td>
                 <td>&ndash;</td>
                 <td>Entrez gene id not known to the cBioPortal instance. This record will not be loaded. Might be new or deprecated Entrez gene id.</td>
                 <td>29974, 2, 144568</td>
+                <td><!-- Trigger/Open The Modal -->
+                        <a href="#showValues" data-toggle="modal" data-backdrop="false" data-target=".modalbrca_tcga_pub2value">See all 8 values </a>
+
+                        <div class="modal fade modalbrca_tcga_pub2value" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
+                          <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                              <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="gridSystemModalLabel">Listing all values for the message: Entrez gene id not known to the cBioPortal instance. This record will not be loaded. Might be new or deprecated Entrez gene id.</h4>
+                              </div>
+                              <div class="modal-body">
+                                <table class="table">
+                                  <thead>
+                                    <tr>
+                                      <th>Line Number</th>
+                                      <th>Column Number</th>
+                                      <th>Value Encountered</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                      <tr>
+                                        <td>2</td>
+                                        <td>&ndash;
+</td>
+                                        <td>29974</td>
+                                      </tr>
+                                      <tr>
+                                        <td>3</td>
+                                        <td>&ndash;
+</td>
+                                        <td>29974</td>
+                                      </tr>
+                                      <tr>
+                                        <td>5</td>
+                                        <td>&ndash;
+</td>
+                                        <td>2</td>
+                                      </tr>
+                                      <tr>
+                                        <td>8</td>
+                                        <td>&ndash;
+</td>
+                                        <td>2</td>
+                                      </tr>
+                                      <tr>
+                                        <td>9</td>
+                                        <td>&ndash;
+</td>
+                                        <td>2</td>
+                                      </tr>
+                                      <tr>
+                                        <td>11</td>
+                                        <td>&ndash;
+</td>
+                                        <td>144568</td>
+                                      </tr>
+                                      <tr>
+                                        <td>12</td>
+                                        <td>&ndash;
+</td>
+                                        <td>144568</td>
+                                      </tr>
+                                      <tr>
+                                        <td>16</td>
+                                        <td>&ndash;
+</td>
+                                        <td>144568</td>
+                                      </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+                            </div>
+                          </div>
+                        </div></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
-                <td>4, 6, 7, (4 more)</td>
+                <td>4, 6, 7&hellip; </td>
                 <td>&ndash;</td>
                 <td>Line will not be loaded due to the variant classification filter. Filtered types: [Silent, Intron, 3&#39;UTR, 3&#39;Flank, 5&#39;UTR, 5&#39;Flank, IGR, RNA]</td>
                 <td>Silent</td>
+                <td><!-- Trigger/Open The Modal -->
+                        <a href="#showValues" data-toggle="modal" data-backdrop="false" data-target=".modalbrca_tcga_pub3value">See all 7 values </a>
+
+                        <div class="modal fade modalbrca_tcga_pub3value" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
+                          <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                              <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="gridSystemModalLabel">Listing all values for the message: Line will not be loaded due to the variant classification filter. Filtered types: [Silent, Intron, 3'UTR, 3'Flank, 5'UTR, 5'Flank, IGR, RNA]</h4>
+                              </div>
+                              <div class="modal-body">
+                                <table class="table">
+                                  <thead>
+                                    <tr>
+                                      <th>Line Number</th>
+                                      <th>Column Number</th>
+                                      <th>Value Encountered</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                      <tr>
+                                        <td>4</td>
+                                        <td>&ndash;
+</td>
+                                        <td>Silent</td>
+                                      </tr>
+                                      <tr>
+                                        <td>6</td>
+                                        <td>&ndash;
+</td>
+                                        <td>Silent</td>
+                                      </tr>
+                                      <tr>
+                                        <td>7</td>
+                                        <td>&ndash;
+</td>
+                                        <td>Silent</td>
+                                      </tr>
+                                      <tr>
+                                        <td>10</td>
+                                        <td>&ndash;
+</td>
+                                        <td>Silent</td>
+                                      </tr>
+                                      <tr>
+                                        <td>13</td>
+                                        <td>&ndash;
+</td>
+                                        <td>Silent</td>
+                                      </tr>
+                                      <tr>
+                                        <td>14</td>
+                                        <td>&ndash;
+</td>
+                                        <td>Silent</td>
+                                      </tr>
+                                      <tr>
+                                        <td>15</td>
+                                        <td>&ndash;
+</td>
+                                        <td>Silent</td>
+                                      </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+                            </div>
+                          </div>
+                        </div></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
-                <td>8, 9, 11, (1 more)</td>
+                <td>8, 9, 11&hellip; </td>
                 <td>17</td>
                 <td>Normal sample id not in list of sample ids configured in corresponding metafile. Please check your metafile field &#39;normal_samples_list&#39;.</td>
-                <td>TCGA-A8-A08G-10, TCGA-B6-A0IQ-10, TCGA-A1-A0SO-10, (1 more)</td>
+                <td>TCGA-A8-A08G-10, TCGA-B6-A0IQ-10, TCGA-A1-A0SO-10&hellip; </td>
+                <td><!-- Trigger/Open The Modal -->
+                        <a href="#showValues" data-toggle="modal" data-backdrop="false" data-target=".modalbrca_tcga_pub4value">See all 4 values </a>
+
+                        <div class="modal fade modalbrca_tcga_pub4value" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
+                          <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                              <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="gridSystemModalLabel">Listing all values for the message: Normal sample id not in list of sample ids configured in corresponding metafile. Please check your metafile field 'normal_samples_list'.</h4>
+                              </div>
+                              <div class="modal-body">
+                                <table class="table">
+                                  <thead>
+                                    <tr>
+                                      <th>Line Number</th>
+                                      <th>Column Number</th>
+                                      <th>Value Encountered</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                      <tr>
+                                        <td>8</td>
+                                        <td>17</td>
+                                        <td>TCGA-A8-A08G-10</td>
+                                      </tr>
+                                      <tr>
+                                        <td>9</td>
+                                        <td>17</td>
+                                        <td>TCGA-B6-A0IQ-10</td>
+                                      </tr>
+                                      <tr>
+                                        <td>11</td>
+                                        <td>17</td>
+                                        <td>TCGA-A1-A0SO-10</td>
+                                      </tr>
+                                      <tr>
+                                        <td>12</td>
+                                        <td>17</td>
+                                        <td>TCGA-A8-A08P-10</td>
+                                      </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+                            </div>
+                          </div>
+                        </div></td>
               </tr>
               <tr class="warning">
                 <td><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning</span></td>
@@ -219,6 +419,7 @@
                 <td>&ndash;</td>
                 <td>Given value for Variant_Classification column is not one of the expected values. This can result in mapping issues and subsequent missing features in the mutation view UI, such as missing COSMIC information.</td>
                 <td>Missense_mUtAtioN</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -226,6 +427,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -233,6 +435,7 @@
                 <td>&ndash;</td>
                 <td>Read 16 lines. Lines with warning: 8. Lines with error: 4</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -263,6 +466,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -272,6 +476,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -279,6 +484,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -309,6 +515,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -318,6 +525,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -325,6 +533,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -355,6 +564,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -364,6 +574,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -371,6 +582,7 @@
                 <td>5</td>
                 <td>datatype definition for attribute &#39;DFS_MONTHS&#39; must be NUMBER</td>
                 <td>STRING</td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -378,6 +590,7 @@
                 <td>3 <br/>Column names: OS_MONTHS</td>
                 <td>Value of numeric attribute is not a real number</td>
                 <td>TEST</td>
+                <td></td>
               </tr>
               <tr class="warning">
                 <td><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning</span></td>
@@ -385,6 +598,7 @@
                 <td>&ndash;</td>
                 <td>Missing clinical data for a patient associated with samples</td>
                 <td>TCGA-A2-A0T2</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -392,6 +606,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -399,6 +614,7 @@
                 <td>&ndash;</td>
                 <td>Read 829 lines. Lines with warning: 0. Lines with error: 3</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -429,6 +645,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -438,6 +655,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -445,6 +663,7 @@
                 <td>&ndash;</td>
                 <td>Validation of file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -452,6 +671,7 @@
                 <td>&ndash;</td>
                 <td>Read 831 lines. Lines with warning: 0. Lines with error: 0</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -482,6 +702,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -491,6 +712,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -498,6 +720,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -528,6 +751,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -537,13 +761,68 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="warning">
                 <td><span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span><span class="sr-only">Warning</span></td>
                 <td>&ndash;</td>
                 <td>&ndash;</td>
                 <td>Unrecognized field in meta file</td>
-                <td>stable_id, show_profile_in_analysis_tab, profile_description, (1 more)</td>
+                <td>stable_id, show_profile_in_analysis_tab, profile_description&hellip; </td>
+                <td><!-- Trigger/Open The Modal -->
+                        <a href="#showValues" data-toggle="modal" data-backdrop="false" data-target=".modalmeta_patients2value">See all 4 values </a>
+
+                        <div class="modal fade modalmeta_patients2value" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
+                          <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-content">
+                              <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title" id="gridSystemModalLabel">Listing all values for the message: Unrecognized field in meta file</h4>
+                              </div>
+                              <div class="modal-body">
+                                <table class="table">
+                                  <thead>
+                                    <tr>
+                                      <th>Line Number</th>
+                                      <th>Column Number</th>
+                                      <th>Value Encountered</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                      <tr>
+                                        <td>&ndash;
+</td>
+                                        <td>&ndash;
+</td>
+                                        <td>stable_id</td>
+                                      </tr>
+                                      <tr>
+                                        <td>&ndash;
+</td>
+                                        <td>&ndash;
+</td>
+                                        <td>show_profile_in_analysis_tab</td>
+                                      </tr>
+                                      <tr>
+                                        <td>&ndash;
+</td>
+                                        <td>&ndash;
+</td>
+                                        <td>profile_description</td>
+                                      </tr>
+                                      <tr>
+                                        <td>&ndash;
+</td>
+                                        <td>&ndash;
+</td>
+                                        <td>profile_name</td>
+                                      </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+                            </div>
+                          </div>
+                        </div></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -551,6 +830,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -581,6 +861,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -590,6 +871,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -597,6 +879,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -627,6 +910,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -636,6 +920,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -643,6 +928,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -650,6 +936,7 @@
                 <td>&ndash;</td>
                 <td>No reference genome specified -- using default (hg19)</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>

--- a/core/src/test/scripts/test_data/study_wr_clin/result_report.html
+++ b/core/src/test/scripts/test_data/study_wr_clin/result_report.html
@@ -86,6 +86,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -95,6 +96,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/cancer-types.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -102,6 +104,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/genes.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -109,6 +112,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/genesets.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -116,6 +120,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/genesets_version.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="info">
                 <td><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="sr-only">Debug</span></td>
@@ -123,6 +128,7 @@
                 <td>&ndash;</td>
                 <td>Reading portal information from test_data/api_json_system_tests/gene-panels.json</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -130,6 +136,7 @@
                 <td>&ndash;</td>
                 <td>No sample attribute file detected</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -161,6 +168,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -170,6 +178,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -177,6 +186,7 @@
                 <td>&ndash;</td>
                 <td>Invalid stable id for genetic_alteration_type &#39;MRNA_EXPRESSION&#39;, data_type &#39;Z-SCORE&#39;; expected one of [mrna_U133_Zscores, rna_seq_mrna_median_Zscores, mrna_median_Zscores, rna_seq_v2_mrna_median_Zscores, rna_seq_v2_mrna_median_normals_Zscores, mirna_median_Zscores, mrna_merged_median_Zscores, mrna_zbynorm, mrna_seq_tpm_Zscores, mrna_seq_cpm_Zscores, rna_seq_mrna_capture_Zscores, mrna_seq_fpkm_capture_Zscores, mrna_seq_fpkm_polya_Zscores, mrna_U133_all_sample_Zscores, mrna_all_sample_Zscores, rna_seq_mrna_median_all_sample_Zscores, mrna_median_all_sample_Zscores, rna_seq_v2_mrna_median_all_sample_Zscores, rna_seq_v2_mrna_median_all_sample_ref_normal_Zscores, mrna_seq_cpm_all_sample_Zscores, mrna_seq_tpm_all_sample_Zscores, rna_seq_mrna_capture_all_sample_Zscores, mrna_seq_fpkm_capture_all_sample_Zscores, mrna_seq_fpkm_polya_all_sample_Zscores]</td>
                 <td>mrna</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -207,6 +217,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -216,6 +227,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -223,6 +235,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -253,6 +266,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -262,6 +276,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="danger">
                 <td><span class="glyphicon glyphicon-remove" aria-hidden="true"></span><span class="sr-only">Error</span></td>
@@ -269,6 +284,7 @@
                 <td>&ndash;</td>
                 <td>Could not determine the file type. Please check your meta files for correct configuration.</td>
                 <td>genetic_alteration_type: CLINICAL, datatype: FREE-FORM</td>
+                <td></td>
               </tr>
             </tbody>
             </table>
@@ -299,6 +315,7 @@
                 <th>Column Number</th>
                 <th>Message</th>
                 <th>Value Encountered</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -308,6 +325,7 @@
                 <td>&ndash;</td>
                 <td>Starting validation of meta file</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -315,6 +333,7 @@
                 <td>&ndash;</td>
                 <td>Validation of meta file complete</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
               <tr class="success">
                 <td><span class="glyphicon glyphicon-ok" aria-hidden="true"></span><span class="sr-only">Info</span></td>
@@ -322,6 +341,7 @@
                 <td>&ndash;</td>
                 <td>No reference genome specified -- using default (hg19)</td>
                 <td>&ndash;</td>
+                <td></td>
               </tr>
             </tbody>
             </table>

--- a/docs/Using-the-dataset-validator.md
+++ b/docs/Using-the-dataset-validator.md
@@ -21,7 +21,7 @@ This will tell you the parameters you can use:
 usage: validateData.py [-h] -s STUDY_DIRECTORY
                        [-u URL_SERVER | -p PORTAL_INFO_DIR | -n]
                        [-P PORTAL_PROPERTIES] [-html HTML_TABLE]
-                       [-e ERROR_FILE] [-v] [-r] [-m] [-a MAX_REPORTED_VALUES]
+                       [-e ERROR_FILE] [-v] [-r] [-m]
 
 cBioPortal study validator
 
@@ -51,12 +51,6 @@ optional arguments:
   -m, --strict_maf_checks
                         Option to enable strict mode for validator when validating
                         mutation data
-  -a MAX_REPORTED_VALUES, --max_reported_values MAX_REPORTED_VALUES
-                        Cutoff in HTML report for the maximum number of line
-                        numbers and values encountered to report for each
-                        message. For example, set this to a high number to
-                        report all genes that could not be loaded, instead of
-                        reporting "GeneA, GeneB, GeneC, 213 more"
 ```
 
 For more information on the `--portal_info_dir` option, see [Offline validation](#offline-validation) below. If your cBioPortal is not using `hg19`, 
@@ -801,7 +795,7 @@ The following parameters can be used:
 usage: validateStudies.py [-h] [-d ROOT_DIRECTORY] [-l LIST_OF_STUDIES]
                           [-html HTML_FOLDER]
                           [-u URL_SERVER | -p PORTAL_INFO_DIR | -n]
-                          [-P PORTAL_PROPERTIES] [-m] [-a MAX_REPORTED_VALUES]
+                          [-P PORTAL_PROPERTIES] [-m]
 
 Wrapper where cBioPortal study validator is run for multiple studies
 
@@ -826,12 +820,6 @@ optional arguments:
   -m, --strict_maf_checks
                         Option to enable strict mode for validator when
                         validating mutation data
-  -a MAX_REPORTED_VALUES, --max_reported_values MAX_REPORTED_VALUES
-                        Cutoff in HTML report for the maximum number of line
-                        numbers and values encountered to report for each
-                        message. For example, set this to a high number to
-                        report all genes that could not be loaded, instead of
-                        reporting "GeneA, GeneB, GeneC, 213 more"
 ```
 
 Parameters `--url_server`, `--portal_info_dir`, `--no_portal_checks` and `--portal_properties` are equal to the parameters with the same name in `validateData.py`. The script will save a log file with validation output (`log-validate-studies.txt`) and output the validation status from the input studies:

--- a/docs/Using-the-metaImport-script.md
+++ b/docs/Using-the-metaImport-script.md
@@ -14,7 +14,7 @@ $./metaImport.py -h
 usage: metaImport.py [-h] -s STUDY_DIRECTORY
                      [-u URL_SERVER | -p PORTAL_INFO_DIR | -n]
                      [-jar JAR_PATH] [-html HTML_TABLE]
-                     [-v] [-o] [-r] [-m] [-a MAX_REPORTED_VALUES]
+                     [-v] [-o] [-r] [-m]
 
 cBioPortal meta Importer
 
@@ -45,13 +45,6 @@ optional arguments:
   -m, --strict_maf_checks
                         Option to enable strict mode for validator when
                         validating mutation data
-  -a MAX_REPORTED_VALUES, --max_reported_values MAX_REPORTED_VALUES
-                        Cutoff in report for the maximum number of line
-                        numbers and values encountered to report for each
-                        message in the HTML report. For example, set this to a
-                        high number to report all genes that could not be
-                        loaded, instead of reporting "(GeneA, GeneB, GeneC,
-                        213 more)".
 ```
 
 #### Example of Importing a study


### PR DESCRIPTION
Currently, the report does not allow to visualize more than 3 genes/values that fall under the same warning or error.

In this PR a link is introduced in each log that has more than 3 values. The link opens a modal displaying the full content of the log. The validator/importer also allowed you to change this threshold value of 3, which has now been removed for simplicity.

Image of the new report with a modal opened:
![Screenshot from 2021-08-05 16-31-43](https://user-images.githubusercontent.com/20278013/128367835-cd8ee4ce-1e1f-421f-a56d-049ace685172.png)

