### PR TITLE
Fixes divide by zero events on the study view page

### DIFF
--- a/service/src/main/java/org/cbioportal/service/util/ProfiledCasesCounter.java
+++ b/service/src/main/java/org/cbioportal/service/util/ProfiledCasesCounter.java
@@ -94,7 +94,10 @@ public class ProfiledCasesCounter<T extends AlterationCountByGene> {
                     alterationCountByGene.setNumberOfProfiledCases(totalProfiledSamples);
                 }
             } else {
-                alterationCountByGene.setNumberOfProfiledCases(casesWithoutPanelData.size());
+                // we use profiledCasesCount instead of casesWithoutPanelData to
+                // prevent a divide by zero error which can happen for targeted studies
+                // in which certain genes have events that are not captured by the panel.
+                alterationCountByGene.setNumberOfProfiledCases(profiledCasesCount);
             }
             alterationCountByGene.setMatchingGenePanelIds(allMatchingGenePanelIds);
         }

--- a/service/src/test/java/org/cbioportal/service/util/ProfiledCasesCounterTest.java
+++ b/service/src/test/java/org/cbioportal/service/util/ProfiledCasesCounterTest.java
@@ -106,21 +106,21 @@ public class ProfiledCasesCounterTest {
 
         Assert.assertEquals(Integer.valueOf(3), alterationCounts.get(0).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(1).getNumberOfProfiledCases());
-        Assert.assertEquals(Integer.valueOf(1), alterationCounts.get(2).getNumberOfProfiledCases());
+        Assert.assertEquals(Integer.valueOf(3), alterationCounts.get(2).getNumberOfProfiledCases());
         
         
         profiledSamplesCounter.calculate(alterationCounts, genePanelDataList, false, profiledSamplesCounter.patientUniqueIdentifier);
         
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(0).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(1).getNumberOfProfiledCases());
-        Assert.assertEquals(Integer.valueOf(1), alterationCounts.get(2).getNumberOfProfiledCases());
+        Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(2).getNumberOfProfiledCases());
 
         profiledSamplesCounter.calculate(alterationCounts, genePanelDataList, true, profiledSamplesCounter.patientUniqueIdentifier);
 
         Assert.assertEquals(4, alterationCounts.size());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(0).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(1).getNumberOfProfiledCases());
-        Assert.assertEquals(Integer.valueOf(1), alterationCounts.get(2).getNumberOfProfiledCases());
+        Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(2).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(3).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(4), alterationCounts.get(3).getEntrezGeneId());
 


### PR DESCRIPTION
PR fixes scenarios in which off panel genes have events that are not capture by the gene panel.  Prior to PR, if an event took place in a gene that was not on the panel (corner cases in studies like MSK-IMPACT or GENIE), the number of profiled samples calculated would be WES/WGS samples, which could be 0...and cause a divide by zero error (see image).   Code now uses total profiled samples (all profiled cases) for genes that are not on panel (this was behavior prior to optimization PR).

![image](https://user-images.githubusercontent.com/366003/147974433-fe121fdb-ab11-43e7-bbd2-d0b3d7f8c22a.png)
