### PR TITLE
Fix logging bug introduced by session service upgrade

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -15,10 +15,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
             <version>${spring.version}</version>
         </dependency>
         <dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -91,6 +91,12 @@
         <groupId>com.github.cbioportal</groupId>
         <artifactId>session-service</artifactId>
         <classifier>model</classifier>
+        <exclusions>
+            <exclusion>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
A transitive dependency of the session service caused DEBUG log messages to show for the `web` module. This PR corrects that and suppresses log messages.