### PR TITLE
use new shenandoah image

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /cbioportal
 ARG MAVEN_OPTS=-DskipTests
 RUN mvn ${MAVEN_OPTS} clean install
 
-FROM shipilev/openjdk-shenandoah:11
+FROM shipilev/openjdk:11
 
 ENV PORTAL_WEB_HOME=/cbioportal-webapp
 


### PR DESCRIPTION
Old image is no longer building. Image was renamed. I guess maybe b/c shenandoah is part of 11 now by default? I’m not 100% sure. We might be able to switch to the official image now but it would require some more investigation into the memory profile etc