### PR TITLE
Fix errors when importing data with empty Start_Position or End_Position

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1695,7 +1695,7 @@ class MutationsExtendedValidator(CustomDriverAnnotationValidator):
             tumor_seq_allele2 = data[self.cols.index('Tumor_Seq_Allele2')].strip()
         if set(necessary_columns_check10).issubset(self.cols):
             # Set positions to False if position are empty, so checks will not be performed
-            if data[self.cols.index('Start_Position')] == "" or data[self.cols.index('End_Position')] == "":
+            if data[self.cols.index('Start_Position')] == '' or data[self.cols.index('Start_Position')] == 'NA' or data[self.cols.index('End_Position')] == '' or data[self.cols.index('End_Position')] == 'NA':
                 positions = False
             else:
                 positions = True
@@ -2202,7 +2202,7 @@ class MutationsExtendedValidator(CustomDriverAnnotationValidator):
 
     def checkStartPosition(self, value):
         """Check that the Start_Position value is an integer."""
-        if value == 'NA':
+        if value == '' or value == 'NA':
             self.logger.warning(
                 'The start position of this variant is not '
                     'defined. The chromosome plot in the patient view '
@@ -2222,7 +2222,7 @@ class MutationsExtendedValidator(CustomDriverAnnotationValidator):
 
     def checkEndPosition(self, value):
         """Check that the End_Position value is an integer."""
-        if value == 'NA':
+        if value == '' or value == 'NA':
             self.logger.warning(
                 'The end position of this variant is not '
                     'defined. The chromosome plot in the patient view '

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -1479,8 +1479,8 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
                 'mutations/data_mutations_wrong_gene_position.maf',
                 validateData.MutationsExtendedValidator,
                 extra_meta_fields={'swissprot_identifier': 'name'})
-        # we expect 4 errors:
-        self.assertEqual(4, len(record_list))
+        # we expect 2 errors:
+        self.assertEqual(2, len(record_list))
         record_iterator = iter(record_list)
         # first is an error about wrong value in Start_Position:
         record = next(record_iterator)
@@ -1488,16 +1488,6 @@ class MutationsSpecialCasesTestCase(PostClinicalDataFileTestCase):
         self.assertIn('The start position of this variant is not '
                       'an integer', record.getMessage())
         # second is an error about wrong value in End_Position:
-        record = next(record_iterator)
-        self.assertEqual(logging.ERROR, record.levelno)
-        self.assertIn('The end position of this variant is not '
-                      'an integer', record.getMessage())
-        # third is an error about no value in Start_Position:
-        record = next(record_iterator)
-        self.assertEqual(logging.ERROR, record.levelno)
-        self.assertIn('The start position of this variant is not '
-                      'an integer', record.getMessage())
-        # forth is an error about no value in End_Position:
         record = next(record_iterator)
         self.assertEqual(logging.ERROR, record.levelno)
         self.assertIn('The end position of this variant is not '


### PR DESCRIPTION
Describe changes proposed in this pull request:

The current [file format description for mutation data](https://docs.cbioportal.org/5.1-data-loading/data-loading/file-formats#mutation-data) lists `Start_Position` and `End_Position` as optional attributes. 

If those columns are not present at all the import of data without start/end position works just fine. However, **if these columns are present in the header and are left empty** you will get an error message stating that `''` is  not an integer value. 
By looking at the source code of the validator I identified `NA` as an alternative option. The usage of `NA` however leads to an error message in the `checkAlleleMAFFormat` function where it tries to cast `NA` to a float. 

Therefore I propose to gor for an empty string for `Start_Position` and `End_Position` as this successfully passes the validator and is much more intuitive.