### PR TITLE
Add validation for Arm-level CNA data and update docs

### DIFF
--- a/core/src/test/scripts/test_data/data_generic_assay_categorical_invalid_predefined_data.txt
+++ b/core/src/test/scripts/test_data/data_generic_assay_categorical_invalid_predefined_data.txt
@@ -1,0 +1,3 @@
+ENTITY_STABLE_ID	name	description	TCGA-A1-A0SB-01	TCGA-A1-A0SD-01	TCGA-A1-A0SE-01	TCGA-A1-A0SH-01	TCGA-A2-A04U-01	TCGA-B6-A0RS-01	TCGA-BH-A0HP-01	TCGA-BH-A18P-01
+1p	1p	1p	category_1	gain	loss	unchanged	Gained	Lost	Unchange	Unknown
+2p	2p	2p	Gain	Gain	Loss	Unchanged	Gain	Loss	Unchanged	NA

--- a/core/src/test/scripts/test_data/data_generic_assay_categorical_valid_predefined_data.txt
+++ b/core/src/test/scripts/test_data/data_generic_assay_categorical_valid_predefined_data.txt
@@ -1,0 +1,3 @@
+ENTITY_STABLE_ID	name	description	TCGA-A1-A0SB-01	TCGA-A1-A0SD-01	TCGA-A1-A0SE-01	TCGA-A1-A0SH-01	TCGA-A2-A04U-01	TCGA-B6-A0RS-01	TCGA-BH-A0HP-01	TCGA-BH-A18P-01
+1p	1p	1p	Loss	Gain	Gain	Gain	Unchanged	Loss	Loss	
+2p	2p	2p	Gain	Gain	Loss	Unchanged	Gain	Loss	Unchanged	NA

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -2799,6 +2799,30 @@ class GenericAssayCategoricalTestCase(PostClinicalDataFileTestCase):
 
         self.assertEqual(len(record_list), 0)
 
+    def test_generic_assay_predefined_datatype_with_invalid_data_value(self):
+        self.logger.setLevel(logging.ERROR)
+        record_list = self.validate('data_generic_assay_categorical_invalid_predefined_data.txt',
+                                    validateData.GenericAssayCategoricalValidator,
+                                    extra_meta_fields={
+                                        'generic_assay_type': 'ARMLEVEL_CNA',
+                                        'generic_entity_meta_properties': 'name,description'})
+
+        self.assertEqual(len(record_list), 8)
+        record_iterator = iter(record_list)
+        record = next(record_iterator)
+        self.assertEqual(record.levelno, logging.ERROR)
+        self.assertIn('possible values are [Gain, Loss, Unchanged]', record.getMessage())
+
+    def test_generic_assay_predefined_datatype_with_valid_data_value(self):
+        self.logger.setLevel(logging.ERROR)
+        record_list = self.validate('data_generic_assay_categorical_valid_predefined_data.txt',
+                                    validateData.GenericAssayCategoricalValidator,
+                                    extra_meta_fields={
+                                        'generic_assay_type': 'ARMLEVEL_CNA',
+                                        'generic_entity_meta_properties': 'name,description'})
+
+        self.assertEqual(len(record_list), 0)
+
 class GenericAssayBinaryTestCase(PostClinicalDataFileTestCase):
     def test_generic_assay_with_with_valid_binary_data(self):
         self.logger.setLevel(logging.ERROR)

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -20,6 +20,7 @@
     * [Gene Set Data](#gene-set-data)
     * [Study Tags file](#study-tags-file)
     * [Generic Assay](#generic-assay)
+        * [Arm Level CNA Data](#arm-level-cna-data)
     * [Resource Data](#resource-data)
 
 # Introduction
@@ -1509,7 +1510,7 @@ Generic Assay data will be considered `sample_level` data if the `patient_level`
 ### Note on `Generic Assay` genetic_alteration_type and datatype
 All generic assay data is registered to be of the type of `genetic_alteration_type` and data type can choose from `LIMIT-VALUE`, `CATEGORICAL` and `BINARY`. 
 - ***LIMIT-VALUE***: This datatype is intended to be used for any numerical data set with similar structure (entities measured in samples). The `LIMIT-VALUE` is validated to contain any continuous number optionally prefixed with a '>' or '<' threshold symbol (e.g., '>8.00').
-- ***CATEGORICAL (under development)***: This datatype is intended to be used for any categorical data set with similar structure (entities measured in samples). Any text is allowed in `CATEGORICAL` except blank.
+- ***CATEGORICAL (under development)***: This datatype is intended to be used for any categorical data set with similar structure (entities measured in samples). Any text is allowed in `CATEGORICAL`.
 - ***BINARY (under development)***: This datatype is intended to be used for any binary data set with similar structure (entities measured in samples). The `BINARY` is validated to contain only reserved text (`true`, `false`, `yes`, `no`).
 
 If the value for the generic entity in the respective sample could not (or was not) be measured (or detected), the value should be 'NA' or leave that cell blank.
@@ -1533,6 +1534,13 @@ Example with 3 generic entities and 3 samples:
 <tr><td>AEW541</td><td>Larotrectinib</td><td>TrkA/B/C inhibitor</td><td>https://en.wikipedia.org/wiki/Larotrectinib</td><td>>8</td><td>2.33</td><td>2.68</td></tr>
 <tr><td>AZD0530</td><td>Saracatinib</td><td>Src/Bcr-Abl inhibitor</td><td>https://en.wikipedia.org/wiki/Saracatinib</td><td>NA</td><td>>8</td><td>4.60</td></tr>
 </table>
+
+### Arm Level CNA Data
+Arm-level copy-number data is a predefined subtype of Generic Assay Data.
+
+Allowed values for Arm-level copy-number data are `Loss`, `Gain`, and `Unchanged`, use `NA` or leave the cell blank to indicate a missing value.
+
+Please find example file format here: [Meta file example](https://github.com/cBioPortal/cbioportal-frontend/blob/master/end-to-end-test/local/studies/lgg_ucsf_2014_test_generic_assay/meta_armlevel_CNA.txt) and [Data file example](https://github.com/cBioPortal/cbioportal-frontend/blob/master/end-to-end-test/local/studies/lgg_ucsf_2014_test_generic_assay/data_armlevel_CNA.txt)
 
 ## Resource Data
 


### PR DESCRIPTION
Fix #8926

Describe changes proposed in this pull request:
- In `validateData.py`, update validation logic for `Generic Assay Categorical Data`, if we are validating predefined types (e.g. Arm-Level CNA data), then use predefined list of values to validate data files.
- Update `File-Format.md` with new predefined data type and links to example files. [Document preview](https://github.com/cBioPortal/cbioportal/blob/e07ee866b4af9cd184157954805bc12c9e2ea106/docs/File-Formats.md) 
![image](https://user-images.githubusercontent.com/15748980/137359054-ab27cac1-2141-409e-83bf-a5d98d46f15b.png)
![image](https://user-images.githubusercontent.com/15748980/138761894-65a1594b-54cd-496b-906b-a3d95a2d8a97.png)

