### PR TITLE
Remove log4j 1.x and upgrade to log4j 2.16

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/model/LinkOutRequest.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/model/LinkOutRequest.java
@@ -37,7 +37,8 @@ import org.mskcc.cbio.portal.web_api.ProtocolException;
 import org.mskcc.cbio.portal.dao.DaoCancerStudy;
 import org.mskcc.cbio.portal.dao.DaoException;
 import org.owasp.validator.html.PolicyException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.servlet.http.HttpServletRequest;
 import java.net.URLEncoder;
@@ -55,7 +56,7 @@ public class LinkOutRequest {
     public static final String STABLE_PARAM_REPORT = "report";
     public static final String REPORT_FULL = "full";
     public static final String REPORT_ONCOPRINT_HTML = "oncoprint_html";
-    private static Logger logger = Logger.getLogger(LinkOutRequest.class);
+    private static Logger logger = LogManager.getLogger(LinkOutRequest.class);
 
     private String cancerStudyId;
     private String geneList;

--- a/core/src/main/java/org/mskcc/cbio/portal/model/Patient.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/model/Patient.java
@@ -34,7 +34,8 @@ package org.mskcc.cbio.portal.model;
 
 import java.util.Map;
 import java.util.HashMap;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * Encapsulates Patient Data.
@@ -48,7 +49,7 @@ public class Patient {
     private CancerStudy cancerStudy;
 
 	private Map<String, ClinicalData> clinicalDataMap;
-    private static final Logger logger = Logger.getLogger(Patient.class);
+    private static final Logger logger = LogManager.getLogger(Patient.class);
 
     public Patient(CancerStudy cancerStudy, String stableId)
     {

--- a/core/src/main/java/org/mskcc/cbio/portal/mut_diagram/Pileup.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/mut_diagram/Pileup.java
@@ -41,7 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.mskcc.cbio.portal.model.ExtendedMutation;
 
 import com.google.common.base.Joiner;
@@ -57,7 +58,7 @@ import com.google.common.collect.Sets;
  * Pileup of one or mutations at a single location.
  */
 public final class Pileup {
-    private static final Logger logger = Logger.getLogger(Pileup.class);
+    private static final Logger logger = LogManager.getLogger(Pileup.class);
     private final String label;
     private final int location;
     private final int count;

--- a/core/src/main/java/org/mskcc/cbio/portal/mut_diagram/impl/CacheFeatureService.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/mut_diagram/impl/CacheFeatureService.java
@@ -37,7 +37,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.mskcc.cbio.portal.mut_diagram.FeatureService;
 import org.mskcc.cbio.portal.mut_diagram.Sequence;
 
@@ -50,7 +51,7 @@ import com.google.common.cache.CacheLoader;
  */
 public final class CacheFeatureService implements FeatureService {
     private static final List<Sequence> EMPTY = Collections.emptyList();
-    private static final Logger logger = Logger.getLogger(CacheFeatureService.class);
+    private static final Logger logger = LogManager.getLogger(CacheFeatureService.class);
     private final Cache<String, List<Sequence>> cache;
 
     /**

--- a/core/src/main/java/org/mskcc/cbio/portal/mut_diagram/impl/CgdsIdMappingService.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/mut_diagram/impl/CgdsIdMappingService.java
@@ -37,7 +37,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.mskcc.cbio.portal.dao.DaoException;
 import org.mskcc.cbio.portal.dao.DaoGeneOptimized;
 import org.mskcc.cbio.portal.dao.DaoUniProtIdMapping;
@@ -48,7 +49,7 @@ import org.mskcc.cbio.portal.mut_diagram.IdMappingService;
  * Implementation of IdMappingService that reads from the CGDS data source.
  */
 public final class CgdsIdMappingService implements IdMappingService {
-    private static final Logger logger = Logger.getLogger(CgdsIdMappingService.class);
+    private static final Logger logger = LogManager.getLogger(CgdsIdMappingService.class);
     private final DaoGeneOptimized geneDao;
 
     public CgdsIdMappingService(final DaoGeneOptimized geneDao) {

--- a/core/src/main/java/org/mskcc/cbio/portal/mut_diagram/impl/PfamGraphicsCacheLoader.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/mut_diagram/impl/PfamGraphicsCacheLoader.java
@@ -36,7 +36,8 @@ import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.mskcc.cbio.portal.mut_diagram.Sequence;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -49,7 +50,7 @@ import com.google.common.collect.ImmutableList;
  * Feature service cache loader that calls the Pfam graphics service.
  */
 public final class PfamGraphicsCacheLoader extends CacheLoader<String, List<Sequence>> {
-    private static final Logger logger = Logger.getLogger(PfamGraphicsCacheLoader.class);
+    private static final Logger logger = LogManager.getLogger(PfamGraphicsCacheLoader.class);
     static final String URL_PREFIX = "http://pfam.sanger.ac.uk/protein/";
     static final String URL_SUFFIX = "/graphic";
     private final ObjectMapper objectMapper;

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/CheckDarwinAccessServlet.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/CheckDarwinAccessServlet.java
@@ -34,7 +34,8 @@ package org.mskcc.cbio.portal.servlet;
 
 import org.mskcc.cbio.portal.util.SpringUtil;
 import org.mskcc.cbio.portal.util.GlobalProperties;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
@@ -68,7 +69,7 @@ import javax.servlet.ServletException;
 "deidentification_id"
 })
 public class CheckDarwinAccessServlet extends HttpServlet {
-    private static Logger logger = Logger.getLogger(CheckDarwinAccessServlet.class);
+    private static Logger logger = LogManager.getLogger(CheckDarwinAccessServlet.class);
     private static final String DDP_INFO_ENDPOINT = "/info";
 
     @Override

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/CnaJSON.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/CnaJSON.java
@@ -35,7 +35,8 @@ package org.mskcc.cbio.portal.servlet;
 import org.mskcc.cbio.portal.model.*;
 import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.util.*;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.cbioportal.model.CNA;
 
 import java.io.*;
@@ -52,7 +53,7 @@ import javax.servlet.ServletException;
  * @author jj
  */
 public class CnaJSON extends HttpServlet {
-    private static Logger logger = Logger.getLogger(CnaJSON.class);
+    private static Logger logger = LogManager.getLogger(CnaJSON.class);
     
     public static final String CMD = "cmd";
     public static final String GET_DRUG_CMD = "get_drug";

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/CrossCancerJSON.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/CrossCancerJSON.java
@@ -36,7 +36,8 @@ import java.io.*;
 import javax.servlet.ServletException;
 import javax.servlet.http.*;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.json.simple.JSONValue;
 import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.*;
@@ -46,7 +47,7 @@ import org.mskcc.cbio.portal.web_api.*;
 import java.util.*;
 
 public class CrossCancerJSON extends HttpServlet {
-    private static Logger logger = Logger.getLogger(CrossCancerJSON.class);
+    private static Logger logger = LogManager.getLogger(CrossCancerJSON.class);
 
     // class which process access control to cancer studies
     private AccessControl accessControl;

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/DrugsJSON.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/DrugsJSON.java
@@ -40,7 +40,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONValue;
 import org.mskcc.cbio.portal.dao.DaoDrug;
@@ -55,7 +56,7 @@ import org.mskcc.cbio.portal.model.DrugInteraction;
  * @author jj
  */
 public class DrugsJSON extends HttpServlet {
-    private static Logger logger = Logger.getLogger(DrugsJSON.class);
+    private static Logger logger = LogManager.getLogger(DrugsJSON.class);
     
     public static final String DRUG_IDS = "drug_ids";
     

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/OmaRedirectServlet.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/OmaRedirectServlet.java
@@ -39,7 +39,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.mskcc.cbio.portal.util.OmaLinkUtil;
@@ -51,7 +52,7 @@ import org.mskcc.cbio.portal.util.OmaLinkUtil;
  */
 public class OmaRedirectServlet extends HttpServlet {
 
-    private static Logger logger = Logger.getLogger(OmaRedirectServlet.class);
+    private static Logger logger = LogManager.getLogger(OmaRedirectServlet.class);
 
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/PatientView.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/PatientView.java
@@ -39,7 +39,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.mskcc.cbio.portal.util.*;
 
 import org.springframework.web.context.support.SpringBeanAutowiringSupport;
@@ -62,7 +63,7 @@ public class PatientView extends HttpServlet {
     public static final String DRUG_TYPE_CANCER_DRUG = "cancer_drug";
     public static final String DRUG_TYPE_FDA_ONLY = "fda_approved";
 
-    private static Logger logger = Logger.getLogger(PatientView.class);
+    private static Logger logger = LogManager.getLogger(PatientView.class);
 
     @Override
     public void init(ServletConfig config) throws ServletException {

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/SimilarPatientsJSON.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/SimilarPatientsJSON.java
@@ -38,7 +38,8 @@ import java.util.*;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.*;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.json.simple.*;
 import org.mskcc.cbio.portal.dao.*;
 import org.mskcc.cbio.portal.model.*;
@@ -50,7 +51,7 @@ import org.mskcc.cbio.portal.util.SpringUtil;
  * @author jj
  */
 public class SimilarPatientsJSON extends HttpServlet {
-    private static Logger logger = Logger.getLogger(SimilarPatientsJSON.class);
+    private static Logger logger = LogManager.getLogger(SimilarPatientsJSON.class);
     
     public static final String MUTATION = "mutation";
     public static final String CNA = "cna";

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/WebService.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/WebService.java
@@ -45,7 +45,8 @@ import java.util.*;
 import java.util.regex.Pattern;
 import javax.servlet.http.*;
 import javax.servlet.ServletException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * Core Web Service.
@@ -54,7 +55,7 @@ import org.apache.log4j.Logger;
  * @author Arthur Goldberg goldberg@cbio.mskcc.org
  */
 public class WebService extends HttpServlet {
-    private static Logger logger = Logger.getLogger(WebService.class);
+    private static Logger logger = LogManager.getLogger(WebService.class);
     public static final String CANCER_STUDY_ID = "cancer_study_id";
     public static final String CANCER_TYPE_ID = "cancer_type_id";
     public static final String GENETIC_PROFILE_ID = "genetic_profile_id";

--- a/core/src/main/java/org/mskcc/cbio/portal/util/ProgressMonitor.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/ProgressMonitor.java
@@ -32,7 +32,7 @@
 
 package org.mskcc.cbio.portal.util;
 
-import org.apache.log4j.*;
+import org.apache.logging.log4j.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -50,7 +50,7 @@ public class ProgressMonitor {
     private int curValue;
     private String currentMessage;
     private StringBuffer log = new StringBuffer();
-    private static org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(ProgressMonitor.class);
+    private static org.apache.logging.log4j.Logger logger = org.apache.logging.log4j.LogManager.getLogger(ProgressMonitor.class);
     private boolean consoleMode;
     private boolean showProgress;
     private TreeSet<String> warnings = new TreeSet<>();

--- a/core/src/main/java/org/mskcc/cbio/portal/util/ServerDetector.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/ServerDetector.java
@@ -22,7 +22,8 @@
 
 package org.mskcc.cbio.portal.util;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 
 /**
@@ -32,7 +33,7 @@ import org.apache.log4j.Logger;
  *
  */
 public class ServerDetector {
-    private static final Logger logger = Logger.getLogger(ServerDetector.class);
+    private static final Logger logger = LogManager.getLogger(ServerDetector.class);
     private static boolean isInstanceInitialized = false;
     private static ServerDetector instance = new ServerDetector();
 

--- a/pom.xml
+++ b/pom.xml
@@ -572,14 +572,14 @@
       </dependency>
       <!-- slf4j -->
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.32</version>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-to-slf4j</artifactId>
+        <version>2.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.30</version>
+        <version>1.7.32</version>
       </dependency>
       <!-- spring -->
       <dependency>
@@ -790,7 +790,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.16.0</version>
       </dependency>
       <!-- junit -->
       <dependency>

--- a/portal/src/org/mskcc/portal/oncotator/OncotatorService.java
+++ b/portal/src/org/mskcc/portal/oncotator/OncotatorService.java
@@ -3,7 +3,7 @@ package org.mskcc.portal.oncotator;
 import org.mskcc.cgds.dao.DaoException;
 import org.mskcc.cgds.dao.DaoOncotatorCache;
 import org.mskcc.portal.util.WebFileConnect;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.io.BufferedReader;

--- a/src/main/resources/log4j.properties.EXAMPLE
+++ b/src/main/resources/log4j.properties.EXAMPLE
@@ -9,11 +9,11 @@ log4j.category.org.mskcc=INFO
 #log4j.logger.org.springframework.security=DEBUG
 #log4j.logger.org.springframework.integration=DEBUG
 
-log4j.appender.a = org.apache.log4j.ConsoleAppender
+log4j.appender.a = org.apache.logging.log4j.ConsoleAppender
 log4j.appender.a.target=System.out
 log4j.appender.a.immediateFlush=true
 log4j.appender.a.encoding=UTF-8
 log4j.appender.a.threshold=Error
 
-log4j.appender.a.layout = org.apache.log4j.PatternLayout
+log4j.appender.a.layout = org.apache.logging.log4j.PatternLayout
 log4j.appender.a.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} [%t] %-5p %c - %m%n

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -115,8 +115,8 @@
       <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/web/src/main/java/org/cbioportal/logging/LoggingAspect.java
+++ b/web/src/main/java/org/cbioportal/logging/LoggingAspect.java
@@ -1,7 +1,7 @@
 package org.cbioportal.logging;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;


### PR DESCRIPTION
- We were still importing log4j 1 via log4j-to-slf4j
- Updated log4j-to-slf4j to 2.16
- Updated logging in core using this guide: https://logging.apache.org/log4j/2.x/manual/migration.html

Output from `mvn clean install dependency:tree -DskipTests | grep log4j`:

```
[INFO] +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.15.0:compile
[INFO] |  \- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.15.0:compile
[INFO] +- org.apache.logging.log4j:log4j-core:jar:2.15.0:compile
[INFO] |  \- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:compile
[INFO] |     \- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.15.0:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.15.0:compile
[INFO] |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:compile
[INFO] |     \- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
```