### PR TITLE
Fix another XSS

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/UrlParamFilter.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/UrlParamFilter.java
@@ -1,0 +1,37 @@
+package org.mskcc.cbio.portal.util;
+
+import org.springframework.stereotype.Component;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.InvalidParameterException;
+
+@Component("urlParamFilter")
+public class UrlParamFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        // Nothing to init (Sonar asks you to comment if you leave a method empty)
+    }
+    
+    @Override
+    public final void doFilter(
+        final ServletRequest servletRequest,
+        final ServletResponse servletResponse,
+        final FilterChain chain
+    ) throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+        if (request.getParameter("configUrl") != null && !request.getParameter("configUrl").isEmpty()) {
+            throw new InvalidParameterException();
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+    
+    @Override
+    public final void destroy() {
+        // Nothing to destroy (Sonar asks you to comment if you leave a method empty)
+    }
+}

--- a/core/src/test/java/org/mskcc/cbio/portal/util/UrlParamFilterTest.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/util/UrlParamFilterTest.java
@@ -1,0 +1,43 @@
+package org.mskcc.cbio.portal.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.InvalidParameterException;
+
+public class UrlParamFilterTest {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void shouldFilterMaliciousURL() throws ServletException, IOException {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getParameter("configUrl")).thenReturn("asdf");
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        exceptionRule.expect(InvalidParameterException.class);
+        new UrlParamFilter().doFilter(request, response, chain);
+        
+        Mockito.verify(chain, Mockito.times(0)).doFilter(request, response);
+    }
+
+    @Test
+    public void shouldNotFilterRegularURL() throws ServletException, IOException {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getParameter("configUrl")).thenReturn(null);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        new UrlParamFilter().doFilter(request, response, chain);
+
+        Mockito.verify(chain, Mockito.times(1)).doFilter(request, response);
+    }
+}

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -73,6 +73,14 @@
         <filter-name>requestBodyGZipFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
+    <filter>
+        <filter-name>urlParamFilter</filter-name>
+        <filter-class>org.mskcc.cbio.portal.util.UrlParamFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>urlParamFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
     
     <filter>
         <filter-name>CorsFilter</filter-name>


### PR DESCRIPTION
- Springfox doesn't have a fix, so we're just going to block that url param

Note: `configUrl` is used to point to another origin of the [api-docs](https://www.cbioportal.org/api/v2/api-docs?group=default). We don't use it so fine to disable