### PR TITLE
Downgrade to Java 8

### DIFF
--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -11,7 +11,7 @@
 # NOTE: the .git folder is included in the build stage, but excluded 
 # from the final image. No confidential information is exposed.
 # (see: stackoverflow.com/questions/56278325)
-FROM maven:3-openjdk-11 as build
+FROM maven:3-openjdk-8 as build
 
 # download maven dependencies first to take advantage of docker caching
 COPY pom.xml                                     /cbioportal/
@@ -37,7 +37,7 @@ RUN mvn dependency:go-offline --fail-never
 COPY $PWD /cbioportal
 RUN mvn -DskipTests clean install
 
-FROM openjdk:11-jre-slim
+FROM shipilev/openjdk-shenandoah:8
 
 # download system dependencies first to take advantage of docker caching
 RUN apt-get update; apt-get install -y --no-install-recommends \

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -10,16 +10,13 @@
 # Use from root directory of repo like:
 #
 # docker build -f docker/web/Dockerfile -t cbioportal-container:web-shenandoah-tag-name .
-#
-# WARNING: the shendoah image is a nightly, untested, experimental build. If
-# you want to use an official openjdk image instead use the web-and-data image.
-FROM maven:3-openjdk-11 as build
+FROM maven:3-openjdk-8 as build
 COPY $PWD /cbioportal
 WORKDIR /cbioportal
 ARG MAVEN_OPTS=-DskipTests
 RUN mvn ${MAVEN_OPTS} clean install
 
-FROM shipilev/openjdk:11
+FROM shipilev/openjdk-shenandoah:8
 
 ENV PORTAL_WEB_HOME=/cbioportal-webapp
 


### PR DESCRIPTION
- There's a bad RCE involving Spring + Java 9 + Tomcat
- Downgrading to Java 8 keeps us safe and can be released quickly
since we already support Java 8