### PR TITLE
Throws exceptions for missing sample list id

### DIFF
--- a/model/src/main/java/org/cbioportal/model/Sample.java
+++ b/model/src/main/java/org/cbioportal/model/Sample.java
@@ -1,6 +1,7 @@
 package org.cbioportal.model;
 
 import javax.validation.constraints.NotNull;
+import java.util.Objects;
 
 public class Sample extends UniqueKeyBase {
 
@@ -129,4 +130,17 @@ public class Sample extends UniqueKeyBase {
     public Boolean getProfiledForFusions() { return profiledForFusions; }
 
     public void setProfiledForFusions(Boolean profiledForFusions) { this.profiledForFusions = profiledForFusions; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Sample)) return false;
+        Sample sample = (Sample) o;
+        return getStableId().equals(sample.getStableId()) && getCancerStudyIdentifier().equals(sample.getCancerStudyIdentifier());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getStableId(), getCancerStudyIdentifier());
+    }
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SampleRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/SampleRepository.java
@@ -44,8 +44,10 @@ public interface SampleRepository {
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<Sample> fetchSamples(List<String> studyIds, List<String> sampleIds, String projection);
 
+    List<Sample> fetchSamplesBySampleListIds(List<String> sampleListIds, String projection);
+    
     @Cacheable(cacheResolver = "staticRepositoryCacheOneResolver", condition = "@cacheEnabledConfig.getEnabled()")
-    List<Sample> fetchSamples(List<String> sampleListIds, String projection);
+    List<Sample> fetchSampleBySampleListId(String sampleListIds, String projection);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     BaseMeta fetchMetaSamples(List<String> studyIds, List<String> sampleIds);

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularProfileMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/MolecularProfileMapper.xml
@@ -39,9 +39,14 @@
         INNER JOIN reference_genome ON cancer_study.REFERENCE_GENOME_ID = reference_genome.REFERENCE_GENOME_ID
         <if test="studyIds != null">
             WHERE cancer_study.CANCER_STUDY_IDENTIFIER IN
-            <foreach item="item" collection="studyIds" open="(" separator="," close=")">
-                #{item}
-            </foreach>
+            <if test="studyIds.isEmpty()">
+                (NULL)
+            </if>
+            <if test="!studyIds.isEmpty()">
+                <foreach item="item" collection="studyIds" open="(" separator="," close=")">
+                    #{item}
+                </foreach>
+            </if>
         </if>
         <if test="sortBy != null and projection != 'ID'">
             ORDER BY ${sortBy} ${direction}

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/SampleMyBatisRepositoryTest.java
@@ -288,7 +288,7 @@ public class SampleMyBatisRepositoryTest {
         sampleListIds.add("study_tcga_pub_all");
         sampleListIds.add("study_tcga_pub_acgh");
 
-        List<Sample> result = sampleMyBatisRepository.fetchSamples(sampleListIds, "SUMMARY");
+        List<Sample> result = sampleMyBatisRepository.fetchSamplesBySampleListIds(sampleListIds, "SUMMARY");
 
         Assert.assertEquals(14, result.size());
         Assert.assertEquals("TCGA-A1-A0SB-01", result.get(0).getStableId());

--- a/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
@@ -1,6 +1,5 @@
 package org.cbioportal.service.impl;
 
-import org.cbioportal.model.CopyNumberSeg;
 import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.Sample;
 import org.cbioportal.model.meta.BaseMeta;
@@ -15,9 +14,6 @@ import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
-import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -150,7 +146,7 @@ public class SampleServiceImpl implements SampleService {
     @Override
 	public List<Sample> fetchSamples(List<String> sampleListIds, String projection) {
 
-        List<Sample> samples = sampleRepository.fetchSamples(sampleListIds, projection);
+        List<Sample> samples = sampleRepository.fetchSamplesBySampleListIds(sampleListIds, projection);
 
         processSamples(samples, projection);
         return samples;

--- a/service/src/test/java/org/cbioportal/service/impl/SampleServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/SampleServiceImplTest.java
@@ -286,7 +286,7 @@ public class SampleServiceImplTest extends BaseServiceImplTest {
         Sample sample = new Sample();
         expectedSampleList.add(sample);
 
-        Mockito.when(sampleRepository.fetchSamples(Arrays.asList(SAMPLE_LIST_ID), PROJECTION))
+        Mockito.when(sampleRepository.fetchSamplesBySampleListIds(Arrays.asList(SAMPLE_LIST_ID), PROJECTION))
                 .thenReturn(expectedSampleList);
 
         List<Sample> result = sampleService.fetchSamples(Arrays.asList(SAMPLE_LIST_ID), PROJECTION);


### PR DESCRIPTION
Fix https://github.com/cbioportal/cbioportal/issues/9138

**Issue Description:**
Sometimes, Results view page will try to get samples from the sample list id, but an outdated query can have a sample list id that does not exist anymore.
In this case, we want to throw a 404 exception because we cannot find that sample list id in our database.

**Describe changes proposed in this pull request:**
- Update MolecularProfileMapper.xml (studyIds can be an empty list, this update will fix this issue)
- Throw SampleListNotFoundException for the case when we have a missing sample list id in `/samples/fetch` endpoint
- Renaming `fetchSamples` method to `fetchSampleBySampleListIds`, and have it iteratively call `fetchSampleBySampleListId` method that is cached.