### PR TITLE
Only evict Redis cache if keys present

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomRedisCache.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/CustomRedisCache.java
@@ -110,7 +110,9 @@ public class CustomRedisCache extends AbstractValueAdaptingCache {
                 .filter(key -> key.startsWith(name))
                 .filter(key -> key.matches((String) pattern))
                 .toArray(String[]::new);
-            return redissonClient.getKeys().delete(keys) > 0;
+            // Calling delete() with empty array causes an error in the Redisson client.
+            if (keys.length > 0)
+                return redissonClient.getKeys().delete(keys) > 0;
         } else {
             LOG.warn("Pattern passed for cache key eviction is not of String type. Cache eviction could not be performed.");
         }


### PR DESCRIPTION
# Problem
When evicting the Redis cache when no cache keys are present, the Redisson library throws an error.

# Solution
Only evict the cache when there are keys.