### PR TITLE
Exclude transitive mongo-java-driver dependency from session service

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -100,6 +100,10 @@
                 <artifactId>spring-boot-starter-web</artifactId>
                 <groupId>org.springframework.boot</groupId>
             </exclusion>
+            <exclusion>
+                <artifactId>spring-boot-starter-data-mongodb</artifactId>
+                <groupId>org.springframework.boot</groupId>
+            </exclusion>
         </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fixes #8898

# Problem
The `JsonWriterSettings()` method used by SessionServiceController (via `queryDBObject.toString()` call) is deprecated. The method has been removed in newer _mongo-java-driver_ versions. cBioPortal expects the version of _mongo-java-driver_  to be 3.9.12. The newer version of _mongo-java-driver_ is pulled in as a transitive dependency via _spring-boot-starter-data-mongodb_ from session-service:

```
[INFO] --- maven-dependency-plugin:3.0.0:tree (default-cli) @ web ---
[INFO] org.mskcc.cbio:web:jar:0-unknown-version-SNAPSHOT
[INFO] +- org.mongodb:mongo-java-driver:jar:3.12.9:compile
[INFO] \- com.github.cbioportal:session-service:jar:model:v0.5.0:compile
[INFO]    \- org.springframework.boot:spring-boot-starter-data-mongodb:jar:2.3.3.RELEASE:compile
[INFO]       \- org.mongodb:mongodb-driver-sync:jar:4.0.5:compile
[INFO]          +- org.mongodb:bson:jar:4.0.5:compile
[INFO]          \- org.mongodb:mongodb-driver-core:jar:4.0.5:compile
```

# Solution
The transitive dependency _spring-boot-starter-data-mongodb_ from session-service is exluded on import.