### PR TITLE
Exlcude tomcat from mskcc artifacts included in core

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -96,6 +96,10 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
             </exclusion>
+            <exclusion>
+                <artifactId>spring-boot-starter-web</artifactId>
+                <groupId>org.springframework.boot</groupId>
+            </exclusion>
         </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fix #8941

- spring boot's tomcat was somehow leaking from the session service jar into the
main portal, and from there into core
- this broke the cli output for all scripts, as they thought
they were running on a sever, and muted their output