### PR TITLE
Fix Generic Assay entities deletion error and profile property error

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoCancerStudy.java
@@ -570,10 +570,9 @@ public final class DaoCancerStudy {
         PreparedStatement pstmt = null;
         ResultSet rs = null;
         try {
-            // check whether should delete generic assay meta
-            if (DaoGenericAssay.geneticEntitiesOnlyExistInSingleStudy(internalCancerStudyId)) {
-                deleteGenericAssayMeta(internalCancerStudyId);
-            }
+            // check whether should delete generic assay meta profile by profile
+            DaoGenericAssay.checkAndDeleteGenericAssayMetaInStudy(internalCancerStudyId);
+            
             con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
             for (String statementString : deleteStudyStatements) {
                 pstmt = con.prepareStatement(statementString);
@@ -610,35 +609,6 @@ public final class DaoCancerStudy {
             con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
             for (String statementString : deleteStudyStatements) {
                 pstmt = con.prepareStatement(statementString);
-                pstmt.executeUpdate();
-                pstmt.close();
-            }
-        } catch (SQLException e) {
-            throw new DaoException(e);
-        } finally {
-            JdbcUtil.closeAll(DaoCancerStudy.class, con, pstmt, rs);
-        }
-    }
-
-    /**
-     * delete generic assay meta records if meta is not shared with other studies
-     * @throws DaoException
-     */
-    public static void deleteGenericAssayMeta(int internalCancerStudyId) throws DaoException {
-        String[] deleteGenericAssayStatements = {
-                "DELETE FROM generic_entity_properties WHERE GENETIC_ENTITY_ID IN (SELECT GENETIC_ENTITY_ID FROM genetic_alteration WHERE GENETIC_PROFILE_ID IN (SELECT GENETIC_PROFILE_ID FROM genetic_profile WHERE CANCER_STUDY_ID=?))",
-                "DELETE FROM genetic_entity WHERE ID IN (SELECT GENETIC_ENTITY_ID FROM genetic_alteration WHERE GENETIC_PROFILE_ID IN (SELECT GENETIC_PROFILE_ID FROM genetic_profile WHERE CANCER_STUDY_ID=? AND GENETIC_ALTERATION_TYPE='GENERIC_ASSAY'))"
-                };
-        Connection con = null;
-        PreparedStatement pstmt = null;
-        ResultSet rs = null;
-        try {
-            con = JdbcUtil.getDbConnection(DaoCancerStudy.class);
-            for (String statementString : deleteGenericAssayStatements) {
-                pstmt = con.prepareStatement(statementString);
-                if (statementString.contains("?")) {
-                    pstmt.setInt(1, internalCancerStudyId);
-                }
                 pstmt.executeUpdate();
                 pstmt.close();
             }

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGeneticProfile.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/DaoGeneticProfile.java
@@ -112,17 +112,18 @@ public final class DaoGeneticProfile {
             pstmt.setString(6, profile.getProfileDescription());
             pstmt.setBoolean(7, profile.showProfileInAnalysisTab());
 
-            // `pivot_threshold_value` and `value_sort_order` fields are treatment data 
-            // specific. These fields are set to null when not present in profile object.
+            // `pivot_threshold_value` and `value_sort_order` `GENERIC_ASSAY_TYPE` fields are geneirc assay data specific.
+            // These fields are set to null when not present in profile object.
             if (profile.getPivotThreshold() == null) {
                 pstmt.setNull(8, java.sql.Types.FLOAT);
-                pstmt.setNull(9, java.sql.Types.INTEGER);
             } else {
                 pstmt.setFloat(8, profile.getPivotThreshold());
+            }
+            if (profile.getSortOrder() == null) {
+                pstmt.setNull(9, java.sql.Types.INTEGER);
+            } else {
                 pstmt.setString(9, profile.getSortOrder());
             }
-
-            // `GENERIC_ASSAY_TYPE` is for Generic Assay, this field is set to null when not present in profile object.
             if (profile.getGenericAssayType() == null) {
                 pstmt.setNull(10, java.sql.Types.VARCHAR);
             } else {


### PR DESCRIPTION
Fix #9358
Fix #9415

This pr address two things:

- Generic Assay entities don't get deleted correctly when the profile that gets deleted is the only one profile related. When deleting a study, we should do as follows: 
    - Find all Generic Assay profiles in this study. 
    - Go through each profile one by one, try to determine if we need to delete entities per profile instead of per study

- When importing a Generic Assay profile, the property pivot_threshold_value and value_sort_order should be imported separately.