### PR TITLE
Update maven-external-version-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
           <plugin>
             <groupId>com.github.cbioportal.maven-external-version</groupId>
             <artifactId>maven-external-version-plugin</artifactId>
-            <version>f09c2b9608744881111f24e55d55a91e54e6cb5f</version>
+            <version>f09c2b9608</version>
             <extensions>true</extensions>
             <configuration>
               <strategy hint="script">


### PR DESCRIPTION
Build failed because jitpack has a build error for `maven-external-version-plugin`, but we found the short version commit number build successfully, so decided to change with short version commit number.

long version: https://jitpack.io/com/github/cbioportal/maven-external-version/f09c2b9608744881111f24e55d55a91e54e6cb5f//build.log
short version: https://jitpack.io/com/github/cbioportal/maven-external-version/f09c2b9608/build.log