### PR TITLE
Correct cache-assignment in Repository calls

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/AlterationDriverAnnotationRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/AlterationDriverAnnotationRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface AlterationDriverAnnotationRepository {
 
-    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<AlterationDriverAnnotation> getAlterationDriverAnnotations(List<String> molecularProfileCaseIdentifiers);
 
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/DiscreteCopyNumberRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/DiscreteCopyNumberRepository.java
@@ -39,7 +39,7 @@ public interface DiscreteCopyNumberRepository {
                                                                                    String projection);
 
 
-    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
                                                                                                 List<String> sampleIds,
                                                                                                 List<GeneFilterQuery> geneFilterQuery,

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/MutationRepository.java
@@ -27,7 +27,7 @@ public interface MutationRepository {
                                                            Integer pageSize, Integer pageNumber,
                                                            String sortBy, String direction);
 
-    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<Mutation> getMutationsInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
                                                                       List<String> sampleIds,
                                                                       List<GeneFilterQuery> geneQueries,
@@ -61,7 +61,7 @@ public interface MutationRepository {
                                                          List<Integer> entrezGeneIds, String projection, Integer pageSize, Integer pageNumber, String sortBy,
                                                          String direction);
 
-    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<Mutation> getFusionsInMultipleMolecularProfilesByGeneQueries(List<String> molecularProfileIds,
                                                                       List<String> sampleIds,
                                                                       List<GeneFilterQuery> geneQueries,

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/StructuralVariantRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/StructuralVariantRepository.java
@@ -8,12 +8,12 @@ import org.springframework.cache.annotation.Cacheable;
 
 public interface StructuralVariantRepository {
 
-    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<StructuralVariant> fetchStructuralVariants(List<String> molecularProfileIds,
                                                     List<String> sampleIds,
                                                     List<Integer> entrezGeneIds);
 
-    @Cacheable(cacheNames = "GeneralRepositoryCache", condition = "@cacheEnabledConfig.getEnabled()")
+    @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<StructuralVariant> fetchStructuralVariantsByGeneQueries(List<String> molecularProfileIds,
                                                                  List<String> sampleIds,
                                                                  List<GeneFilterQuery> geneQueries);


### PR DESCRIPTION
# Problem
At several places @Cacheable annotations point to non-existing cache names.

# Solution
This PR will correct @Cacheable annotations to reference _cacheResolvers_ as used at all other placed in the code.