### PR TITLE
Additional binning functions for genetic data

### DIFF
--- a/web/src/main/java/org/cbioportal/web/parameter/BinsGeneratorConfig.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/BinsGeneratorConfig.java
@@ -1,0 +1,26 @@
+package org.cbioportal.web.parameter;
+
+import java.math.BigDecimal;
+
+public class BinsGeneratorConfig {
+
+    private BigDecimal binSize;
+    private BigDecimal anchorValue;
+
+    public BigDecimal getBinSize() {
+        return binSize;
+    }
+
+    public void setBinSize(BigDecimal binSize) {
+        this.binSize = binSize;
+    }
+
+    public BigDecimal getAnchorValue() {
+        return anchorValue;
+    }
+
+    public void setAnchorValue(BigDecimal anchorValue) {
+        this.anchorValue = anchorValue;
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/web/parameter/DataBinFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/DataBinFilter.java
@@ -5,11 +5,28 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import javax.validation.constraints.AssertTrue;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 public class DataBinFilter implements Serializable {
 
+    public enum BinMethod {
+        MEDIAN,
+        QUARTILE,
+        CUSTOM,
+        GENERATE;
+    }
+
     private Boolean disableLogScale = false;
-    private List<BigDecimal> customBins;
+    private List<BigDecimal> customBins;                    // needed for 'Custom bins' frontend option
+    
+    // FIXME: Code added for backwards compatibility.
+    // Replace by commented out line after merge of PR:
+    // https://github.com/cBioPortal/cbioportal-frontend/pull/4102
+    private BinMethod binMethod = BinMethod.CUSTOM;
+    //private BinMethod binMethod;                           // needed for 'Median split' and 'Quartile' frontend options
+    
+    private BinsGeneratorConfig binsGeneratorConfig;          // needed for 'Generate Bins' frontend option
     private BigDecimal start;
     private BigDecimal end;
 
@@ -43,6 +60,23 @@ public class DataBinFilter implements Serializable {
 
     public void setEnd(BigDecimal end) {
         this.end = end;
+    }
+
+    public BinMethod getBinMethod() {
+        return binMethod;
+    }
+
+    public void setBinMethod(BinMethod binMethod) {
+        this.binMethod = binMethod;
+    }
+
+    public BinsGeneratorConfig getBinsGeneratorConfig() {
+        return binsGeneratorConfig;
+    }
+
+    public void setBinsGeneratorConfig(
+        BinsGeneratorConfig binsGeneratorConfig) {
+        this.binsGeneratorConfig = binsGeneratorConfig;
     }
 
     // TODO: make this work

--- a/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
+++ b/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
@@ -419,7 +419,7 @@ public class DataBinHelper {
         // Assumes that elements are sorted in ascending order
         BigDecimal minValue = sortedNumericalValues.get(0);
         BigDecimal maxValue = sortedNumericalValues.get(sortedNumericalValues.size()-1);
-        Assert.isTrue(minValue.compareTo(maxValue) != 1, "minValue larger than maxValue. Input is not sorted in ascending order!");
+        Assert.isTrue(minValue.compareTo(maxValue) < 1, "minValue larger than maxValue. Input is not sorted in ascending order!");
         
         List<BigDecimal> bins = new ArrayList<>();
         

--- a/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
+++ b/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
@@ -1,6 +1,7 @@
 package org.cbioportal.web.util;
 
 import com.google.common.collect.Range;
+import org.apache.commons.lang3.ObjectUtils;
 import org.cbioportal.model.DataBin;
 import org.springframework.stereotype.Component;
 
@@ -143,18 +144,17 @@ public class DataBinHelper {
     }
 
     public BigDecimal calcQ1(List<BigDecimal> sortedValues) {
-        return sortedValues.size() > 0 ?
-            sortedValues.get((int) Math.floor(sortedValues.size() / 4.0)) : null;
+        return sortedValues.isEmpty() ?
+            null : sortedValues.get((int) Math.floor(sortedValues.size() / 4.0));
     }
 
     public BigDecimal calcMedian(List<BigDecimal> sortedValues) {
-        return sortedValues.size() > 0 ?
-            sortedValues.get((int) Math.ceil((sortedValues.size() * (1.0 / 2.0)))) : null;
+        return ObjectUtils.median(sortedValues.toArray(new BigDecimal[0]));
     }
 
     public BigDecimal calcQ3(List<BigDecimal> sortedValues) {
-        return sortedValues.size() > 0 ?
-            sortedValues.get((int) Math.floor(sortedValues.size() * (3.0 / 4.0))) : null;
+        return sortedValues.isEmpty() ?
+             null : sortedValues.get((int) Math.floor(sortedValues.size() * (3.0 / 4.0)));
     }
 
     public List<BigDecimal> filterIntervals(List<BigDecimal> intervals, BigDecimal lowerOutlier, BigDecimal upperOutlier) {

--- a/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
+++ b/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
@@ -411,14 +411,16 @@ public class DataBinHelper {
         Assert.notNull(sortedNumericalValues, "sortedNumerical values is null!");
         Assert.notNull(binSize, "binSize values is null!");
         Assert.notNull(anchorValue, "anchorValue values is null!");
-
-        BigDecimal minValue = min(sortedNumericalValues);
-        BigDecimal maxValue = max(sortedNumericalValues);
         
-        if (minValue == null) {
+        if (sortedNumericalValues.isEmpty()) {
             return null;
         }
-    
+
+        // Assumes that elements are sorted in ascending order
+        BigDecimal minValue = sortedNumericalValues.get(0);
+        BigDecimal maxValue = sortedNumericalValues.get(sortedNumericalValues.size()-1);
+        Assert.isTrue(minValue.compareTo(maxValue) != 1, "minValue larger than maxValue. Input is not sorted in ascending order!");
+        
         List<BigDecimal> bins = new ArrayList<>();
         
         // Calculate the lower boundary.

--- a/web/src/main/java/org/cbioportal/web/util/LinearDataBinner.java
+++ b/web/src/main/java/org/cbioportal/web/util/LinearDataBinner.java
@@ -70,6 +70,8 @@ public class LinearDataBinner {
         return dataBins;
     }
 
+    // Add bins that have a defined start and end value.
+    // Ignore bins for lower (<=) and upper (>) limits.
     public List<DataBin> initDataBins(List<BigDecimal> bins) {
         List<DataBin> dataBins = new ArrayList<>();
         for (int i = 0; i < bins.size() - 1; i++) {

--- a/web/src/test/java/org/cbioportal/web/util/DataBinHelperTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/DataBinHelperTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -91,6 +92,15 @@ public class DataBinHelperTest {
             dataBinHelper.generateBins(sortedNumericalValues, new BigDecimal(10),
                 new BigDecimal(40));
         assertEquals(decList(), boundaries);
+    }
+
+    @Test
+    public void emptyNumericalValues() {
+        List<BigDecimal> sortedNumericalValues = new ArrayList<>();
+        List<BigDecimal> boundaries =
+            dataBinHelper.generateBins(sortedNumericalValues, new BigDecimal(10),
+                new BigDecimal(40));
+        assertNull(boundaries);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/web/src/test/java/org/cbioportal/web/util/DataBinHelperTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/DataBinHelperTest.java
@@ -1,0 +1,120 @@
+package org.cbioportal.web.util;
+
+import static org.junit.Assert.*;
+
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DataBinHelperTest {
+
+    private DataBinHelper dataBinHelper;
+
+    @Before
+    public void setUp() throws Exception {
+        dataBinHelper = new DataBinHelper();
+    }
+
+    @Test
+    public void rangeSmallerThanAnchor() {
+        List<BigDecimal> sortedNumericalValues =
+            Arrays.asList(new BigDecimal(-62), new BigDecimal(-38));
+        List<BigDecimal> boundaries =
+            dataBinHelper.generateBins(sortedNumericalValues, new BigDecimal(10),
+                new BigDecimal(0));
+        assertEquals(decList(-60, -50, -40), boundaries);
+    }
+
+    @Test
+    public void rangeLargerThanAnchor() {
+        List<BigDecimal> sortedNumericalValues =
+            Arrays.asList(new BigDecimal(-62), new BigDecimal(-38));
+        List<BigDecimal> boundaries =
+            dataBinHelper.generateBins(sortedNumericalValues, new BigDecimal(10),
+                new BigDecimal(-70));
+        assertEquals(decList(-60, -50, -40), boundaries);
+    }
+
+    @Test
+    public void rangeSpansAnchor() {
+        List<BigDecimal> sortedNumericalValues =
+            Arrays.asList(new BigDecimal(-62), new BigDecimal(-38));
+        List<BigDecimal> boundaries =
+            dataBinHelper.generateBins(sortedNumericalValues, new BigDecimal(10),
+                new BigDecimal(-20));
+        assertEquals(decList(-60, -50, -40), boundaries);
+    }
+
+    @Test
+    public void rangeSmallerThanAnchorPositiveRange() {
+        List<BigDecimal> sortedNumericalValues =
+            Arrays.asList(new BigDecimal(38), new BigDecimal(62));
+        List<BigDecimal> boundaries =
+            dataBinHelper.generateBins(sortedNumericalValues, new BigDecimal(10),
+                new BigDecimal(100));
+        assertEquals(decList(40, 50, 60), boundaries);
+    }
+
+    @Test
+    public void rangeLargerThanAnchorPositiveRange() {
+        List<BigDecimal> sortedNumericalValues =
+            Arrays.asList(new BigDecimal(38), new BigDecimal(62));
+        List<BigDecimal> boundaries =
+            dataBinHelper.generateBins(sortedNumericalValues, new BigDecimal(10),
+                new BigDecimal(0));
+        assertEquals(decList(40, 50, 60), boundaries);
+    }
+
+    @Test
+    public void rangeSpansAnchorPositiveRange() {
+        List<BigDecimal> sortedNumericalValues =
+            Arrays.asList(new BigDecimal(38), new BigDecimal(62));
+        List<BigDecimal> boundaries =
+            dataBinHelper.generateBins(sortedNumericalValues, new BigDecimal(10),
+                new BigDecimal(40));
+        assertEquals(decList(40, 50, 60), boundaries);
+    }
+
+    @Test
+    public void singleValueNoBoundaries() {
+        List<BigDecimal> sortedNumericalValues =
+            Arrays.asList(new BigDecimal(38));
+        List<BigDecimal> boundaries =
+            dataBinHelper.generateBins(sortedNumericalValues, new BigDecimal(10),
+                new BigDecimal(40));
+        assertEquals(decList(), boundaries);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullCustomBinsArg() {
+        List<BigDecimal> boundaries =
+            dataBinHelper.generateBins(null, new BigDecimal(10),
+                new BigDecimal(40));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullBinSizeArg() {
+        List<BigDecimal> boundaries =
+            dataBinHelper.generateBins(Collections.emptyList(), null,
+                new BigDecimal(40));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullAnchorPointArg() {
+        List<BigDecimal> boundaries =
+            dataBinHelper.generateBins(Collections.emptyList(), new BigDecimal(10),
+               null);
+    }
+    
+    private List<BigDecimal> decList(int... numbers) {
+        return Arrays.stream(numbers).mapToObj(BigDecimal::new).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
# Description
This PR will add three new binning functions for histograms in Study View. It adds:
- Quartiles
- Split around median
- Generate bins based on bin size and anchor value. Creates bins upward from and downward from the _anchor value_. The size of each bin is the _bins size_. Bins are generated to cover the entire range of the data. 

# Backwards compatibility
The PR is compatible with the current frontend version. After update of PR https://github.com/cBioPortal/cbioportal-frontend/pull/4102 the _DataBinFilter_ class should be updated to remove this backward compatibility.

# Tests
Tests are added for all new binning functionality.