### PR TITLE
Turn off aspectj logging by default to improve request processing time.

### DIFF
--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -345,6 +345,11 @@ persistence.cache_type=no-cache
 #hrrs.logging.filepath=
 #hrrs.enable.logging=false
 
+# enable/disable aspectj logging
+# if active, all enter/exits to methods in web, service-impl,
+# and mybatis packages are logged 
+#aspect.enable.logging=false
+
 # ensembl URL template for transcript lookup in Mutations tab. Default is http://grch37.ensembl.org/homo_sapiens/Transcript/Summary?t=<%= transcriptId %>
 #ensembl.transcript_url=http://ensembl.org/homo_sapiens/Transcript/Summary?t=<%= transcriptId %>
 

--- a/web/src/main/java/org/cbioportal/logging/LoggingAspect.java
+++ b/web/src/main/java/org/cbioportal/logging/LoggingAspect.java
@@ -7,9 +7,11 @@ import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
+import org.cbioportal.utils.config.annotation.ConditionalOnProperty;
 
 @Aspect
 @Component
+@ConditionalOnProperty(name = "aspect.enable.logging", havingValue = "true")
 public class LoggingAspect {
 
     private static final Logger logger = LogManager.getLogger("LoggingAspect");


### PR DESCRIPTION
Improves response time /clinical-data-bin-counts by removing "cross-cutting" calls to logging for every entry/exit to methods in service-impl, web, and mybatis. Also, brings clarity to business logic that takes most processing time.

Before:
![image](https://user-images.githubusercontent.com/366003/145608301-3701174c-21f1-4c0d-82fb-3c881cce2d82.png)

After:
![image](https://user-images.githubusercontent.com/366003/145608375-4f1a4cb6-cf01-459a-a405-8eb2ec8599a6.png)
