### PR TITLE
Fix validator unit tests matching database cleanup

### DIFF
--- a/core/src/test/scripts/test_data/data_cancertype_blank_color_col.txt
+++ b/core/src/test/scripts/test_data/data_cancertype_blank_color_col.txt
@@ -1,1 +1,1 @@
-luad	Lung Adenocarcinoma	lung,pulmonary,adenocarcinoma of the lung	  	Lung
+luad	Lung Adenocarcinoma	  	Lung

--- a/core/src/test/scripts/test_data/data_cancertype_confirming_existing.txt
+++ b/core/src/test/scripts/test_data/data_cancertype_confirming_existing.txt
@@ -1,1 +1,1 @@
-brca	Invasive Breast Carcinoma	Spam,Spam,Spam	HotPink	Breast
+brca	Invasive Breast Carcinoma	HotPink	Breast

--- a/core/src/test/scripts/test_data/data_cancertype_invalid_color.txt
+++ b/core/src/test/scripts/test_data/data_cancertype_invalid_color.txt
@@ -1,1 +1,1 @@
-net	Neuroendocrine Tumour	endocrine,hormonal,neural,nervous	Zebra	tissue
+net	Neuroendocrine Tumour	Zebra	tissue

--- a/core/src/test/scripts/test_data/data_cancertype_lung.txt
+++ b/core/src/test/scripts/test_data/data_cancertype_lung.txt
@@ -1,1 +1,1 @@
-luad	Lung Adenocarcinoma	lung,pulmonary,adenocarcinoma of the lung	Gainsboro	Lung
+luad	Lung Adenocarcinoma	Gainsboro	Lung

--- a/core/src/test/scripts/test_data/data_cancertype_lung_twice.txt
+++ b/core/src/test/scripts/test_data/data_cancertype_lung_twice.txt
@@ -1,2 +1,2 @@
-luad	Lung Adenocarcinoma	lung,pulmonary,adenocarcinoma of the lung	Gainsboro	Lung
-luad	Lung Adenocarcinoma	lung,pulmonary,adenocarcinoma of the lung	AntiqueWhite	Lung
+luad	Lung Adenocarcinoma	Gainsboro	Lung
+luad	Lung Adenocarcinoma	AntiqueWhite	Lung

--- a/core/src/test/scripts/test_data/data_cancertype_missing_color_col.txt
+++ b/core/src/test/scripts/test_data/data_cancertype_missing_color_col.txt
@@ -1,1 +1,1 @@
-luad	Lung Adenocarcinoma	lung,pulmonary,adenocarcinoma of the lung	Lung
+luad	Lung Adenocarcinoma	Lung

--- a/core/src/test/scripts/test_data/data_cancertype_redefining.txt
+++ b/core/src/test/scripts/test_data/data_cancertype_redefining.txt
@@ -1,1 +1,1 @@
-brca	Breast Cancer	Spam,Spam,Spam	HotPink	Breast
+brca	Breast Cancer	HotPink	Breast

--- a/core/src/test/scripts/test_data/data_cancertype_undefined_parent.txt
+++ b/core/src/test/scripts/test_data/data_cancertype_undefined_parent.txt
@@ -1,2 +1,2 @@
-luad	Lung Adenocarcinoma	lung,pulmonary,adenocarcinoma of the lung	Gainsboro	Long
-new	new type	to test tissue special case	PaleGreen	tissue
+luad	Lung Adenocarcinoma	Gainsboro	Long
+new	new type	PaleGreen	tissue

--- a/core/src/test/scripts/test_data/meta_study/exceed_maximum_length_meta_attribute_value/meta_study.txt
+++ b/core/src/test/scripts/test_data/meta_study/exceed_maximum_length_meta_attribute_value/meta_study.txt
@@ -1,8 +1,0 @@
-type_of_cancer: brca-es0
-cancer_study_identifier: study_es_0
-name: Test study es_0
-description: Test study es_0
-citation: The Hyve
-pmid: 23000897
-groups: PUBLIC;GDAC;SU2C-PI3K
-add_global_case_list: true

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -537,7 +537,7 @@ class CancerTypeFileValidationTestCase(DataFileTestCase):
         self.assertEqual(len(record_list), 1)
         record = record_list.pop()
         self.assertEqual(record.levelno, logging.ERROR)
-        self.assertEqual(record.column_number, 4)
+        self.assertEqual(record.column_number, 3)
         self.assertIn('blank', record.getMessage().lower())
 
     def test_cancer_type_undefined_parent(self):
@@ -548,7 +548,7 @@ class CancerTypeFileValidationTestCase(DataFileTestCase):
         self.assertEqual(len(record_list), 1)
         record = record_list.pop()
         self.assertEqual(record.levelno, logging.ERROR)
-        self.assertEqual(record.column_number, 5)
+        self.assertEqual(record.column_number, 4)
 
     def test_cancer_type_invalid_color(self):
         """Test error if a cancer type's color is not a web color name."""
@@ -558,7 +558,7 @@ class CancerTypeFileValidationTestCase(DataFileTestCase):
         self.assertEqual(len(record_list), 1)
         record = record_list.pop()
         self.assertEqual(record.levelno, logging.ERROR)
-        self.assertEqual(record.column_number, 4)
+        self.assertEqual(record.column_number, 3)
 
     def test_cancer_type_matching_portal(self):
         """Test when an existing cancer type is defined exactly as known."""
@@ -2427,21 +2427,6 @@ class MetaFilesTestCase(LogBufferTestCase):
         # expecting one warning about stable_id not being recognized in _samples
         self.assertEqual(warning.levelno, logging.WARNING)
         self.assertEqual(warning.cause, 'stable_id')
-
-    def test_exceed_maximum_length_meta_attribute_value(self):
-        """Test to check whether the validator throws a warning for invalid length of attributes in meta files."""
-        self.logger.setLevel(logging.WARNING)
-        validateData.process_metadata_files(
-            'test_data/meta_study/exceed_maximum_length_meta_attribute_value',
-            PORTAL_INSTANCE,
-            self.logger, False, False)
-        record_list = self.get_log_records()
-        # expecting 1 error:
-        self.assertEqual(len(record_list), 1)
-
-        # expecting one error about the maximum length of 'short_name' meta_study
-        record = record_list.pop()
-        self.assertEqual("The maximum length of the 'short_name' value is 64", record.getMessage())
 
     def test_invalid_pmid_values(self):
         """Test to check whether the validator throws an error for invalid PMID values in meta_study.txt."""


### PR DESCRIPTION
Fix validator tests that have been broken due to changes in the database fields (PR #8382). 
