### PR TITLE
Implement caching on samples fetch endpoint

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/SampleServiceImpl.java
@@ -14,6 +14,7 @@ import org.cbioportal.service.exception.PatientNotFoundException;
 import org.cbioportal.service.exception.SampleNotFoundException;
 import org.cbioportal.service.exception.StudyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -144,6 +145,10 @@ public class SampleServiceImpl implements SampleService {
     }
 
     @Override
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
 	public List<Sample> fetchSamples(List<String> sampleListIds, String projection) {
 
         List<Sample> samples = sampleRepository.fetchSamplesBySampleListIds(sampleListIds, projection);

--- a/web/src/main/java/org/cbioportal/web/SampleController.java
+++ b/web/src/main/java/org/cbioportal/web/SampleController.java
@@ -249,11 +249,22 @@ public class SampleController {
             if (interceptedSampleFilter.getSampleListIds() != null) {
                 List<String> sampleListIds = interceptedSampleFilter.getSampleListIds();
                 
+                samples = new ArrayList<Sample>();
+                
                 for (String sampleListId : sampleListIds) {
                     // check that all sample lists exist (this method throws an exception if one does not)
                     sampleListService.getSampleList(sampleListId);
                 }
-                samples = sampleService.fetchSamples(sampleListIds, projection.name());
+                
+                for (String sampleListId : sampleListIds) {
+                    // fetch by sampleId so that we get cache at level of id instead list of ids
+                    samples.addAll(
+                        sampleService.fetchSamples(Arrays.asList(sampleListId), projection.name())
+                    );
+                }
+                
+                //samples = sampleService.fetchSamples(sampleListIds, projection.name());
+            
             } else {
                 if (interceptedSampleFilter.getSampleIdentifiers() != null) {
                     extractStudyAndSampleIds(interceptedSampleFilter, studyIds, sampleIds);


### PR DESCRIPTION
Sample endpoint should be cached at service level and with granularity at sample list id.   Only when sample list id is passed.

Fixes https://github.com/cbioportal/cbioportal/issues/9351