### PR TITLE
Update maven plugins for compatibility with JDK 17 (mvn dep)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1065,7 +1065,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.8.1</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>
@@ -1102,7 +1102,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>2.2</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
@inodb @Luke-Sikina this makes the app buildable with latest install of maven, which seems to have as a dependency JKD 17.  The old plugins are not compatible.