### PR TITLE
Update fetchGenericAssayDataCounts endpoint

### DIFF
--- a/web/src/main/java/org/cbioportal/web/StudyViewController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyViewController.java
@@ -508,6 +508,12 @@ public class StudyViewController {
 
         List<GenericAssayDataFilter> gaFilters = interceptedGenericAssayDataCountFilter.getGenericAssayDataFilters();
         StudyViewFilter studyViewFilter = interceptedGenericAssayDataCountFilter.getStudyViewFilter();
+        // when there is only one filter, it means study view is doing a single chart filter operation
+        // remove filter from studyViewFilter to return all data counts
+        // the reason we do this is to make sure after chart get filtered, user can still see unselected portion of the chart
+        if (gaFilters.size() == 1) {
+            studyViewFilterUtil.removeSelfFromGenericAssayFilter(gaFilters.get(0).getStableId(), studyViewFilter);
+        }
         List<SampleIdentifier> filteredSampleIdentifiers = studyViewFilterApplier.apply(studyViewFilter);
 
         if (filteredSampleIdentifiers.isEmpty()) {

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
@@ -36,6 +36,11 @@ public class StudyViewFilterUtil {
         }
     }
 
+    public void removeSelfFromGenericAssayFilter(String stableId, StudyViewFilter studyViewFilter) {
+        if (studyViewFilter!= null && studyViewFilter.getGenericAssayDataFilters() != null) {
+            studyViewFilter.getGenericAssayDataFilters().removeIf(f -> f.getStableId().equals(stableId));
+        }
+    }
 
     public void removeSelfCustomDataFromFilter(String attributeId, StudyViewFilter studyViewFilter) {
         if (studyViewFilter!= null && studyViewFilter.getCustomDataFilters() != null) {


### PR DESCRIPTION
Update `/generic-assay-data-counts/fetch` endpoint to correct data count for single chart filtering operation

In the study view page, we fetch single chart for calling `/generic-assay-data-counts/fetch` again, and at this time, we do not want to get filtered data count from that endpoint. We want to get original data count without filtering, because we want to show unselected portion of the chart, this change it to update this logic.

Note: this endpoint is in development, there is no frontend usage right now.