### PR TITLE
Upgrade Springfox

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -19,8 +19,7 @@
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger2</artifactId>
-            <version>2.9.2</version>
+            <artifactId>springfox-oas</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/persistence/persistence-api/pom.xml
+++ b/persistence/persistence-api/pom.xml
@@ -33,10 +33,10 @@
       <artifactId>redisson</artifactId>
       <version>3.13.2</version>
     </dependency>
-      <dependency>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,7 @@
     <webapp-runner.version>8.5.61.0</webapp-runner.version>
     <slf4j.version>1.7.32</slf4j.version>
     <logback.version>1.2.10</logback.version>
+    <springfox.version>3.0.0</springfox.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -889,18 +890,23 @@
       </dependency>
       <dependency>
         <groupId>io.springfox</groupId>
-        <artifactId>springfox-swagger2</artifactId>
-        <version>2.9.2</version>
-      </dependency>
-      <dependency>
-        <groupId>io.springfox</groupId>
-        <artifactId>springfox-swagger-ui</artifactId>
-        <version>2.9.2</version>
-      </dependency>
-      <dependency>
-        <groupId>io.springfox</groupId>
         <artifactId>springfox-bean-validators</artifactId>
-        <version>2.9.2</version>
+        <version>${springfox.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.springfox</groupId>
+        <artifactId>springfox-boot-starter</artifactId>
+        <version>${springfox.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.springfox</groupId>
+        <artifactId>springfox-oas</artifactId>
+        <version>${springfox.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.springfox</groupId>
+        <artifactId>springfox-spring-web</artifactId>
+        <version>${springfox.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mapstruct</groupId>

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -85,9 +85,10 @@
     <http pattern="/saml/gfx/**" security="none"/>
     <http pattern="/reactapp/**" security="none"/>
     <http pattern="/api/swagger-resources/**" security="none"/>
-    <http pattern="/api/swagger-ui.html" security="none"/>
+    <http pattern="/api/swagger-ui/**" security="none"/>
     <http pattern="/api/health" security="none"/>
-    <http pattern="/api/api-docs" security="none"/>
+    <http pattern="/api/api-docs/**" security="none"/>
+    <http pattern="/api/v2/api-docs/**" security="none"/>
     <http pattern="/api/cache/**" security="none"/>
     <http pattern="/api/cacheStatistics" security="none"/>
     <http pattern="/api/**/keysInCache" security="none"/>

--- a/src/main/resources/springfox.properties
+++ b/src/main/resources/springfox.properties
@@ -1,1 +1,1 @@
-springfox.documentation.swagger.v2.path:/api-docs
+springfox.documentation.swagger.v2.path=/api-docs

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -33,11 +33,20 @@
     </dependency>
     <dependency>
       <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger2</artifactId>
+      <artifactId>springfox-oas</artifactId>
     </dependency>
     <dependency>
       <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger-ui</artifactId>
+      <artifactId>springfox-spring-web</artifactId>
+    </dependency>
+<!--
+    Even though this isn't a spring boot project, we need this artifact.
+    Removing it causes a wire time error:
+        No qualifying bean of type 'springfox.documentation.spring.web.DescriptionResolver'
+-->
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-boot-starter</artifactId>
     </dependency>
     <dependency>
       <groupId>io.springfox</groupId>

--- a/web/src/main/java/org/cbioportal/web/DocRedirectController.java
+++ b/web/src/main/java/org/cbioportal/web/DocRedirectController.java
@@ -1,0 +1,31 @@
+package org.cbioportal.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.view.RedirectView;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Springfox 3.0 doesn't completely respect the path we specify for the swagger UI
+ * This redirect puts the api-doc json in the specified path so that the swagger UI works
+ * and the frontend can pull the json.
+ */
+@Controller
+public class DocRedirectController {
+    @GetMapping("/api-docs")
+    public RedirectView redirectWithUsingRedirectView(
+        @RequestParam(value = "group", defaultValue = "default")
+        String group,
+        final RedirectAttributes redirectAttributes,
+        HttpServletRequest request
+    ) {
+        redirectAttributes.addAttribute("group", group);
+        return new RedirectView("/api/v2/api-docs");
+    }
+}

--- a/web/src/main/java/org/cbioportal/web/config/SwaggerConfig.java
+++ b/web/src/main/java/org/cbioportal/web/config/SwaggerConfig.java
@@ -1,22 +1,22 @@
 package org.cbioportal.web.config;
 
-import java.util.Collections;
-
 import org.cbioportal.web.config.annotation.InternalApi;
 import org.cbioportal.web.config.annotation.PublicApi;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.Contact;
 import springfox.documentation.service.Tag;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
-
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 import springfox.documentation.swagger.web.UiConfiguration;
 import springfox.documentation.swagger.web.UiConfigurationBuilder;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.Collections;
 
 @Configuration
 @EnableSwagger2
@@ -73,7 +73,7 @@ public class SwaggerConfig {
     }
 
     private ApiInfo publicApiInfo() {
-        ApiInfo apiInfo = new ApiInfo(
+        return new ApiInfo(
             "cBioPortal web Public API [Beta]",
             "A web service for supplying JSON formatted data to cBioPortal clients. " +
                 "Please note that this API is currently in beta and subject to change.",
@@ -81,12 +81,13 @@ public class SwaggerConfig {
             null,
             new Contact("cBioPortal", "https://www.cbioportal.org", "cbioportal@googlegroups.com"),
             "License",
-            "https://github.com/cBioPortal/cbioportal/blob/master/LICENSE", Collections.emptyList());
-        return apiInfo;
+            "https://github.com/cBioPortal/cbioportal/blob/master/LICENSE",
+            Collections.emptyList()
+        );
     }
 
     private ApiInfo internalApiInfo() {
-        ApiInfo apiInfo = new ApiInfo(
+        return new ApiInfo(
             "cBioPortal web Internal API [Beta]",
             "A web service for supplying JSON formatted data to cBioPortal clients. " +
                 "Please note that interal API is currently in beta and subject to change.",
@@ -94,7 +95,8 @@ public class SwaggerConfig {
             null,
             new Contact("cBioPortal", "https://www.cbioportal.org", "cbioportal@googlegroups.com"),
             "License",
-            "https://github.com/cBioPortal/cbioportal/blob/master/LICENSE", Collections.emptyList());
-        return apiInfo;
+            "https://github.com/cBioPortal/cbioportal/blob/master/LICENSE",
+            Collections.emptyList()
+        );
     }
 }

--- a/web/src/main/resources/applicationContext-web.xml
+++ b/web/src/main/resources/applicationContext-web.xml
@@ -37,7 +37,7 @@
     <context:component-scan base-package="org.cbioportal.documentation" />
     <aop:aspectj-autoproxy/>
 
-    <mvc:resources mapping="/swagger-ui.html" location="classpath:/META-INF/resources/"/>
+    <mvc:resources mapping="/swagger-ui/**" location="classpath:/META-INF/resources/webjars/springfox-swagger-ui/"/>
     <mvc:resources mapping="/webjars/**" location="classpath:/META-INF/resources/webjars/"/>
     <mvc:resources mapping="/images/**" location="/images/"/>
     <mvc:resources mapping="/css/**" location="/css/"/>
@@ -45,7 +45,7 @@
     <mvc:resources mapping="/content/**" location="/content/"/>
     <mvc:resources mapping="/gfx/**" location="/gfx/"/>
     <mvc:resources mapping="/swf/**" location="/swf/"/>
-    <mvc:view-controller path="/api" view-name="redirect:/api/swagger-ui.html"/>
+    <mvc:view-controller path="/api" view-name="redirect:/api/swagger-ui/index.html"/>
 
     <bean id="contentNegotiationManager" class="org.springframework.web.accept.ContentNegotiationManagerFactoryBean">
         <property name="favorPathExtension" value="false" />


### PR DESCRIPTION
- Fix Swagger XSS issue
- Move springfox from 2.9.2 -> 3.0.0
- Unify springfox versions properly in pom
  - springfox.version variable
  - get rid of stray springfox versions in package poms
- Update paths in application context for new swagger UI
- Redirect for swagger api-docs
  - Springfox does not completely respect swagger.v2.path
    - Swagger UI does
    - the api json path does not
  - Add a redirect controller to fix this