### PR TITLE
fix typo frontend config

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -17,7 +17,7 @@ window.legacySupportFrontendConfig = {
     showTranscriptDropdown : <%=GlobalProperties.showTranscriptDropdown()%>,
     showGenomeNexus : <%=GlobalProperties.showGenomeNexus()%>,
     showGenomeNexusAnnotationSources : <%=GlobalProperties.showGenomeNexusAnnotationSources()%>,
-    genomeNexusIsoformOverrideSource : <%GlobalProperties.getGenomeNexusIsoformOverrideSource()%>,
+    genomeNexusIsoformOverrideSource : <%=GlobalProperties.getGenomeNexusIsoformOverrideSource()%>,
     showMutationMapperToolGrch38 : <%=GlobalProperties.showMutationMapperToolGrch38()%>,
     showSignal : <%=GlobalProperties.showSignal()%>,
     showNdex : <%=GlobalProperties.showNdex()%>,


### PR DESCRIPTION
Introduced with `genomeNexusIsoformOverrideSource` prop: https://github.com/cBioPortal/cbioportal/pull/9838. Causes embedding of MSK Portal in an internal MSK system to malfunction. Not sure why this didn't affect other portals