### PR TITLE
Do not run studyIdHasTreatments() more than neccesary

### DIFF
--- a/service/src/main/java/org/cbioportal/service/impl/TreatmentServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/TreatmentServiceImpl.java
@@ -24,6 +24,7 @@ public class TreatmentServiceImpl implements TreatmentService {
             return new ImmutablePair<>(sampleIds, studyIds);
         }
         Set<String> studiesWithTreatments = studyIds.stream()
+            .distinct()
             .filter(studyId -> treatmentRepository.studyIdHasTreatments(studyId, key))
             .collect(Collectors.toSet());
         


### PR DESCRIPTION
# Problem
The `/api/treatments/patient` endpoint becomes very slow for large studies. This is caused by redundant calls to the _studyIdHasTreatments()_ method.

# Solution
Reduce the number of calls by calling for unique studyIds, rather than for all studyIds.