### PR TITLE
Docker image upgrade (eclipse-temurin-11) and arm64 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,3 +31,8 @@ trim_trailing_whitespace = false
 # Formats for HTML files only
 [**.html]
 insert_final_newline = false
+
+[{*.yml, *.yaml}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,7 +1,7 @@
 name: Docker Image CI
 on:
   push:
-    branches: 
+    branches:
       - master
       - release-*
       - rc
@@ -15,47 +15,86 @@ jobs:
     if: github.repository == 'cBioPortal/cbioportal'
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout git repo'
-        uses: actions/checkout@v1
-      - name: Extract branch or tag name
-        # The GITHUB_REF variable is like "refs/head/branch_name" or
-        # "refs/tag/tag_name". If the tag is prefixed with v, this is a new
-        # version and we want to push it with the tag "latest" as well because
-        # that is the version we refer to in the docucmentation. One can give 
-        # the same image multiple tags by using ","
-        run: echo "##[set-output name=image_tag_names;]$(echo ${GITHUB_REF##*/} | sed 's/^v/latest,/g')"
-        id: extract_tags
-      - name: 'Docker build with cache'
-        uses: whoan/docker-build-with-cache-action@v5
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
         with:
-          username: "${{ secrets.DOCKER_USERNAME }}"
-          password: "${{ secrets.DOCKER_PASSWORD }}"
-          image_name: cbioportal/cbioportal
-          image_tag: ${{ steps.extract_tags.outputs.image_tag_names }}
+          images: |
+            cbioportal/cbioportal
+          # The latest tag will also be generated on tag event with a valid semver tag
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+
+      # The following two actions are required to build multi-platform images
+      # buildx is an extension of docker build, QUEM is used to convert the binary to varies architecture
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Publish Docker Image on Tag
+        uses: docker/build-push-action@v3
+        with:
           context: .
-          dockerfile: docker/web-and-data/Dockerfile
-          pull_image_and_stages: false
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+          file: docker/web-and-data/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha
 
   build_and_publish_web:
       if: github.repository == 'cBioPortal/cbioportal'
       runs-on: ubuntu-latest
       steps:
-        - name: 'Checkout git repo'
-          uses: actions/checkout@v1
-        - name: Extract branch or tag name
-          # For the web docker image we don't publish it as latest
-          # just extract branch/tag name and strip v prefix
-          run: echo "##[set-output name=image_tag_names;]$(echo ${GITHUB_REF##*/} | sed 's/^v//g')"
-          id: extract_tags
-        - name: 'Docker build with cache'
-          uses: whoan/docker-build-with-cache-action@v5
-          with:
-            username: "${{ secrets.DOCKER_USERNAME }}"
-            password: "${{ secrets.DOCKER_PASSWORD }}"
-            image_name: cbioportal/cbioportal
-            image_tag: ${{ steps.extract_tags.outputs.image_tag_names }}-web-shenandoah
-            context: .
-            dockerfile: docker/web/Dockerfile
-            pull_image_and_stages: false
+        - name: Checkout git repo
+          uses: actions/checkout@v3
 
-# Reference: https://github.com/marketplace/actions/build-docker-images-using-cache
+        - name: Extract metadata
+          id: meta
+          uses: docker/metadata-action@v4
+          with:
+            images: |
+              cbioportal/cbioportal
+            # Do not generate latest tag
+            flavor: |
+              latest=false
+              suffix=-web-shenandoah
+            tags: |
+              type=ref,event=branch
+              type=semver,pattern={{version}}
+
+        # The following two actions are required to build multi-platform images
+        # buildx is an extension of docker build, QUEM is used to convert the binary to varies architecture
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v2
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v2
+
+        - name: Login to DockerHub
+          uses: docker/login-action@v2
+          with:
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+
+        - name: Publish Docker Image on Tag
+          uses: docker/build-push-action@v3
+          with:
+            context: .
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            platforms: linux/amd64,linux/arm64
+            file: docker/web/Dockerfile
+            cache-from: type=gha
+            cache-to: type=gha
+

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     name: Integration tests
     runs-on: ubuntu-latest
-    env: 
+    env:
       PORTAL_SOURCE_DIR: /home/runner/work/cbioportal/cbioportal/cbioportal
       PORTAL_COMPOSE_DIR: /home/runner/work/cbioportal/cbioportal/cbioportal-docker-compose
       PORTAL_INFO_DIR: /home/runner/work/cbioportal/cbioportal/portalInfo

--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -11,7 +11,7 @@
 # NOTE: the .git folder is included in the build stage, but excluded 
 # from the final image. No confidential information is exposed.
 # (see: stackoverflow.com/questions/56278325)
-FROM maven:3-openjdk-11 as build
+FROM maven:3-eclipse-temurin-11 as build
 
 # download maven dependencies first to take advantage of docker caching
 COPY pom.xml                                     /cbioportal/
@@ -35,9 +35,10 @@ COPY portal/pom.xml                                 portal/
 RUN mvn dependency:go-offline --fail-never
 
 COPY $PWD /cbioportal
-RUN mvn -DskipTests clean install
+# Use quite output so we can see the build steps easily
+RUN mvn -DskipTests clean install -q
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11
 
 # download system dependencies first to take advantage of docker caching
 RUN apt-get update; apt-get install -y --no-install-recommends \

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -13,13 +13,14 @@
 #
 # WARNING: the shendoah image is a nightly, untested, experimental build. If
 # you want to use an official openjdk image instead use the web-and-data image.
-FROM maven:3-openjdk-11 as build
+FROM maven:3-eclipse-temurin-11 as build
 COPY $PWD /cbioportal
 WORKDIR /cbioportal
 ARG MAVEN_OPTS=-DskipTests
-RUN mvn ${MAVEN_OPTS} clean install
+# Use quite output so we can see the build steps easily
+RUN mvn ${MAVEN_OPTS} clean install -q
 
-FROM shipilev/openjdk:11
+FROM eclipse-temurin:11
 
 ENV PORTAL_WEB_HOME=/cbioportal-webapp
 
@@ -29,4 +30,4 @@ COPY --from=build /cbioportal/portal/target/dependency/webapp-runner.jar /webapp
 RUN mkdir -p $PORTAL_WEB_HOME
 RUN cd $PORTAL_WEB_HOME && jar -xvf /app.war
 
-CMD ["/bin/sh", "-c", "/usr/bin/java ${JAVA_OPTS} -jar /webapp-runner.jar ${WEBAPP_OPTS} ${PORTAL_WEB_HOME}"]
+CMD ["java", "${JAVA_OPTS} -jar /webapp-runner.jar ${WEBAPP_OPTS} ${PORTAL_WEB_HOME}"]


### PR DESCRIPTION
This is the effort to make all apps running on both amd64 cpu and arm64 cpu. This is related to https://github.com/oncokb/oncokb/issues/3271

**Changes included in this PR:**
- Use docker/build-push-action to build multi-platform images. We support amd64 and arm64.
- Update default docker JDK/MavenJDK to eclipse-temurin-11. OpenJDK 11 is already retired https://togithub.com/docker-library/openjdk/issues/505
