### PR TITLE
Fixed issue where /api/cache/<study_id> returned Unauthorized

### DIFF
--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -261,8 +261,6 @@
     <servlet-mapping>
         <servlet-name>api</servlet-name>
         <url-pattern>/api/*</url-pattern>
-        <url-pattern>/health</url-pattern>
-        <url-pattern>/cache</url-pattern>
     </servlet-mapping>
 
     <servlet>

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -87,7 +87,7 @@
     <http pattern="/api/swagger-resources/**" security="none"/>
     <http pattern="/api/swagger-ui.html" security="none"/>
     <http pattern="/api/health" security="none"/>
-    <http pattern="/api/cache" security="none"/>
+    <http pattern="/api/cache/**" security="none"/>
 
     <!-- This must come before the default entry point which will capture everything not matched by pattern -->
     <http use-expressions="true" pattern="/api/**" entry-point-ref="restAuthenticationEntryPoint" create-session="never">


### PR DESCRIPTION
I was able to call the /api/cache endpoint, but not the /api/cache/<study_id>, as it was returning an Unauthorized error.

To fix this the following have been modified:
- **portal/src/main/webapp/WEB-INF/web.xml:** Removed <url-pattern>/health</url-pattern> and <url-pattern>/cache</url-pattern> as both were already covered by /api/* url pattern.

- **security/security-spring/src/main/resources/applicationContext-security.xml:** Changed url to api/cache/** instead of only /api/cache.