### PR TITLE
Fixes Structural Variant Genes Table disappearing issue

### DIFF
--- a/model/src/main/java/org/cbioportal/model/MolecularProfile.java
+++ b/model/src/main/java/org/cbioportal/model/MolecularProfile.java
@@ -80,10 +80,11 @@ public class MolecularProfile implements Serializable {
     }
 
     public MolecularAlterationType getMolecularAlterationType() {
-        // Alteration type is always set to STRUCTURAL_VARIANT when importing fusion profile
+        // TODO: remove this logic once all the fusions are migrated to structural variants
+        // most fusion profiles are imported as SV data but this also handles the archer
+        // study case where the fusions are imported under a mutations profile instead
         // https://github.com/cBioPortal/cbioportal/blob/8704058562c386afeac3082e50f39c1097d47983/core/src/main/java/org/mskcc/cbio/portal/util/GeneticProfileReader.java#L93
         // But somehow there was no migration for existing data. To resolve it replace FUSION alteration type by STRUCTURAL_VARIANT.
-        // TODO: remove this logic once all the fusions are migrated to structural variants
         return (molecularAlterationType.equals(MolecularAlterationType.FUSION) ||
                 (molecularAlterationType.equals(MolecularAlterationType.MUTATION_EXTENDED)
                 && this.datatype.equals("FUSION")))
@@ -162,7 +163,7 @@ public class MolecularProfile implements Serializable {
     public void setGenericAssayType(String genericAssayType) {
         this.genericAssayType = genericAssayType;
     }
-    
+
     public Boolean getPatientLevel() {
         return patientLevel;
     }

--- a/model/src/main/java/org/cbioportal/model/MolecularProfile.java
+++ b/model/src/main/java/org/cbioportal/model/MolecularProfile.java
@@ -84,7 +84,9 @@ public class MolecularProfile implements Serializable {
         // https://github.com/cBioPortal/cbioportal/blob/8704058562c386afeac3082e50f39c1097d47983/core/src/main/java/org/mskcc/cbio/portal/util/GeneticProfileReader.java#L93
         // But somehow there was no migration for existing data. To resolve it replace FUSION alteration type by STRUCTURAL_VARIANT.
         // TODO: remove this logic once all the fusions are migrated to structural variants
-        return molecularAlterationType.equals(MolecularAlterationType.FUSION)
+        return (molecularAlterationType.equals(MolecularAlterationType.FUSION) ||
+                (molecularAlterationType.equals(MolecularAlterationType.MUTATION_EXTENDED)
+                && this.datatype.equals("FUSION")))
                 ? MolecularAlterationType.STRUCTURAL_VARIANT
                 : molecularAlterationType;
     }
@@ -120,7 +122,8 @@ public class MolecularProfile implements Serializable {
     public Boolean getShowProfileInAnalysisTab() {
         // TODO: remove this logic once the data is fixed (when all the fusions are migrated to structural variants)
         return showProfileInAnalysisTab
-                || (getMolecularAlterationType().equals(MolecularAlterationType.STRUCTURAL_VARIANT)
+                || ((molecularAlterationType.equals(MolecularAlterationType.STRUCTURAL_VARIANT)
+                        || molecularAlterationType.equals(MolecularAlterationType.MUTATION_EXTENDED))
                         && datatype.equals("FUSION"));
     }
 

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationMyBatisRepository.java
@@ -62,7 +62,8 @@ public class AlterationMyBatisRepository implements AlterationRepository {
         // if fusions were imported as a "mutations" profile then replace STRUCTURAL_VARIANT in
         // groupedIdentifiersByProfileType map with MUTATION_EXTENDED
         for (MolecularProfile profile : molecularProfileRepository.getMolecularProfiles(molecularProfileIds, "SUMMARY")) {
-            if (profile.getStableId().endsWith("mutations") && profile.getDatatype().equals("FUSION")) {
+            if (profile.getStableId().endsWith("mutations") && profile.getDatatype().equals("FUSION") &&
+                    groupedIdentifiersByProfileType.get(MolecularAlterationType.STRUCTURAL_VARIANT) != null) {
                 groupedIdentifiersByProfileType.put(MolecularAlterationType.MUTATION_EXTENDED,
                         groupedIdentifiersByProfileType.get(MolecularAlterationType.STRUCTURAL_VARIANT));
                 groupedIdentifiersByProfileType.remove(MolecularAlterationType.STRUCTURAL_VARIANT);

--- a/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
@@ -41,7 +41,7 @@ public class SampleServiceImpl implements SampleService {
     private CopyNumberSegmentRepository copyNumberSegmentRepository;
     @Autowired
     private MolecularProfileRepository molecularProfileRepository;
-    
+
     @Override
     public List<Sample> getAllSamples(String keyword, List<String> studyIds, String projection,
                                       Integer pageSize, Integer pageNumber, String sort, String direction) {
@@ -54,7 +54,7 @@ public class SampleServiceImpl implements SampleService {
     public BaseMeta getMetaSamples(String keyword, List<String> studyIds) {
         return sampleRepository.getMetaSamples(keyword, studyIds);
     }
-    
+
     @Override
     public List<Sample> getAllSamplesInStudy(String studyId, String projection, Integer pageSize, Integer pageNumber,
                                              String sortBy, String direction) throws StudyNotFoundException {
@@ -132,7 +132,7 @@ public class SampleServiceImpl implements SampleService {
     @Override
 	public List<Sample> getSamplesOfPatientsInMultipleStudies(List<String> studyIds, List<String> patientIds,
 			String projection) {
-        
+
         List<Sample> samples = sampleRepository.getSamplesOfPatientsInMultipleStudies(studyIds, patientIds, projection);
 
         processSamples(samples, projection);
@@ -149,9 +149,9 @@ public class SampleServiceImpl implements SampleService {
 
     @Override
 	public List<Sample> fetchSamples(List<String> sampleListIds, String projection) {
-        
+
         List<Sample> samples = sampleRepository.fetchSamples(sampleListIds, projection);
-        
+
         processSamples(samples, projection);
         return samples;
 	}
@@ -164,7 +164,7 @@ public class SampleServiceImpl implements SampleService {
 
     @Override
 	public BaseMeta fetchMetaSamples(List<String> sampleListIds) {
-        
+
         return sampleRepository.fetchMetaSamples(sampleListIds);
 	}
 
@@ -174,8 +174,17 @@ public class SampleServiceImpl implements SampleService {
         return sampleRepository.getSamplesByInternalIds(internalIds);
     }
 
-    private void processSamples(List<Sample> samples, String projection) {
+    private Boolean isProfiledWithSV(MolecularProfile p) {
+        return (p.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.STRUCTURAL_VARIANT) ||
+                hasFusionsAsMutations(p));
+    }
 
+    private Boolean hasFusionsAsMutations(MolecularProfile p) {
+        return (p.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.MUTATION_EXTENDED) &&
+                p.getDatatype().equals("FUSION"));
+    }
+
+    private void processSamples(List<Sample> samples, String projection) {
         if (projection.equals("DETAILED")) {
             Map<String, Set<String>> sequencedSampleIdsMap = new HashMap<>();
             Map<String, Set<String>> structuralVariantSampleIdsMap = new HashMap<>();
@@ -183,22 +192,33 @@ public class SampleServiceImpl implements SampleService {
                 .collect(Collectors.toList());
             List<MolecularProfile> molecularProfiles = molecularProfileRepository.getMolecularProfilesInStudies(distinctStudyIds, projection);
             List<String> studiesProfiledWithSVs = molecularProfiles.stream()
-                        .filter(p -> p.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.STRUCTURAL_VARIANT))
+                        .filter(p -> isProfiledWithSV(p))
+                        .map(MolecularProfile::getCancerStudyIdentifier)
+                        .collect(Collectors.toList());
+            List<String> studiesProfiledWithFusionsAsMutations = molecularProfiles.stream()
+                        .filter(p -> hasFusionsAsMutations(p))
                         .map(MolecularProfile::getCancerStudyIdentifier)
                         .collect(Collectors.toList());
             for (String studyId : distinctStudyIds) {
                 sequencedSampleIdsMap.put(studyId,
                                           new HashSet<String>(sampleListRepository.getAllSampleIdsInSampleList(studyId + SEQUENCED)));
-                structuralVariantSampleIdsMap.put(studyId,
-                                       new HashSet<String>(sampleListRepository.getAllSampleIdsInSampleList(studyId + STRUCTURAL_VARIANT)));
+                // get sv samples from sequenced case list if fusions imported as mutations
+                Set<String> svSamples = new HashSet<>();
+                if (studiesProfiledWithFusionsAsMutations.contains(studyId)) {
+                    // use sample list that has already been fetched
+                    svSamples = new HashSet<>(sequencedSampleIdsMap.get(studyId));
+                } else {
+                    svSamples = new HashSet<String>(sampleListRepository.getAllSampleIdsInSampleList(studyId + STRUCTURAL_VARIANT));
+                }
+                structuralVariantSampleIdsMap.put(studyId, svSamples);
             }
 
             List<Integer> samplesWithCopyNumberSeg = copyNumberSegmentRepository.fetchSamplesWithCopyNumberSegments(
-                samples.stream().map(Sample::getCancerStudyIdentifier).collect(Collectors.toList()), 
+                samples.stream().map(Sample::getCancerStudyIdentifier).collect(Collectors.toList()),
                 samples.stream().map(Sample::getStableId).collect(Collectors.toList()),
                 null
             );
-            
+
             Set<Integer> samplesWithCopyNumberSegMap = new HashSet<>();
             samplesWithCopyNumberSegMap.addAll(samplesWithCopyNumberSeg);
 
@@ -211,9 +231,9 @@ public class SampleServiceImpl implements SampleService {
                         sample.setProfiledForFusions(structuralVariantSampleIdsMap.get(sample.getCancerStudyIdentifier()).contains(sample.getStableId()));
                     } else {
                         /*
-                         * TODO: Eventually all studies with STRUCTURAL_VARIANT data should have case lists, 
-                         * so there should always be an entry in `structuralVariantSampleIdsMap`. This case is 
-                         * to support old `FUSION` data in the mutations table that don't have case lists. In that 
+                         * TODO: Eventually all studies with STRUCTURAL_VARIANT data should have case lists,
+                         * so there should always be an entry in `structuralVariantSampleIdsMap`. This case is
+                         * to support old `FUSION` data in the mutations table that don't have case lists. In that
                          * case we assume any sample that has been sequenced to have been profiled for fusions as well
                          */
                         sample.setProfiledForFusions(sequencedSampleIdsMap.get(sample.getCancerStudyIdentifier()).contains(sample.getStableId()));

--- a/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
@@ -179,6 +179,11 @@ public class SampleServiceImpl implements SampleService {
                 hasFusionsAsMutations(p));
     }
 
+    /**
+     * TODO: Remove this function/logic once fusions are migrated to structural variants.
+     * This case where the molecular alteration type = MUTATION_EXTENDED with datatype = FUSION
+     * is to handle the ARCHER cohort.
+     */
     private Boolean hasFusionsAsMutations(MolecularProfile p) {
         return (p.getMolecularAlterationType().equals(MolecularProfile.MolecularAlterationType.MUTATION_EXTENDED) &&
                 p.getDatatype().equals("FUSION"));
@@ -203,10 +208,10 @@ public class SampleServiceImpl implements SampleService {
                 sequencedSampleIdsMap.put(studyId,
                                           new HashSet<String>(sampleListRepository.getAllSampleIdsInSampleList(studyId + SEQUENCED)));
                 // get sv samples from sequenced case list if fusions imported as mutations
-                Set<String> svSamples = new HashSet<>();
+                Set<String> svSamples = new HashSet<String>();
                 if (studiesProfiledWithFusionsAsMutations.contains(studyId)) {
                     // use sample list that has already been fetched
-                    svSamples = new HashSet<>(sequencedSampleIdsMap.get(studyId));
+                    svSamples = new HashSet<String>(sequencedSampleIdsMap.get(studyId));
                 } else {
                     svSamples = new HashSet<String>(sampleListRepository.getAllSampleIdsInSampleList(studyId + STRUCTURAL_VARIANT));
                 }

--- a/service/src/main/java/org/cbioportal/service/impl/StructuralVariantServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/StructuralVariantServiceImpl.java
@@ -141,14 +141,16 @@ public class StructuralVariantServiceImpl implements StructuralVariantService {
             String molecularProfileId = molecularProfileIds.get(i);
             if (molecularProfileId.endsWith(molecularProfileUtil.STRUCTURAL_VARIANT_PROFILE_SUFFIX)) {
                 structuralVariantMolecularProfileIds.add(molecularProfileId);
-                structuralVariantSampleIds.add(sampleIds.get(i));
+                if (CollectionUtils.isNotEmpty(sampleIds))  {
+                    structuralVariantSampleIds.add(sampleIds.get(i));
+                }
             } else if (molecularProfileId.endsWith(molecularProfileUtil.FUSION_PROFILE_SUFFIX)) {
-                String mutationMolecularProfileId =
-                        molecularProfileId.replace(molecularProfileUtil.FUSION_PROFILE_SUFFIX,
-                                molecularProfileUtil.MUTATION_PROFILE_SUFFIX);
+                String mutationMolecularProfileId = molecularProfileUtil.replaceFusionProfileWithMutationProfile(molecularProfileId);
                 molecularProfileIdReplaceMap.put(mutationMolecularProfileId, molecularProfileId);
                 fusionVariantMolecularProfileIds.add(molecularProfileId);
-                fusionVariantSampleIds.add(sampleIds.get(i));
+                if (CollectionUtils.isNotEmpty(sampleIds))  {
+                    fusionVariantSampleIds.add(sampleIds.get(i));
+                }
             } else if (molecularProfileId.endsWith(molecularProfileUtil.MUTATION_PROFILE_SUFFIX)) {
                 if (!molecularProfileMap.containsKey(molecularProfileId)) {
                     molecularProfileMap.put(molecularProfileId,
@@ -156,8 +158,12 @@ public class StructuralVariantServiceImpl implements StructuralVariantService {
                 }
                 MolecularProfile mp = molecularProfileMap.get(molecularProfileId);
                 if (mp.getDatatype().equals(molecularProfileUtil.FUSIONS_AS_MUTATIONS_DATATYPE)) {
-                    fusionVariantMolecularProfileIds.add(molecularProfileId);
-                    fusionVariantSampleIds.add(sampleIds.get(i));
+                    String mutationMolecularProfileId = molecularProfileUtil.replaceFusionProfileWithMutationProfile(molecularProfileId);
+                    molecularProfileIdReplaceMap.put(mutationMolecularProfileId, molecularProfileId);
+                    fusionVariantMolecularProfileIds.add(mutationMolecularProfileId);
+                    if (CollectionUtils.isNotEmpty(sampleIds))  {
+                        fusionVariantSampleIds.add(sampleIds.get(i));
+                    }
                 }
             }
         }

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -166,7 +166,6 @@ public class StudyViewFilterApplier {
         }
 
         List<MolecularProfile> molecularProfiles = null;
-
         if (!CollectionUtils.isEmpty(studyViewFilter.getGeneFilters())
                 || !CollectionUtils.isEmpty(studyViewFilter.getGenomicDataFilters())
                 || !CollectionUtils.isEmpty(studyViewFilter.getGenericAssayDataFilters())
@@ -535,7 +534,8 @@ public class StudyViewFilterApplier {
             // determine whether a fusions profile was imported as mutations
             Boolean fusionsImportedAsMutations = Boolean.FALSE;
             for (MolecularProfile mp : filteredMolecularProfiles) {
-                if (mp.getStableId().endsWith("mutations") && mp.getDatatype().equals("FUSION")) {
+                if (mp.getStableId().endsWith("mutations")
+                        && mp.getDatatype().equals("FUSION")) {
                     fusionsImportedAsMutations = Boolean.TRUE;
                     break;
                 }


### PR DESCRIPTION
Fix #9011 

Addresses issue where structural variant genes table was not rendering for MSKARCHER.

For similar reasons the Oncoprint, Mutation Tab, and the Patient/Sample-view mutation tables were also not displaying fusion events for ARCHER.

## Before fix:
![image](https://user-images.githubusercontent.com/15623749/140389406-7d0d73d5-91bc-4e49-b19c-7abed85e9c73.png)
![image](https://user-images.githubusercontent.com/15623749/140389811-52fbf71f-5bbe-4097-8e16-316a8ccb9ce2.png)

----
## After fix:

![image](https://user-images.githubusercontent.com/15623749/140389458-951bed4f-0c98-46b1-a57c-9871edb2c4c7.png)
![image](https://user-images.githubusercontent.com/15623749/140390043-677cc3c4-923e-4146-ba37-c8b476e84dc2.png)

# Checks
- [ ] Runs on heroku
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.

# Notify reviewers
@kalletlak  @n1zea144 @inodb 

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
