### PR TITLE
Implement Session Service 'user settings' for Results View

### DIFF
--- a/web/src/main/java/org/cbioportal/web/SessionServiceController.java
+++ b/web/src/main/java/org/cbioportal/web/SessionServiceController.java
@@ -51,7 +51,7 @@ public class SessionServiceController {
     @Value("${session.service.url:}")
     private String sessionServiceURL;
 
-    private static Map<SessionPage, Class<? extends PageSettingsData>> pageTypeToData;
+    private static Map<SessionPage, Class<? extends PageSettingsData>> pageToSettingsDataClass;
     
     static {
          SessionServiceController.pageTypeToData = ImmutableMap.of(
@@ -133,7 +133,7 @@ public class SessionServiceController {
                 Class<? extends PageSettingsData> pageDataClass = pageTypeToData.get(
                     SessionPage.valueOf((String) body.get("page"))
                 );
-                PageSettingsData studyPageSettings = mapper.readValue(
+                PageSettingsData pageSettings = mapper.readValue(
                     body.toString(),
                     pageDataClass
                 );

--- a/web/src/main/java/org/cbioportal/web/SessionServiceController.java
+++ b/web/src/main/java/org/cbioportal/web/SessionServiceController.java
@@ -93,8 +93,11 @@ public class SessionServiceController {
         return sessions.isEmpty() ? null : sessions.get(0);
     }
 
-    private ResponseEntity<Session> addSession(SessionType type, Optional<SessionOperation> operation,
-            JSONObject body) {
+    private ResponseEntity<Session> addSession(
+        SessionType type, 
+        Optional<SessionOperation> operation,
+        JSONObject body
+    ) {
         try {
             HttpEntity<?> httpEntity;
             ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
@@ -331,7 +334,7 @@ public class SessionServiceController {
                 if (pageSettings == null) {
                     addSession(SessionType.settings, Optional.empty(), jsonObject);
                 } else {
-                    updatedPageSettingSession(pageSettings, jsonObject, response);
+                    updatedPageSettingSession(pageSettings, settingsData, response);
                 }
                 response.setStatus(HttpStatus.OK.value());
             } else {
@@ -344,8 +347,11 @@ public class SessionServiceController {
     }
 
     // updates only allowed for type page settings session 
-    private void updatedPageSettingSession(PageSettings pageSettings, @RequestBody JSONObject body,
-                                           HttpServletResponse response) throws IOException {
+    private void updatedPageSettingSession(
+        PageSettings pageSettings, 
+        @RequestBody PageSettingsData body,
+        HttpServletResponse response
+    ) throws IOException {
 
         if (isAuthorized()) {
 
@@ -353,17 +359,16 @@ public class SessionServiceController {
                     false);
 
             PageSettingsData pageSettingsData = pageSettings.getData();
-            StudyPageSettings updatedPageSettings = mapper.readValue(body.toString(), StudyPageSettings.class);
             // only allow owner to update his session and see if the origin(studies) are same
             if (userName().equals(pageSettingsData.getOwner()) &&
-                sameOrigin(pageSettingsData.getOrigin(), updatedPageSettings.getOrigin())) {
+                sameOrigin(pageSettingsData.getOrigin(), body.getOrigin())) {
 
-                updatedPageSettings.setCreated(pageSettingsData.getCreated());
-                updatedPageSettings.setOwner(pageSettingsData.getOwner());
-                updatedPageSettings.setOrigin(pageSettingsData.getOrigin());
+                body.setCreated(pageSettingsData.getCreated());
+                body.setOwner(pageSettingsData.getOwner());
+                body.setOrigin(pageSettingsData.getOrigin());
 
                 RestTemplate restTemplate = new RestTemplate();
-                HttpEntity<Object> httpEntity = new HttpEntity<>(updatedPageSettings, sessionServiceRequestHandler.getHttpHeaders());
+                HttpEntity<Object> httpEntity = new HttpEntity<>(body, sessionServiceRequestHandler.getHttpHeaders());
 
                 restTemplate.put(sessionServiceURL + pageSettings.getType() + "/" + pageSettings.getId(), httpEntity);
                 response.setStatus(HttpStatus.OK.value());

--- a/web/src/main/java/org/cbioportal/web/SessionServiceController.java
+++ b/web/src/main/java/org/cbioportal/web/SessionServiceController.java
@@ -51,15 +51,11 @@ public class SessionServiceController {
     @Value("${session.service.url:}")
     private String sessionServiceURL;
 
-    private static Map<SessionPage, Class<? extends PageSettingsData>> pageToSettingsDataClass;
-    
-    static {
-         SessionServiceController.pageTypeToData = ImmutableMap.of(
-             SessionPage.result_view, ResultPageSettings.class,
-             SessionPage.study_view, StudyPageSettings.class
-         );
-    }
-    
+    private static Map<SessionPage, Class<? extends PageSettingsData>> pageToSettingsDataClass = ImmutableMap.of(
+         SessionPage.study_view, StudyPageSettings.class,
+         SessionPage.results_view, ResultsPageSettings.class
+     );
+
     private boolean isAuthorized() {
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -130,15 +126,15 @@ public class SessionServiceController {
                 if (!(isAuthorized())) {
                     return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
                 }
-                Class<? extends PageSettingsData> pageDataClass = pageTypeToData.get(
+                Class<? extends PageSettingsData> pageDataClass = pageToSettingsDataClass.get(
                     SessionPage.valueOf((String) body.get("page"))
                 );
                 PageSettingsData pageSettings = mapper.readValue(
                     body.toString(),
                     pageDataClass
                 );
-                studyPageSettings.setOwner(userName());
-                httpEntity = new HttpEntity<>(studyPageSettings, sessionServiceRequestHandler.getHttpHeaders());
+                pageSettings.setOwner(userName());
+                httpEntity = new HttpEntity<>(pageSettings, sessionServiceRequestHandler.getHttpHeaders());
 
             } else if(type.equals(SessionType.custom_data)) {
                 // JSON from file to Object

--- a/web/src/main/java/org/cbioportal/web/SessionServiceController.java
+++ b/web/src/main/java/org/cbioportal/web/SessionServiceController.java
@@ -318,8 +318,7 @@ public class SessionServiceController {
     }
 
     @RequestMapping(value = "/settings", method = RequestMethod.POST)
-    public void updateUserPageSettings(@RequestBody PageSettingsData settingsData, HttpServletResponse response)
-            throws IOException {
+    public void updateUserPageSettings(@RequestBody PageSettingsData settingsData, HttpServletResponse response) {
 
         try {
             ObjectMapper objectMapper = new ObjectMapper()
@@ -366,9 +365,6 @@ public class SessionServiceController {
     ) throws IOException {
 
         if (isAuthorized()) {
-
-            ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-                    false);
 
             PageSettingsData pageSettingsData = pageSettings.getData();
             // only allow owner to update his session and see if the origin(studies) are same

--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalTrackConfig.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalTrackConfig.java
@@ -2,9 +2,35 @@ package org.cbioportal.web.parameter;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.io.Serializable;
+
 @JsonInclude(JsonInclude.Include.ALWAYS)
-class ClinicalTrackConfig {
-    public String stableId;
-    public String sortOrder;
-    public Boolean gapOn;
+class ClinicalTrackConfig implements Serializable {
+    private String stableId;
+    private String sortOrder;
+    private Boolean gapOn;
+
+    public String getStableId() {
+        return stableId;
+    }
+
+    public void setStableId(String stableId) {
+        this.stableId = stableId;
+    }
+
+    public String getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(String sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public Boolean getGapOn() {
+        return gapOn;
+    }
+
+    public void setGapOn(Boolean gapOn) {
+        this.gapOn = gapOn;
+    }
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/ClinicalTrackConfig.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ClinicalTrackConfig.java
@@ -1,0 +1,10 @@
+package org.cbioportal.web.parameter;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+class ClinicalTrackConfig {
+    public String stableId;
+    public String sortOrder;
+    public Boolean gapOn;
+}

--- a/web/src/main/java/org/cbioportal/web/parameter/PageSettingsData.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/PageSettingsData.java
@@ -13,7 +13,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "page", visible = true)
-@JsonSubTypes({ @JsonSubTypes.Type(value = StudyPageSettings.class, name = "study_view") })
+@JsonSubTypes({ 
+    @JsonSubTypes.Type(value = ResultPageSettings.class, name = "result_view"),
+    @JsonSubTypes.Type(value = StudyPageSettings.class, name = "study_view") 
+})
 @JsonInclude(Include.NON_NULL)
 public abstract class PageSettingsData implements Serializable {
 

--- a/web/src/main/java/org/cbioportal/web/parameter/PageSettingsData.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/PageSettingsData.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "page", visible = true)
 @JsonSubTypes({ 
-    @JsonSubTypes.Type(value = ResultPageSettings.class, name = "result_view"),
+    @JsonSubTypes.Type(value = ResultsPageSettings.class, name = "results_view"),
     @JsonSubTypes.Type(value = StudyPageSettings.class, name = "study_view") 
 })
 @JsonInclude(Include.NON_NULL)

--- a/web/src/main/java/org/cbioportal/web/parameter/ResultPageSettings.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ResultPageSettings.java
@@ -27,9 +27,3 @@ public class ResultPageSettings extends PageSettingsData implements Serializable
     }
 }
 
-@JsonInclude(Include.ALWAYS)
-class ClinicalTrackConfig {
-    public String stableId;
-    public String sortOrder;
-    public Boolean gapOn;
-}

--- a/web/src/main/java/org/cbioportal/web/parameter/ResultPageSettings.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ResultPageSettings.java
@@ -1,0 +1,30 @@
+package org.cbioportal.web.parameter;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class ResultPageSettings extends PageSettingsData implements Serializable {
+    
+    private List<ClinicalTrackConfig> clinicallist = new ArrayList<>();
+
+    public List<ClinicalTrackConfig> getClinicallist() {
+        return clinicallist;
+    }
+
+    public void setClinicallist(List<ClinicalTrackConfig> clinicallist) {
+        this.clinicallist = clinicallist;
+    }
+}
+
+class ClinicalTrackConfig {
+    public String stableId;
+    public String sortOrder;
+    public boolean gapOn;
+}

--- a/web/src/main/java/org/cbioportal/web/parameter/ResultPageSettings.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ResultPageSettings.java
@@ -11,7 +11,11 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.ALWAYS)
 public class ResultPageSettings extends PageSettingsData implements Serializable {
-    
+
+    /**
+     * Configuration of clinical tracks
+     * Use lowercase instead of camelCase to be compatible with url query param 
+     */
     private List<ClinicalTrackConfig> clinicallist = new ArrayList<>();
 
     public List<ClinicalTrackConfig> getClinicallist() {

--- a/web/src/main/java/org/cbioportal/web/parameter/ResultPageSettings.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ResultPageSettings.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(Include.NON_NULL)
+@JsonInclude(Include.ALWAYS)
 public class ResultPageSettings extends PageSettingsData implements Serializable {
     
     private List<ClinicalTrackConfig> clinicallist = new ArrayList<>();
@@ -23,8 +23,9 @@ public class ResultPageSettings extends PageSettingsData implements Serializable
     }
 }
 
+@JsonInclude(Include.ALWAYS)
 class ClinicalTrackConfig {
     public String stableId;
     public String sortOrder;
-    public boolean gapOn;
+    public Boolean gapOn;
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/ResultsPageSettings.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/ResultsPageSettings.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.ALWAYS)
-public class ResultPageSettings extends PageSettingsData implements Serializable {
+public class ResultsPageSettings extends PageSettingsData implements Serializable {
 
     /**
      * Configuration of clinical tracks

--- a/web/src/main/java/org/cbioportal/web/parameter/SessionPage.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/SessionPage.java
@@ -1,6 +1,6 @@
 package org.cbioportal.web.parameter;
 
 public enum SessionPage {
-
+    result_view,
     study_view;
 }

--- a/web/src/main/java/org/cbioportal/web/parameter/SessionPage.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/SessionPage.java
@@ -1,6 +1,6 @@
 package org.cbioportal.web.parameter;
 
 public enum SessionPage {
-    result_view,
+    results_view,
     study_view;
 }


### PR DESCRIPTION
This PR will provide support in the cBioPortal backend to store user settings for Results View in Session Service. At the moment this is only done for user settings in Study View.

Changes:
- Add `results_view` to `SessionPage` type
- Add `ResultsPageSettings` containing result page configuration (at the moment only `clinicallist`) 
- Map `SessionPage`-type to `PageSettingsData`-implementation using `SessionServiceController.pageTypeToData`
- Prevent unnecessary unmarshalling by directly passing the `PageSettingsData body` to `updatedPageSettingSession`
