### PR TITLE
Add new alteration counts endpoint

### DIFF
--- a/model/src/main/java/org/cbioportal/model/AlterationCountDetailed.java
+++ b/model/src/main/java/org/cbioportal/model/AlterationCountDetailed.java
@@ -1,0 +1,55 @@
+package org.cbioportal.model;
+
+import java.util.List;
+import java.util.Set;
+
+public class AlterationCountDetailed {
+    private List<AlterationCountByGene> alterationCountsByGene;
+    private Long profiledCasesCount;
+    private Set<GenePanelToGene> profiledGenes;
+    private boolean allGenesProfiled;
+
+    public AlterationCountDetailed(
+        List<AlterationCountByGene> alterationCountsByGene,
+        Long profiledCasesCount,
+        Set<GenePanelToGene> profiledGenes,
+        boolean allGenesProfiled
+    ) {
+        this.alterationCountsByGene = alterationCountsByGene;
+        this.profiledCasesCount = profiledCasesCount;
+        this.profiledGenes = profiledGenes;
+        this.allGenesProfiled = allGenesProfiled;
+    }
+
+    public List<AlterationCountByGene> getAlterationCountsByGene() {
+        return alterationCountsByGene;
+    }
+
+    public void setAlterationCountsByGene(List<AlterationCountByGene> alterationCountsByGene) {
+        this.alterationCountsByGene = alterationCountsByGene;
+    }
+
+    public Long getProfiledCasesCount() {
+        return profiledCasesCount;
+    }
+
+    public void setProfiledCasesCount(Long profiledCasesCount) {
+        this.profiledCasesCount = profiledCasesCount;
+    }
+
+    public Set<GenePanelToGene> getProfiledGenes() {
+        return profiledGenes;
+    }
+
+    public void setProfiledGenes(Set<GenePanelToGene> profiledGenes) {
+        this.profiledGenes = profiledGenes;
+    }
+
+    public boolean isAllGenesProfiled() {
+        return allGenesProfiled;
+    }
+
+    public void setAllGenesProfiled(boolean allGenesProfiled) {
+        this.allGenesProfiled = allGenesProfiled;
+    }
+}

--- a/model/src/main/java/org/cbioportal/model/AlterationCountType.java
+++ b/model/src/main/java/org/cbioportal/model/AlterationCountType.java
@@ -1,0 +1,6 @@
+package org.cbioportal.model;
+
+public enum AlterationCountType {
+    SAMPLE,
+    PATIENT
+}

--- a/service/src/main/java/org/cbioportal/service/impl/AlterationCountServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/AlterationCountServiceImpl.java
@@ -281,7 +281,10 @@ public class AlterationCountServiceImpl implements AlterationCountService {
             .values()
             .stream()
             .flatMap(Collection::stream)
-            .collect(Collectors.toMap(S::getEntrezGeneId, S::getHugoGeneSymbol, (a, b) -> a));
+            // Collectors.toMap throws exception when hugo gene symbol is null, 
+            // we need a custom collect function to keep null values as is 
+            // .collect(Collectors.toMap(S::getEntrezGeneId, S::getHugoGeneSymbol, (a, b) -> a));
+            .collect(HashMap::new, (map, count) -> map.put(count.getEntrezGeneId(), count.getHugoGeneSymbol()), HashMap::putAll);
 
         studyAlterationCountByMolecularProfileIds.forEach((molecularProfileId, studyAlterationCountByGenes) -> {
             Map<Integer, S> map = studyAlterationCountByGenes.stream().collect(Collectors.toMap(S::getEntrezGeneId, c -> c));

--- a/service/src/main/java/org/cbioportal/service/util/AlterationEnrichmentUtil.java
+++ b/service/src/main/java/org/cbioportal/service/util/AlterationEnrichmentUtil.java
@@ -177,12 +177,12 @@ public class AlterationEnrichmentUtil<T extends AlterationCountByGene> {
             .fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileCaseIdentifiers);
 
         profiledCasesCounter.calculate(alterationCountByGenes, genePanelDataList,
-                includeMissingAlterationsFromGenePanel, profiledCasesCounter.sampleUniqueIdentifier);
+                includeMissingAlterationsFromGenePanel, ProfiledCasesCounter.SAMPLE_UNIQUE_IDENTIFIER);
 
         return genePanelDataList
             .stream()
             .filter(GenePanelData::getProfiled)
-            .map(profiledCasesCounter.sampleUniqueIdentifier)
+            .map(ProfiledCasesCounter.SAMPLE_UNIQUE_IDENTIFIER)
             .distinct()
             .count();
     }
@@ -206,12 +206,12 @@ public class AlterationEnrichmentUtil<T extends AlterationCountByGene> {
             .fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(molecularProfileCaseIdentifiers);
 
         profiledCasesCounter.calculate(alterationCountByGenes, genePanelDataList,
-            includeMissingAlterationsFromGenePanel, profiledCasesCounter.patientUniqueIdentifier);
+            includeMissingAlterationsFromGenePanel, ProfiledCasesCounter.PATIENT_UNIQUE_IDENTIFIER);
 
         return genePanelDataList
             .stream()
             .filter(GenePanelData::getProfiled)
-            .map(profiledCasesCounter.patientUniqueIdentifier)
+            .map(ProfiledCasesCounter.PATIENT_UNIQUE_IDENTIFIER)
             .distinct()
             .count();
     }

--- a/service/src/main/java/org/cbioportal/service/util/ProfiledCasesCounter.java
+++ b/service/src/main/java/org/cbioportal/service/util/ProfiledCasesCounter.java
@@ -158,6 +158,8 @@ public class ProfiledCasesCounter<T extends AlterationCountByGene> {
                     alterationCountByGene.setTotalCount(0);
                     alterationCountByGene.setHugoGeneSymbol(hugoGeneSymbol);
 
+                    // ideally we should be instantiating an object of type <T> instead of the base type to avoid this
+                    // unsafe cast, but it's not straightforward to do that without knowing the actual runtime class
                     alterationCounts.add((T) alterationCountByGene);
                 }
             });

--- a/service/src/test/java/org/cbioportal/service/impl/AlterationCountServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/AlterationCountServiceImplTest.java
@@ -2,7 +2,6 @@ package org.cbioportal.service.impl;
 
 import org.apache.commons.math3.util.Pair;
 import org.cbioportal.model.*;
-import org.cbioportal.model.QueryElement;
 import org.cbioportal.model.util.Select;
 import org.cbioportal.persistence.AlterationRepository;
 import org.cbioportal.persistence.MolecularProfileRepository;

--- a/service/src/test/java/org/cbioportal/service/impl/AlterationEnrichmentServiceImplTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/AlterationEnrichmentServiceImplTest.java
@@ -9,7 +9,6 @@ import org.cbioportal.model.EnrichmentType;
 import org.cbioportal.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.model.MutationCountByGene;
 import org.cbioportal.model.MutationEventType;
-import org.cbioportal.model.QueryElement;
 import org.cbioportal.model.util.Select;
 import org.cbioportal.service.AlterationCountService;
 import org.cbioportal.service.util.AlterationEnrichmentUtil;

--- a/service/src/test/java/org/cbioportal/service/util/ProfiledCasesCounterTest.java
+++ b/service/src/test/java/org/cbioportal/service/util/ProfiledCasesCounterTest.java
@@ -102,20 +102,20 @@ public class ProfiledCasesCounterTest {
         alterationCount3.setEntrezGeneId(ENTREZ_GENE_ID_3);
         alterationCounts.add(alterationCount3);
 
-        profiledSamplesCounter.calculate(alterationCounts, genePanelDataList, false, profiledSamplesCounter.sampleUniqueIdentifier);
+        profiledSamplesCounter.calculate(alterationCounts, genePanelDataList, false, ProfiledCasesCounter.SAMPLE_UNIQUE_IDENTIFIER);
 
         Assert.assertEquals(Integer.valueOf(3), alterationCounts.get(0).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(1).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(3), alterationCounts.get(2).getNumberOfProfiledCases());
         
         
-        profiledSamplesCounter.calculate(alterationCounts, genePanelDataList, false, profiledSamplesCounter.patientUniqueIdentifier);
+        profiledSamplesCounter.calculate(alterationCounts, genePanelDataList, false, ProfiledCasesCounter.PATIENT_UNIQUE_IDENTIFIER);
         
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(0).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(1).getNumberOfProfiledCases());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(2).getNumberOfProfiledCases());
 
-        profiledSamplesCounter.calculate(alterationCounts, genePanelDataList, true, profiledSamplesCounter.patientUniqueIdentifier);
+        profiledSamplesCounter.calculate(alterationCounts, genePanelDataList, true, ProfiledCasesCounter.PATIENT_UNIQUE_IDENTIFIER);
 
         Assert.assertEquals(4, alterationCounts.size());
         Assert.assertEquals(Integer.valueOf(2), alterationCounts.get(0).getNumberOfProfiledCases());

--- a/web/src/main/java/org/cbioportal/web/AlterationCountController.java
+++ b/web/src/main/java/org/cbioportal/web/AlterationCountController.java
@@ -1,0 +1,75 @@
+package org.cbioportal.web;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.apache.commons.math3.util.Pair;
+import org.cbioportal.model.*;
+import org.cbioportal.web.config.annotation.InternalApi;
+import org.cbioportal.web.parameter.AlterationCountFilter;
+import org.cbioportal.web.util.AlterationCountUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
+import java.util.*;
+
+@InternalApi
+@RestController
+@Validated
+@Api(tags = "Alteration Counts")
+public class AlterationCountController {
+    @Autowired
+    private AlterationCountUtil alterationCountUtil;
+
+    @PreAuthorize("hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
+    @PostMapping(value = "/alteration-counts/fetch",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation("Fetch alteration counts in molecular profiles")
+    public ResponseEntity<AlterationCountDetailed> fetchAlterationCounts(
+        @ApiParam(value = "List of entrez gene ids")
+        @RequestParam(required = false)
+        List<Integer> entrezGeneIds,
+        @ApiParam("Type of the count e.g. SAMPLE or PATIENT")
+        @RequestParam(defaultValue = "SAMPLE") AlterationCountType alterationCountType,
+        @ApiParam(required = true, value = "Alteration Filter")
+        @Valid @RequestBody(required = false)
+        AlterationCountFilter alterationCountFilter,
+        @ApiIgnore // prevent reference to this attribute in the swagger-ui interface. this attribute is needed for the @PreAuthorize tag above.
+        @RequestAttribute(required = false, value = "involvedCancerStudies") Collection<String> involvedCancerStudies,
+        @ApiIgnore // prevent reference to this attribute in the swagger-ui interface.
+        @Valid @RequestAttribute(required = false, value = "interceptedAlterationCountFilter")
+        AlterationCountFilter interceptedAlterationCountFilter
+    ) {
+        Pair<List<AlterationCountByGene>, Long> alterationCount = this.alterationCountUtil.getAlterationCounts(
+            interceptedAlterationCountFilter,
+            alterationCountType,
+            entrezGeneIds
+        );
+        List<AlterationCountByGene> alterationCountsByGene = alterationCount.getFirst();
+        Long profiledCaseCount = alterationCount.getSecond();
+        Set<GenePanelToGene> profiledGenes = this.alterationCountUtil.getProfiledGenes(
+            interceptedAlterationCountFilter,
+            alterationCountType,
+            entrezGeneIds
+        );
+        boolean allGenesProfiled = profiledGenes == null;
+        
+        return new ResponseEntity<>(
+            new AlterationCountDetailed(
+                alterationCountsByGene,
+                profiledCaseCount,
+                profiledGenes,
+                allGenesProfiled
+            ),
+            HttpStatus.OK
+        );
+    }
+}

--- a/web/src/main/java/org/cbioportal/web/parameter/AlterationCountFilter.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/AlterationCountFilter.java
@@ -1,0 +1,29 @@
+package org.cbioportal.web.parameter;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.cbioportal.model.AlterationFilter;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AlterationCountFilter {
+    private AlterationFilter alterationFilter;
+    private List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers;
+
+    public AlterationFilter getAlterationFilter() {
+        return alterationFilter;
+    }
+
+    public void setAlterationFilter(AlterationFilter alterationFilter) {
+        this.alterationFilter = alterationFilter;
+    }
+
+    public List<MolecularProfileCaseIdentifier> getMolecularProfileCaseIdentifiers() {
+        return molecularProfileCaseIdentifiers;
+    }
+
+    public void setMolecularProfileCaseIdentifiers(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers) {
+        this.molecularProfileCaseIdentifiers = molecularProfileCaseIdentifiers;
+    }
+}

--- a/web/src/main/java/org/cbioportal/web/util/AlterationCountUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/AlterationCountUtil.java
@@ -1,0 +1,110 @@
+package org.cbioportal.web.util;
+
+import org.apache.commons.math3.util.Pair;
+import org.cbioportal.model.*;
+import org.cbioportal.model.util.Select;
+import org.cbioportal.service.AlterationCountService;
+import org.cbioportal.service.GenePanelService;
+import org.cbioportal.web.parameter.AlterationCountFilter;
+import org.cbioportal.web.parameter.Projection;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+public class AlterationCountUtil {
+    @Autowired
+    private AlterationCountService alterationCountService;
+    @Autowired
+    private GenePanelService genePanelService;
+    
+    public Pair<List<AlterationCountByGene>, Long> getAlterationCounts(
+        AlterationCountFilter alterationCountFilter,
+        AlterationCountType alterationCountType,
+        List<Integer> entrezGeneIds
+    ) {
+        // select all genes if no list of entrez gene ids provided
+        Select<Integer> geneSelect = (entrezGeneIds == null || entrezGeneIds.isEmpty()) ?
+            Select.all(): Select.byValues(entrezGeneIds);
+        List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers =
+            alterationCountFilter.getMolecularProfileCaseIdentifiers();
+        boolean includeFrequency = true;
+        boolean includeMissingAlterationsFromGenePanel = false;
+        AlterationFilter alterationFilter = alterationCountFilter.getAlterationFilter();
+
+         return alterationCountType.equals(AlterationCountType.SAMPLE) ?
+            alterationCountService.getSampleAlterationCounts(
+                molecularProfileCaseIdentifiers,
+                geneSelect,
+                includeFrequency,
+                includeMissingAlterationsFromGenePanel,
+                alterationFilter
+            ) :
+            alterationCountService.getPatientAlterationCounts(
+                molecularProfileCaseIdentifiers,
+                geneSelect,
+                includeFrequency,
+                includeMissingAlterationsFromGenePanel,
+                alterationFilter
+            );
+    }
+    
+    public Set<GenePanelToGene> getProfiledGenes(
+        AlterationCountFilter alterationCountFilter,
+        AlterationCountType alterationCountType,
+        List<Integer> entrezGeneIds
+    ) {
+        List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers =
+            alterationCountFilter.getMolecularProfileCaseIdentifiers();
+        Set<GenePanelToGene> profiledGenes;
+        List<GenePanelData> genePanelDataList = alterationCountType.equals(AlterationCountType.SAMPLE) ?
+            genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileCaseIdentifiers) :
+            genePanelService.fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(molecularProfileCaseIdentifiers);
+
+        if (genePanelDataList
+            .stream()
+            .anyMatch(
+                genePanelData -> genePanelData.getProfiled() && genePanelData.getGenePanelId() == null
+            )
+        ) {
+            // if there is at least one sample/patient with all genes profiled,
+            // then all genes are profiled for the current data set
+            profiledGenes = null;
+        } else {
+            List<String> profiledPanelIds =  genePanelDataList
+                .stream()
+                .filter(GenePanelData::getProfiled)
+                .map(GenePanelData::getGenePanelId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+            if (profiledPanelIds.isEmpty()) {
+                profiledGenes = Collections.emptySet();
+            } else {
+                List<GenePanel> panels = genePanelService.fetchGenePanels(
+                    profiledPanelIds,
+                    Projection.DETAILED.name()
+                );
+
+                Stream<GenePanelToGene> genePanelGenes = panels
+                    .stream()
+                    .map(GenePanel::getGenes)
+                    .filter(Objects::nonNull)
+                    .flatMap(Collection::stream);
+
+                // if entrezGeneIds is not empty, further filter by given entrez gene ids
+                if (entrezGeneIds != null && !entrezGeneIds.isEmpty()) {
+                    Set<Integer> entrezGeneIdSet = new HashSet<>(entrezGeneIds);
+                    genePanelGenes = genePanelGenes.filter(gene -> entrezGeneIdSet.contains(gene.getEntrezGeneId()));
+                }
+
+                profiledGenes = genePanelGenes.collect(Collectors.toSet());
+            }
+        }
+
+        return profiledGenes;
+    }
+}


### PR DESCRIPTION
Related to #9305

- Add an endpoint to fetch alteration counts by gene
- Request parameters are entrez gene ids, molecular profile case identifiers, and an alteration filter.
- Fetching by study or cohort is not supported yet.