### PR TITLE
Introduced threads around calculateStatic/DynamicDataBin computation

### DIFF
--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataBinAsyncMethods.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataBinAsyncMethods.java
@@ -1,0 +1,58 @@
+package org.cbioportal.web.util;
+
+import org.cbioportal.model.ClinicalData;
+import org.cbioportal.model.ClinicalDataBin;
+import org.cbioportal.web.parameter.ClinicalDataBinFilter;
+import org.cbioportal.web.parameter.ClinicalDataType;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.scheduling.annotation.Async;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+@Component
+public class ClinicalDataBinAsyncMethods {
+
+    @Autowired
+    private DataBinner dataBinner;
+
+    @Autowired
+    private StudyViewFilterUtil studyViewFilterUtil;
+
+    @Async
+    public CompletableFuture<List<ClinicalDataBin>> calculateStaticClinicalDataBins(ClinicalDataBinFilter attribute,
+                                                                                    ClinicalDataType clinicalDataType,
+                                                                                    List<ClinicalData> filteredClinicalData,
+                                                                                    List<ClinicalData> unfilteredClinicalData,
+                                                                                    List<String> filteredIds,
+                                                                                    List<String> unfilteredIds) {
+        List<ClinicalDataBin> dataBins = dataBinner
+            .calculateClinicalDataBins(attribute, clinicalDataType,
+                                       filteredClinicalData, unfilteredClinicalData,
+                                       filteredIds, unfilteredIds)
+            .stream()
+            .map(dataBin -> studyViewFilterUtil.dataBinToClinicalDataBin(attribute, dataBin))
+            .collect(Collectors.toList());
+
+        return CompletableFuture.supplyAsync(() -> dataBins);
+    }
+
+    @Async
+    public CompletableFuture<List<ClinicalDataBin>> calculateDynamicClinicalDataBins(ClinicalDataBinFilter attribute,
+                                                                                     ClinicalDataType clinicalDataType,
+                                                                                     List<ClinicalData> filteredClinicalData,
+                                                                                     List<String> filteredIds) {
+        List<ClinicalDataBin> dataBins = dataBinner
+            .calculateDataBins(attribute, clinicalDataType,
+                               filteredClinicalData,
+                               filteredIds)
+            .stream()
+            .map(dataBin -> studyViewFilterUtil.dataBinToClinicalDataBin(attribute, dataBin))
+            .collect(Collectors.toList());
+
+        return CompletableFuture.supplyAsync(() -> dataBins);
+    }
+}

--- a/web/src/test/java/org/cbioportal/web/util/ClinicalDataBinUtilTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/ClinicalDataBinUtilTest.java
@@ -48,7 +48,10 @@ public class ClinicalDataBinUtilTest {
     private StudyViewFilterUtil studyViewFilterUtil;
     @Spy
     private ClinicalAttributeUtil clinicalAttributeUtil;
-    
+
+    @Spy
+    @InjectMocks
+    private ClinicalDataBinAsyncMethods clinicalDataBinAsyncMethods;
     @Spy
     @InjectMocks
     private DataBinner dataBinner;


### PR DESCRIPTION
In an effort to improve backend performance via call to endpoint /clinical-data-bin-counts/fetch, threading was introduced to parallelize calls to ClinicalDataBinUtil.calculateStaticDataBins() which through profiling appeared to be one bottleneck in backend servicing of these requests. Threading mechanism was patterned matched against implementation used to improve co-expression computation.

The optimization was tested against the MSK IMPACT Study (~75k samples) using a laptop running the codebase connecting to a remote MySQL via vpn and deploying the war with a cold cache.

An example call to ClinicalDataBinUtil.calculateStaticDataBins before optimization:

![image](https://user-images.githubusercontent.com/366003/144470831-7b7393ea-07b0-47ff-91ba-1f3dc03fa5aa.png)

An example call to ClinicalDataBinUtil.calculateStaticDataBins after optimization:

![image](https://user-images.githubusercontent.com/366003/144471710-b54142b4-3cdd-452f-ae50-cd5e8f3df5a8.png)



