### PR TITLE
Fix stable id typo in docs on SV data

### DIFF
--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -920,7 +920,7 @@ An example metadata file would be:
 cancer_study_identifier: msk_impact_2017
 genetic_alteration_type: STRUCTURAL_VARIANT
 datatype: SV
-stable_id: structural_variants
+stable_id: msk_impact_2017_structural_variants
 show_profile_in_analysis_tab: true
 profile_name: mskimpact2017 SV Data
 profile_description: Structural Variant Data for mskimpact2017


### PR DESCRIPTION
This is the id name that I see here:

https://www.cbioportal.org/api/studies/msk_impact_2017/molecular-profiles?direction=ASC&pageNumber=0&pageSize=10000000&projection=SUMMARY
