### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -1,5 +1,8 @@
 name: Core tests
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Setup and Test

--- a/.github/workflows/genie-performance-test.yml
+++ b/.github/workflows/genie-performance-test.yml
@@ -4,9 +4,14 @@ on:
   schedule:
     - cron:  '0 8 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   probe-genie-endpoint:
     
+    permissions:
+      contents: none
     name: Genie private endpoint probe
 
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,9 +8,15 @@
 name: Labeler
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   label:
 
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -1,5 +1,8 @@
 name: Sanity checks
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Sanity Check

--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -1,5 +1,8 @@
 name: Python validator
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Validate Data


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
