### PR TITLE
Add properties to show selected columns in mutations table on init

### DIFF
--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -191,6 +191,15 @@ Namespace columns are custom columns in the MAF file that can be shown in Mutati
 skin.mutation_table.namespace_column.show_by_default=
 ```
 
+### Default visible columns on init in Mutations Table
+
+Define the columns that are going to be visible in the Mutation Table on the Patient View and the Results View. If namespace columns are set to visible by default, they will also be shown.
+
+```
+# skin.patient_view.mutation_table.columns.show_on_init=
+# skin.results_view.mutation_table.columns.show_on_init=
+```
+
 ### Hide p- and q-values in survival types table
 
 ```

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -139,6 +139,8 @@
             "skin.geneset_hierarchy.default_gsva_score",
             "skin.geneset_hierarchy.collapse_by_default",
             "skin.mutation_table.namespace_column.show_by_default",
+            "skin.patient_view.mutation_table.columns.show_on_init",
+            "skin.results_view.mutation_table.columns.show_on_init",
             "comparison.categorical_na_values",
             "skin.hide_download_controls"
         };

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -93,6 +93,10 @@ skin.study_view.link_text=To build your own case set, try out our enhanced Study
 # controls whether namespace columns of the MAF file are immediately visible in mutation tables (default is 'false')
 # skin.mutation_table.namespace_column.show_by_default=true
 
+# controls which columns from the mutation tables are immediately visible in mutation tables
+# skin.patient_view.mutation_table.columns.show_on_init=Gene,Protein Change,Annotation,Mutation Type,Copy #,Cosmic,# Mut in Sample
+# skin.results_view.mutation_table.columns.show_on_init=Sample Id,Protein Change,Annotation,Mutation Type,Copy #,Cosmic,# Mut in Sample
+
 # setting controlling the home page
 ## enable this to show studies for which the user does not have permission (will appear greyed out and cannot be analyzed in study view or results view). 
 # skin.home_page.show_unauthorized_studies=false


### PR DESCRIPTION
An organization has added 150 custom namespace columns to the MAF file for studies. They want to visualize two of these are  immediately when a user opens Patient View, together with `Gene` and `Protein Change`, while the rest of the columns are hidden in the Columns selection menu.

To do so, we propose to introduce two properties that will allow to define the columns that are shown on initialization for the mutation table, one for the results view and the other for the patient view. If the property is not defined, we keep the default columns that are currently shown in the view. Also, the property works together with the `skin.mutation_table.namespace_column.show_by_default` property; if it is set to true, it will show all the namespace columns together with the other defined columns in the properties added in this PR.