### PR TITLE
Rename oncoprint clinical tracks config property

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -172,9 +172,11 @@ public class GlobalProperties {
     @Value("${frontend.config:}") // default is empty string
     public void setFrontendConfig(String property) { frontendConfig = property; }
 
-    private static String oncoprintDefaultTracksConfig;
-    @Value("${oncoprint.clinical_tracks.show_by_default:}") // default is empty string
-    public void setOncoprintDefaultTracksConfig(String property) { oncoprintDefaultTracksConfig = property; }
+    private static String oncoprintClinicalTracksConfigJson;
+    @Value("${oncoprint.clinical_tracks.config_json:}") // default is empty string
+    public void setOncoprintClinicalTracksConfigJson(String property) {
+        oncoprintClinicalTracksConfigJson = property; 
+    }
 
     // properties for showing the right logo in the header_bar and default logo
     public static final String SKIN_RIGHT_LOGO = "skin.right_logo";
@@ -1192,9 +1194,9 @@ public class GlobalProperties {
         }
     }
 
-    public static String getOncoprintDefaultTracksConfig() {
-        if (oncoprintDefaultTracksConfig.length() > 0) {
-            return readFile(oncoprintDefaultTracksConfig);
+    public static String getOncoprintClinicalTracksConfigJson() {
+        if (oncoprintClinicalTracksConfigJson.length() > 0) {
+            return readFile(oncoprintClinicalTracksConfigJson);
         } else {
             return null;
         }

--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -366,7 +366,7 @@ oncoprint.defaultview=sample
 Configuration of tracks that will be visible by default in the oncoprint. It points to a JSON file on the classpath.
 
 ```
-oncoprint.clinical_tracks.show_by_default=classpath:/oncoprint-default-tracks.json
+oncoprint.clinical_tracks.config_json=classpath:/oncoprint-default-tracks.json
 ```
 
 ## Custom annotation of driver and passenger mutations

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -124,7 +124,7 @@
             "bitly.user",
             "bitly.access.token",
             "oncoprint.custom_driver_annotation.tiers.default",
-            "oncoprint.clinical_tracks.show_by_default",
+            "oncoprint.clinical_tracks.config_json",
             "ensembl.transcript_url",
             "enable_persistent_cache",
             "enable_request_body_gzip_compression",
@@ -171,7 +171,7 @@
 
         obj.put("frontendConfigOverride",GlobalProperties.getFrontendConfig());
 
-        obj.put("oncoprint_clinical_tracks_show_by_default",GlobalProperties.getOncoprintDefaultTracksConfig());
+        obj.put("oncoprint_clinical_tracks_config_json",GlobalProperties.getOncoprintClinicalTracksConfigJson());
 
         obj.put("authenticationMethod",GlobalProperties.authenticationMethod());
 

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -292,7 +292,7 @@ oncoprint.defaultview=patient
 oncoprint.oncokb.default=true
 oncoprint.hotspots.default=true
 # oncoprint.hide_vus.default=true
-# oncoprint.clinical_tracks.show_by_default=classpath:/oncoprint-default-tracks.json
+# oncoprint.clinical_tracks.config_json=classpath:/oncoprint-default-tracks.json
 
 # Custom gene sets
 # querypage.setsofgenes.location=file:/<path>


### PR DESCRIPTION
Rename the oncoprint clinical tracks configuration property from `oncoprint_clinical_tracks_show_by_default` to `oncoprint_clinical_tracks_config_json`, as suggested in [frontend PR 4152]( https://github.com/cBioPortal/cbioportal-frontend/pull/4152#discussion_r929804188)

Duplicate of https://github.com/cBioPortal/cbioportal/pull/9709 to test if PR from private repo will trigger circleci. 