### PR TITLE
Validator: clarify SV error

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -3109,8 +3109,7 @@ class StructuralVariantValidator(Validator):
         # Check whether at least one of the Site1 or Site2 is valid.
         if site1_gene is None and site2_gene is None:
             self.logger.error(
-                'No Entrez gene id or gene symbol provided for site 1 and site 2. '
-                'This record will not be loaded',
+                'No Entrez gene id or gene symbol provided for site 1 and site 2',
                 extra={'line_number': self.line_number})
         elif site1_gene is None and site2_gene is not None:
             self.logger.warning(

--- a/core/src/test/scripts/unit_tests_validate_data.py
+++ b/core/src/test/scripts/unit_tests_validate_data.py
@@ -1768,12 +1768,12 @@ class StructuralVariantValidationTestCase(PostClinicalDataFileTestCase):
         record = next(record_iterator)
         self.assertEqual(logging.ERROR, record.levelno)
         self.assertEqual(3, record.line_number)
-        self.assertIn("No Entrez gene id or gene symbol provided for site 1 and site 2. This record will not be loaded", record.message)
+        self.assertIn("No Entrez gene id or gene symbol provided for site 1 and site 2", record.message)
         
         record = next(record_iterator)
         self.assertEqual(logging.ERROR, record.levelno)
         self.assertEqual(8, record.line_number)
-        self.assertIn("No Entrez gene id or gene symbol provided for site 1 and site 2. This record will not be loaded", record.message)
+        self.assertIn("No Entrez gene id or gene symbol provided for site 1 and site 2", record.message)
         
     def test_duplicate_line(self):
         """Test if duplicate lines are detected"""


### PR DESCRIPTION
Change this SV error message:
```
No Entrez gene id or gene symbol provided for site 1 and site 2. This record will not be loaded
```

By:
```
No Entrez gene id or gene symbol provided for site 1 and site 2
```

Reason: avoid confusion with warnings that contain the message `This record will not be loaded` ([example](https://github.com/cBioPortal/cbioportal/blob/master/core/src/main/scripts/importer/validateData.py#L917)). 