### PR TITLE
Fix 9594 api endpoints cleanup

### DIFF
--- a/web/src/main/java/org/cbioportal/web/GenericAssayController.java
+++ b/web/src/main/java/org/cbioportal/web/GenericAssayController.java
@@ -71,6 +71,20 @@ public class GenericAssayController {
             }
             return new ResponseEntity<>(result, HttpStatus.OK);
     }
+    
+    @RequestMapping(value = "/generic_assay_meta/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Fetch meta data for generic-assay by ID")
+    public ResponseEntity<List<GenericAssayMeta>> fetchGenericAssayMetaRedirect(
+        @ApiParam(required = true, value = "List of Molecular Profile ID or List of Stable ID")
+        @Valid @RequestBody GenericAssayMetaFilter genericAssayMetaFilter,
+        @ApiParam("Level of detail of the response")
+        @RequestParam(defaultValue = "SUMMARY") Projection projection) throws GenericAssayNotFoundException {
+        
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Location", "/generic-assay-meta/fetch");
+        return new ResponseEntity<>(headers, HttpStatus.PERMANENT_REDIRECT);
+    }
 
     // PreAuthorize is removed for performance reason
     @RequestMapping(value = "/generic-assay-meta/{molecularProfileId}", method = RequestMethod.GET,

--- a/web/src/main/java/org/cbioportal/web/GenericAssayController.java
+++ b/web/src/main/java/org/cbioportal/web/GenericAssayController.java
@@ -52,7 +52,7 @@ public class GenericAssayController {
     private GenericAssayService genericAssayService;
     
     // PreAuthorize is removed for performance reason
-    @RequestMapping(value = "/generic_assay_meta/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
+    @RequestMapping(value = "/generic-assay-meta/fetch", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch meta data for generic-assay by ID")
     public ResponseEntity<List<GenericAssayMeta>> fetchGenericAssayMeta(

--- a/web/src/main/java/org/cbioportal/web/GenericAssayDataController.java
+++ b/web/src/main/java/org/cbioportal/web/GenericAssayDataController.java
@@ -64,7 +64,7 @@ public class GenericAssayDataController {
     }
     
     @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
-    @RequestMapping(value = "/generic_assay_data/{molecularProfileId}/fetch",
+    @RequestMapping(value = "/generic-assay-data/{molecularProfileId}/fetch",
         method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("fetch generic_assay_data in a molecular profile")
@@ -95,7 +95,7 @@ public class GenericAssayDataController {
     }
 
     @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
-    @RequestMapping(value = "/generic_assay_data/fetch", method = RequestMethod.POST,
+    @RequestMapping(value = "/generic-assay-data/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch generic_assay_data")
     public ResponseEntity<List<GenericAssayData>> fetchGenericAssayDataInMultipleMolecularProfiles(

--- a/web/src/main/java/org/cbioportal/web/GenericAssayDataController.java
+++ b/web/src/main/java/org/cbioportal/web/GenericAssayDataController.java
@@ -62,6 +62,24 @@ public class GenericAssayDataController {
             return new ResponseEntity<>(result, HttpStatus.OK);
         }
     }
+
+    @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
+    @RequestMapping(value = "/generic_assay_data/{molecularProfileId}/fetch",
+        method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("fetch generic_assay_data in a molecular profile")
+    public ResponseEntity<List<GenericAssayData>> fetchGenericAssayDataInMolecularProfileRedirect(
+        @ApiParam(required = true, value = "Molecular Profile ID")
+        @PathVariable String molecularProfileId,
+        @ApiParam(required = true, value = "List of Sample IDs/Sample List ID and Generic Assay IDs")
+        @Valid @RequestBody GenericAssayFilter genericAssayDataFilter,
+        @ApiParam("Level of detail of the response")
+        @RequestParam(defaultValue = "SUMMARY") Projection projection) throws MolecularProfileNotFoundException {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Location", "/generic-assay-data/" + molecularProfileId + "/fetch");
+        return new ResponseEntity<>(headers, HttpStatus.PERMANENT_REDIRECT);
+    }
     
     @PreAuthorize("hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/generic-assay-data/{molecularProfileId}/fetch",
@@ -95,9 +113,29 @@ public class GenericAssayDataController {
     }
 
     @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
-    @RequestMapping(value = "/generic-assay-data/fetch", method = RequestMethod.POST,
+    @RequestMapping(value = "/generic_assay_data/fetch", method = RequestMethod.POST,
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Fetch generic_assay_data")
+    public ResponseEntity<List<GenericAssayData>> fetchGenericAssayDataInMultipleMolecularProfilesRedirect(
+        @ApiIgnore // prevent reference to this attribute in the swagger-ui interface
+        @RequestAttribute(required = false, value = "involvedCancerStudies") Collection<String> involvedCancerStudies,
+        @ApiIgnore // prevent reference to this attribute in the swagger-ui interface. this attribute is needed for the @PreAuthorize tag above.
+        @RequestAttribute(required = false, value = "interceptedGenericAssayDataMultipleStudyFilter") GenericAssayDataMultipleStudyFilter interceptedGenericAssayDataMultipleStudyFilter,
+        @ApiParam(required = true, value = "List of Molecular Profile ID and Sample ID pairs or List of Molecular" +
+            "Profile IDs and Generic Assay IDs")
+        @Valid @RequestBody(required = false) GenericAssayDataMultipleStudyFilter genericAssayDataMultipleStudyFilter,
+        @ApiParam("Level of detail of the response")
+        @RequestParam(defaultValue = "SUMMARY") Projection projection) throws MolecularProfileNotFoundException {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Location", "/generic-assay-data/fetch");
+        return new ResponseEntity<>(headers, HttpStatus.PERMANENT_REDIRECT);
+    }
+
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
+    @RequestMapping(value = "/generic-assay-data/fetch", method = RequestMethod.POST,
+        consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Fetch generic-assay-data")
     public ResponseEntity<List<GenericAssayData>> fetchGenericAssayDataInMultipleMolecularProfiles(
         @ApiIgnore // prevent reference to this attribute in the swagger-ui interface
         @RequestAttribute(required = false, value = "involvedCancerStudies") Collection<String> involvedCancerStudies,

--- a/web/src/main/java/org/cbioportal/web/config/SwaggerConfig.java
+++ b/web/src/main/java/org/cbioportal/web/config/SwaggerConfig.java
@@ -46,9 +46,10 @@ public class SwaggerConfig {
             new Tag(PublicApiTags.COPY_NUMBER_SEGMENTS, "", 11),
             new Tag(PublicApiTags.GENES, "", 12),
             new Tag(PublicApiTags.GENE_PANELS, "", 13),
-            new Tag(PublicApiTags.GENERIC_ASSAYS, "", 14),
-            new Tag(PublicApiTags.GENERIC_ASSAY_DATA, "", 15),
-            new Tag(PublicApiTags.INFO, "", 16)
+            new Tag(PublicApiTags.GENE_PANEL_DATA, "", 14),
+            new Tag(PublicApiTags.GENERIC_ASSAYS, "", 15),
+            new Tag(PublicApiTags.GENERIC_ASSAY_DATA, "", 16),
+            new Tag(PublicApiTags.INFO, "", 17)
         );
 
         return d;

--- a/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
+++ b/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
@@ -94,7 +94,7 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
     public static final String ALTERATION_ENRICHMENT_FETCH_PATH = "/alteration-enrichments/fetch";
     public static final String TREATMENT_FETCH_PATH = "/treatments/fetch";
     public static final String STRUCTURAL_VARIANT_FETCH_PATH = "/structural-variant/fetch";
-    public static final String GENERIC_ASSAY_DATA_MULTIPLE_STUDY_FETCH_PATH = "/generic_assay_data/fetch";
+    public static final String GENERIC_ASSAY_DATA_MULTIPLE_STUDY_FETCH_PATH = "/generic-assay-data/fetch";
     public static final String TREATMENTS_PATIENT_PATH = "/treatments/patient";
     public static final String TREATMENTS_SAMPLE_PATH = "/treatments/sample";
     public static final String GENERIC_ASSAY_ENRICHMENT_FETCH_PATH = "/generic-assay-enrichments/fetch";

--- a/web/src/test/java/org/cbioportal/web/GenericAssayControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GenericAssayControllerTest.java
@@ -130,7 +130,7 @@ public class GenericAssayControllerTest {
 
         Mockito.when(genericAssayService.getGenericAssayMetaByStableIdsAndMolecularIds(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(genericAssayMetaItems);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/generic_assay_meta/fetch")
+        mockMvc.perform(MockMvcRequestBuilders.post("/generic-assay-meta/fetch")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(genericAssayMetaFilter)))

--- a/web/src/test/java/org/cbioportal/web/GenericAssayDataControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GenericAssayDataControllerTest.java
@@ -83,7 +83,7 @@ public class GenericAssayDataControllerTest {
         genericAssayDataFilter.setSampleIds(Arrays.asList(SAMPLE_ID));	
         genericAssayDataFilter.setGenericAssayStableIds(Arrays.asList(GENERIC_ASSAY_STABLE_ID_1, GENERIC_ASSAY_STABLE_ID_2, GENERIC_ASSAY_STABLE_ID_3, GENERIC_ASSAY_STABLE_ID_4));	
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/generic_assay_data/" + PROF_ID + "/fetch")	
+        mockMvc.perform(MockMvcRequestBuilders.post("/generic-assay-data/" + PROF_ID + "/fetch")	
                 .accept(MediaType.APPLICATION_JSON)	
                 .contentType(MediaType.APPLICATION_JSON)	
                 .content(objectMapper.writeValueAsString(genericAssayDataFilter)))	
@@ -109,7 +109,7 @@ public class GenericAssayDataControllerTest {
         Mockito.when(genericAssayService.fetchGenericAssayData(Mockito.anyList(), Mockito.any(),
             Mockito.any(), Mockito.any())).thenReturn(genericAssayDataItems);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/generic_assay_data/fetch")
+        mockMvc.perform(MockMvcRequestBuilders.post("/generic-assay-data/fetch")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(genericAssayDataMultipleStudyFilter)))


### PR DESCRIPTION
Fix #9594 

- Updated swagger.config to include GENE_PANEL_DATA to Public API
- Replace _ with - in API endpoints in generic assay and generic assay data
- redirect the old endpoints to new endpoints in generic assay and generic assay data controllers
