### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,10 +111,6 @@ jobs:
             - attach_workspace:
                 at: /tmp/repos
             - run:
-                # needed to get python3 on the path (https://discuss.circleci.com/t/pyenv-pyvenv-command-not-found/4087/2)
-                name: Add python3 to path [corrects bug in circle ci image and may be removed in the future]
-                command: pyenv local 3.6.5 && virtualenv venv
-            - run:
                 name: Setup python libraries
                 command: |
                     pip3 install requests pyyaml


### PR DESCRIPTION
New circle ci ubuntu image has python 3.9 preinstalled. So no need to add python 3.6.5 again. https://circleci.com/docs/2.0/images/linux-vm/16.04-to-20.04-migration
