### PR TITLE
Fix error for fetching data from multiple studies in categorical Generic Assay study view chart 

### DIFF
--- a/service/src/main/java/org/cbioportal/service/StudyViewService.java
+++ b/service/src/main/java/org/cbioportal/service/StudyViewService.java
@@ -19,5 +19,5 @@ public interface StudyViewService {
     List<CopyNumberCountByGene> getCNAAlterationCountByGenes(List<String> studyIds, List<String> sampleIds, AlterationFilter annotationFilter)
         throws StudyNotFoundException;
 
-    List<GenericAssayDataCountItem> fetchGenericAssayDataCounts(List<String> molecularProfileIds, List<String> sampleIds, List<String> stableIds) throws MolecularProfileNotFoundException;
+    List<GenericAssayDataCountItem> fetchGenericAssayDataCounts(List<String> sampleIds, List<String> studyIds, List<String> stableIds, List<String> profileTypes);
 }

--- a/service/src/test/java/org/cbioportal/service/impl/StudyViewServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/StudyViewServiceImplTest.java
@@ -259,8 +259,10 @@ public class StudyViewServiceImplTest extends BaseServiceImplTest {
     public void fetchGenericAssayDataCounts() throws Exception {
 
         List<String> stableIds = Arrays.asList(BaseServiceImplTest.STABLE_ID_1, BaseServiceImplTest.STABLE_ID_2);
-        List<String> molecularProfileIds = Arrays.asList(BaseServiceImplTest.MOLECULAR_PROFILE_ID);
+        List<String> molecularProfileIds = Collections.nCopies(3, BaseServiceImplTest.STUDY_ID + "_" + BaseServiceImplTest.MOLECULAR_PROFILE_ID_A);
         List<String> sampleIds = Arrays.asList(BaseServiceImplTest.SAMPLE_ID1, BaseServiceImplTest.SAMPLE_ID2, BaseServiceImplTest.SAMPLE_ID3);
+        List<String> studyIds = Collections.nCopies(3, BaseServiceImplTest.STUDY_ID);
+        List<String> profileTypes = Arrays.asList(BaseServiceImplTest.MOLECULAR_PROFILE_ID_A);
 
         List<GenericAssayData> gaDataList = new ArrayList<>();
         GenericAssayData gaData1 = new GenericAssayData();
@@ -302,6 +304,15 @@ public class StudyViewServiceImplTest extends BaseServiceImplTest {
         Mockito.when(genericAssayService.fetchGenericAssayData(molecularProfileIds, sampleIds, stableIds, "SUMMARY"))
             .thenReturn(gaDataList);
 
+        List<MolecularProfile> molecularProfiles = new ArrayList<>();
+        MolecularProfile molecularProfile = new MolecularProfile();
+        molecularProfile.setCancerStudyIdentifier(BaseServiceImplTest.STUDY_ID);
+        molecularProfile.setStableId(BaseServiceImplTest.STUDY_ID + "_" + BaseServiceImplTest.MOLECULAR_PROFILE_ID_A);
+        molecularProfiles.add(molecularProfile);
+        
+        Mockito.when(molecularProfileService.getMolecularProfilesInStudies(studyIds, "SUMMARY"))
+            .thenReturn(molecularProfiles);
+
         List<GenericAssayDataCountItem> expectedCountItems = new ArrayList<>();
         GenericAssayDataCountItem countItem1 = new GenericAssayDataCountItem();
         countItem1.setStableId(BaseServiceImplTest.STABLE_ID_1);
@@ -325,7 +336,7 @@ public class StudyViewServiceImplTest extends BaseServiceImplTest {
         countItem2.setCounts(Arrays.asList(count3, count4));
         expectedCountItems.add(countItem2);
         
-        List<GenericAssayDataCountItem> result = studyViewService.fetchGenericAssayDataCounts(molecularProfileIds, sampleIds, stableIds);
+        List<GenericAssayDataCountItem> result = studyViewService.fetchGenericAssayDataCounts(sampleIds, studyIds, stableIds, profileTypes);
 
         Assert.assertEquals(2, result.size());
 

--- a/web/src/main/java/org/cbioportal/web/StudyViewController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyViewController.java
@@ -539,7 +539,7 @@ public class StudyViewController {
         @RequestAttribute(required = false, value = "involvedCancerStudies") Collection<String> involvedCancerStudies,
         @ApiIgnore // prevent reference to this attribute in the swagger-ui interface. this
         // attribute is needed for the @PreAuthorize tag above.
-        @Valid @RequestAttribute(required = false, value = "interceptedGenericAssayDataCountFilter") GenericAssayDataCountFilter interceptedGenericAssayDataCountFilter) throws MolecularProfileNotFoundException {
+        @Valid @RequestAttribute(required = false, value = "interceptedGenericAssayDataCountFilter") GenericAssayDataCountFilter interceptedGenericAssayDataCountFilter) {
 
         List<GenericAssayDataFilter> gaFilters = interceptedGenericAssayDataCountFilter.getGenericAssayDataFilters();
         StudyViewFilter studyViewFilter = interceptedGenericAssayDataCountFilter.getStudyViewFilter();
@@ -557,16 +557,13 @@ public class StudyViewController {
         
         List<String> studyIds = new ArrayList<>();
         List<String> sampleIds = new ArrayList<>();
-        List<String> molecularProfileIds = new ArrayList<>();
         studyViewFilterUtil.extractStudyAndSampleIds(filteredSampleIdentifiers, studyIds, sampleIds);
-        List<MolecularProfile> molecularProfiles = molecularProfileService.getMolecularProfilesInStudies(studyIds,
-            "SUMMARY");
-        studyViewFilterUtil.extractMolecularProfileIdsFromFilters(gaFilters, molecularProfiles, molecularProfileIds);
         
         List<GenericAssayDataCountItem> result = studyViewService.fetchGenericAssayDataCounts(
-            molecularProfileIds, 
-            sampleIds, 
-            gaFilters.stream().map(GenericAssayDataFilter::getStableId).collect(Collectors.toList()));
+            sampleIds,
+            studyIds,
+            gaFilters.stream().map(GenericAssayDataFilter::getStableId).collect(Collectors.toList()),
+            gaFilters.stream().map(GenericAssayDataFilter::getProfileType).collect(Collectors.toList()));
 
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
@@ -250,16 +250,6 @@ public class StudyViewFilterUtil {
 
         return combinedResult;
     }
-
-    public void extractMolecularProfileIdsFromFilters(List<GenericAssayDataFilter> gaFilters, List<MolecularProfile> molecularProfiles, List<String> molecularProfileIds) {
-        Map<String, List<MolecularProfile>> molecularProfileMap = molecularProfileUtil.categorizeMolecularProfilesByStableIdSuffixes(molecularProfiles);
-        molecularProfileIds.addAll(gaFilters
-            .stream()
-            .map(f ->  molecularProfileMap.getOrDefault(f.getProfileType(), Collections.emptyList()))
-            .flatMap(porfiles -> porfiles.stream().map(MolecularProfile::getStableId))
-            .collect(Collectors.toList())
-        );
-    }
     
     private List<ClinicalData> filterClinicalDataByStudyAndSampleAndAttribute(
         List<ClinicalData> clinicalData,

--- a/web/src/test/java/org/cbioportal/web/StudyViewControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StudyViewControllerTest.java
@@ -673,7 +673,7 @@ public class StudyViewControllerTest {
         genericAssayDataCountItem.setCounts(genericAssayDataCounts);
         genericAssayDataCountItems.add(genericAssayDataCountItem);
 
-        Mockito.when(studyViewService.fetchGenericAssayDataCounts(anyList(), anyList(),
+        Mockito.when(studyViewService.fetchGenericAssayDataCounts(anyList(), anyList(), anyList(),
             anyList())).thenReturn(genericAssayDataCountItems);
 
         GenericAssayDataCountFilter genericAssayDataCountFilter = new GenericAssayDataCountFilter();


### PR DESCRIPTION
Related to https://github.com/cBioPortal/cbioportal/issues/8912

The purpose of this pr is to fix an error when generating categorical generic assay chart in study view when querying multiple studies.

**Issue description:**
In `GenericAssayService`: `fetchGenericAssayData` will accept a list of `molecularProfileIds`, those ids will be needed to get samples from `SampleService`, for multi-studies query, `molecularProfileIds` must indicate which sample belongs to which molecular profile, so we should pass a list of `molecularProfileIds` that has the same size as `sampleIds` for this purpose.

**Solution:**
Change `molecularProfileIds` from a list of unique ids to a list of ids that have the same size as `sampleIds`.