### PR TITLE
Use Apache Commons Text 1.10 to mitigate CVE-2022-42889

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
     <module>security</module>
     <module>utils</module>
   </modules>
-  
+
   <dependencies>
       <!--logging implementation shared by modules-->
       <dependency>
@@ -453,7 +453,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.9</version>
+        <version>1.10.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Fix #9860 

As reported by Comprehensive Cancer Center Mainfranken using email yesterday and mentioned in #9860, [CVE-2022-42889](https://nvd.nist.gov/vuln/detail/CVE-2022-42889) affects Apache Commons Text versions 1.5 through 1.9.

This PR changes Apache Commons Text version 1.9 to 1.10 to mitigate this vulnerability.
