### PR TITLE
Fixing resource definition importer and updating file format

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportResourceDefinition.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportResourceDefinition.java
@@ -232,11 +232,7 @@ public class ImportResourceDefinition extends ConsoleRunnable {
     }
 
     private int findAndValidateOptionalColumnIndexInHeaders(String columnHeader, Map<String, Integer> headerIndexMap) {
-        if (headerIndexMap.containsKey(columnHeader)) {
-            return headerIndexMap.get(columnHeader);
-        } else {
-            return MISSING_COLUMN_INDEX;
-        }
+        return headerIndexMap.getOrDefault(columnHeader, MISSING_COLUMN_INDEX);
     }
 
     public int getNumResourceDefinitionsAdded() {

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -1627,9 +1627,9 @@ The resource definition file should follow this format, it has three **required*
 - **RESOURCE_ID (required)**: a unique resource ID. This field allows only numbers, letters, points, underscores and hyphens.
 - **DISPLAY_NAME (required)**: a display name for resources.
 - **RESOURCE_TYPE (required)**: resource type for resources, must be SAMPLE, PATIENT or STUDY.
-- **DESCRIPTION (required)**: a discription for resources.
-- **OPEN_BY_DEFAULT (required)**: define if the resource will be open by default (`true` / `false`), dafault is `false`.
-- **PRIORITY (required)**: if not given, will give a default value.
+- **DESCRIPTION (optional)**: a discription for resources.
+- **OPEN_BY_DEFAULT (optional)**: define if the resource will be open by default (`true` / `false`), dafault is `false`.
+- **PRIORITY (optional)**: if not given, will give a default value.
 
 ### Example *Resource Definition* data file
 <table>


### PR DESCRIPTION
Fix #9781
Describe changes proposed in this pull request:
- Updating importer to allow missing these three optional columns from resource definition data file (`DESCRIPTION, OPEN_BY_DEFAULT, PRIORITY`)
- Verified validator works well
