### PR TITLE
Rename comparison.categorical_na_value to comparison.categorical_na_values

### DIFF
--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -196,7 +196,7 @@ skin.show_settings_menu=
 ## Customize "NA" values in group comparison
 Customize "NA" category in group comparison, for example "NA" and "unknown", all values are treated as "NA" and could be shown or hidden together on comparison page.
 ```
-comparison.categorical_na_value=NA,unknown
+comparison.categorical_na_values=NA,unknown
 ```
 
 ## Hide logout button

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -136,7 +136,7 @@
             "skin.geneset_hierarchy.default_gsva_score",
             "skin.geneset_hierarchy.collapse_by_default",
             "skin.mutation_table.namespace_column.show_by_default",
-            "comparison.categorical_na_value"
+            "comparison.categorical_na_values"
         };
 
 

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -393,4 +393,4 @@ persistence.cache_type=no-cache
 # enable_treatment_groups=false
 
 # Set comparison categorical "NA" value (not case sensitive)
-# comparison.categorical_na_value=NA,unknown
+# comparison.categorical_na_values=NA,unknown

--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataEnrichmentUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataEnrichmentUtil.java
@@ -40,7 +40,7 @@ public class ClinicalDataEnrichmentUtil {
     @Autowired
     private ClinicalAttributeUtil clinicalAttributeUtil;
 
-    @Value("${comparison.categorical_na_value:}")
+    @Value("${comparison.categorical_na_values:}")
     private String ComparisonCategoricalNaValuesString;
 
     public List<ClinicalDataEnrichment> createEnrichmentsForNumericData(List<ClinicalAttribute> attributes,


### PR DESCRIPTION
Related to https://github.com/cBioPortal/cbioportal-frontend/pull/4201. Rename `comparison.categorical_na_value` to `comparison.categorical_na_values` on both frontend and backend