### PR TITLE
Add properties to show selected columns in copy-number and structural variant tables on init

### DIFF
--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -191,13 +191,14 @@ Namespace columns are custom columns in the MAF file that can be shown in Mutati
 skin.mutation_table.namespace_column.show_by_default=
 ```
 
-### Default visible columns on init in Mutations Table
+### Default visible columns on init in Mutation, Copy-Number and Structural Variant Tables
 
-Define the columns that are going to be visible in the Mutation Table on the Patient View and the Results View. If namespace columns are set to visible by default, they will also be shown.
-
+Define the columns that are going to be visible in the Mutation, Copy-Number and Structural Variant Tables on the Patient View and the Mutation Table in the Results View. The `skin.mutation_table.namespace_column.show_by_default` takes precedence over these settings for namespace columns.
 ```
-skin.patient_view.mutation_table.columns.show_on_init=
 skin.results_view.mutation_table.columns.show_on_init=
+skin.patient_view.mutation_table.columns.show_on_init=
+skin.patient_view.copy_number_table.columns.show_on_init=
+skin.patient_view.structural_variant_table.columns.show_on_init=
 ```
 
 ### Hide p- and q-values in survival types table

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -141,6 +141,8 @@
             "skin.mutation_table.namespace_column.show_by_default",
             "skin.patient_view.mutation_table.columns.show_on_init",
             "skin.results_view.mutation_table.columns.show_on_init",
+            "skin.patient_view.copy_number_table.columns.show_on_init",
+            "skin.patient_view.structural_variant_table.columns.show_on_init",
             "comparison.categorical_na_values",
             "skin.hide_download_controls"
         };

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -94,8 +94,10 @@ skin.study_view.link_text=To build your own case set, try out our enhanced Study
 # skin.mutation_table.namespace_column.show_by_default=true
 
 # controls which columns from the mutation tables are immediately visible in mutation tables
-# skin.patient_view.mutation_table.columns.show_on_init=Gene,Protein Change,Annotation,Mutation Type,Copy #,Cosmic,# Mut in Sample
 # skin.results_view.mutation_table.columns.show_on_init=Sample Id,Protein Change,Annotation,Mutation Type,Copy #,Cosmic,# Mut in Sample
+# skin.patient_view.mutation_table.columns.show_on_init=Gene,Protein Change,Annotation,Mutation Type,Copy #,Cosmic,# Mut in Sample
+# skin.patient_view.copy_number_table.columns.show_on_init=Gene,CNA,Annotation,Cytoband,Cohort
+# skin.patient_view.structural_variant_table.columns.show_on_init=Gene 1,Gene2,Status,Annotation,Variant Class,Event Info,Connection Type
 
 # setting controlling the home page
 ## enable this to show studies for which the user does not have permission (will appear greyed out and cannot be analyzed in study view or results view). 


### PR DESCRIPTION
Following #9912, this PR extends the functionality to the patient view tables of Copy Number and Structural Variant data (properties that will allow to define the columns that are shown on initialization for Copy Number and Structural Variant patient view tables). 
