### PR TITLE
fix 2.12.9 migation script

### DIFF
--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -420,7 +420,7 @@ def main():
         if is_version_larger(MULTI_REFERENCE_GENOME_SUPPORT_MIGRATION_STEP, db_version):
             #retrieve reference genomes from database
             check_reference_genome(portal_properties, cursor, parser.force)
-        if not is_version_larger(SAMPLE_FK_MIGRATION_STEP, db_version):
+        if is_version_larger(SAMPLE_FK_MIGRATION_STEP, db_version):
             check_and_remove_type_of_cancer_id_foreign_key(cursor)
         run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction)
         # TODO: remove this after we update mysql version

--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -426,8 +426,10 @@ def main():
     with contextlib.closing(connection):
         db_version = get_db_version(cursor)
         if is_version_larger(MULTI_REFERENCE_GENOME_SUPPORT_MIGRATION_STEP, db_version):
+            run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction, stop_at_version=MULTI_REFERENCE_GENOME_SUPPORT_MIGRATION_STEP)
             #retrieve reference genomes from database
             check_reference_genome(portal_properties, cursor, parser.force)
+            db_version = get_db_version(cursor)
         if is_version_larger(SAMPLE_FK_MIGRATION_STEP, db_version):
             run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction, stop_at_version=SAMPLE_FK_MIGRATION_STEP)
             check_and_remove_type_of_cancer_id_foreign_key(cursor)

--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -23,7 +23,7 @@ ALLOWABLE_GENOME_REFERENCES = ['37', 'hg19', 'GRCh37', '38', 'hg38', 'GRCh38', '
 DEFAULT_GENOME_REFERENCE = 'hg19'
 MULTI_REFERENCE_GENOME_SUPPORT_MIGRATION_STEP = (2,11,0)
 GENERIC_ASSAY_MIGRATION_STEP = (2,12,1)
-SAMPLE_FK_MIGRATION_STEP = (2,12,8)
+SAMPLE_FK_MIGRATION_STEP = (2,12,9)
 
 class PortalProperties(object):
     """ Properties object class, just has fields for db conn """

--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -310,7 +310,7 @@ def run_migration(db_version, sql_filename, connection, cursor, no_transaction, 
             # stop at the version specified
             if stop_at_version is not None and is_version_equal(sql_version, stop_at_version):
                 break
-            else
+            else:
                 run_line = is_version_larger(sql_version, db_version)
                 continue
         # skip blank lines

--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -432,7 +432,6 @@ def main():
             run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction, stop_at_version=SAMPLE_FK_MIGRATION_STEP)
             check_and_remove_type_of_cancer_id_foreign_key(cursor)
             db_version = get_db_version(cursor)
-            print('Migrated to {}.{}.{}'.format(*db_version), file=OUTPUT_FILE)
         run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction)
         # TODO: remove this after we update mysql version
         # check invalid foreign key only when current db version larger or qeuals to GENERIC_ASSAY_MIGRATION_STEP

--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -307,11 +307,12 @@ def run_migration(db_version, sql_filename, connection, cursor, no_transaction, 
     for line in sql_file:
         if line.startswith('##'):
             sql_version = tuple(map(int, line.split(':')[1].strip().split('.')))
-            run_line = is_version_larger(sql_version, db_version)
-            continue
-        # stop at the version specified
-        if stop_at_version is not None and is_version_equal(sql_version, stop_at_version):
-            return
+            # stop at the version specified
+            if stop_at_version is not None and is_version_equal(sql_version, stop_at_version):
+                break
+            else
+                run_line = is_version_larger(sql_version, db_version)
+                continue
         # skip blank lines
         if len(line.strip()) < 1:
             continue
@@ -428,8 +429,10 @@ def main():
             #retrieve reference genomes from database
             check_reference_genome(portal_properties, cursor, parser.force)
         if is_version_larger(SAMPLE_FK_MIGRATION_STEP, db_version):
-            run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction, SAMPLE_FK_MIGRATION_STEP)
+            run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction, stop_at_version=SAMPLE_FK_MIGRATION_STEP)
             check_and_remove_type_of_cancer_id_foreign_key(cursor)
+            db_version = get_db_version(cursor)
+            print('Migrated to {}.{}.{}'.format(*db_version), file=OUTPUT_FILE)
         run_migration(db_version, sql_filename, connection, cursor, parser.no_transaction)
         # TODO: remove this after we update mysql version
         # check invalid foreign key only when current db version larger or qeuals to GENERIC_ASSAY_MIGRATION_STEP


### PR DESCRIPTION
Fix #9271. Should run for any db version smaller than 2.12.9. This also handles the case where the database is very old and the foreign key constraint does not exist yet. It will migrate old ones to 2.12.9, then run the python function to sort the foreign key and then finish the rest of the migration.