### PR TITLE
Always load frontend in https when localdev is true

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -98,10 +98,13 @@ if (/localdist=true/.test(window.location.href)) {
 }
 window.localdist = localStorage.getItem("localdist") === "true";
 
-if (window.localdist || window.localdev) {
-	window.frontendConfig.frontendUrl = '//localhost:3000/'
+if (window.localdist) {
+    window.frontendConfig.frontendUrl = '//localhost:3000/'
+} else if ( window.localdev) {
+    // localdev always on https now (with fake cert)
+    window.frontendConfig.frontendUrl = 'https://localhost:3000/'
 } else if (localStorage.netlify) {
-	var netlifyInstance = '//' + localStorage.getItem('netlify') + '.netlify.app/';
+	var netlifyInstance = 'https://' + localStorage.getItem('netlify') + '.netlify.app/';
 	window.frontendConfig.frontendUrl = netlifyInstance;
 }
 // clean userEmailAddress config


### PR DESCRIPTION
This prevents us from having to start webpack dev server in ssl and not ssl to test against local instance vs live instance