### PR TITLE
Remove check to omit _normals.txt files

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -417,12 +417,6 @@ class Validator(object):
 
         self.logger.debug('Starting validation of file')
 
-        # Validate whether it's a normal file (skip for now)
-        if self.filename.endswith("_normals.txt") or 'mrna_seq_v2_rsem_normal_samples' in self.filename:
-            self.logger.info('Ignoring *_normals.txt files (TMP) '
-                        'Continuing with validation...')
-            return
-
         # Validate whether the file can be opened
         try:
             opened_file = open(self.filename, 'r', newline=None)


### PR DESCRIPTION
Revert PR #7900. `_normals.txt` files are now under `normals` folder (check cBioPortal/datahub#1440 and #8790), so the check to omit those files when validating is not needed anymore. Removing this check will also help us find if there are any `_normals.txt` files that are not inside the `normals` folder.