### PR TITLE
Allow cna gene filters come different data types

### DIFF
--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -542,8 +542,7 @@ public class StudyViewFilterApplier {
                     structuralVariantGeneFilters.add(genefilter);
                 } else if (alterationType == MolecularAlterationType.MUTATION_EXTENDED) {
                     mutatedGeneFilters.add(genefilter);
-                } else if (alterationType == MolecularAlterationType.COPY_NUMBER_ALTERATION
-                        && dataTypes.size() == 1 && dataTypes.iterator().next().equals("DISCRETE")) {
+                } else if (alterationType == MolecularAlterationType.COPY_NUMBER_ALTERATION) {
                     cnaGeneFilters.add(genefilter);
                 }
             }


### PR DESCRIPTION
Fix #9658 

This fixed the issue that when you filter by CNA genes in the CNA table on the study view page, although it shows that you have some samples can be selected, but you get 0 samples after filtering.

**Issue description:**
It's because when we filter based on CNA gene filters, we will check if all related CNA profiles are DISCRETE data. So that means if the CNA gene filters contain profiles with more than one type of data, e.g. contains DISCRETE and LOG2-VALUE, then the backend won't apply such CNA gene filters.

**My solution:**
Remove the constrain for data types, allow more than one data types in related profiles, so that we always apply CNA gene filters if there are any.

**My concern:**
We have this constrain from the very beginning, not sure why it's becoming a problem now. Based on my understanding, we should consider all CNA data types, but we should verify this.