### PR TITLE
Fix mysql "local infile" problem in integration tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -280,7 +280,7 @@
               <url>${db.test.url}</url>
               <username>${db.test.username}</username>
               <password>${db.test.password}</password>
-              <sqlCommand>SET storage_engine=INNODB</sqlCommand>
+              <sqlCommand>SET default_storage_engine=InnoDB</sqlCommand>
               <sqlCommand>SET SESSION sql_mode = 'ANSI_QUOTES'</sqlCommand>
               <srcFiles>
                 <srcFile>${project.build.testOutputDirectory}/cgds-test.sql</srcFile>

--- a/core/src/test/resources/applicationContext-dao.xml
+++ b/core/src/test/resources/applicationContext-dao.xml
@@ -58,7 +58,7 @@
 	<!-- Values are for testing only, so need to correspond to the cgds in the pom.xml -->
 	<bean id="dbcpDataSource" destroy-method="close" class="org.apache.commons.dbcp2.BasicDataSource">
 		<property name="driverClassName" value="com.mysql.jdbc.Driver" />
-		<property name="url" value="jdbc:mysql://localhost:3306/cgds_test" />
+		<property name="url" value="jdbc:mysql://localhost:3306/cgds_test?allowLoadLocalInfile=true&amp;useSSL=false" />
         <!-- - test db credentials should be keep in sync with parent pom.xml -->
 		<property name="username" value="${db.test.username:cbio_user}" />
 		<property name="password" value="${db.test.password:somepassword}" />

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,37 +1,127 @@
 # Introduction
-This page is about how to run and debug, in an IDE agnostic way,
-any test classes added to the backend (Java layer).
+
+This page is about how to run and debug, in an IDE agnostic way, any test classes added to the backend (Java layer).
 
 # Steps
 
-1. make sure you have a test database with name `cgds_test` available in mysql (this can be an empty db schema)
-2. make sure you have built the project once with e.g. `mvn clean install -DskipTests`
-3. Run integration tests with 
+## Set up test instance of MySQL server
+
+### System installed (assumes Linux OS)
+
+1. Start mysql:
+
+```
+sudo systemctl start mysql
+```
+
+2. Log into database:
+
+```shell
+sudo mysql -u root
+```
+
+or
+
+```shell
+mysql -u root -p
+```
+
+3. In the MySQL console run:
+
+```shell
+SET GLOBAL local_infile=1;
+CREATE DATABASE cgds_test;
+CREATE USER 'cbio_user'@'localhost' IDENTIFIED BY 'somepassword';
+GRANT ALL ON cgds_test.* TO 'cbio_user'@'localhost'";
+FLUSH PRIVILEGES;
+SET default_storage_engine=InnoDB;
+SET SESSION sql_mode = 'ANSI_QUOTES';
+```
+
+4. (Optional) Load schema and seed:
+
+When running tests through Maven this step can be skipped. In MySQL console run:
+
+```shell
+source <path-to-file>/cgds-test.sql
+source <path-to-file>/seed_mini.sql
+```
+
+#### Note
+
+_Cgds-test.sql_ should be generated with `/db-scripts/src/main/resources/gen-cgds-test-schema.sh`.
+
+## Docker container
+
+1. Create file `init.sql` with the following contents:
+
+```shell
+SET GLOBAL local_infile=1;
+CREATE DATABASE cgds_test;
+CREATE USER 'cbio_user'@'localhost' IDENTIFIED BY 'somepassword';
+GRANT ALL ON cgds_test.* TO 'cbio_user'@'localhost'";
+FLUSH PRIVILEGES;
+SET default_storage_engine=InnoDB;
+SET SESSION sql_mode = 'ANSI_QUOTES';
+```
+
+2. Run (making sure the file paths are correct):
+
+```shell
+ docker run -ti --rm \
+  --name testdb \
+  --env MYSQL_ROOT_PASSWORD=root \
+  --env MYSQL_USER=cbio_user \
+  --env MYSQL_PASSWORD=somepassword \
+  --env MYSQL_DATABASE=cgds_test \
+  -v <path-to-file>/init.sql:/docker-entrypoint-initdb.d/first_file.sql \
+  -v <path-to-file>/cgds-test.sql:/docker-entrypoint-initdb.d/second_file.sql \
+  -v <path-to-file>/seed_mini.sql:/docker-entrypoint-initdb.d/third_file.sql \
+  -p 3306:3306 mysql:5.7
+```
+
+#### Notes
+
+- When running tests through Maven, the line with volume mounts (starting with `-v`) to the schema (_cgds-test.sql_) and
+  seed (_seed_mini.sql_) should be skipped.
+- _Cgds-test.sql_ should be generated with `/db-scripts/src/main/resources/gen-cgds-test-schema.sh`.
+
+## Running the tests with Maven
+
+1. Make sure you have built the project once with e.g. `mvn clean install -DskipTests`
+2. Run integration tests with
+
 ```
 mvn integration-test -Ddb.test.username=cbio -Ddb.test.password=<your_db_password>
 ```
+
 This will create the tables in `cgds_test` and populate your schema with test data.
 
-4. you can run all other tests with
+3. you can run all other tests with
+
 ```
 mvn test -Ddb.test.username=cbio -Ddb.test.password=<your_db_password>
 ```
 
-5. you can run a specific test with
+4. you can run a specific test with
+
 ```
 mvn test -pl core -Dtest=TestIntegrationTest -Ddb.test.username=cbio -Ddb.test.password= <your_db_password>
 ```
-where `-pl` is the name of the module (in this example `core`) and `-Dtest` is the name of the Java test
-class (in this example `TestIntegrationTest`).
 
-6. you can debug a specific test with
+where `-pl` is the name of the module (in this example `core`) and `-Dtest` is the name of the Java test class (in this
+example `TestIntegrationTest`).
+
+5. you can debug a specific test with
+
 ```
 mvn integration-test -Dmaven.surefire.debug -pl core test -Dtest=TestIntegrationTest -Ddb.test.username=cbio -Ddb.test.password=<your_db_password> 
 ```
-where `-pl` is the name of the module (in this example `core`) and `-Dtest` is the name of the Java test
-class (in this example `TestIntegrationTest`).
-This command will pause execution and wait for you to connect your IDE to the listening port,
-reporting something like below:
+
+where `-pl` is the name of the module (in this example `core`) and `-Dtest` is the name of the Java test class (in this
+example `TestIntegrationTest`). This command will pause execution and wait for you to connect your IDE to the listening
+port, reporting something like below:
+
 ```
 [INFO] Surefire report directory: /cbioportal/core/target/surefire-reports
 
@@ -44,5 +134,5 @@ reporting something like below:
 -------------------------------------------------------
 Listening for transport dt_socket at address: 5005
 ```
-Once you connected your IDE (after setting a breakpoint in the code), the execution will continue
-in your debugger view.
+
+Once you connected your IDE (after setting a breakpoint in the code), the execution will continue in your debugger view.

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
 
     <db.test.driver>com.mysql.jdbc.Driver</db.test.driver>
     <!-- For MySQL < 5.5 change 'default_storage_engine' to 'storage_engine' -->
-    <db.test.url>jdbc:mysql://127.0.0.1:3306/cgds_test?sessionVariables=default_storage_engine=InnoDB</db.test.url>
+    <db.test.url>jdbc:mysql://127.0.0.1:3306/cgds_test?sessionVariables=default_storage_engine=InnoDB&amp;allowLoadLocalInfile=true</db.test.url>
     <db.test.username>cbio_user</db.test.username>
     <db.test.password>somepassword</db.test.password>
 


### PR DESCRIPTION
# Problem
Running integration tests locally resulted in errors reporting permission problems on the test database.

# Cause
The problem is caused by the need to allow 'LOCAL INFILE' permissions in both client and server (see: https://stackoverflow.com/questions/18437689/error-1148-the-used-command-is-not-allowed-with-this-mysql-version/20722521)

# Solution
The cBioPortal test config was updated to allow 'LOCAL INFILE' permissions.