### PR TITLE
Do not call clinical events fetch when there are no clinical events

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/ClinicalEventServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/ClinicalEventServiceImpl.java
@@ -33,7 +33,7 @@ public class ClinicalEventServiceImpl implements ClinicalEventService {
         List<ClinicalEvent> clinicalEvents = clinicalEventRepository.getAllClinicalEventsOfPatientInStudy(studyId,
             patientId, projection, pageSize, pageNumber, sortBy, direction);
 
-        if (!projection.equals("ID")) {
+        if (!projection.equals("ID") && !clinicalEvents.isEmpty() ) {
 
             List<ClinicalEventData> clinicalEventDataList = clinicalEventRepository.getDataOfClinicalEvents(
                 clinicalEvents.stream().map(ClinicalEvent::getClinicalEventId).collect(Collectors.toList()));


### PR DESCRIPTION
The mapper is requesting ALL clinical events for all patients when passed list is empty