### PR TITLE
Optimization to ProfiledCasesCounter when counting profiled samples.

### DIFF
--- a/service/src/main/java/org/cbioportal/service/util/AlterationEnrichmentUtil.java
+++ b/service/src/main/java/org/cbioportal/service/util/AlterationEnrichmentUtil.java
@@ -81,11 +81,17 @@ public class AlterationEnrichmentUtil<T extends AlterationCountByGene> {
             .stream()
             .filter(gene -> {
                 // filter genes where number of altered cases in all groups is 0
+                // or where number of altered cases > number of profiled cases
+                // (the latter can happen in targeted studies when the gene is not on a panel,
+                // but it is a participant in a structural variant, e.g. fusion, with a gene
+                // that is on the panel
                 return groups.stream().filter(group -> {
                     AlterationCountByGene mutationCountByGene = mutationCountsbyEntrezGeneIdAndGroup
                         .getOrDefault(group, new HashMap<Integer, AlterationCountByGene>())
                         .get(gene.getEntrezGeneId());
-                    return mutationCountByGene == null ? false : mutationCountByGene.getNumberOfAlteredCases() != 0;
+                    return mutationCountByGene == null ? false : (mutationCountByGene.getNumberOfAlteredCases() != 0
+                                                                  && mutationCountByGene.getNumberOfAlteredCases() <=
+                                                                  mutationCountByGene.getNumberOfProfiledCases());
                 }).count() > 0;
             })
             .map(gene -> {

--- a/service/src/test/java/org/cbioportal/service/util/ProfiledCasesCounterTest.java
+++ b/service/src/test/java/org/cbioportal/service/util/ProfiledCasesCounterTest.java
@@ -106,21 +106,21 @@ public class ProfiledCasesCounterTest {
 
         Assert.assertEquals(Integer.valueOf(3), alterationCounts.get(0).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(1).getNumberOfProfiledCases());
-        Assert.assertEquals(Integer.valueOf(3), alterationCounts.get(2).getNumberOfProfiledCases());
+        Assert.assertEquals(Integer.valueOf(1), alterationCounts.get(2).getNumberOfProfiledCases());
         
         
         profiledSamplesCounter.calculate(alterationCounts, genePanelDataList, false, profiledSamplesCounter.patientUniqueIdentifier);
         
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(0).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(1).getNumberOfProfiledCases());
-        Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(2).getNumberOfProfiledCases());
+        Assert.assertEquals(Integer.valueOf(1), alterationCounts.get(2).getNumberOfProfiledCases());
 
         profiledSamplesCounter.calculate(alterationCounts, genePanelDataList, true, profiledSamplesCounter.patientUniqueIdentifier);
 
         Assert.assertEquals(4, alterationCounts.size());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(0).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(1).getNumberOfProfiledCases());
-        Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(2).getNumberOfProfiledCases());
+        Assert.assertEquals(Integer.valueOf(1), alterationCounts.get(2).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(3).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(4), alterationCounts.get(3).getEntrezGeneId());
 


### PR DESCRIPTION
This PR is an update to closed [PR 9048](https://github.com/cBioPortal/cbioportal/pull/9048) to optimize the counting of profiled samples.  This PR includes a fix to a bug that was first [reported](https://groups.google.com/g/cbioportal/c/lDIpbTnk2JA) by a google group user when performing the following [group comparison](https://www.cbioportal.org/comparison/alterations?comparisonId=61a12cf9f8f71021ce576cb2&unselectedGroups=%5B%5D) using the MSKCC IMPACT 2017 cohort.

This PR addresses a situation in [AlterationEnrichmentUtil.createAlterationsEnrichments()](https://github.com/n1zea144/cbioportal/blob/demo-profiled-cases-counter-opt/service/src/main/java/org/cbioportal/service/util/AlterationEnrichmentUtil.java#L92) in which a chi square test is performed on a gene that results in a apache commons math exception because it has more altered samples than the number of samples profiled.  This condition occurs when there is a sample with an altered gene (in this case SERPINE2) that doesn't exist on a targeted panel, but is fused with a gene that does (CUL3).  This exception was not brought to light until a bug was uncovered and fixed in [PR 9048](https://github.com/cBioPortal/cbioportal/pull/9048).