### PR TITLE
RFC59: Return unauthorized studies from /api/studies endpoint

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/AccessControl.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/AccessControl.java
@@ -61,7 +61,7 @@ public interface AccessControl {
      * @throws DaoException         Database Error.
      * @throws ProtocolException    Protocol Error.
      */
-    @PostFilter("hasPermission(filterObject.getCancerStudyStableId(), 'CancerStudyId', 'read')")
+    @PostFilter("hasPermission(filterObject.getCancerStudyStableId(), 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     List<CancerStudy> getCancerStudies() throws DaoException, ProtocolException;
 
     /**
@@ -71,7 +71,7 @@ public interface AccessControl {
      * @return ListCancerStudy
      * @throws DaoException
      */
-    @PostFilter("hasPermission(#stableStudyId, 'CancerStudyId', 'read')")
+    @PostFilter("hasPermission(#stableStudyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     List<CancerStudy> isAccessibleCancerStudy(String stableStudyId) throws DaoException;
 
     UserDetails getUserDetails();

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -168,6 +168,15 @@ Different samples of a patient may have been analyzed with different gene panels
 skin.patientview.filter_genes_profiled_all_samples=
 ```
 
+## Control unauthorized studies to be displayed on the home page
+By default, on an authenticated portal the home page will only show studies for which the current user is authorized.
+By setting the _skin.home_page.show_unauthorized_studies_ property to _true_ the home page will also show unauthorized
+studies. The unauthorized studies will appear greyed out and cannot be selected for downstream analysis in Results View or
+Study View.
+```
+skin.home_page.show_unauthorized_studies=
+```
+
 ## Control the appearance of the settings menu in study view and group comparison that controls custom annotation-based filtering
 A settings menu that allows the user to filter alterations in study view and group comparison may be used
 when [custom driver annotations](File-Formats.md#custom-driver-annotations) were loaded for the study or studies displayed

--- a/model/src/main/java/org/cbioportal/model/CancerStudy.java
+++ b/model/src/main/java/org/cbioportal/model/CancerStudy.java
@@ -4,7 +4,7 @@ import java.io.Serializable;
 import java.util.Date;
 import javax.validation.constraints.NotNull;
 
-public class CancerStudy implements Serializable {
+public class CancerStudy implements ReadPermission, Serializable {
 
     private Integer cancerStudyId;
     @NotNull
@@ -31,7 +31,8 @@ public class CancerStudy implements Serializable {
     private Integer massSpectrometrySampleCount;
     private Integer completeSampleCount;
     private String referenceGenome;
-
+    private Boolean readPermission = true;
+    
     public Integer getCancerStudyId() {
         return cancerStudyId;
     }
@@ -219,4 +220,14 @@ public class CancerStudy implements Serializable {
     public String getReferenceGenome() { return  referenceGenome; }
     
     public void setReferenceGenome(String referenceGenome) { this.referenceGenome = referenceGenome; }
+
+    @Override
+    public void setReadPermission(Boolean permission) {
+        this.readPermission = permission;
+    }
+
+    @Override
+    public Boolean getReadPermission() {
+        return readPermission;
+    }
 }

--- a/model/src/main/java/org/cbioportal/model/ReadPermission.java
+++ b/model/src/main/java/org/cbioportal/model/ReadPermission.java
@@ -1,0 +1,6 @@
+package org.cbioportal.model;
+
+public interface ReadPermission {
+    public void setReadPermission(Boolean permission);
+    public Boolean getReadPermission();
+}

--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,11 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.mskcc.cbio</groupId>
+        <artifactId>permission-evaluator</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.mongodb</groupId>
         <artifactId>mongo-java-driver</artifactId>
         <version>3.12.9</version>

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -103,6 +103,7 @@
             "skin.show_tweet_button",
             "skin.patientview.filter_genes_profiled_all_samples",
             "skin.patientview.show_mskcc_slide_viewer",
+            "skin.home_page.show_unauthorized_studies",
             "skin.show_settings_menu",
             "skin.hide_logout_button",
             "quick_search.enabled",

--- a/security/permission-evaluator/pom.xml
+++ b/security/permission-evaluator/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>security</artifactId>
+        <groupId>org.mskcc.cbio</groupId>
+        <version>0-unknown-version-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>permission-evaluator</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mskcc.cbio</groupId>
+            <artifactId>persistence-mybatis</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/security/permission-evaluator/src/main/java/org/cbioportal/security/CancerStudyPermissionEvaluator.java
+++ b/security/permission-evaluator/src/main/java/org/cbioportal/security/CancerStudyPermissionEvaluator.java
@@ -30,7 +30,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.cbioportal.security.spring;
+package org.cbioportal.security;
 
 import java.io.Serializable;
 import java.util.*;
@@ -38,6 +38,7 @@ import org.apache.commons.logging.*;
 import org.cbioportal.model.*;
 import org.cbioportal.persistence.cachemaputil.CacheMapUtil;
 import org.springframework.beans.factory.annotation.*;
+import org.cbioportal.utils.security.AccessLevel;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -50,7 +51,7 @@ import org.springframework.security.core.authority.AuthorityUtils;
  *
  * @author Benjamin Gross
  */
-class CancerStudyPermissionEvaluator implements PermissionEvaluator {
+public class CancerStudyPermissionEvaluator implements PermissionEvaluator {
 
     @Autowired
     private CacheMapUtil cacheMapUtil;
@@ -125,7 +126,7 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
         // authentication will always have authorities.
         Object user = authentication.getPrincipal();
         if (user != null) {
-            return hasAccessToCancerStudy(authentication, cancerStudy);
+            return hasAccessToCancerStudy(authentication, cancerStudy, (AccessLevel) permission);
         } else {
             return false;
         }
@@ -219,11 +220,21 @@ class CancerStudyPermissionEvaluator implements PermissionEvaluator {
     /**
      * Helper function to determine if given user has access to given cancer study.
      *
+     * @param authentication Spring Authentication object of the logged-in user.
      * @param cancerStudy cancer study to check for
-     * @param authentication Spring Authentication of the logged-in user.
+     * @param permission requested permission level (can be org.cbioportal.utils.security.AccessLevel.READ or org.cbioportal.utils.security.AccessLevel.LIST)
      * @return boolean
      */
-    private boolean hasAccessToCancerStudy(Authentication authentication, CancerStudy cancerStudy) {
+    private boolean hasAccessToCancerStudy(Authentication authentication, CancerStudy cancerStudy, AccessLevel permission) {
+        
+        // The 'list' permission is only requested by the /api/studies endpoint of StudyController. This permission is
+        // requested by the Study Overview page when the portal instance is configured to show all studies (with non-
+        // authorized study options greyed out), instead of only showing authorized studies.
+        // When the 'list' permission is requested, CancerPermissionEvaluator returns true always.
+        if (AccessLevel.LIST == permission) {
+            return true;
+        }
+        
         Set<String> grantedAuthorities = getGrantedAuthorities(authentication);
         String stableStudyID = cancerStudy.getCancerStudyIdentifier();
         if (log.isDebugEnabled()) {

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -13,6 +13,7 @@
     <packaging>pom</packaging>
     <modules>
         <module>security-spring</module>
+        <module>permission-evaluator</module>
     </modules>
 
     <dependencies>

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -72,7 +72,7 @@
     <b:bean id="expressionHandler" class="org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler">
         <b:property name="permissionEvaluator" ref="customPermissionEvaluator"/>
     </b:bean>
-    <b:bean id="customPermissionEvaluator" class="org.cbioportal.security.spring.CancerStudyPermissionEvaluator"/>
+    <b:bean id="customPermissionEvaluator" class="org.cbioportal.security.CancerStudyPermissionEvaluator"/>
 
     <!-- fstatic resources not processed by spring security filters -->
     <http pattern="/css/**" security="none"/>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>org.mskcc.cbio</groupId>
-            <artifactId>utils</artifactId>
+            <artifactId>permission-evaluator</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -41,7 +41,6 @@
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
         </dependency>
-
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>

--- a/service/src/main/java/org/cbioportal/service/ReadPermissionService.java
+++ b/service/src/main/java/org/cbioportal/service/ReadPermissionService.java
@@ -1,0 +1,10 @@
+package org.cbioportal.service;
+
+import org.cbioportal.model.ReadPermission;
+import org.springframework.security.core.Authentication;
+
+import java.util.Collection;
+
+public interface ReadPermissionService {
+    public void setReadPermission(Collection<? extends ReadPermission> entities, Authentication authentication);
+}

--- a/service/src/main/java/org/cbioportal/service/StudyService.java
+++ b/service/src/main/java/org/cbioportal/service/StudyService.java
@@ -4,13 +4,15 @@ import org.cbioportal.model.CancerStudy;
 import org.cbioportal.model.CancerStudyTags;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.utils.security.AccessLevel;
+import org.springframework.security.core.Authentication;
 
 import java.util.List;
 
 public interface StudyService {
 
-    List<CancerStudy> getAllStudies(String keyword, String projection, Integer pageSize, Integer pageNumber, 
-                                    String sortBy, String direction);
+    List<CancerStudy> getAllStudies(String keyword, String projection, Integer pageSize, Integer pageNumber,
+                                    String sortBy, String direction, Authentication authentication, AccessLevel accessLevel);
 
     BaseMeta getMetaStudies(String keyword);
 

--- a/service/src/main/java/org/cbioportal/service/impl/ClinicalAttributeServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ClinicalAttributeServiceImpl.java
@@ -27,7 +27,7 @@ public class ClinicalAttributeServiceImpl implements ClinicalAttributeService {
     private String AUTHENTICATE;
 
     @Override
-    @PostFilter("hasPermission(filterObject.cancerStudyIdentifier, 'CancerStudyId', 'read')")
+    @PostFilter("hasPermission(filterObject.cancerStudyIdentifier, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     public List<ClinicalAttribute> getAllClinicalAttributes(String projection, Integer pageSize, Integer pageNumber,
                                                             String sortBy, String direction) {
         

--- a/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularDataServiceImpl.java
@@ -258,7 +258,7 @@ public class MolecularDataServiceImpl implements MolecularDataService {
     }
 
     @Override
-    @PreAuthorize("hasPermission(#molecularProfileIds, 'Collection<MolecularProfileId>', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileIds, 'Collection<MolecularProfileId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     public BaseMeta getMetaMolecularDataInMultipleMolecularProfiles(List<String> molecularProfileIds,
             List<String> sampleIds, List<Integer> entrezGeneIds) {
 

--- a/service/src/main/java/org/cbioportal/service/impl/MolecularProfileServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/MolecularProfileServiceImpl.java
@@ -31,7 +31,7 @@ public class MolecularProfileServiceImpl implements MolecularProfileService {
     private String AUTHENTICATE;
 
     @Override
-    @PostFilter("hasPermission(filterObject, 'read')")
+    @PostFilter("hasPermission(filterObject, T(org.cbioportal.utils.security.AccessLevel).READ)")
     public List<MolecularProfile> getAllMolecularProfiles(String projection, Integer pageSize, Integer pageNumber,
                                                           String sortBy, String direction) {
 

--- a/service/src/main/java/org/cbioportal/service/impl/PatientServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/PatientServiceImpl.java
@@ -26,7 +26,7 @@ public class PatientServiceImpl implements PatientService {
     private String AUTHENTICATE;
 
     @Override
-    @PostFilter("hasPermission(filterObject, 'read')")
+    @PostFilter("hasPermission(filterObject, T(org.cbioportal.utils.security.AccessLevel).READ)")
     public List<Patient> getAllPatients(String keyword, String projection, Integer pageSize, Integer pageNumber,
             String sortBy, String direction) {
         

--- a/service/src/main/java/org/cbioportal/service/impl/ReadPermissionServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ReadPermissionServiceImpl.java
@@ -1,0 +1,31 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.service.ReadPermissionService;
+import org.cbioportal.model.ReadPermission;
+import org.cbioportal.security.CancerStudyPermissionEvaluator;
+import org.cbioportal.utils.security.AccessLevel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+
+@Service
+public class ReadPermissionServiceImpl implements ReadPermissionService {
+
+    // The CancerStudyPermissionEvaluator bean does not exist on portals w/o user-authentication
+    @Autowired(required = false)
+    private CancerStudyPermissionEvaluator cancerStudyPermissionEvaluator;
+
+    @Override
+    public void setReadPermission(Collection<? extends ReadPermission> entities, Authentication authentication) {
+        entities.forEach(s -> {
+            // Add user read-permission to each entity when authentication is used (defaults
+            // to 'true' on portals w/o user-authentication).
+            boolean hasReadPermission = authentication == null || cancerStudyPermissionEvaluator == null ||
+                cancerStudyPermissionEvaluator.hasPermission(authentication, s, AccessLevel.READ);
+            s.setReadPermission(hasReadPermission);
+        });
+    }
+
+}

--- a/service/src/main/java/org/cbioportal/service/impl/SampleListServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleListServiceImpl.java
@@ -29,7 +29,7 @@ public class SampleListServiceImpl implements SampleListService {
     private String AUTHENTICATE;
 
     @Override
-    @PostFilter("hasPermission(filterObject, 'read')")
+    @PostFilter("hasPermission(filterObject, T(org.cbioportal.utils.security.AccessLevel).READ)")
     public List<SampleList> getAllSampleLists(String projection, Integer pageSize, Integer pageNumber, String sortBy,
                                               String direction) {
         

--- a/service/src/main/java/org/cbioportal/service/impl/StudyServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/StudyServiceImpl.java
@@ -6,33 +6,37 @@ import org.cbioportal.model.TypeOfCancer;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.persistence.StudyRepository;
 import org.cbioportal.service.CancerTypeService;
+import org.cbioportal.service.ReadPermissionService;
 import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.utils.security.AccessLevel;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PostFilter;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 
 @Service
 public class StudyServiceImpl implements StudyService {
 
     @Autowired
     private StudyRepository studyRepository;
+    
     @Autowired
     private CancerTypeService cancerTypeService;
-    @Value("${authenticate:false}")
-    private String AUTHENTICATE;
+
+    @Autowired
+    private ReadPermissionService readPermissionService;
 
     @Override
-    @PostFilter("hasPermission(filterObject, 'read')")
+    @PostFilter("hasPermission(filterObject,#accessLevel)")
     public List<CancerStudy> getAllStudies(String keyword, String projection, Integer pageSize, Integer pageNumber,
-                                           String sortBy, String direction) {
+                                           String sortBy, String direction, Authentication authentication, AccessLevel accessLevel) {
 
         List<CancerStudy> allStudies = studyRepository.getAllStudies(keyword, projection, pageSize, pageNumber, sortBy, direction);
         Map<String,CancerStudy> sortedAllStudiesByCancerStudyIdentifier = allStudies.stream().collect(Collectors.toMap(c -> c.getCancerStudyIdentifier(), c -> c, (e1, e2) -> e2, LinkedHashMap::new));
@@ -48,11 +52,18 @@ public class StudyServiceImpl implements StudyService {
                 }
             }
         }
+
         // For authenticated portals it is essential to make a new list, such
         // that @PostFilter does not taint the list stored in the mybatis
         // second-level cache. When making changes to this make sure to copy the
         // allStudies list at least for the AUTHENTICATE.equals("true") case
-        return sortedAllStudiesByCancerStudyIdentifier.values().stream().collect(Collectors.toList());
+        List<CancerStudy> returnedStudyObjects = sortedAllStudiesByCancerStudyIdentifier.values().stream().collect(Collectors.toList());
+        
+        // When using prop. 'skin.home_page.show_unauthorized_studies' this endpoint
+        // returns the full list of studies, some of which can be accessed by the user.
+        readPermissionService.setReadPermission(returnedStudyObjects, authentication);
+        
+        return returnedStudyObjects;
     }
 
     @Override
@@ -62,7 +73,7 @@ public class StudyServiceImpl implements StudyService {
         }
         else {
             BaseMeta baseMeta = new BaseMeta();
-            baseMeta.setTotalCount(getAllStudies(keyword, "SUMMARY", null, null, null, null).size());
+            baseMeta.setTotalCount(getAllStudies(keyword, "SUMMARY", null, null, null, null, null, AccessLevel.READ).size());
             return baseMeta;
         }
     }

--- a/service/src/test/java/org/cbioportal/service/impl/ReadPermissionServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/ReadPermissionServiceImplTest.java
@@ -1,0 +1,69 @@
+package org.cbioportal.service.impl;
+
+import org.cbioportal.model.CancerStudy;
+import org.cbioportal.security.CancerStudyPermissionEvaluator;
+import org.cbioportal.utils.security.AccessLevel;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReadPermissionServiceImplTest {
+
+    @InjectMocks
+    private ReadPermissionServiceImpl readPermissionService;
+
+    @Mock
+    private CancerStudyPermissionEvaluator cancerStudyPermissionEvaluator;
+    
+    Authentication authentication;
+    List<CancerStudy> cancerStudies;
+    
+    @Before
+    public void init() {
+        CancerStudy cancerStudy1 = new CancerStudy();
+        CancerStudy cancerStudy2 = new CancerStudy();
+        cancerStudies = new ArrayList<>();
+        cancerStudies.add(cancerStudy1);
+        cancerStudies.add(cancerStudy2);
+        authentication = mock(Authentication.class);
+        when(cancerStudyPermissionEvaluator.hasPermission(any(), any(), eq(AccessLevel.READ))).thenReturn(false, true);
+    }
+    
+    @Test
+    public void setReadPermissionSuccess() {
+        readPermissionService.setReadPermission(cancerStudies, authentication);
+        Assert.assertFalse(cancerStudies.get(0).getReadPermission());
+        Assert.assertTrue(cancerStudies.get(1).getReadPermission());
+    }
+    
+    @Test
+    public void setReadPermissionUnAuthenticatedPortal() {
+        ReflectionTestUtils.setField(readPermissionService, "cancerStudyPermissionEvaluator", null);
+        readPermissionService.setReadPermission(cancerStudies, authentication);
+        Assert.assertTrue(cancerStudies.get(0).getReadPermission());
+        Assert.assertTrue(cancerStudies.get(1).getReadPermission());
+        ReflectionTestUtils.setField(readPermissionService, "cancerStudyPermissionEvaluator", cancerStudyPermissionEvaluator);
+    }
+    
+    @Test
+    public void setReadPermissionNoAuthObject() {
+        readPermissionService.setReadPermission(cancerStudies, null);
+        Assert.assertTrue(cancerStudies.get(0).getReadPermission());
+        Assert.assertTrue(cancerStudies.get(1).getReadPermission());
+    }
+}

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -90,6 +90,10 @@ skin.study_view.link_text=To build your own case set, try out our enhanced Study
 # controls the appearance the logout button on a portal with user authentication
 # skin.hide_logout_button=false
 
+# setting controlling the home page
+## enable this to show studies for which the user does not have permission (will appear greyed out and cannot be analyzed in study view or results view). 
+# skin.home_page.show_unauthorized_studies=false
+
 ## enable and set this property to specify a study group to be used to identify public studies for which no specific authorization entries are needed in the `authorities` table
 # always_show_study_group=
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -15,12 +15,10 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/utils/src/main/java/org/cbioportal/utils/security/AccessLevel.java
+++ b/utils/src/main/java/org/cbioportal/utils/security/AccessLevel.java
@@ -1,0 +1,5 @@
+package org.cbioportal.utils.security;
+
+public enum AccessLevel {
+    READ, LIST
+}

--- a/web/src/main/java/org/cbioportal/web/AlterationDriverAnnotationController.java
+++ b/web/src/main/java/org/cbioportal/web/AlterationDriverAnnotationController.java
@@ -27,7 +27,7 @@ public class AlterationDriverAnnotationController {
     @Autowired
     private AlterationDriverAnnotationService alterationDriverAnnotationService;
 
-    @PreAuthorize("hasPermission(#molecularProfileIds, 'Collection<MolecularProfileId>', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileIds, 'Collection<MolecularProfileId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @PostMapping(value = "/custom-driver-annotation-report/fetch",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/AlterationEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/AlterationEnrichmentController.java
@@ -30,7 +30,7 @@ public class AlterationEnrichmentController {
     @Autowired
     private AlterationEnrichmentService alterationEnrichmentService;
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @PostMapping(value = "/alteration-enrichments/fetch",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/ClinicalAttributeController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalAttributeController.java
@@ -77,7 +77,7 @@ public class ClinicalAttributeController {
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/clinical-attributes", method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all clinical attributes in the specified study")
@@ -111,7 +111,7 @@ public class ClinicalAttributeController {
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/clinical-attributes/{clinicalAttributeId}", method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get specified clinical attribute")
@@ -126,7 +126,7 @@ public class ClinicalAttributeController {
                 HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/clinical-attributes/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical attributes")

--- a/web/src/main/java/org/cbioportal/web/ClinicalAttributeCountController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalAttributeCountController.java
@@ -47,7 +47,7 @@ public class ClinicalAttributeCountController {
     @Autowired
     private ClinicalAttributeService clinicalAttributeService;
  
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/clinical-attributes/counts/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
                     produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get counts for clinical attributes according to their data availability for selected samples/patients")

--- a/web/src/main/java/org/cbioportal/web/ClinicalDataController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalDataController.java
@@ -51,7 +51,7 @@ public class ClinicalDataController {
     @Autowired
     private ClinicalDataService clinicalDataService;
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/samples/{sampleId}/clinical-data", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all clinical data of a sample in a study")
@@ -90,7 +90,7 @@ public class ClinicalDataController {
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/patients/{patientId}/clinical-data", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all clinical data of a patient in a study")
@@ -129,7 +129,7 @@ public class ClinicalDataController {
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/clinical-data", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all clinical data in a study")
@@ -167,7 +167,7 @@ public class ClinicalDataController {
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/clinical-data/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical data by patient IDs or sample IDs (specific study)")
@@ -195,7 +195,7 @@ public class ClinicalDataController {
         }
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/clinical-data/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical data by patient IDs or sample IDs (all studies)")

--- a/web/src/main/java/org/cbioportal/web/ClinicalDataEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalDataEnrichmentController.java
@@ -52,7 +52,7 @@ public class ClinicalDataEnrichmentController {
     @Autowired
     private SampleService sampleService;
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/clinical-data-enrichments/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical data enrichments for the sample groups")
     public ResponseEntity<List<ClinicalDataEnrichment>> fetchClinicalEnrichments(

--- a/web/src/main/java/org/cbioportal/web/ClinicalEventController.java
+++ b/web/src/main/java/org/cbioportal/web/ClinicalEventController.java
@@ -40,7 +40,7 @@ public class ClinicalEventController {
     @Autowired
     private ClinicalEventService clinicalEventService;
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/patients/{patientId}/clinical-events", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all clinical events of a patient in a study")
@@ -77,7 +77,7 @@ public class ClinicalEventController {
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/clinical-events", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all clinical events in a study")

--- a/web/src/main/java/org/cbioportal/web/CoExpressionController.java
+++ b/web/src/main/java/org/cbioportal/web/CoExpressionController.java
@@ -33,7 +33,7 @@ public class CoExpressionController {
     private CoExpressionService coExpressionService;
 
     // requires permission to access both molecularProfileIdA and molecularProfileIdB because service layer does not enforce requirement that both profiles are in the same study
-    @PreAuthorize("hasPermission(#molecularProfileIdA, 'MolecularProfileId', 'read') and hasPermission(#molecularProfileIdB, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileIdA, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ) and hasPermission(#molecularProfileIdB, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/co-expressions/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/CopyNumberSegmentController.java
+++ b/web/src/main/java/org/cbioportal/web/CopyNumberSegmentController.java
@@ -48,7 +48,7 @@ public class CopyNumberSegmentController {
     @Autowired
     private CopyNumberSegmentService copyNumberSegmentService;
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/samples/{sampleId}/copy-number-segments", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get copy number segments in a sample in a study")
@@ -87,7 +87,7 @@ public class CopyNumberSegmentController {
         }
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/copy-number-segments/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch copy number segments by sample ID")

--- a/web/src/main/java/org/cbioportal/web/DiscreteCopyNumberController.java
+++ b/web/src/main/java/org/cbioportal/web/DiscreteCopyNumberController.java
@@ -43,7 +43,7 @@ public class DiscreteCopyNumberController {
     @Autowired
     private DiscreteCopyNumberService discreteCopyNumberService;
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/discrete-copy-number", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get discrete copy number alterations in a molecular profile")
@@ -71,7 +71,7 @@ public class DiscreteCopyNumberController {
         }
     }
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/discrete-copy-number/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/DiscreteCopyNumberCountController.java
+++ b/web/src/main/java/org/cbioportal/web/DiscreteCopyNumberCountController.java
@@ -45,7 +45,7 @@ public class DiscreteCopyNumberCountController {
     @Autowired
     private DiscreteCopyNumberService discreteCopyNumberService;
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/discrete-copy-number-counts/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/ExpressionEnrichmentController.java
+++ b/web/src/main/java/org/cbioportal/web/ExpressionEnrichmentController.java
@@ -36,7 +36,7 @@ public class ExpressionEnrichmentController {
     @Autowired
     private ExpressionEnrichmentService expressionEnrichmentService;
     
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/expression-enrichments/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
@@ -56,7 +56,7 @@ public class ExpressionEnrichmentController {
                 HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/generic-assay-enrichments/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/GenePanelController.java
+++ b/web/src/main/java/org/cbioportal/web/GenePanelController.java
@@ -99,7 +99,7 @@ public class GenePanelController {
         return new ResponseEntity<>(genePanelService.fetchGenePanels(genePanelIds, projection.name()), HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/gene-panel-data/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get gene panel data")
@@ -121,7 +121,7 @@ public class GenePanelController {
         return new ResponseEntity<>(genePanelDataList, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/gene-panel-data/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch gene panel data")

--- a/web/src/main/java/org/cbioportal/web/GenericAssayController.java
+++ b/web/src/main/java/org/cbioportal/web/GenericAssayController.java
@@ -50,7 +50,7 @@ public class GenericAssayController {
     @Autowired
     private GenericAssayService genericAssayService;
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/generic_assay_meta/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch meta data for generic-assay by ID")
@@ -75,7 +75,7 @@ public class GenericAssayController {
             return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/generic_assay_data/{molecularProfileId}/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
@@ -106,7 +106,7 @@ public class GenericAssayController {
         }
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/generic_assay_data/fetch", method = RequestMethod.POST,
     consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch generic_assay_data")

--- a/web/src/main/java/org/cbioportal/web/GenesetCorrelationController.java
+++ b/web/src/main/java/org/cbioportal/web/GenesetCorrelationController.java
@@ -60,7 +60,7 @@ public class GenesetCorrelationController {
     @Autowired
     private GenesetCorrelationService genesetCorrelationService;
 
-    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfileId', 'read')")
+    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/genesets/{genesetId}/expression-correlation/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get the genes in a gene set that have expression correlated to the gene set scores (calculated using Spearman's correlation)")

--- a/web/src/main/java/org/cbioportal/web/GenesetDataController.java
+++ b/web/src/main/java/org/cbioportal/web/GenesetDataController.java
@@ -34,7 +34,7 @@ public class GenesetDataController {
     @Autowired
     private GenesetDataService genesetDataService;
 
-    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfileId', 'read')")
+    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/genetic-profiles/{geneticProfileId}/geneset-genetic-data/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch gene set \"genetic data\" items (gene set scores) by profile Id, gene set ids and sample ids")

--- a/web/src/main/java/org/cbioportal/web/GenesetHierarchyController.java
+++ b/web/src/main/java/org/cbioportal/web/GenesetHierarchyController.java
@@ -58,7 +58,7 @@ public class GenesetHierarchyController {
     @Autowired
     private GenesetHierarchyService genesetHierarchyService;
 
-    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfileId', 'read')")
+    @PreAuthorize("hasPermission(#geneticProfileId, 'GeneticProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/geneset-hierarchy/fetch", method = RequestMethod.POST,
             consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get gene set hierarchical organization information. I.e. how different gene sets relate to other gene sets, in a hierarchy")

--- a/web/src/main/java/org/cbioportal/web/MolecularDataController.java
+++ b/web/src/main/java/org/cbioportal/web/MolecularDataController.java
@@ -44,7 +44,7 @@ public class MolecularDataController {
     @Autowired
     private MolecularDataService molecularDataService;
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/molecular-data", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all molecular data in a molecular profile")
@@ -70,7 +70,7 @@ public class MolecularDataController {
         }
     }
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/molecular-data/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
@@ -101,7 +101,7 @@ public class MolecularDataController {
         }
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-data/fetch", method = RequestMethod.POST,
     consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch molecular data")

--- a/web/src/main/java/org/cbioportal/web/MolecularProfileController.java
+++ b/web/src/main/java/org/cbioportal/web/MolecularProfileController.java
@@ -76,7 +76,7 @@ public class MolecularProfileController {
         }
     }
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get molecular profile")
@@ -87,7 +87,7 @@ public class MolecularProfileController {
         return new ResponseEntity<>(molecularProfileService.getMolecularProfile(molecularProfileId), HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/molecular-profiles", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all molecular profiles in a study")
@@ -120,7 +120,7 @@ public class MolecularProfileController {
         }
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch molecular profiles")

--- a/web/src/main/java/org/cbioportal/web/MrnaPercentileController.java
+++ b/web/src/main/java/org/cbioportal/web/MrnaPercentileController.java
@@ -33,7 +33,7 @@ public class MrnaPercentileController {
     @Autowired
     private MrnaPercentileService mrnaPercentileService;
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mrna-percentile/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/MutationController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationController.java
@@ -50,7 +50,7 @@ public class MutationController {
     @Autowired
     private MutationService mutationService;
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mutations", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get mutations in a molecular profile by Sample List ID")
@@ -90,7 +90,7 @@ public class MutationController {
         }
     }
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mutations/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch mutations in a molecular profile")
@@ -143,7 +143,7 @@ public class MutationController {
         }
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/mutations/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch mutations in multiple molecular profiles by sample IDs")

--- a/web/src/main/java/org/cbioportal/web/MutationSpectrumController.java
+++ b/web/src/main/java/org/cbioportal/web/MutationSpectrumController.java
@@ -32,7 +32,7 @@ public class MutationSpectrumController {
     @Autowired
     private MutationSpectrumService mutationSpectrumService;
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/mutation-spectrums/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/PatientController.java
+++ b/web/src/main/java/org/cbioportal/web/PatientController.java
@@ -77,7 +77,7 @@ public class PatientController {
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/patients", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all patients in a study")
@@ -110,7 +110,7 @@ public class PatientController {
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/patients/{patientId}", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get a patient in a study")
@@ -123,7 +123,7 @@ public class PatientController {
         return new ResponseEntity<>(patientService.getPatientInStudy(studyId, patientId), HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/patients/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<Patient>> fetchPatients(

--- a/web/src/main/java/org/cbioportal/web/ResourceDataController.java
+++ b/web/src/main/java/org/cbioportal/web/ResourceDataController.java
@@ -38,7 +38,7 @@ public class ResourceDataController {
     @Autowired
     private ResourceDataService resourceDataService;
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/samples/{sampleId}/resource-data", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all resource data of a sample in a study")
@@ -74,7 +74,7 @@ public class ResourceDataController {
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/patients/{patientId}/resource-data", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all resource data of a patient in a study")
@@ -110,7 +110,7 @@ public class ResourceDataController {
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/resource-data", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all resource data for a study")

--- a/web/src/main/java/org/cbioportal/web/ResourceDefinitionController.java
+++ b/web/src/main/java/org/cbioportal/web/ResourceDefinitionController.java
@@ -33,7 +33,7 @@ public class ResourceDefinitionController {
     @Autowired
     private ResourceDefinitionService resourceDefinitionService;
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/resource-definitions", method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all resource definitions in the specified study")
@@ -64,7 +64,7 @@ public class ResourceDefinitionController {
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/resource-definitions/{resourceId}", method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get specified resource definition")
@@ -79,7 +79,7 @@ public class ResourceDefinitionController {
                 HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/resource-definitions/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all resource definitions for specified studies")

--- a/web/src/main/java/org/cbioportal/web/SampleController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleController.java
@@ -11,6 +11,7 @@ import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.cbioportal.service.SampleService;
+import org.cbioportal.utils.security.AccessLevel;
 import org.cbioportal.utils.security.PortalSecurityConfig;
 import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
@@ -100,7 +101,9 @@ public class SampleController {
                     PagingConstants.MAX_PAGE_SIZE,
                     0,
                     null,
-                    direction.name()
+                    direction.name(),
+                    null,
+                    AccessLevel.READ
                 )
                 .stream()
                 .map(CancerStudy::getCancerStudyIdentifier)
@@ -120,7 +123,7 @@ public class SampleController {
         );
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/samples", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all samples in a study")
@@ -153,7 +156,7 @@ public class SampleController {
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/samples/{sampleId}", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get a sample in a study")
@@ -166,7 +169,7 @@ public class SampleController {
         return new ResponseEntity<>(sampleService.getSampleInStudy(studyId, sampleId), HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/patients/{patientId}/samples", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all samples of a patient in a study")
@@ -202,7 +205,7 @@ public class SampleController {
         }
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/samples/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch samples by ID")

--- a/web/src/main/java/org/cbioportal/web/SampleListController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleListController.java
@@ -72,7 +72,7 @@ public class SampleListController {
         }
     }
 
-    @PreAuthorize("hasPermission(#sampleListId, 'SampleListId', 'read')")
+    @PreAuthorize("hasPermission(#sampleListId, 'SampleListId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/sample-lists/{sampleListId}", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get sample list")
@@ -83,7 +83,7 @@ public class SampleListController {
         return new ResponseEntity<>(sampleListService.getSampleList(sampleListId), HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/sample-lists", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all sample lists in a study")
@@ -116,7 +116,7 @@ public class SampleListController {
         }
     }
 
-    @PreAuthorize("hasPermission(#sampleListId, 'SampleListId', 'read')")
+    @PreAuthorize("hasPermission(#sampleListId, 'SampleListId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/sample-lists/{sampleListId}/sample-ids", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all sample IDs in a sample list")
@@ -127,7 +127,7 @@ public class SampleListController {
         return new ResponseEntity<>(sampleListService.getAllSampleIdsInSampleList(sampleListId), HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#sampleListIds, 'Collection<SampleListId>', 'read')")
+    @PreAuthorize("hasPermission(#sampleListIds, 'Collection<SampleListId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/sample-lists/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
     produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch sample lists by ID")

--- a/web/src/main/java/org/cbioportal/web/SignificantCopyNumberRegionController.java
+++ b/web/src/main/java/org/cbioportal/web/SignificantCopyNumberRegionController.java
@@ -38,7 +38,7 @@ public class SignificantCopyNumberRegionController {
     @Autowired
     private SignificantCopyNumberRegionService significantCopyNumberRegionService;
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/significant-copy-number-regions", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get significant copy number alteration regions in a study")

--- a/web/src/main/java/org/cbioportal/web/SignificantlyMutatedGenesController.java
+++ b/web/src/main/java/org/cbioportal/web/SignificantlyMutatedGenesController.java
@@ -38,7 +38,7 @@ public class SignificantlyMutatedGenesController {
     @Autowired
     private SignificantlyMutatedGeneService significantlyMutatedGeneService;
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/significantly-mutated-genes", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get significantly mutated genes in a study")

--- a/web/src/main/java/org/cbioportal/web/StructuralVariantController.java
+++ b/web/src/main/java/org/cbioportal/web/StructuralVariantController.java
@@ -57,7 +57,7 @@ public class StructuralVariantController {
     @Autowired
     private StructuralVariantService structuralVariantService;
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/structural-variant/fetch", method = RequestMethod.POST,
             consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch structural variants for entrezGeneIds and molecularProfileIds or sampleMolecularIdentifiers")

--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -7,6 +7,7 @@ import org.cbioportal.model.CancerStudy;
 import org.cbioportal.model.CancerStudyTags;
 import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.utils.security.AccessLevel;
 import org.cbioportal.utils.security.PortalSecurityConfig;
 import org.cbioportal.web.config.PublicApiTags;
 import org.cbioportal.web.config.annotation.PublicApi;
@@ -21,6 +22,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -57,6 +59,9 @@ public class StudyController {
     @Value("${authenticate}")
     private String authenticate;
 
+    @Value("${skin.home_page.show_unauthorized_studies:false}")
+    private boolean showUnauthorizedStudiesOnHomePage;
+
     @Autowired
     private StudyService studyService;
     
@@ -72,7 +77,7 @@ public class StudyController {
             defaultResponse = studyService.getAllStudies(
                 null, Projection.SUMMARY.name(),
                 10000000, 0,
-                null, Direction.ASC.name());
+                null, Direction.ASC.name(), null,AccessLevel.READ);
         }
     }
 
@@ -93,7 +98,8 @@ public class StudyController {
         @ApiParam("Name of the property that the result list is sorted by")
         @RequestParam(required = false) StudySortBy sortBy,
         @ApiParam("Direction of the sort")
-        @RequestParam(defaultValue = "ASC") Direction direction) {
+        @RequestParam(defaultValue = "ASC") Direction direction,
+        Authentication authentication) {
         
         // Only use this feature on the public portal and make sure it is never used
         // on portals using auth, as in auth setting, different users will have different
@@ -117,11 +123,11 @@ public class StudyController {
         } else {
             return new ResponseEntity<>(
                 studyService.getAllStudies(keyword, projection.name(), pageSize, pageNumber,
-                    sortBy == null ? null : sortBy.getOriginalValue(), direction.name()), HttpStatus.OK);
+                    sortBy == null ? null : sortBy.getOriginalValue(), direction.name(), authentication, getAccessLevel()), HttpStatus.OK);
         }
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get a study")
@@ -132,7 +138,7 @@ public class StudyController {
         return new ResponseEntity<>(studyService.getStudy(studyId), HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
     produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch studies by IDs")
@@ -155,7 +161,7 @@ public class StudyController {
 
     }
 
-    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', 'read')")
+    @PreAuthorize("hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/{studyId}/tags", method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get the tags of a study")
@@ -174,7 +180,7 @@ public class StudyController {
         return new ResponseEntity<>(map, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/tags/fetch", method = RequestMethod.POST,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get the study tags by IDs")
@@ -185,5 +191,10 @@ public class StudyController {
         List<CancerStudyTags> cancerStudyTags = studyService.getTagsForMultipleStudies(studyIds);
 
         return new ResponseEntity<>(cancerStudyTags, HttpStatus.OK);
+    }
+    
+    private AccessLevel getAccessLevel() {
+        return PortalSecurityConfig.userAuthorizationEnabled(authenticate)
+            && showUnauthorizedStudiesOnHomePage ? AccessLevel.LIST : AccessLevel.READ;
     }
 }

--- a/web/src/main/java/org/cbioportal/web/StudyViewController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyViewController.java
@@ -78,7 +78,7 @@ public class StudyViewController {
     @Autowired
     private MolecularProfileService molecularProfileService;
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/clinical-data-counts/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical data counts by study view filter")
@@ -110,7 +110,7 @@ public class StudyViewController {
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/clinical-data-bin-counts/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical data bin counts by study view filter")
@@ -149,7 +149,7 @@ public class StudyViewController {
         );
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/mutated-genes/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch mutated genes by study view filter")
@@ -175,7 +175,7 @@ public class StudyViewController {
         return new ResponseEntity<>(alterationCountByGenes, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/structuralvariant-genes/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch structural variant genes by study view filter")
@@ -202,7 +202,7 @@ public class StudyViewController {
     }
 
     
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/cna-genes/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch CNA genes by study view filter")
@@ -228,7 +228,7 @@ public class StudyViewController {
         return new ResponseEntity<>(copyNumberCountByGenes, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/filtered-samples/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch sample IDs by study view filter")
@@ -255,7 +255,7 @@ public class StudyViewController {
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profile-sample-counts/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch sample counts by study view filter")
@@ -293,7 +293,7 @@ public class StudyViewController {
         return Double.parseDouble(c.getAttrValue());
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/clinical-data-density-plot/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch clinical data density plot bins by study view filter")
@@ -496,7 +496,7 @@ public class StudyViewController {
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/sample-lists-counts/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch case list sample counts by study view filter")
@@ -554,7 +554,7 @@ public class StudyViewController {
 
     }
     
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/genomic-data-bin-counts/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch genomic data bin counts by study view filter")
     public ResponseEntity<List<GenomicDataBin>> fetchGenomicDataBinCounts(
@@ -569,7 +569,7 @@ public class StudyViewController {
         return new ResponseEntity<>(studyViewFilterApplier.getDataBins(dataBinMethod, interceptedGenomicDataBinCountFilter), HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/generic-assay-data-counts/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch generic assay data counts by study view filter")
     public ResponseEntity<List<GenericAssayDataCountItem>> fetchGenericAssayDataCounts(
@@ -607,7 +607,7 @@ public class StudyViewController {
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/generic-assay-data-bin-counts/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch generic assay data bin counts by study view filter")
     public ResponseEntity<List<GenericAssayDataBin>> fetchGenericAssayDataBinCounts(

--- a/web/src/main/java/org/cbioportal/web/TreatmentController.java
+++ b/web/src/main/java/org/cbioportal/web/TreatmentController.java
@@ -39,7 +39,7 @@ public class TreatmentController {
     @Autowired
     private StudyViewFilterApplier studyViewFilterApplier;
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/treatments/patient", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all patient level treatments")
     public ResponseEntity<List<PatientTreatmentRow>> getAllPatientTreatments(
@@ -67,7 +67,7 @@ public class TreatmentController {
     }
 
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/treatments/sample", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get all sample level treatments")
     public ResponseEntity<List<SampleTreatmentRow>> getAllSampleTreatments(
@@ -94,7 +94,7 @@ public class TreatmentController {
         return new ResponseEntity<>(treatments, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/treatments/display-patient", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Should patient level treatments be displayed")
     public ResponseEntity<Boolean> getContainsTreatmentData(
@@ -107,7 +107,7 @@ public class TreatmentController {
         return new ResponseEntity<>(containsTreatmentData, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/treatments/display-sample", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Should sample level treatments be displayed")
     public ResponseEntity<Boolean> getContainsSampleTreatmentData(

--- a/web/src/main/java/org/cbioportal/web/VariantCountController.java
+++ b/web/src/main/java/org/cbioportal/web/VariantCountController.java
@@ -35,7 +35,7 @@ public class VariantCountController {
     @Autowired
     private VariantCountService variantCountService;
 
-    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', 'read')")
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/molecular-profiles/{molecularProfileId}/variant-counts/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)

--- a/web/src/main/java/org/cbioportal/web/studyview/CustomDataController.java
+++ b/web/src/main/java/org/cbioportal/web/studyview/CustomDataController.java
@@ -56,7 +56,7 @@ public class CustomDataController {
     @Autowired
     private PatientService patientService;
 
-    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', 'read')")
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/custom-data-counts/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch custom data counts by study view filter")
     public ResponseEntity<List<ClinicalDataCountItem>> fetchCustomDataCounts(

--- a/web/src/test/java/org/cbioportal/web/StudyControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StudyControllerTest.java
@@ -6,6 +6,7 @@ import org.cbioportal.model.TypeOfCancer;
 import org.cbioportal.model.meta.BaseMeta;
 import org.cbioportal.service.StudyService;
 import org.cbioportal.service.exception.StudyNotFoundException;
+import org.cbioportal.utils.security.AccessLevel;
 import org.cbioportal.web.parameter.HeaderKeyConstants;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -19,6 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -31,6 +33,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.TimeZone;
+
+import static org.mockito.ArgumentMatchers.eq;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
@@ -73,6 +77,9 @@ public class StudyControllerTest {
 
     @Autowired
     private StudyService studyService;
+    
+    @Autowired
+    private StudyController studyController;
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -96,7 +103,7 @@ public class StudyControllerTest {
         List<CancerStudy> cancerStudyList = createExampleStudies();
 
         Mockito.when(studyService.getAllStudies(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-                Mockito.any(), Mockito.any())).thenReturn(cancerStudyList);
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(cancerStudyList);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/studies")
                 .accept(MediaType.APPLICATION_JSON))
@@ -128,6 +135,35 @@ public class StudyControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].status").value(TEST_STATUS_2))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[1].cancerTypeId").value(TEST_TYPE_OF_CANCER_ID_2));
 
+    }
+
+    @Test
+    public void getAllStudiesSetAccessLevelReadIsDefault() throws Exception {
+
+        AccessLevel expectedAccessLevel = AccessLevel.READ;
+        Mockito.when(studyService.getAllStudies(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), eq(expectedAccessLevel))).thenReturn(new ArrayList<>());
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/studies")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+    }
+
+    @Test
+    public void getAllStudiesSetAccessLevelListConditionally() throws Exception {
+
+        ReflectionTestUtils.setField(studyController, "showUnauthorizedStudiesOnHomePage", true);
+        
+        AccessLevel expectedAccessLevel = AccessLevel.LIST;
+        Mockito.when(studyService.getAllStudies(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), eq(expectedAccessLevel))).thenReturn(new ArrayList<>());
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/studies")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        ReflectionTestUtils.setField(studyController, "showUnauthorizedStudiesOnHomePage", false);
     }
 
     @Test


### PR DESCRIPTION
# Description
[RFC59](https://docs.google.com/document/d/1NkNhBG1sk0ZvCOwk3XtiuRT9a_tKkFCgXC9I3XT-Ye4/edit#heading=h.q104c5krmron) describes the feature where depending on the `skin.home_page.show_unauthorized_studies` property in _portal.properties_ cBioPortal home page shows studies that the user does not have read permissions for (a.k.a. unauthorized studies). This PR includes the backend changes for this feature.

This PR will:
1. Implement the _list_ permission level in the CancerStudyPermissionEvaluator.
2. Update the PostFilter call in CancerStudyServiceImpl to pass 'read' or 'list' permission level.
3. Add a new field _readPermission_ to the CancerStudy model.
4. Make CancerStudyServiceImpl set the field _readPermission_ on CancerStudy objects.
5. Move the CancerStudyPermissionEvaluator to new _security/permission-evaluator_ module (since used by both _security-spring_ and _service_ modules).
6. Implement _skin.home_page.show_unauthorized_studies_ param in _portal.properties_ (includes documentation)

# Tests
- Tests are included for the StudyController to pass the correct permisssion level to the service.
- Tests are included for the CancerStudyServiceImpl to set the _hasReadPermission_ member of CancerStudy objects. 