### PR TITLE
Permit all access to /api/api-docs endpoint

### DIFF
--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -87,6 +87,7 @@
     <http pattern="/api/swagger-resources/**" security="none"/>
     <http pattern="/api/swagger-ui.html" security="none"/>
     <http pattern="/api/health" security="none"/>
+    <http pattern="/api/api-docs" security="none"/>
     <http pattern="/api/cache/**" security="none"/>
     <http pattern="/api/cacheStatistics" security="none"/>
     <http pattern="/api/**/keysInCache" security="none"/>


### PR DESCRIPTION
# Problem
On portals with user authentication the `/api/api-docs` endpoint cannot be accessed when the user is logged in. Programmatic access using a DAT (Data Access Token) does not work. The prevents programmatic access for libraries (R, python) that make use of this endpoint.

# Solution
Since this endpoint does not expose confidential information, the most simple solution here is to exclude this endpoint from endpoints managed by Spring Security. The same has been done for the `/api/swagger-ui.html` that provides the same information in human readable format.