### PR TITLE
Fix calculation of quartile values for study view data binning

### DIFF
--- a/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
+++ b/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
@@ -1,7 +1,6 @@
 package org.cbioportal.web.util;
 
 import com.google.common.collect.Range;
-import org.apache.commons.lang3.ObjectUtils;
 import org.cbioportal.model.DataBin;
 import org.springframework.stereotype.Component;
 
@@ -66,6 +65,28 @@ public class DataBinHelper {
 
         return dataBin;
     }
+    
+    public List<BigDecimal> calcQuartileBoundaries(List<BigDecimal> sortedValues) {
+        // Edge case: some of Q1, Q2, and Q3 are the same value.
+        // Solution: reduce bins to represent unique values only.
+        // Note: cannot use stream.distinct() because BigDecimal does
+        // not play nice with this (e.g., "2.5E+2" is not identical to "250"
+        // when using Object.equals())
+        final BigDecimal q1 = calcQ1(sortedValues);
+        final BigDecimal q2 = calcMedian(sortedValues);
+        final BigDecimal q3 = calcQ3(sortedValues);
+        List<BigDecimal> boundaries = new ArrayList<>();
+        boundaries.add(q1);
+        // Check Q1 smaller than Q2
+        if (q1.compareTo(q2) < 0) {
+            boundaries.add(q2);
+        }
+        // Check Q2 smaller than Q3
+        if (q2.compareTo(q3) < 0) {
+            boundaries.add(q3);
+        }
+        return boundaries;
+    }
 
     public Range<BigDecimal> calcBoxRange(List<BigDecimal> sortedValues) {
         if (sortedValues == null || sortedValues.size() == 0) {
@@ -75,7 +96,7 @@ public class DataBinHelper {
         // Find a generous IQR. This is generous because if (values.length / 4)
         // is not an int, then really you should average the two elements on either
         // side to find q1 and q3.
-        Range<BigDecimal> interquartileRange = calcInterquartileRange(sortedValues);
+        Range<BigDecimal> interquartileRange = calcInterquartileRangeApproximation(sortedValues);
 
         BigDecimal q1 = interquartileRange.lowerEndpoint();
         BigDecimal q3 = interquartileRange.upperEndpoint();
@@ -119,18 +140,18 @@ public class DataBinHelper {
         return Range.closed(minValue, maxValue);
     }
 
-    public Range<BigDecimal> calcInterquartileRange(List<BigDecimal> sortedValues) {
+    public Range<BigDecimal> calcInterquartileRangeApproximation(List<BigDecimal> sortedValues) {
         Range<BigDecimal> iqr = null;
 
         if (sortedValues.size() > 0) {
-            BigDecimal q1 = calcQ1(sortedValues);
-            BigDecimal q3 = calcQ3(sortedValues);
+            BigDecimal q1 = valueCloseToQ1(sortedValues);
+            BigDecimal q3 = valueCloseToQ3(sortedValues);
             BigDecimal max = sortedValues.get(sortedValues.size() - 1);
 
-            // if iqr == 0 AND max == q3 then recursively try finding a non-zero iqr
+            // if iqr == 0 AND max == q3 then recursively try finding a non-zero iqr approximation.
             if (q1.compareTo(q3) == 0 && max.compareTo(q3) == 0) {
                 // filter out max and try again
-                iqr = this.calcInterquartileRange(
+                iqr = this.calcInterquartileRangeApproximation(
                     sortedValues.stream().filter(d -> d.compareTo(max) == -1).collect(Collectors.toList()));
             }
 
@@ -144,18 +165,54 @@ public class DataBinHelper {
     }
 
     public BigDecimal calcQ1(List<BigDecimal> sortedValues) {
-        return sortedValues.isEmpty() ?
-            null : sortedValues.get((int) Math.floor(sortedValues.size() * 0.25));
+        if (sortedValues == null || sortedValues.isEmpty()) {
+            return null;
+        }
+        // Stop is one position before the median array index.
+        int stopIndex = (int) (sortedValues.size() * 0.5) - 1;
+        return calcMedian(sortedValues, 0,  stopIndex);
     }
 
     public BigDecimal calcMedian(List<BigDecimal> sortedValues) {
-        return sortedValues.isEmpty() ?
-            null : sortedValues.get((int) Math.floor(sortedValues.size() * 0.50));
+        return (sortedValues == null || sortedValues.isEmpty()) ? null
+            : calcMedian(sortedValues, 0, sortedValues.size() - 1);
     }
 
     public BigDecimal calcQ3(List<BigDecimal> sortedValues) {
-        return sortedValues.isEmpty() ?
-             null : sortedValues.get((int) Math.floor(sortedValues.size() * 0.75));
+        if (sortedValues == null || sortedValues.isEmpty()) {
+            return null;
+        }
+        // Start one position after the median array index.
+        int startIndex = (int) (sortedValues.size() * 0.5);
+        if (sortedValues.size() % 2 != 0) {
+            startIndex += 1;
+        }
+        return calcMedian(sortedValues, startIndex, sortedValues.size() - 1);
+   }
+
+    private BigDecimal calcMedian(List<BigDecimal> sortedValues, int start, int stop) {
+        if (sortedValues == null || sortedValues.isEmpty()) {
+            return null;
+        }
+        final List<BigDecimal> values = sortedValues.subList(start, stop + 1);
+        double index = values.size() * 0.5;
+        BigDecimal value = values.get((int) index);
+        if (values.size() % 2 != 0) {
+            return value;
+        } else {
+            BigDecimal valueBelow = values.get((int) index - 1);
+            return value.add(valueBelow).divide(new BigDecimal("2.0"));
+        }
+    }
+
+    public BigDecimal valueCloseToQ1(List<BigDecimal> sortedValues) {
+        return (sortedValues == null || sortedValues.isEmpty()) ?
+            null : sortedValues.get((int) (sortedValues.size() * 0.25));
+    }
+
+    public BigDecimal valueCloseToQ3(List<BigDecimal> sortedValues) {
+        return (sortedValues == null || sortedValues.isEmpty()) ?
+            null : sortedValues.get((int) (sortedValues.size() * 0.75));
     }
 
     public List<BigDecimal> filterIntervals(List<BigDecimal> intervals, BigDecimal lowerOutlier, BigDecimal upperOutlier) {

--- a/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
+++ b/web/src/main/java/org/cbioportal/web/util/DataBinHelper.java
@@ -145,16 +145,17 @@ public class DataBinHelper {
 
     public BigDecimal calcQ1(List<BigDecimal> sortedValues) {
         return sortedValues.isEmpty() ?
-            null : sortedValues.get((int) Math.floor(sortedValues.size() / 4.0));
+            null : sortedValues.get((int) Math.floor(sortedValues.size() * 0.25));
     }
 
     public BigDecimal calcMedian(List<BigDecimal> sortedValues) {
-        return ObjectUtils.median(sortedValues.toArray(new BigDecimal[0]));
+        return sortedValues.isEmpty() ?
+            null : sortedValues.get((int) Math.floor(sortedValues.size() * 0.50));
     }
 
     public BigDecimal calcQ3(List<BigDecimal> sortedValues) {
         return sortedValues.isEmpty() ?
-             null : sortedValues.get((int) Math.floor(sortedValues.size() * (3.0 / 4.0)));
+             null : sortedValues.get((int) Math.floor(sortedValues.size() * 0.75));
     }
 
     public List<BigDecimal> filterIntervals(List<BigDecimal> intervals, BigDecimal lowerOutlier, BigDecimal upperOutlier) {

--- a/web/src/main/java/org/cbioportal/web/util/DataBinner.java
+++ b/web/src/main/java/org/cbioportal/web/util/DataBinner.java
@@ -309,14 +309,8 @@ public class DataBinner {
             } else if (DataBinFilter.BinMethod.MEDIAN == binMethod) {
                 // NOOP - handled later
             } else if (DataBinFilter.BinMethod.QUARTILE == binMethod) {
-                // Edge case: some of Q1, Q2, and Q3 are the same value.
-                // Solution: reduce bins to represent unique values only.
-                List<BigDecimal> bins = Stream.of(
-                    this.dataBinHelper.calcQ1(sortedNumericalValues),
-                    this.dataBinHelper.calcMedian(sortedNumericalValues),
-                    this.dataBinHelper.calcQ3(sortedNumericalValues)
-                ).distinct().collect(Collectors.toList());
-                dataBins = linearDataBinner.calculateDataBins(bins, numericalValues);
+                List<BigDecimal> boundaries = this.dataBinHelper.calcQuartileBoundaries(sortedNumericalValues);
+                dataBins = linearDataBinner.calculateDataBins(boundaries, numericalValues);
             } else if (boxRange.upperEndpoint().subtract(boxRange.lowerEndpoint()).compareTo(new BigDecimal(1000)) == 1  &&
                 (disableLogScale == null || !disableLogScale)) {
                 dataBins = logScaleDataBinner.calculateDataBins(

--- a/web/src/main/java/org/cbioportal/web/util/LinearDataBinner.java
+++ b/web/src/main/java/org/cbioportal/web/util/LinearDataBinner.java
@@ -70,14 +70,14 @@ public class LinearDataBinner {
         return dataBins;
     }
 
-    // Add bins that have a defined start and end value.
-    // Ignore bins for lower (<=) and upper (>) limits.
-    public List<DataBin> initDataBins(List<BigDecimal> bins) {
+    // Add boundaries that have a defined start and end value.
+    // Ignore boundaries for lower (<=) and upper (>) limits.
+    public List<DataBin> initDataBins(List<BigDecimal> boundaries) {
         List<DataBin> dataBins = new ArrayList<>();
-        for (int i = 0; i < bins.size() - 1; i++) {
+        for (int i = 0; i < boundaries.size() - 1; i++) {
             DataBin dataBin = new DataBin();
-            dataBin.setStart(bins.get(i));
-            dataBin.setEnd(bins.get(i + 1));
+            dataBin.setStart(boundaries.get(i));
+            dataBin.setEnd(boundaries.get(i + 1));
             dataBin.setCount(0);
             dataBins.add(dataBin);
         }

--- a/web/src/test/java/org/cbioportal/web/util/DataBinHelperTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/DataBinHelperTest.java
@@ -124,6 +124,181 @@ public class DataBinHelperTest {
                null);
     }
     
+    @Test
+    public void testMedianEvenSeries() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6);
+        assertEquals(new BigDecimal("3.5"), dataBinHelper.calcMedian(values));
+    }
+    
+    @Test
+    public void testMedianUnevenSeries() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6, 7);
+        assertEquals(new BigDecimal("4"), dataBinHelper.calcMedian(values));
+    }
+
+    @Test
+    public void testMedianNullSeries() {
+        assertNull(dataBinHelper.calcMedian(null));
+    }
+
+
+    @Test
+    public void testMedianEmptySeries() {
+        assertNull(dataBinHelper.calcMedian(new ArrayList<>()));
+    }
+
+    @Test
+    public void testQ1EvenSeries() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6);
+        assertEquals(new BigDecimal("2"), dataBinHelper.calcQ1(values));
+    }
+
+    @Test
+    public void testQ1UnevenSeries() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+        assertEquals(new BigDecimal("3"), dataBinHelper.calcQ1(values));
+    }
+    
+    @Test
+    public void testQ1NullSeries() {
+        assertNull(dataBinHelper.calcQ1(null));
+    }
+    
+    @Test
+    public void testQ1EmptySeries() {
+        assertNull(dataBinHelper.calcQ1(new ArrayList<>()));
+    }
+    
+    @Test
+    public void testQ3EvenSeries() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6);
+        assertEquals(new BigDecimal("5"), dataBinHelper.calcQ3(values));
+    }
+
+    @Test
+    public void testQ3UnevenSeries() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertEquals(new BigDecimal("7.5"), dataBinHelper.calcQ3(values));
+    }
+
+    @Test
+    public void testQ3NullSeries() {
+        assertNull(dataBinHelper.calcQ3(null));
+    }
+
+    @Test
+    public void testQ3EmptySeries() {
+        assertNull(dataBinHelper.calcQ3(new ArrayList<>()));
+    }
+
+    @Test
+    public void testValueCloseToQ1EvenSeries() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6);
+        assertEquals(new BigDecimal("2"), dataBinHelper.valueCloseToQ1(values));
+    }
+
+    @Test
+    public void testValueCloseToQ1UnevenSeries() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertEquals(new BigDecimal("3"), dataBinHelper.valueCloseToQ1(values));
+    }
+
+    @Test
+    public void testValueCloseToQ1NullSeries() {
+        assertNull(dataBinHelper.valueCloseToQ1(null));
+    }
+
+    @Test
+    public void testValueCloseToQ1EmptySeries() {
+        assertNull(dataBinHelper.valueCloseToQ1(new ArrayList<>()));
+    }
+
+    @Test
+    public void testValueCloseToQ3EvenSeries() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6);
+        assertEquals(new BigDecimal("5"), dataBinHelper.valueCloseToQ3(values));
+    }
+
+    @Test
+    public void testValueCloseToQ3UnevenSeries() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertEquals(new BigDecimal("7"), dataBinHelper.valueCloseToQ3(values));
+    }
+
+    @Test
+    public void testValueCloseToQ3NullSeries() {
+        assertNull(dataBinHelper.valueCloseToQ3(null));
+    }
+
+    @Test
+    public void testValueCloseToQ3EmptySeries() {
+        assertNull(dataBinHelper.valueCloseToQ3(new ArrayList<>()));
+    }
+
+    @Test
+    public void testCalcQuartileBoundariesUniqueSeries() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        final List<BigDecimal> expected = Arrays.asList(new BigDecimal("2.5"), new BigDecimal("5"), new BigDecimal("7.5"));
+        final List<BigDecimal> observed = dataBinHelper.calcQuartileBoundaries(values);
+        assertEquals(3, observed.size());
+        assertEquals(0, observed.get(0).compareTo(expected.get(0)));
+        assertEquals(0, observed.get(1).compareTo(expected.get(1)));
+        assertEquals(0, observed.get(2).compareTo(expected.get(2)));
+    }
+    
+    @Test
+    public void testCalcQuartileBoundariesIdenticalSeries() {
+        List<BigDecimal> values = decList(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+        final List<BigDecimal> observed = dataBinHelper.calcQuartileBoundaries(values);
+        assertEquals(1, observed.size());
+        assertEquals(0, observed.get(0).compareTo(new BigDecimal("1")));
+    }
+    
+    @Test
+    public void testCalcQuartileBoundariesIdenitcalUpperValues() {
+        List<BigDecimal> values = decList(1, 1, 1, 10, 10, 10, 10, 10, 10);
+        final List<BigDecimal> expected = Arrays.asList(new BigDecimal("1"), new BigDecimal("10"));
+        final List<BigDecimal> observed = dataBinHelper.calcQuartileBoundaries(values);
+        assertEquals(2, observed.size());
+        assertEquals(0, observed.get(0).compareTo(expected.get(0)));
+        assertEquals(0, observed.get(1).compareTo(expected.get(1)));
+    }
+    
+    @Test
+    public void testCalcQuartileBoundariesIdenticalLowerValues() {
+        List<BigDecimal> values = decList(1, 1, 1, 1, 1, 1, 10, 10, 10);
+        final List<BigDecimal> expected = Arrays.asList(new BigDecimal("1"), new BigDecimal("10"));
+        final List<BigDecimal> observed = dataBinHelper.calcQuartileBoundaries(values);
+        assertEquals(2, observed.size());
+        assertEquals(0, observed.get(0).compareTo(expected.get(0)));
+        assertEquals(0, observed.get(1).compareTo(expected.get(1)));
+    }
+    
+    @Test
+    public void testCalcQuartileBoundariesFractions() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6, 7, 8);
+        final List<BigDecimal> expected = Arrays.asList(new BigDecimal("2.5"), new BigDecimal("4.5"), new BigDecimal("6.5"));
+        final List<BigDecimal> observed = dataBinHelper.calcQuartileBoundaries(values);
+        assertEquals(3, observed.size());
+        assertEquals(0, observed.get(0).compareTo(expected.get(0)));
+        assertEquals(0, observed.get(1).compareTo(expected.get(1)));
+        assertEquals(0, observed.get(2).compareTo(expected.get(2)));
+    }
+
+    @Test
+    public void testCalcInterquartileRangeApproximation() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6, 7, 8);
+        assertEquals(new BigDecimal("3"), dataBinHelper.calcInterquartileRangeApproximation(values).lowerEndpoint());
+        assertEquals(new BigDecimal("7"), dataBinHelper.calcInterquartileRangeApproximation(values).upperEndpoint());
+    }
+
+    @Test
+    public void testCalsIqrUnevenSeries() {
+        List<BigDecimal> values = decList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+        assertEquals(new BigDecimal("3"), dataBinHelper.calcInterquartileRangeApproximation(values).lowerEndpoint());
+        assertEquals(new BigDecimal("9"), dataBinHelper.calcInterquartileRangeApproximation(values).upperEndpoint());
+    }
+    
     private List<BigDecimal> decList(int... numbers) {
         return Arrays.stream(numbers).mapToObj(BigDecimal::new).collect(Collectors.toList());
     }

--- a/web/src/test/java/org/cbioportal/web/util/DataBinnerMocker.java
+++ b/web/src/test/java/org/cbioportal/web/util/DataBinnerMocker.java
@@ -867,6 +867,14 @@ public class DataBinnerMocker {
             "696476372", "3532676582", "3851721681"
         };
     }
+    
+    public static String[] mockQ1Q2Q3Identical() {
+        return new String[]{"10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250"};
+    }
+    
+    public static String[] mockQ2Q3Identical() {
+        return new String[]{"10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250", "250"};
+    }
 
     public static Map<String, String[]> mockData() {
         Map<String, String[]> mockData = new LinkedHashMap<>();
@@ -888,6 +896,8 @@ public class DataBinnerMocker {
         mockData.put("genie_N_SCANS_PET_CT_PT", mockGenieNScansPetCtPt());
         mockData.put("genie_N_SCANS_BONE_PT", mockGenieNScansBonePt());
         mockData.put("random_BIG_NUMBER", mockBigNumbers());
+        mockData.put("q1q2q3_identical", mockQ1Q2Q3Identical());
+        mockData.put("q2q3_identical", mockQ2Q3Identical());
 
         return mockData;
     }

--- a/web/src/test/java/org/cbioportal/web/util/DataBinnerTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/DataBinnerTest.java
@@ -802,6 +802,51 @@ public class DataBinnerTest {
     }
 
     @Test
+    public void testLinearDataBinnerQuartileBinsLowComplexitySeriesQ1Q2Q3Identical() {
+        String studyId = "skcm_broad";
+        String attributeId = "AGE_AT_PROCUREMENT";
+        String[] values = mockData.get("q1q2q3_identical");
+
+        ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
+        clinicalDataBinFilter.setAttributeId(attributeId);
+        clinicalDataBinFilter.setBinMethod(BinMethod.QUARTILE);
+
+        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<String> patientIds = getCaseIds(clinicalData, true);
+
+        List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
+
+        List<DataBin> expected = Arrays.asList(
+            createDataBin("<=", null ,"250", 50)
+        );
+
+        testBinsIdentical(expected, dataBins);
+    }
+
+    @Test
+    public void testLinearDataBinnerQuartileBinsLowComplexitySeriesQ2Q3Identical() {
+        String studyId = "skcm_broad";
+        String attributeId = "AGE_AT_PROCUREMENT";
+        String[] values = mockData.get("q2q3_identical");
+
+        ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
+        clinicalDataBinFilter.setAttributeId(attributeId);
+        clinicalDataBinFilter.setBinMethod(BinMethod.QUARTILE);
+
+        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<String> patientIds = getCaseIds(clinicalData, true);
+
+        List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
+
+        List<DataBin> expected = Arrays.asList(
+            createDataBin("<=", null, "15", 6),
+            createDataBin(null, "15", "250", 17)
+        );
+
+        testBinsIdentical(expected, dataBins);
+    }
+
+    @Test
     public void testLinearDataBinnerWithBigNumbers() {
         String studyId = "random_";
         String attributeId = "BIG_NUMBER";


### PR DESCRIPTION
# Problem
Functions used for calculation of quartile values for numeric data do not take into account low complexity series where Q1, Q2 and or Q3 are identical. This resulted in in correct values where low complexity applied.

# Solution
Strategy for low complexity data series was added to quartile calculation. Tests were added to document this behavior.