### PR TITLE
Customize NA category in comparison page

### DIFF
--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -193,6 +193,12 @@ in these sections. This menu will only appear, when setting the property _skin.s
 skin.show_settings_menu=
 ```
 
+## Customize "NA" values in group comparison
+Customize "NA" category in group comparison, for example "NA" and "unknown", all values are treated as "NA" and could be shown or hidden together on comparison page.
+```
+comparison.categorical_na_value=NA,unknown
+```
+
 ## Hide logout button
 When the user is logged-in, a button with logout and data access token options is shown at the right side of the header section.
 This button can be hidden by setting the property _skin.hide_logout_button to _true_ (default is _false_). Hiding the logout button will remove

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -135,7 +135,8 @@
             "skin.geneset_hierarchy.default_p_value",
             "skin.geneset_hierarchy.default_gsva_score",
             "skin.geneset_hierarchy.collapse_by_default",
-            "skin.mutation_table.namespace_column.show_by_default"
+            "skin.mutation_table.namespace_column.show_by_default",
+            "comparison.categorical_na_value"
         };
 
 

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -393,4 +393,4 @@ persistence.cache_type=no-cache
 # enable_treatment_groups=false
 
 # Set comparison categorical "NA" value (not case sensitive)
-comparison.categorical_na_value=NA,unknown
+# comparison.categorical_na_value=NA,unknown

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -391,3 +391,6 @@ persistence.cache_type=no-cache
 
 # Feature flag for treatment groups
 # enable_treatment_groups=false
+
+# Set comparison categorical "NA" value (not case sensitive)
+comparison.categorical_na_value=NA,unknown


### PR DESCRIPTION
Fix #9372 

- [x] Support "NA" category value customize on backend, calculate p-value and q-value without "NA" 
