### PR TITLE
Fix comparison categorical na value delimiter

### DIFF
--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataEnrichmentUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataEnrichmentUtil.java
@@ -248,7 +248,7 @@ public class ClinicalDataEnrichmentUtil {
                             .stream()
                             .filter(clinicalDataCount -> {
                                     if (ComparisonCategoricalNaValuesString != null) {
-                                        String[] ComparisonCategoricalNaValues = ComparisonCategoricalNaValuesString.split("|");
+                                        String[] ComparisonCategoricalNaValues = ComparisonCategoricalNaValuesString.split("\\|");
                                         for (String naValue : ComparisonCategoricalNaValues) {
                                             if (clinicalDataCount.getValue().equalsIgnoreCase(naValue)) {
                                                 return false;


### PR DESCRIPTION
The error is because String.split() accepts a regex, `|` has a special meaning in regex. 
For example:
```
String valueString = "NA";
String[] values = valueString.split("|");
System.out.println(Arrays.toString(values));
```
Output:
```
[N, A]
```
VS
```
String valueString = "NA";
String[] values = valueString.split("\\|");
System.out.println(Arrays.toString(values));
```
Output:
```
[NA]
```
