### PR TITLE
RFC 59 - show studies for which a user is not authorized

### DIFF
--- a/docs/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/Customizing-your-instance-of-cBioPortal.md
@@ -224,6 +224,18 @@ Below you can find the complete list of all the available skin properties.
 			<td>0.5</td>
 		</tr>
 		<tr>
+			<td>skin.show_unauthorized_studies</td>
+			<td>show unauthorized studies in the studies list</td>
+			<td>false</td>
+			<td>true / false</td>
+		</tr>
+		<tr>
+			<td>skin.global_message_for_unauthorized_studies</td>
+			<td>show a global message when user hovers over the lock icon of an unauthorized study</td>
+			<td>The study is unauthorized. You need to request access.</td>
+			<td>text</td>
+		</tr>
+		<tr>
             <td>skin.query.max_tree_depth</td>
             <td>sets the maximum number of subcategories shown in the query component hierarchy before each study. E.g. when set to 0, the hierarchy is flat, meaning only the study elements show in the component, without any tissue or cancer type sorting.</td>
             <td>3</td>

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -511,8 +511,18 @@ skin.show_gsva=true
 
 # Set default thresholds for geneset hierarchy
 ```
-skin.geneset_hierarchy.default_gsva_score=0.3
-skin.geneset_hierarchy.default_p_value=0.02
+skin.geneset_hierarchy.default_gsva_score=0.5
+skin.geneset_hierarchy.default_p_value=0.05
+```
+
+# Show the unauthorized studies in the studies list
+```
+skin.show_unauthorized_studies=false
+```
+
+# Show a global message when user hovers over the lock icon of an unauthorized study
+```
+skin.global_message_for_unauthorized_studies=The study is unauthorized. You need to request access.
 ```
 
 # Request Body Compression

--- a/model/src/main/java/org/cbioportal/model/CancerStudy.java
+++ b/model/src/main/java/org/cbioportal/model/CancerStudy.java
@@ -13,6 +13,7 @@ public class CancerStudy implements Serializable {
     private String name;
     private String description;
     private Boolean publicStudy;
+    private Boolean isAuthorized;
     private String pmid;
     private String citation;
     private String groups;
@@ -219,4 +220,12 @@ public class CancerStudy implements Serializable {
     public String getReferenceGenome() { return  referenceGenome; }
     
     public void setReferenceGenome(String referenceGenome) { this.referenceGenome = referenceGenome; }
+
+    public Boolean getIsAuthorized() {
+        return isAuthorized;
+    }
+
+    public void setIsAuthorized(Boolean isAuthorized) {
+        this.isAuthorized = isAuthorized;
+    }
 }

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -126,6 +126,8 @@
             "skin.citation_rule_text",
             "skin.geneset_hierarchy.default_p_value",
             "skin.geneset_hierarchy.default_gsva_score",
+            "skin.show_unauthorized_studies",
+            "skin.global_message_for_unauthorized_studies",
         };
 
 

--- a/service/src/main/java/org/cbioportal/service/StudyService.java
+++ b/service/src/main/java/org/cbioportal/service/StudyService.java
@@ -12,6 +12,9 @@ public interface StudyService {
     List<CancerStudy> getAllStudies(String keyword, String projection, Integer pageSize, Integer pageNumber, 
                                     String sortBy, String direction);
 
+    List<CancerStudy> getAllStudiesWithAuthorizationInfo(String keyword, String projection, Integer pageSize, Integer pageNumber,
+                                    String sortBy, String direction);
+
     BaseMeta getMetaStudies(String keyword);
 
     CancerStudy getStudy(String studyId) throws StudyNotFoundException;

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -345,6 +345,12 @@ persistence.cache_type=no-cache
 # skin.geneset_hierarchy.default_gsva_score=0.5
 # skin.geneset_hierarchy.default_p_value=0.05
 
+# Show unauthorized studies in the studies list
+# skin.show_unauthorized_studies=false
+
+# Show a global message when user hovers over the lock icon of an unauthorized study
+# skin.global_message_for_unauthorized_studies=The study is unauthorized. You need to request access.
+
 # Compress some particularly large request bodies. enable_request_body_gzip_compression enables the feature, and
 # request_gzip_body_size_bytes sets the maximum allowable uncompressed request body size in bytes. Requests larger than
 # this value will be rejected. If unset, the default value will be 50000000, or 50 Mb.

--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -54,7 +54,10 @@ public class StudyController {
 
     @Value("${app.name:unknown}")
     private String appName;
-    
+
+    @Value("${skin.show_unauthorized_studies:false}")
+    private String showUnauthorizedStudies;
+
     private boolean usingAuth() {
         return !authenticate.isEmpty()
             && !authenticate.equals("false")
@@ -119,9 +122,14 @@ public class StudyController {
                 .toString());
             return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
         } else {
-            return new ResponseEntity<>(
-                studyService.getAllStudies(keyword, projection.name(), pageSize, pageNumber,
-                    sortBy == null ? null : sortBy.getOriginalValue(), direction.name()), HttpStatus.OK);
+            return (
+                showUnauthorizedStudies.equals("false") ?
+                    ( new ResponseEntity<>(
+                    studyService.getAllStudies(keyword, projection.name(), pageSize, pageNumber,
+                    sortBy == null ? null : sortBy.getOriginalValue(), direction.name()), HttpStatus.OK)) :
+                    ( new ResponseEntity<>(
+                    studyService.getAllStudiesWithAuthorizationInfo(keyword, projection.name(), pageSize, pageNumber,
+                    sortBy == null ? null : sortBy.getOriginalValue(), direction.name()), HttpStatus.OK)));
         }
     }
 


### PR DESCRIPTION
Worked on Rfc 59 (https://docs.google.com/document/d/1NkNhBG1sk0ZvCOwk3XtiuRT9a_tKkFCgXC9I3XT-Ye4/edit#heading=h.6c2l76kgw1ta) to retrieve all studies (authorized and unauthorized), each having a boolean variable isAuthorized, when the skin.show_unauthorized_studies is true in portal.properties (default is false). 

This will be used in frontend to show also the unauthorized studies, but grayed out and with a lock icon as in image below.
![Screenshot from 2021-08-17 12-24-03](https://user-images.githubusercontent.com/53996876/129889241-e37ce184-8268-4d42-ac3c-3aaab9cbceb2.png)

Frontend PR is https://github.com/cBioPortal/cbioportal-frontend/pull/3932