### PR TITLE
Port Spring RCE fix to 3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,22 +17,6 @@
 
   <repositories>
     <repository>
-      <id>plugins-release</id>
-      <name>Spring Plugins</name>
-      <url>https://repo.spring.io/plugins-release</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>spring-milestones</id>
-      <name>Spring Milestones</name>
-      <url>https://repo.spring.io/milestone</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
       <id>alfresco</id>
       <name>Alfresco</name>
       <url>https://artifacts.alfresco.com/nexus/content/repositories/public/</url>
@@ -292,7 +276,7 @@
   <properties>
     <frontend.version>694be26a0b4a6ba15d9d221d5d3f0ce6a9481772</frontend.version>
     <frontend.groupId>com.github.cbioportal</frontend.groupId>
-    <spring.version>5.2.6.RELEASE</spring.version>
+    <spring.version>5.2.20.RELEASE</spring.version>
     <spring.integration.version>5.3.0.RELEASE</spring.integration.version>
     <spring.security.version>5.3.1.RELEASE</spring.security.version>
     <spring.social.version>1.1.6.RELEASE</spring.social.version>


### PR DESCRIPTION
- upgrade spring version
- not porting the java version shift, because we never
switched to 8 for 3.7 in the first place