### PR TITLE
Remove filter validation from generic-assay-meta endpoint

### DIFF
--- a/web/src/main/java/org/cbioportal/web/GenericAssayController.java
+++ b/web/src/main/java/org/cbioportal/web/GenericAssayController.java
@@ -8,6 +8,7 @@ import springfox.documentation.annotations.ApiIgnore;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -56,17 +57,19 @@ public class GenericAssayController {
     @ApiOperation("Fetch meta data for generic-assay by ID")
     public ResponseEntity<List<GenericAssayMeta>> fetchGenericAssayMetaData(
         @ApiParam(required = true, value = "List of Molecular Profile ID or List of Stable ID")
-        @Valid @RequestBody GenericAssayMetaFilter genericAssayMetaFilter,
+        @RequestBody GenericAssayMetaFilter genericAssayMetaFilter,
         @ApiParam("Level of detail of the response")
         @RequestParam(defaultValue = "SUMMARY") Projection projection) throws GenericAssayNotFoundException {
-            List<GenericAssayMeta> result;
+            List<GenericAssayMeta> result = Collections.emptyList();
 
-            if (genericAssayMetaFilter.getGenericAssayStableIds() == null) {
-                result = genericAssayService.getGenericAssayMetaByStableIdsAndMolecularIds(null, genericAssayMetaFilter.getMolecularProfileIds(), projection.name());
-            } else if (genericAssayMetaFilter.getMolecularProfileIds() == null) {
-                result = genericAssayService.getGenericAssayMetaByStableIdsAndMolecularIds(genericAssayMetaFilter.getGenericAssayStableIds(), null, projection.name());
-            } else {
-                result = genericAssayService.getGenericAssayMetaByStableIdsAndMolecularIds(genericAssayMetaFilter.getGenericAssayStableIds(), genericAssayMetaFilter.getMolecularProfileIds(), projection.name());
+            if (genericAssayMetaFilter != null) {
+                if (genericAssayMetaFilter.getGenericAssayStableIds() == null) {
+                    result = genericAssayService.getGenericAssayMetaByStableIdsAndMolecularIds(null, genericAssayMetaFilter.getMolecularProfileIds(), projection.name());
+                } else if (genericAssayMetaFilter.getMolecularProfileIds() == null) {
+                    result = genericAssayService.getGenericAssayMetaByStableIdsAndMolecularIds(genericAssayMetaFilter.getGenericAssayStableIds(), null, projection.name());
+                } else {
+                    result = genericAssayService.getGenericAssayMetaByStableIdsAndMolecularIds(genericAssayMetaFilter.getGenericAssayStableIds(), genericAssayMetaFilter.getMolecularProfileIds(), projection.name());
+                }   
             }
             return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/web/src/main/java/org/cbioportal/web/parameter/GenericAssayMetaFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/GenericAssayMetaFilter.java
@@ -6,9 +6,7 @@ import java.io.Serializable;
 
 public class GenericAssayMetaFilter implements Serializable {
 
-    @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> molecularProfileIds;
-    @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
     private List<String> genericAssayStableIds;
 
     public List<String> getMolecularProfileIds() {


### PR DESCRIPTION
Fix #9025 

Describe changes proposed in this pull request:
- Remove filter validation from `generic-assay-meta/fetch` endpoint to allow empty request