### PR TITLE
Docs update for unauthorized studies portal prop

### DIFF
--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -176,7 +176,9 @@ Study View.
 ```
 skin.home_page.show_unauthorized_studies=
 ```
-If show_unauthorized_studies has been enabled, then a global message for the studies that are unauthorized can be configured by the property below. The message will appear in a tooltip when hover over the lock icon for the study and can also contain placecards like {$.Owner.email} for the studies that have this information in the study tags.
+If _show_unauthorized_studies_ feature has been enabled, a message (template) can be defined by the property below that informs the user of insufficient permissions. This message will appear inside a tooltip when hovering the lock icon next to the study name on the Study Selection page. This message may contain placeholders for study-specific information derived from [study tags data](https://docs.cbioportal.org/5.1-data-loading/data-loading/file-formats#study-tags-file). The information in the study tags JSON file can be accessed using Json Path placeholders. For example `{$.Owner.email}` points to member `{Owner: {email: "me@myself.org"}}`. For the studies that don't have this information available in the study tags, the default message "The study is unauthorized. You need to request access." will be displayed. In addition to the study tags information, the cancer study identifier can be included in the message using {$.studyId} placeholder (does not have to be present in study tags file).
+For example:
+skin.home_page.unauthorized_studies_global_message=You do not have access to this study. You can request access with {$.Owner.email} (please mention the '{$.studyId}' study identifier).
 ```
 skin.home_page.unauthorized_studies_global_message=
 ```


### PR DESCRIPTION
Updated portal property reference docs for the configuration of a global message for unauthorized studies.

This docs update is related to PR https://github.com/cBioPortal/cbioportal-frontend/pull/4138