### PR TITLE
update mysqlclient for python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.20.0
 markupsafe==2.0.1
 Jinja2==2.11.3
-mysqlclient==1.3.13
+mysqlclient==2.1.0
 PyYAML==5.4


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Python package `mysqlclient` updated to version 2.1.0

This upgrade makes cBioPortal compatible with Python 3.10. 
Downside: Support for Python 3.5 is removed. However, this should not be a huge problem, as the Docker images already use Python 3.9.
