### PR TITLE
Implement molecular data endpoint to use one db query per gene, for caching reasons

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
@@ -189,8 +189,13 @@ public class MolecularDataServiceImpl implements MolecularDataService {
             samples = sampleService.fetchSamples(studyIds, sampleIds, "ID");
         }
 
-        List<GeneMolecularAlteration> molecularAlterations = molecularDataRepository
-            .getGeneMolecularAlterationsInMultipleMolecularProfiles(distinctMolecularProfileIds, entrezGeneIds, projection);
+        // query each entrezGeneId separately so they can be cached
+        List<GeneMolecularAlteration> molecularAlterations = entrezGeneIds.stream()
+            .flatMap(gene -> molecularDataRepository.getGeneMolecularAlterationsInMultipleMolecularProfiles(
+                    distinctMolecularProfileIds, Collections.singletonList(gene), projection
+                ).stream()
+            )
+        .collect(Collectors.toList());
         Map<String, List<GeneMolecularAlteration>> molecularAlterationsMap = molecularAlterations.stream().collect(
             groupingBy(GeneMolecularAlteration::getMolecularProfileId));
         


### PR DESCRIPTION
Questions for backend team:
- Do you see any reason *not* to do this?
- As long as we're here, should we do this for the rest of the molecular data endpoints too? For mutation/structural variant endpoints too?