### PR TITLE
Upgrade to Java 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
     build_backend:
         docker:
-            - image: maven:3-openjdk-11
+            - image: maven:3-openjdk-17
         working_directory: /tmp/repos/cbioportal
         steps:
             - checkout
@@ -21,7 +21,11 @@ jobs:
                 name: Build and unzip war
                 command: |
                     mvn -DskipTests clean install && \
-                    unzip portal/target/cbioportal*.war -d portal/target/war-exploded
+                    mkdir portal/target/war-exploded && \
+                    mv portal/target/cbioportal*.war portal/target/war-exploded/ && \
+                    cd portal/target/war-exploded/ && \
+                    jar -xvf cbioportal*.war && \
+                    cd ../../..
             - save_cache:
                 paths:
                   - ~/.m2
@@ -180,6 +184,7 @@ jobs:
             - run:
                 name: Start cbioportal and other services
                 command: |
+                    export DOCKER_IMAGE_CBIOPORTAL='cbioportal/cbioportal:demo-java-17' && \
                     $TEST_HOME/docker_compose/start.sh
             - run:
                 name: Change owner of keycloak MySQL database files (needed by cache)

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ./cbioportal
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 17'
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: 'Cache Maven packages'
         uses: actions/cache@v1
         with:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,6 +8,7 @@ jobs:
       PORTAL_SOURCE_DIR: /home/runner/work/cbioportal/cbioportal/cbioportal
       PORTAL_COMPOSE_DIR: /home/runner/work/cbioportal/cbioportal/cbioportal-docker-compose
       PORTAL_INFO_DIR: /home/runner/work/cbioportal/cbioportal/portalInfo
+      DOCKER_IMAGE_CBIOPORTAL: cbioportal/cbioportal:demo-java-17
     steps:
       - name: 'Checkout cbioportal repo'
         uses: actions/checkout@v2
@@ -19,10 +20,10 @@ jobs:
           sudo apt-get install python3-setuptools && \
           pip3 install -U wheel && \
           pip3 install -r ./requirements.txt
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 17'
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: 'Cache Maven packages'
         uses: actions/cache@v1
         with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The cBioPortal for Cancer Genomics provides visualization, analysis, and downloa
 
 If you would like to know how to setup a private instance of the portal and/or get set up for developing, see the [documentation](https://docs.cbioportal.org). For details on contributing code changes via pull requests, see our [Contributing document](CONTRIBUTING.md).
 
-If you are interested in coordinating the development of new features, please contact cbioportal@cbio.mskcc.org or reach out on https://slack.cbioportal.org.
+If you are interested in coordinating the development of new features, please contact cbioportal@cbioportal.org or reach out on https://slack.cbioportal.org.
 
 ## 📘 Documentation
 See [https://docs.cbioportal.org](https://docs.cbioportal.org)

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -141,11 +141,12 @@
     </dependency>
     <!--svg to PDF Converter-->
     <dependency>
-      <groupId>batik</groupId>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik</artifactId>
+      <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>batik</groupId>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-rasterizer</artifactId>
     </dependency>
     <dependency>

--- a/core/src/main/java/org/mskcc/cbio/portal/util/GzippedInputStreamRequestWrapper.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GzippedInputStreamRequestWrapper.java
@@ -1,5 +1,6 @@
 package org.mskcc.cbio.portal.util;
 
+import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
@@ -55,6 +56,21 @@ public class GzippedInputStreamRequestWrapper extends HttpServletRequestWrapper 
             @Override
             public int readLine(byte[] b, int off, int len) throws IOException {
                 return super.readLine(b, off, len);
+            }
+
+            @Override
+            public boolean isFinished() {
+                return inputStream.available() == 0;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+                // noop
             }
 
             @Override

--- a/core/src/test/java/org/mskcc/cbio/portal/servlet/NullHttpServletRequest.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/servlet/NullHttpServletRequest.java
@@ -50,11 +50,7 @@ import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletInputStream;
 import javax.servlet.DispatcherType;
 import javax.servlet.AsyncContext;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.Part;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import javax.servlet.http.*;
 
 /**
  * Useful for unit testing code that uses HttpServletRequest.
@@ -176,7 +172,12 @@ public class NullHttpServletRequest implements HttpServletRequest{
       return null;
    }
 
-   public Collection<Part> getParts() {
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) throws IOException, ServletException {
+        throw new UnsupportedOperationException();
+    }
+
+    public Collection<Part> getParts() {
       return null;
    }
 

--- a/core/src/test/java/org/mskcc/cbio/portal/servlet/NullHttpServletResponse.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/servlet/NullHttpServletResponse.java
@@ -57,6 +57,7 @@ package org.mskcc.cbio.portal.servlet;
  * Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.ServletResponse;
 import javax.servlet.ServletOutputStream;
@@ -86,14 +87,18 @@ public class NullHttpServletResponse implements  HttpServletResponse {
     /**
      * An OutputStream implementation for JUnit tests.
      */
-    private static class NullServletOutputStream extends
-            ServletOutputStream {
+    private static class NullServletOutputStream extends ServletOutputStream {
 
         public void write(int b) {
             // do nothing
         }
         public boolean isReady() {
             return false;
+        }
+
+        @Override
+        public void setWriteListener(WriteListener writeListener) {
+            throw new UnsupportedOperationException();
         }
     }
 

--- a/core/src/test/java/org/mskcc/cbio/portal/util/TestRequestBodyGZipFilter.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/util/TestRequestBodyGZipFilter.java
@@ -8,6 +8,7 @@ import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import javax.servlet.FilterChain;
+import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -163,6 +164,21 @@ public class TestRequestBodyGZipFilter {
 
         GzippedJsonFileInputStream() {
             this.byteInputStream = new ByteArrayInputStream(GZIPPED_JSON_FILE_BYTES);
+        }
+
+        @Override
+        public boolean isFinished() {
+            return byteInputStream.available() == 0;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            // noop
         }
 
         @Override

--- a/core/src/test/resources/applicationContext-dao.xml
+++ b/core/src/test/resources/applicationContext-dao.xml
@@ -58,7 +58,7 @@
 	<!-- Values are for testing only, so need to correspond to the cgds in the pom.xml -->
 	<bean id="dbcpDataSource" destroy-method="close" class="org.apache.commons.dbcp2.BasicDataSource">
 		<property name="driverClassName" value="com.mysql.jdbc.Driver" />
-		<property name="url" value="jdbc:mysql://localhost:3306/cgds_test?allowLoadLocalInfile=true&amp;useSSL=false" />
+		<property name="url" value="jdbc:mysql://localhost:3306/cgds_test?allowLoadLocalInfile=true&amp;useSSL=false&amp;enabledTLSProtocols=TLSv1.2" />
         <!-- - test db credentials should be keep in sync with parent pom.xml -->
 		<property name="username" value="${db.test.username:cbio_user}" />
 		<property name="password" value="${db.test.password:somepassword}" />

--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -11,7 +11,7 @@
 # NOTE: the .git folder is included in the build stage, but excluded 
 # from the final image. No confidential information is exposed.
 # (see: stackoverflow.com/questions/56278325)
-FROM maven:3-openjdk-11 as build
+FROM maven:3-openjdk-17 as build
 
 # download maven dependencies first to take advantage of docker caching
 COPY pom.xml                                     /cbioportal/
@@ -37,7 +37,8 @@ RUN mvn dependency:go-offline --fail-never
 COPY $PWD /cbioportal
 RUN mvn -DskipTests clean install
 
-FROM openjdk:11-jre-slim
+# We shouldn't use openjdk images. See here for explanation: https://hub.docker.com/_/openjdk
+FROM eclipse-temurin:17
 
 # download system dependencies first to take advantage of docker caching
 RUN apt-get update; apt-get install -y --no-install-recommends \

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -13,13 +13,14 @@
 #
 # WARNING: the shendoah image is a nightly, untested, experimental build. If
 # you want to use an official openjdk image instead use the web-and-data image.
-FROM maven:3-openjdk-11 as build
+FROM maven:3-openjdk-17 as build
 COPY $PWD /cbioportal
 WORKDIR /cbioportal
 ARG MAVEN_OPTS=-DskipTests
 RUN mvn ${MAVEN_OPTS} clean install
 
-FROM shipilev/openjdk:11
+# We shouldn't use openjdk images. See here for explanation: https://hub.docker.com/_/openjdk
+FROM eclipse-temurin:17
 
 ENV PORTAL_WEB_HOME=/cbioportal-webapp
 

--- a/docs/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/Customizing-your-instance-of-cBioPortal.md
@@ -241,6 +241,12 @@ Below you can find the complete list of all the available skin properties.
             <td>false</td>
             <td>true / false</td>
         </tr>
+		<tr>
+            <td>skin.hide_download_controls</td>
+            <td>removes all download and copy-to-clipboard options.</td>
+            <td>false</td>
+            <td>true / false</td>
+        </tr>
         <tr>
             <td>skin.show_settings_menu</td>
             <td>controls the appearance of the settings menu in study view and group comparison that controls annotation-based filtering.</td>

--- a/docs/portal.properties-Reference.md
+++ b/docs/portal.properties-Reference.md
@@ -162,6 +162,11 @@ Add a custom logo in the right side of the menu. Place here the full name of the
 skin.right_logo=
 ```
 
+Prevent users from saving data by removing all Download tabs and download and copy-to-clipboard controls.
+```
+skin.hide_download_controls=
+```
+
 ## Control default setting for filtering of genes in mutation and CNA tables of patient view
 Different samples of a patient may have been analyzed with different gene panels. In patient view mutations and discrete CNA's can be filtered based on whether the gene of respective mutations/CNA's was profiled in all samples of the patient (mutations profiled in `all samples`), or not (mutations profiled in `any sample`). Setting this field to `true` will make patient view select the `all samples` filter at startup. When set to false or left blank the patient view will default to the `any samples` filter setting.
 ```

--- a/persistence/persistence-api/pom.xml
+++ b/persistence/persistence-api/pom.xml
@@ -29,6 +29,14 @@
       <artifactId>ehcache</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.redisson</groupId>
       <artifactId>redisson</artifactId>
       <version>3.13.2</version>

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/config/EhCacheConfig.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/config/EhCacheConfig.java
@@ -3,6 +3,7 @@ package org.cbioportal.persistence.config;
 import org.cbioportal.persistence.util.CustomEhcachingProvider;
 import org.cbioportal.persistence.util.CustomKeyGenerator;
 import org.cbioportal.utils.config.annotation.ConditionalOnProperty;
+import org.ehcache.jsr107.EhcacheCachingProvider;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachingConfigurerSupport;
 import org.springframework.cache.annotation.EnableCaching;
@@ -12,6 +13,10 @@ import org.springframework.cache.jcache.JCacheCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
+import java.util.Iterator;
+
 @Configuration
 @EnableCaching
 @ConditionalOnProperty(name = "persistence.cache_type", havingValue = {"ehcache-heap", "ehcache-disk", "ehcache-hybrid"})
@@ -20,6 +25,15 @@ public class EhCacheConfig extends CachingConfigurerSupport {
     @Bean
     @Override
     public CacheManager cacheManager() {
+        // We somehow end up with both a redisson cache provider and an ehcache provider when using EhCache
+        // This just removes the redundant cache provider
+        Iterator<CachingProvider> iterator = Caching.getCachingProviders().iterator();
+        while(iterator.hasNext()) {
+            CachingProvider provider = iterator.next();
+            if (!(provider instanceof EhcacheCachingProvider)) {
+                iterator.remove();
+            }
+        }
         return new JCacheCacheManager(
             customEhcachingProvider().getCacheManager()
         );

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/EhcacheStatistics.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/EhcacheStatistics.java
@@ -33,9 +33,9 @@
 package org.cbioportal.persistence.util;
 
 import org.cbioportal.utils.config.annotation.ConditionalOnProperty;
+import org.ehcache.core.internal.statistics.DefaultStatisticsService;
 import org.ehcache.core.statistics.*;
 import org.ehcache.config.ResourceType;
-import org.ehcache.impl.internal.statistics.DefaultStatisticsService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,12 @@
   </scm>
 
   <repositories>
+    <!--See: https://github.com/ulisesbocchio/spring-boot-security-saml-samples/issues/22-->
+    <repository>
+      <id>shibboleth</id>
+      <name>Shibboleth</name>
+      <url>https://build.shibboleth.net/nexus/content/repositories/releases/</url>
+    </repository>
     <repository>
       <id>alfresco</id>
       <name>Alfresco</name>
@@ -61,7 +67,7 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.5</version>
+            <version>0.8.8</version>
             <executions>
               <!--
                     Prepares the property pointing to the JaCoCo runtime agent which
@@ -284,7 +290,7 @@
     <spring.security.version>5.3.13.RELEASE</spring.security.version>
     <spring.social.version>1.1.6.RELEASE</spring.social.version>
     <jackson.version>2.13.0</jackson.version>
-    <mysql-connector.version>5.1.48</mysql-connector.version>
+    <mysql-connector.version>5.1.49</mysql-connector.version>
     <webapp-runner.version>8.5.61.0</webapp-runner.version>
     <slf4j.version>1.7.32</slf4j.version>
     <logback.version>1.2.10</logback.version>
@@ -732,7 +738,7 @@
       <dependency>
         <groupId>org.springframework.security.extensions</groupId>
         <artifactId>spring-security-saml2-core</artifactId>
-        <version>1.0.3.RELEASE</version>
+        <version>1.0.10.RELEASE</version>
       </dependency>
       <!-- Spring Social -->
       <dependency>
@@ -845,7 +851,7 @@
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
       </dependency>
       <!-- jsonwebtoken -->
       <dependency>
@@ -980,19 +986,20 @@
         <version>2.3</version>
       </dependency>
       <dependency>
-        <groupId>batik</groupId>
+        <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik</artifactId>
-        <version>1.5</version>
+        <version>1.14</version>
+        <type>pom</type>
       </dependency>
       <dependency>
-        <groupId>batik</groupId>
+        <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-rasterizer</artifactId>
-        <version>1.5</version>
+        <version>1.14</version>
       </dependency>
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-codec</artifactId>
-        <version>1.7</version>
+        <version>1.14</version>
         <exclusions>
           <exclusion>
             <groupId>xalan</groupId>
@@ -1120,7 +1127,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.3.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
   </profiles>
 
   <properties>
-    <frontend.version>46f5fd5b520a9cc6a684d2c40d05b4f381b86b22</frontend.version>
+    <frontend.version>2004ec63289004efa93cbb4fc58c96f17625799e</frontend.version>
     <frontend.groupId>com.github.cbioportal</frontend.groupId>
     <spring.version>5.2.20.RELEASE</spring.version>
     <spring.integration.version>5.3.0.RELEASE</spring.integration.version>

--- a/pom.xml
+++ b/pom.xml
@@ -279,9 +279,9 @@
   <properties>
     <frontend.version>2004ec63289004efa93cbb4fc58c96f17625799e</frontend.version>
     <frontend.groupId>com.github.cbioportal</frontend.groupId>
-    <spring.version>5.2.20.RELEASE</spring.version>
-    <spring.integration.version>5.3.0.RELEASE</spring.integration.version>
-    <spring.security.version>5.3.1.RELEASE</spring.security.version>
+    <spring.version>5.3.20</spring.version>
+    <spring.integration.version>5.3.10.RELEASE</spring.integration.version>
+    <spring.security.version>5.3.13.RELEASE</spring.security.version>
     <spring.social.version>1.1.6.RELEASE</spring.social.version>
     <jackson.version>2.13.0</jackson.version>
     <mysql-connector.version>5.1.48</mysql-connector.version>
@@ -570,7 +570,7 @@
       <dependency>
         <groupId>org.mybatis</groupId>
         <artifactId>mybatis</artifactId>
-        <version>3.5.7</version>
+        <version>3.5.10</version>
       </dependency>
       <!-- slf4j -->
       <dependency>
@@ -822,7 +822,18 @@
       <dependency>
         <groupId>org.ehcache</groupId>
         <artifactId>ehcache</artifactId>
-        <version>3.7.1</version>
+        <version>3.10.0</version>
+      </dependency>
+      <!-- These are used by the caching provider. They were in the JVM itself circa java 8, but not in 17 -->
+      <dependency>
+        <groupId>jakarta.xml.bind</groupId>
+        <artifactId>jakarta.xml.bind-api</artifactId>
+        <version>2.3.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-runtime</artifactId>
+        <version>2.3.2</version>
       </dependency>
       <!-- Google guice -->
       <dependency>
@@ -866,7 +877,7 @@
       <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-catalina</artifactId>
-        <version>7.0.68</version>
+        <version>7.0.109</version>
         <scope>
           ${tomcat.catalina.scope}
         </scope>
@@ -1074,8 +1085,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <source>17</source>
+            <target>17</target>
             <compilerArgs>
               <arg>-parameters</arg>
             </compilerArgs>

--- a/portal/src/integration-tests/saml-oauth2-setup/pom.xml
+++ b/portal/src/integration-tests/saml-oauth2-setup/pom.xml
@@ -10,6 +10,16 @@
         <module>saml-idp</module>
     </modules>
 
+    <repositories>
+        <!--See: https://github.com/ulisesbocchio/spring-boot-security-saml-samples/issues/22-->
+        <repository>
+            <id>shibboleth</id>
+            <name>Shibboleth</name>
+            <url>https://build.shibboleth.net/nexus/content/repositories/releases/</url>
+        </repository>
+    </repositories>
+    
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -20,13 +30,19 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>5.8.0</version>
+            <version>5.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-client-java</artifactId>
-            <version>5.8.0</version>
+            <version>5.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20220320</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -38,8 +54,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                     <compilerArgs>
                         <arg>-parameters</arg>
                     </compilerArgs>

--- a/portal/src/integration-tests/saml-oauth2-setup/saml-idp/pom.xml
+++ b/portal/src/integration-tests/saml-oauth2-setup/saml-idp/pom.xml
@@ -6,6 +6,15 @@
     <version>0.0.1-SNAPSHOT</version>
     <packaging>war</packaging>
 
+    <repositories>
+        <!--See: https://github.com/ulisesbocchio/spring-boot-security-saml-samples/issues/22-->
+        <repository>
+            <id>shibboleth</id>
+            <name>Shibboleth</name>
+            <url>https://build.shibboleth.net/nexus/content/repositories/releases/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.security.extensions</groupId>
@@ -36,7 +45,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.3.2</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -137,7 +137,8 @@
             "skin.geneset_hierarchy.default_gsva_score",
             "skin.geneset_hierarchy.collapse_by_default",
             "skin.mutation_table.namespace_column.show_by_default",
-            "comparison.categorical_na_values"
+            "comparison.categorical_na_values",
+            "skin.hide_download_controls"
         };
 
 

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -87,6 +87,7 @@
     <http pattern="/api/swagger-resources/**" security="none"/>
     <http pattern="/api/swagger-ui.html" security="none"/>
     <http pattern="/api/health" security="none"/>
+    <http pattern="/api/api-docs" security="none"/>
     <http pattern="/api/cache/**" security="none"/>
     <http pattern="/api/cacheStatistics" security="none"/>
     <http pattern="/api/**/keysInCache" security="none"/>

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -99,6 +99,9 @@ skin.study_view.link_text=To build your own case set, try out our enhanced Study
 ## enable this to configure a global message for the studies that are unauthorized; the message can contain placecards like {$.Owner.email} for the studies that have the information in the study tags 
 # skin.home_page.unauthorized_studies_global_message=The study is unauthorized. You need to request access.
 
+setting controlling whether Download tabs and download/copy-to-clipboard controls should be shown
+# skin.hide_download_controls=true
+
 ## enable and set this property to specify a study group to be used to identify public studies for which no specific authorization entries are needed in the `authorities` table
 # always_show_study_group=
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -139,6 +139,10 @@
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.el</groupId>
       <artifactId>javax.el-api</artifactId>
     </dependency>

--- a/web/src/test/java/org/cbioportal/web/CacheControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/CacheControllerTest.java
@@ -1,7 +1,5 @@
 package org.cbioportal.web;
 
-import org.cbioportal.model.CancerStudy;
-import org.cbioportal.persistence.StudyRepository;
 import org.cbioportal.service.CacheService;
 import org.cbioportal.service.exception.CacheOperationException;
 import org.junit.Before;
@@ -21,9 +19,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-
-import java.util.Arrays;
-import java.util.List;
 
 import static org.mockito.Mockito.*;
 


### PR DESCRIPTION
- Upgrade dependencies where needed for Java 17
- Add dependencies that were removed from JVM so that ehcache works
- Fix CI workflows
- Fix integration test with temporary reference to Java 17 image
  - Once we move the cbioportal-docker-compose repo to a 5.x cbioportal
  image, we can revert this
- Switch docker images over to Java 17 base images, move away from
Oracle openjdk images