### PR TITLE
Fix ASCN namespace import

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportExtendedMutationData.java
@@ -73,7 +73,7 @@ public class ImportExtendedMutationData{
     private Set<String> filteredMutations = new HashSet<String>();
     private Set<String> namespaces = new HashSet<String>();
     private Pattern SEQUENCE_SAMPLES_REGEX = Pattern.compile("^.*sequenced_samples:(.*)$");
-    private final String ASCN_NAMESPACE = "ascn";
+    private final String ASCN_NAMESPACE = "ASCN";
 
     /**
      * construct an ImportExtendedMutationData.


### PR DESCRIPTION
# Problem
Namespace import of ASCN columns from MAF file was broken in previous commit because the namespace match is now case sensitive.

# Solution
Correct case for namespace name used to decide whether to import ASCN columns. 