### PR TITLE
Add CLI arg to scrpits to override server detection

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,10 +17,22 @@
     <dependency>
       <groupId>org.mskcc.cbio</groupId>
       <artifactId>persistence-connections</artifactId>
+        <exclusions>
+          <exclusion>
+            <artifactId>catalina</artifactId>
+            <groupId>org.apache.catalina</groupId>
+          </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mskcc.cbio</groupId>
       <artifactId>security-spring</artifactId>
+        <exclusions>
+          <exclusion>
+            <artifactId>catalina</artifactId>
+            <groupId>org.apache.catalina</groupId>
+          </exclusion>
+        </exclusions>
     </dependency>
 
     <dependency>

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ExportDataForDownload.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ExportDataForDownload.java
@@ -71,6 +71,7 @@ public class ExportDataForDownload {
 
       parser = new OptionParser();
       parser.accepts("noprogress");
+      parser.accepts("notaserver", "asserts that this is not a sever, adds more cli output");
       OptionSpec<String> htmlIndexFile = parser.accepts( "htmlIndexFile", "output file to store html " +
               "index of files produced" ).
          withRequiredArg().describedAs( "htmlIndexFile" ).ofType( String.class );

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportCaisesClinicalXML.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportCaisesClinicalXML.java
@@ -74,6 +74,7 @@ public class ImportCaisesClinicalXML extends ConsoleRunnable {
 
            OptionParser parser = new OptionParser();
            parser.accepts("noprogress");
+           parser.accepts("notaserver", "asserts that this is not a sever, adds more cli output");
            OptionSpec<String> data = parser.accepts( "data",
                    "caises data file" ).withRequiredArg().describedAs( "data_clinical_caises.xml" ).ofType( String.class );  
            OptionSpec<String> study = parser.accepts("study",

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportClinicalData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportClinicalData.java
@@ -621,6 +621,7 @@ public class ImportClinicalData extends ConsoleRunnable {
 	        parser.accepts( "loadMode", "direct (per record) or bulk load of data" )
 	          .withOptionalArg().describedAs( "[directLoad|bulkLoad (default)]" ).ofType( String.class );
 	        parser.accepts("noprogress", "this option can be given to avoid the messages regarding memory usage and % complete");
+            parser.accepts("notaserver", "asserts that this is not a sever, adds more cli output");
 	        
 	        OptionSet options = null;
 	        try {

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanel.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanel.java
@@ -61,6 +61,7 @@ public class ImportGenePanel extends ConsoleRunnable {
             OptionSpec<String> data = parser.accepts("data",
                 "gene panel file").withRequiredArg().describedAs("data_file.txt").ofType(String.class);
             parser.accepts("noprogress", "this option can be given to avoid the messages regarding memory usage and % complete");
+            parser.accepts("notaserver", "asserts that this is not a sever, adds more cli output");
 
             OptionSet options = null;
             try {
@@ -95,6 +96,7 @@ public class ImportGenePanel extends ConsoleRunnable {
 
         String stableId = extractPropertyValue("stable_id", properties, true);
         String description = extractPropertyValue("description", properties, false);
+        ProgressMonitor.setCurrentMessage("Extracting genes");
         Set<CanonicalGene> canonicalGenes = extractGenes(properties, false);
 
         GenePanel genePanel = DaoGenePanel.getGenePanelByStableId(stableId);

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanelProfileMap.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportGenePanelProfileMap.java
@@ -62,6 +62,7 @@ public class ImportGenePanelProfileMap extends ConsoleRunnable {
             OptionSpec<String> meta = parser.accepts( "meta",
                    "gene panel file" ).withRequiredArg().describedAs( "meta_file.txt" ).ofType( String.class );
             parser.accepts("noprogress", "this option can be given to avoid the messages regarding memory usage and % complete");
+            parser.accepts("notaserver", "asserts that this is not a sever, adds more cli output");
 
             OptionSet options;
             try {

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportResourceData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportResourceData.java
@@ -409,6 +409,7 @@ public class ImportResourceData extends ConsoleRunnable {
                     .describedAs("[directLoad|bulkLoad (default)]").ofType(String.class);
             parser.accepts("noprogress",
                     "this option can be given to avoid the messages regarding memory usage and % complete");
+            parser.accepts("notaserver", "asserts that this is not a sever, adds more cli output");
 
             OptionSet options = null;
             try {

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportResourceDefinition.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportResourceDefinition.java
@@ -256,6 +256,7 @@ public class ImportResourceDefinition extends ConsoleRunnable {
                     .describedAs("[directLoad|bulkLoad (default)]").ofType(String.class);
             parser.accepts("noprogress",
                     "this option can be given to avoid the messages regarding memory usage and % complete");
+            parser.accepts("notaserver", "asserts that this is not a sever, adds more cli output");
 
             OptionSet options = null;
             try {

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/UpdateGenePanel.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/UpdateGenePanel.java
@@ -36,6 +36,7 @@ public class UpdateGenePanel extends ConsoleRunnable {
                 .ofType(String.class);
             parser.accepts("noprogress",
                 "this option can be given to avoid the messages regarding memory usage and % complete");
+            parser.accepts("notaserver", "asserts that this is not a sever, adds more cli output");
 
             OptionSet options;
             try {

--- a/core/src/main/java/org/mskcc/cbio/portal/util/ConsoleUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/ConsoleUtil.java
@@ -131,6 +131,7 @@ public class ConsoleUtil {
 		// using a real options parser, helps avoid bugs
 		OptionParser parser = new OptionParser();
 		parser.accepts("noprogress", "this option can be given to avoid the messages regarding memory usage and % complete");
+        parser.accepts("notaserver", "asserts that this is not a sever, adds more cli output");
 		OptionSpec<Void> help = parser.accepts( "help", "print this help info" );
 		parser.accepts( "data", "profile data file" ).withRequiredArg().describedAs( "data_file.txt" ).ofType( String.class );
 		parser.accepts( "meta", "meta (description) file" ).withRequiredArg().describedAs( "meta_file.txt" ).ofType( String.class );
@@ -197,6 +198,7 @@ public class ConsoleUtil {
 		// using a real options parser, helps avoid bugs
 		OptionParser parser = new OptionParser();
 		parser.accepts("noprogress", "this option can be given to avoid the messages regarding memory usage and % complete");
+        parser.accepts("notaserver", "asserts that this is not a sever, adds more cli output");
 		OptionSpec<Void> help = parser.accepts( "help", "print this help info" );
 		parser.accepts( "data", "profile data file" ).withRequiredArg().describedAs( "data_file.txt" ).ofType( String.class );
 		parser.accepts( "study", "cancer study identifier" ).withRequiredArg().describedAs( "e.g. brca_tcga" ).ofType( String.class );
@@ -243,6 +245,7 @@ public class ConsoleUtil {
 		// using a real options parser, helps avoid bugs
 		OptionParser parser = new OptionParser();
 		parser.accepts("noprogress", "this option can be given to avoid the messages regarding memory usage and % complete");
+        parser.accepts("notaserver", "asserts that this is not a sever, adds more cli output");
 		OptionSpec<Void> help = parser.accepts( "help", "print this help info" );
         parser.accepts( "data", "profile data file" ).withRequiredArg().describedAs( "data_file.txt" ).ofType( String.class );
         parser.accepts( "update-info", "Update information for existing entities in the database").withOptionalArg().ofType(String.class);

--- a/core/src/main/java/org/mskcc/cbio/portal/util/ProgressMonitor.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/ProgressMonitor.java
@@ -53,6 +53,7 @@ public class ProgressMonitor {
     private static org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(ProgressMonitor.class);
     private boolean consoleMode;
     private boolean showProgress;
+    private boolean noAServer = false;
     private TreeSet<String> warnings = new TreeSet<>();
     private HashMap<String, Integer> warningCounts = new HashMap<>();
     private List<String> debugMessages = new ArrayList<>();
@@ -67,6 +68,9 @@ public class ProgressMonitor {
     }
     
     private static boolean isRunningOnServer() {
+        if (isNotAServer()) {
+            return false;
+        }
         return ServerDetector.getServerId() != null;
     } 
     /**
@@ -83,18 +87,23 @@ public class ProgressMonitor {
      * Sets consoleMode to true and tries to infer showProgress mode from args. If an argument 
      * with name "--noprogress" is found, then showProgress is set to false
      * 
-     * @param args
+     * @param argsAdd cli arg to force outputAdd CLI arg to scrpits to override server detection
      */
     public static void setConsoleModeAndParseShowProgress(String[] args) {
     	//default
 		setConsoleMode(true);
-    	if (Arrays.asList(args).contains("--noprogress")) {
-    		setShowProgress(false);
-    	} else {
-    		//default:
-    		setShowProgress(true);
-    	}
+        //default:
+        setShowProgress(!Arrays.asList(args).contains("--noprogress"));
+        setNotAServer(Arrays.asList(args).contains("--notaserver"));
     		
+    }
+
+    public static boolean isNotAServer() {
+        return progressMonitor.noAServer;
+    }
+
+    public static void setNotAServer(boolean forceOutput) {
+        progressMonitor.noAServer = forceOutput;
     }
 
     /**


### PR DESCRIPTION
- The docker-compose setup doesn't give correct console output
because the tomcat jar is included in core
- To get proper setup, introduce an override that asserts
that this script is not running on a server


Before:
```bash
/cbioportal/core/src/main/scripts# ./importGenePanel.pl --data /data_gene_panel_RMG.txt 
Done.
Total time:  2017 ms
```

After:
```bash

/cbioportal/core/src/main/scripts# ./importGenePanel.pl --data /data_gene_panel_RMG.txt --notaserver
Reading data from:  /data_gene_panel_RMG.txt
Extracting genes

Warnings / Errors:
-------------------
0.  Gene panel RMG already exists in the database but is not being used. Overwriting old gene panel data.; 1x
Done.
Total time:  2115 ms
```