### PR TITLE
Create User-guide.md

### DIFF
--- a/docs/User-guide.md
+++ b/docs/User-guide.md
@@ -1,0 +1,111 @@
+# User Guide
+
+This page lists all the tutorials, videos and other documentation describing how to use the cBioPortal website. An overview of all resources is provided at the top, followed by the same resources listed again but organized by the specific pages of cBioPortal.
+
+If you still have questions after revewing the resources listed below, please check our [user support forum](https://groups.google.com/g/cbioportal) or [email us](mailto:cbioportal@googlegroups.com)
+
+## Overview of Resources
+
+### Tutorial Slides
+1. Single Study Exploration [Google slides](https://www.cbioportal.org/tutorials#single-study-exploration) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%201%20Single%20Study%20Exploration.pdf)
+2. Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
+3. Patient View [Google slides](https://www.cbioportal.org/tutorials#patient-view) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%203%20Patient%20View.pdf)
+4. Virtual Studies [Google slides](https://www.cbioportal.org/tutorials#virtual-studies) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%204%20Virtual%20Studies.pdf)
+5. Onco Query Language (OQL) [Google slides](https://www.cbioportal.org/tutorials#oql) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%205%20Onco%20Query%20Language.pdf)
+6. Group Comparison [Google slides](https://www.cbioportal.org/tutorials#group-comparison) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%205%20Onco%20Query%20Language.pdf)
+7. Pathways [Google slides](https://www.cbioportal.org/tutorials#pathways) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%207%20Pathways.pdf)
+
+### Webinar Recordings
+1. Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp) | [Download PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Webinar%201%20Introduction%20to%20cBioPortal.pdf) | [View slides](https://drive.google.com/drive/folders/0B9KTQJAGhFhhRi1qaTdUWmpLQTA?resourcekey=0-9Mbxt9c_wEbaGRLnAaASlg&usp=sharing)
+2. Mutation Details & Patient View [youtube.com](https://www.youtube.com/watch?v=uJsp9kd2jIk) | [bilibili.com](https://www.bilibili.com/video/BV1Qf4y1m7Lx) | [Download PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Webinar%202%20Mutation%20Details%20and%20Patient%20View.pdf) | [View slides](https://drive.google.com/drive/folders/0B9KTQJAGhFhhRi1qaTdUWmpLQTA?resourcekey=0-9Mbxt9c_wEbaGRLnAaASlg&usp=sharing)
+3. Expression Data Analysis [youtube.com](https://www.youtube.com/watch?v=YUxVv6pkxD4) | [bilibili.com](https://www.bilibili.com/video/BV1HK4y1t7dE) | [Download PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Webinar%203%20Expression%20Data%20Analysis.pdf) | [View slides](https://drive.google.com/drive/folders/0B9KTQJAGhFhhRi1qaTdUWmpLQTA?resourcekey=0-9Mbxt9c_wEbaGRLnAaASlg&usp=sharing)
+4. Group Comparison [youtube.com](https://www.youtube.com/watch?v=Tx4HZCrIe5c) | [bilibili.com](https://www.bilibili.com/video/BV1VZ4y1W76p) | [Download PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Webinar%204%20Group%20Comparison.pdf) | [View slides](https://drive.google.com/drive/folders/0B9KTQJAGhFhhRi1qaTdUWmpLQTA?resourcekey=0-9Mbxt9c_wEbaGRLnAaASlg&usp=sharing)
+5. API & R Client [youtube.com](https://www.youtube.com/watch?v=Nq12o2i0yaw) | [bilibili.com](https://www.bilibili.com/video/BV1jz4y197iU) | [Download PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Webinar%205%20API%20and%20R%20Client.pdf) | [View slides](https://drive.google.com/drive/folders/0B9KTQJAGhFhhRi1qaTdUWmpLQTA?resourcekey=0-9Mbxt9c_wEbaGRLnAaASlg&usp=sharing) | [Workshop code](https://github.com/cBioPortal/2020-cbioportal-r-workshop)
+
+### How-To Videos
+1. Comparing samples based on expression level of a gene [youtube.com](https://www.youtube.com/watch?v=HTiKUXk0j0s)
+2. Proteomic profiles in cBioPortal - An example based on cancer cell lines from the Cancer Cell Line Encyclopedia (CCLE) [youtube.com](https://www.youtube.com/watch?v=62qbjQOH9qc) 
+3. Filtering and adding clinical data to Mutations tab [youtube.com](https://www.youtube.com/watch?v=q9No2073c5o)
+4. Exploring the longitudinal evolution of individual patients [youtube.com](https://www.youtube.com/watch?v=Hbbs-tHh9LQ)
+5. Using Onco Query Language (OQL) to query based on the expression level of genes [youtube.com](https://www.youtube.com/watch?v=kHlFXw2TMzc)
+
+### Documentation
+* [FAQ](https://www.cbioportal.org/faq)
+* [OQL](https://www.cbioportal.org/oql)
+
+## Resources by Page
+### Study View
+* Tutorial Slides: Single Study Exploration [Google slides](https://www.cbioportal.org/tutorials#single-study-exploration) [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%201%20Single%20Study%20Exploration.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=760s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+* How-To Video: Comparing samples based on expression level of a gene [youtube.com](https://www.youtube.com/watch?v=HTiKUXk0j0s)
+* Tutorial Slides: Virtual Studies [Google slides](https://www.cbioportal.org/tutorials#virtual-studies) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%204%20Virtual%20Studies.pdf)
+
+
+### Group Comparison
+* Tutorial Slides: Group Comparison [Google slides](https://www.cbioportal.org/tutorials#group-comparison) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%205%20Onco%20Query%20Language.pdf)
+* Webinar: Group Comparison [youtube.com](https://www.youtube.com/watch?v=Tx4HZCrIe5c) | [bilibili.com](https://www.bilibili.com/video/BV1VZ4y1W76p)
+* How-To Video: Comparing samples based on expression level of a gene [youtube.com](https://www.youtube.com/watch?v=HTiKUXk0j0s)
+
+### Running a Query / Results View
+#### General
+* Tutorial Slides: Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=1462s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+
+
+#### OQL
+* Documentation [OQL](https://www.cbioportal.org/oql)
+* Tutorial: Onco Query Language (OQL) [Google slides](https://www.cbioportal.org/tutorials#oql) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%205%20Onco%20Query%20Language.pdf)
+* Webinar: Expression Data Analysis [youtube.com](https://www.youtube.com/watch?v=YUxVv6pkxD4&t=1559s) | [bilibili.com](https://www.bilibili.com/video/BV1HK4y1t7dE)
+* How-To Video: Using Onco Query Language (OQL) to query based on the expression level of genes [youtube.com](https://www.youtube.com/watch?v=kHlFXw2TMzc)
+
+
+#### OncoPrint
+* Tutorial Slides: Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=1682s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+
+#### Cancer Types Summary
+* Tutorial Slides: Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=2024s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+
+#### Mutual Exclusivity
+* Tutorial Slides: Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=1822s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+
+#### Plots
+* Tutorial Slides: Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=2060s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+#### Mutations
+* Tutorial Slides: Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=2149s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+* Webinar: Mutation Details & Patient View [youtube.com](https://www.youtube.com/watch?v=uJsp9kd2jIk) | [bilibili.com](https://www.bilibili.com/video/BV1Qf4y1m7Lx)
+* How-To Video: Filtering and adding clinical data to Mutations tab [youtube.com](https://www.youtube.com/watch?v=q9No2073c5o)
+
+#### Co-expression
+* Tutorial Slides: Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=2277s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+
+#### Comparison/Survival
+* Tutorial Slides: Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=2334s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+* Tutorial Slides: Group Comparison [Google slides](https://www.cbioportal.org/tutorials#group-comparison) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%205%20Onco%20Query%20Language.pdf)
+* Webinar: Group Comparison [youtube.com](https://www.youtube.com/watch?v=Tx4HZCrIe5c) | [bilibili.com](https://www.bilibili.com/video/BV1VZ4y1W76p)
+
+#### CN Segments
+* Tutorial Slides: Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=2449s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+
+#### Pathways
+* Tutorial: Pathways [Google slides](https://www.cbioportal.org/tutorials#pathways) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%207%20Pathways.pdf)
+* Tutorial Slides: Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=2512s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+
+#### Downloads
+* Tutorial Slides: Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=2543s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+
+### Patient View
+* Tutorial: Patient View [Google slides](https://www.cbioportal.org/tutorials#patient-view) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%203%20Patient%20View.pdf)
+* Tutorial: Pathways [Google slides](https://www.cbioportal.org/tutorials#pathways) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%207%20Pathways.pdf)
+* Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=1022s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
+* Webinar: Mutation Details & Patient View [youtube.com](https://www.youtube.com/watch?v=uJsp9kd2jIk) | [bilibili.com](https://www.bilibili.com/video/BV1Qf4y1m7Lx)
+* How-To Video: Exploring the longitudinal evolution of individual patients [youtube.com](https://www.youtube.com/watch?v=Hbbs-tHh9LQ)

--- a/docs/User-guide.md
+++ b/docs/User-guide.md
@@ -33,6 +33,10 @@ If you still have questions after revewing the resources listed below, please ch
 * [FAQ](https://www.cbioportal.org/faq)
 * [OQL](https://www.cbioportal.org/oql)
 
+### Publications
+* Cerami et al. Cancer Discovery 2012 [PubMed](http://cancerdiscovery.aacrjournals.org/content/2/5/401.abstract)
+* Gao et al. Science Signaling 2013 [PubMed](https://www.ncbi.nlm.nih.gov/pubmed/23550210)
+
 ## Resources by Page
 ### Study View
 * Tutorial Slides: Single Study Exploration [Google slides](https://www.cbioportal.org/tutorials#single-study-exploration) [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%201%20Single%20Study%20Exploration.pdf)
@@ -54,7 +58,7 @@ If you still have questions after revewing the resources listed below, please ch
 
 #### OQL
 * Documentation [OQL](https://www.cbioportal.org/oql)
-* Tutorial: Onco Query Language (OQL) [Google slides](https://www.cbioportal.org/tutorials#oql) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%205%20Onco%20Query%20Language.pdf)
+* Tutorial Slides: Onco Query Language (OQL) [Google slides](https://www.cbioportal.org/tutorials#oql) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%205%20Onco%20Query%20Language.pdf)
 * Webinar: Expression Data Analysis [youtube.com](https://www.youtube.com/watch?v=YUxVv6pkxD4&t=1559s) | [bilibili.com](https://www.bilibili.com/video/BV1HK4y1t7dE)
 * How-To Video: Using Onco Query Language (OQL) to query based on the expression level of genes [youtube.com](https://www.youtube.com/watch?v=kHlFXw2TMzc)
 
@@ -95,7 +99,7 @@ If you still have questions after revewing the resources listed below, please ch
 * Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=2449s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
 
 #### Pathways
-* Tutorial: Pathways [Google slides](https://www.cbioportal.org/tutorials#pathways) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%207%20Pathways.pdf)
+* Tutorial Slides: Pathways [Google slides](https://www.cbioportal.org/tutorials#pathways) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%207%20Pathways.pdf)
 * Tutorial Slides: Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
 * Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=2512s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
 
@@ -104,8 +108,8 @@ If you still have questions after revewing the resources listed below, please ch
 * Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=2543s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
 
 ### Patient View
-* Tutorial: Patient View [Google slides](https://www.cbioportal.org/tutorials#patient-view) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%203%20Patient%20View.pdf)
-* Tutorial: Pathways [Google slides](https://www.cbioportal.org/tutorials#pathways) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%207%20Pathways.pdf)
+* Tutorial Slides: Patient View [Google slides](https://www.cbioportal.org/tutorials#patient-view) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%203%20Patient%20View.pdf)
+* Tutorial Slides: Pathways [Google slides](https://www.cbioportal.org/tutorials#pathways) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%207%20Pathways.pdf)
 * Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=1022s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
 * Webinar: Mutation Details & Patient View [youtube.com](https://www.youtube.com/watch?v=uJsp9kd2jIk) | [bilibili.com](https://www.bilibili.com/video/BV1Qf4y1m7Lx)
 * How-To Video: Exploring the longitudinal evolution of individual patients [youtube.com](https://www.youtube.com/watch?v=Hbbs-tHh9LQ)

--- a/docs/User-guide.md
+++ b/docs/User-guide.md
@@ -33,8 +33,8 @@ Short videos that show how to perform specific analyses or how to use specific p
 3. Filtering and adding clinical data to Mutations tab [youtube.com](https://www.youtube.com/watch?v=q9No2073c5o)
 4. Exploring the longitudinal evolution of individual patients [youtube.com](https://www.youtube.com/watch?v=Hbbs-tHh9LQ)
 5. Using Onco Query Language (OQL) to query based on the expression level of genes [youtube.com](https://www.youtube.com/watch?v=kHlFXw2TMzc)
-6. How to explore a study in study view [youtube.com](https://www.youtube.com/watch?v=N8ffDgkqDWc)
-7. How to run a query [youtube.com](https://www.youtube.com/watch?v=MH-kY5usA70)
+6. How to explore the data in a study [youtube.com](https://www.youtube.com/watch?v=N8ffDgkqDWc)
+7. How to run a query for genes of interest [youtube.com](https://www.youtube.com/watch?v=MH-kY5usA70)
 
 ### Documentation
 * Frequently Asked Questions [FAQ](https://www.cbioportal.org/faq)

--- a/docs/User-guide.md
+++ b/docs/User-guide.md
@@ -33,6 +33,8 @@ Short videos that show how to perform specific analyses or how to use specific p
 3. Filtering and adding clinical data to Mutations tab [youtube.com](https://www.youtube.com/watch?v=q9No2073c5o)
 4. Exploring the longitudinal evolution of individual patients [youtube.com](https://www.youtube.com/watch?v=Hbbs-tHh9LQ)
 5. Using Onco Query Language (OQL) to query based on the expression level of genes [youtube.com](https://www.youtube.com/watch?v=kHlFXw2TMzc)
+6. How to explore a study in study view [youtube.com](https://www.youtube.com/watch?v=N8ffDgkqDWc)
+7. How to run a query [youtube.com](https://www.youtube.com/watch?v=MH-kY5usA70)
 
 ### Documentation
 * Frequently Asked Questions [FAQ](https://www.cbioportal.org/faq)
@@ -49,7 +51,7 @@ If you have an hour, we highly recommend watching the recording of our Introduct
 
 Don't have an hour? Review our tutorial slides for exploring a study ([Google slides](https://www.cbioportal.org/tutorials#single-study-exploration) or [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%201%20Single%20Study%20Exploration.pdf)) and running a query ([Google slides](https://www.cbioportal.org/tutorials#single-study-query) or [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf))
 
-Or, watch two of our short how-to videos which demonstrate how to explore a study (coming soon) and how to run a query (coming soon).
+Or, watch two of our short how-to videos which demonstrate how to explore a study ([youtube.com](https://www.youtube.com/watch?v=N8ffDgkqDWc)) and how to run a query ([youtube.com](https://www.youtube.com/watch?v=MH-kY5usA70)).
 
 
 ## Resources by Page

--- a/docs/User-guide.md
+++ b/docs/User-guide.md
@@ -1,12 +1,15 @@
 # User Guide
 
-This page lists all the tutorials, videos and other documentation describing how to use the cBioPortal website. An overview of all resources is provided at the top, followed by the same resources listed again but organized by the specific pages of cBioPortal.
+This page lists all the tutorials, videos and other documentation describing how to use the cBioPortal website.
+
+An overview of all resources is provided at the top, followed by select resources highlighted for new users, and then the same resources listed again but organized by the specific pages of cBioPortal.
 
 If you still have questions after revewing the resources listed below, please check our [user support forum](https://groups.google.com/g/cbioportal) or [email us](mailto:cbioportal@googlegroups.com)
 
 ## Overview of Resources
 
 ### Tutorial Slides
+These tutorial slides contain annoted screenshots to walk you through using the cBioPortal site.
 1. Single Study Exploration [Google slides](https://www.cbioportal.org/tutorials#single-study-exploration) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%201%20Single%20Study%20Exploration.pdf)
 2. Single Study Query [Google slides](https://www.cbioportal.org/tutorials#single-study-query) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf)
 3. Patient View [Google slides](https://www.cbioportal.org/tutorials#patient-view) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%203%20Patient%20View.pdf)
@@ -16,6 +19,7 @@ If you still have questions after revewing the resources listed below, please ch
 7. Pathways [Google slides](https://www.cbioportal.org/tutorials#pathways) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%207%20Pathways.pdf)
 
 ### Webinar Recordings
+Recordings of live webinars from April & May 2020
 1. Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp) | [Download PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Webinar%201%20Introduction%20to%20cBioPortal.pdf) | [View slides](https://drive.google.com/drive/folders/0B9KTQJAGhFhhRi1qaTdUWmpLQTA?resourcekey=0-9Mbxt9c_wEbaGRLnAaASlg&usp=sharing)
 2. Mutation Details & Patient View [youtube.com](https://www.youtube.com/watch?v=uJsp9kd2jIk) | [bilibili.com](https://www.bilibili.com/video/BV1Qf4y1m7Lx) | [Download PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Webinar%202%20Mutation%20Details%20and%20Patient%20View.pdf) | [View slides](https://drive.google.com/drive/folders/0B9KTQJAGhFhhRi1qaTdUWmpLQTA?resourcekey=0-9Mbxt9c_wEbaGRLnAaASlg&usp=sharing)
 3. Expression Data Analysis [youtube.com](https://www.youtube.com/watch?v=YUxVv6pkxD4) | [bilibili.com](https://www.bilibili.com/video/BV1HK4y1t7dE) | [Download PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Webinar%203%20Expression%20Data%20Analysis.pdf) | [View slides](https://drive.google.com/drive/folders/0B9KTQJAGhFhhRi1qaTdUWmpLQTA?resourcekey=0-9Mbxt9c_wEbaGRLnAaASlg&usp=sharing)
@@ -23,6 +27,7 @@ If you still have questions after revewing the resources listed below, please ch
 5. API & R Client [youtube.com](https://www.youtube.com/watch?v=Nq12o2i0yaw) | [bilibili.com](https://www.bilibili.com/video/BV1jz4y197iU) | [Download PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Webinar%205%20API%20and%20R%20Client.pdf) | [View slides](https://drive.google.com/drive/folders/0B9KTQJAGhFhhRi1qaTdUWmpLQTA?resourcekey=0-9Mbxt9c_wEbaGRLnAaASlg&usp=sharing) | [Workshop code](https://github.com/cBioPortal/2020-cbioportal-r-workshop)
 
 ### How-To Videos
+Short videos that show how to perform specific analyses or how to use specific pages.
 1. Comparing samples based on expression level of a gene [youtube.com](https://www.youtube.com/watch?v=HTiKUXk0j0s)
 2. Proteomic profiles in cBioPortal - An example based on cancer cell lines from the Cancer Cell Line Encyclopedia (CCLE) [youtube.com](https://www.youtube.com/watch?v=62qbjQOH9qc) 
 3. Filtering and adding clinical data to Mutations tab [youtube.com](https://www.youtube.com/watch?v=q9No2073c5o)
@@ -30,16 +35,26 @@ If you still have questions after revewing the resources listed below, please ch
 5. Using Onco Query Language (OQL) to query based on the expression level of genes [youtube.com](https://www.youtube.com/watch?v=kHlFXw2TMzc)
 
 ### Documentation
-* [FAQ](https://www.cbioportal.org/faq)
-* [OQL](https://www.cbioportal.org/oql)
+* Frequently Asked Questions [FAQ](https://www.cbioportal.org/faq)
+* Onco Query Language [OQL](https://www.cbioportal.org/oql)
 
 ### Publications
 * Cerami et al. Cancer Discovery 2012 [PubMed](http://cancerdiscovery.aacrjournals.org/content/2/5/401.abstract)
 * Gao et al. Science Signaling 2013 [PubMed](https://www.ncbi.nlm.nih.gov/pubmed/23550210)
 
+## New Users
+Are you new to cBioPortal? Welcome! We have a few options to help you get started.
+
+If you have an hour, we highly recommend watching the recording of our Introduction to cBioPortal webinar ([youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo) or [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)).
+
+Don't have an hour? Review our tutorial slides for exploring a study ([Google slides](https://www.cbioportal.org/tutorials#single-study-exploration) or [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%201%20Single%20Study%20Exploration.pdf)) and running a query ([Google slides](https://www.cbioportal.org/tutorials#single-study-query) or [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%202%20Single%20Study%20Query.pdf))
+
+Or, watch two of our short how-to videos which demonstrate how to explore a study (coming soon) and how to run a query (coming soon).
+
+
 ## Resources by Page
 ### Study View
-* Tutorial Slides: Single Study Exploration [Google slides](https://www.cbioportal.org/tutorials#single-study-exploration) [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%201%20Single%20Study%20Exploration.pdf)
+* Tutorial Slides: Single Study Exploration [Google slides](https://www.cbioportal.org/tutorials#single-study-exploration) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%201%20Single%20Study%20Exploration.pdf)
 * Webinar: Introduction to cBioPortal [youtube.com](https://www.youtube.com/watch?v=fPIAxH--cSo&t=760s) | [bilibili.com](https://www.bilibili.com/video/BV1tf4y1m7Lp)
 * How-To Video: Comparing samples based on expression level of a gene [youtube.com](https://www.youtube.com/watch?v=HTiKUXk0j0s)
 * Tutorial Slides: Virtual Studies [Google slides](https://www.cbioportal.org/tutorials#virtual-studies) | [PDF](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/docs/tutorials/cBioPortal%20Tutorial%204%20Virtual%20Studies.pdf)


### PR DESCRIPTION
Here's a first attempt at a single page that brings together all our user-facing documentation/videos. The top lists everything on the Tutorials page and add links to FAQ, OQL and the google group. Below is a section for each page/tab on the site - my hope is that these could enable us to bring back the help/video icon on the site, and have the icon link to the relevant section of this page. For most of these page-specific section, the links are just to the results view tutorial slide & webinar 1 (specific to the correct timestamp within webinar 1), but a few do have tab-specific content and I can work on more.

I think the plan was to add this to the rest of the documentation at docs.cbioportal.org. But before we do that, it'd be great to get some feedback @jjgao @schultzn @alisman @inodb 