### PR TITLE
Move back to Java 11, update Spring

### DIFF
--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -11,7 +11,7 @@
 # NOTE: the .git folder is included in the build stage, but excluded 
 # from the final image. No confidential information is exposed.
 # (see: stackoverflow.com/questions/56278325)
-FROM maven:3-openjdk-8 as build
+FROM maven:3-openjdk-11 as build
 
 # download maven dependencies first to take advantage of docker caching
 COPY pom.xml                                     /cbioportal/
@@ -37,7 +37,7 @@ RUN mvn dependency:go-offline --fail-never
 COPY $PWD /cbioportal
 RUN mvn -DskipTests clean install
 
-FROM shipilev/openjdk-shenandoah:8
+FROM openjdk:11-jre-slim
 
 # download system dependencies first to take advantage of docker caching
 RUN apt-get update; apt-get install -y --no-install-recommends \

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -10,13 +10,16 @@
 # Use from root directory of repo like:
 #
 # docker build -f docker/web/Dockerfile -t cbioportal-container:web-shenandoah-tag-name .
-FROM maven:3-openjdk-8 as build
+#
+# WARNING: the shendoah image is a nightly, untested, experimental build. If
+# you want to use an official openjdk image instead use the web-and-data image.
+FROM maven:3-openjdk-11 as build
 COPY $PWD /cbioportal
 WORKDIR /cbioportal
 ARG MAVEN_OPTS=-DskipTests
 RUN mvn ${MAVEN_OPTS} clean install
 
-FROM shipilev/openjdk-shenandoah:8
+FROM shipilev/openjdk:11
 
 ENV PORTAL_WEB_HOME=/cbioportal-webapp
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,22 +17,6 @@
 
   <repositories>
     <repository>
-      <id>plugins-release</id>
-      <name>Spring Plugins</name>
-      <url>https://repo.spring.io/plugins-release</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>spring-milestones</id>
-      <name>Spring Milestones</name>
-      <url>https://repo.spring.io/milestone</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
       <id>alfresco</id>
       <name>Alfresco</name>
       <url>https://artifacts.alfresco.com/nexus/content/repositories/public/</url>
@@ -292,7 +276,7 @@
   <properties>
     <frontend.version>f8782baa28c23ed97a6b3534742e5d67c9f0d308</frontend.version>
     <frontend.groupId>com.github.cbioportal</frontend.groupId>
-    <spring.version>5.2.6.RELEASE</spring.version>
+    <spring.version>5.2.20.RELEASE</spring.version>
     <spring.integration.version>5.3.0.RELEASE</spring.integration.version>
     <spring.security.version>5.3.1.RELEASE</spring.security.version>
     <spring.social.version>1.1.6.RELEASE</spring.social.version>


### PR DESCRIPTION
- Running on the latest spring 5.2.x, we can use Java 11
without getting pwned
- Also switched to maven central for spring artifacts