### PR TITLE
Fix import of cna long entries when entrez ID is missing or wrong

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportCnaDiscreteLongData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportCnaDiscreteLongData.java
@@ -48,7 +48,7 @@ public class ImportCnaDiscreteLongData {
     private Set<CnaEvent.Event> existingCnaEvents = new HashSet<>();
     private int samplesSkipped = 0;
     private Set<String> namespaces;
-    
+
     private final ArrayList<SampleIdGeneticProfileId> sampleIdGeneticProfileIds = new ArrayList<>();
 
     public ImportCnaDiscreteLongData(
@@ -114,7 +114,7 @@ public class ImportCnaDiscreteLongData {
         // Once the CNA import is done, update DISCRETE_LONG input datatype into resulting DISCRETE datatype:
         geneticProfile.setDatatype(DISCRETE.name());
         DaoGeneticProfile.updateDatatype(geneticProfile.getGeneticProfileId(), geneticProfile.getDatatype());
-                
+
         ProgressMonitor.setCurrentMessage(" --> total number of samples skipped (normal samples): " + getSamplesSkipped());
         buf.close();
         MySQLbulkLoader.flushAll();
@@ -139,6 +139,7 @@ public class ImportCnaDiscreteLongData {
         importContainer.genes.add(gene);
 
         if (gene == null) {
+            ProgressMonitor.logWarning("Ignoring line with no Hugo_Symbol and no Entrez_Id");
             return;
         }
 
@@ -152,7 +153,7 @@ public class ImportCnaDiscreteLongData {
         int sampleId = sample.getInternalId();
         CnaEventImportData eventContainer = new CnaEventImportData();
         eventContainer.cnaEvent = cnaUtil.createEvent(geneticProfile, sampleId, entrezId, lineParts);
-        
+
         Table<Long, Integer, CnaEventImportData> geneBySampleEventTable = importContainer.eventsTable;
 
         if (!geneBySampleEventTable.contains(entrezId, sample.getInternalId())) {
@@ -188,7 +189,7 @@ public class ImportCnaDiscreteLongData {
                 CnaEventImportData event = toImport
                     .eventsTable
                     .get(entrezId, sample);
-                if(event == null) {
+                if (event == null) {
                     return "";
                 }
                 return "" + event
@@ -216,6 +217,7 @@ public class ImportCnaDiscreteLongData {
     }
 
     /**
+     * Try to find gene by entrez ID, or else by hugo ID
      * @return null when no gene could be found
      */
     private CanonicalGene getGene(
@@ -227,14 +229,19 @@ public class ImportCnaDiscreteLongData {
         String hugoSymbol = util.getHugoSymbol(parts);
 
         if (Strings.isNullOrEmpty(hugoSymbol) && entrez == 0) {
-            ProgressMonitor.logWarning("Ignoring line with no Hugo_Symbol and no Entrez_Id");
             return null;
         }
+
+        // 1. try entrez:
         if (entrez != 0) {
-            //try entrez:
-            return this.daoGene.getGene(entrez);
-        } else if (!Strings.isNullOrEmpty(hugoSymbol)) {
-            //try hugo:
+            CanonicalGene foundByEntrez = this.daoGene.getGene(entrez);
+            if (foundByEntrez != null) {
+                return foundByEntrez;
+            }
+        }
+
+        // 2. try hugo:
+        if (!Strings.isNullOrEmpty(hugoSymbol)) {
             if (hugoSymbol.contains("///") || hugoSymbol.contains("---")) {
                 //  Ignore gene IDs separated by ///.  This indicates that
                 //  the line contains information regarding multiple genes, and
@@ -254,10 +261,9 @@ public class ImportCnaDiscreteLongData {
                 throw new IllegalStateException("Found multiple genes for Hugo symbol " + hugoSymbol + " while importing cna");
             }
             return genes.get(0);
-        } else {
-            ProgressMonitor.logWarning("Entrez_Id " + entrez + " not found. Record will be skipped for this gene.");
-            return null;
         }
+        ProgressMonitor.logWarning("Entrez_Id " + entrez + " not found. Record will be skipped for this gene.");
+        return null;
     }
 
     /**
@@ -331,7 +337,7 @@ public class ImportCnaDiscreteLongData {
         public Table<Long, Integer, CnaEventImportData> eventsTable = HashBasedTable.create();
         public Set<CanonicalGene> genes = new HashSet<>();
     }
-    
+
     private class CnaEventImportData {
         public int line;
         public CnaEvent cnaEvent;

--- a/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportCnaDiscreteLongData.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/scripts/ImportCnaDiscreteLongData.java
@@ -151,7 +151,7 @@ public class ImportCnaDiscreteLongData {
         long entrezId = gene.getEntrezGeneId();
         int sampleId = sample.getInternalId();
         CnaEventImportData eventContainer = new CnaEventImportData();
-        eventContainer.cnaEvent = cnaUtil.createEvent(geneticProfile, sample.getInternalId(), lineParts);
+        eventContainer.cnaEvent = cnaUtil.createEvent(geneticProfile, sampleId, entrezId, lineParts);
         
         Table<Long, Integer, CnaEventImportData> geneBySampleEventTable = importContainer.eventsTable;
 

--- a/core/src/main/java/org/mskcc/cbio/portal/util/CnaUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/CnaUtil.java
@@ -68,14 +68,14 @@ public class CnaUtil {
     }
 
     public CnaEvent createEvent(
-        GeneticProfile geneticProfile, 
-        int sampleId, 
+        GeneticProfile geneticProfile,
+        int sampleId,
+        long entrezId, 
         String[] parts
     ) throws IOException {
         int cnaProfileId = geneticProfile.getGeneticProfileId();
-        long entrezGeneId = getEntrezSymbol(parts);
         short alteration = createAlteration(parts);
-        CnaEvent cna = new CnaEvent(sampleId, cnaProfileId, entrezGeneId, alteration);
+        CnaEvent cna = new CnaEvent(sampleId, cnaProfileId, entrezId, alteration);
         cna.setDriverFilter(TabDelimitedFileUtil.getPartString(getColumnIndex(CnaUtil.CBP_DRIVER), parts));
         cna.setDriverFilterAnnotation(TabDelimitedFileUtil.getPartString(getColumnIndex(CnaUtil.CBP_DRIVER_ANNOTATION), parts));
         cna.setDriverTiersFilter(TabDelimitedFileUtil.getPartString(getColumnIndex(CnaUtil.CBP_DRIVER_TIERS), parts));

--- a/core/src/test/java/org/mskcc/cbio/portal/scripts/TestImportCnaDiscreteLongData.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/scripts/TestImportCnaDiscreteLongData.java
@@ -264,6 +264,29 @@ public class TestImportCnaDiscreteLongData {
     }
 
     /**
+     * Test that entries are imported when invalid entrez IDs and valid Hugo IDs are provided
+     */
+    @Test
+    public void testImportCnaDiscreteLongDataHandlesEntriesWithWrongEntrezAndCorrectHugo() throws Exception {
+        List<TestGeneticAlteration> beforeGeneticAlterations = getAllGeneticAlterations();
+        assertEquals(beforeGeneticAlterations.size(), 42);
+
+        File file = new File("src/test/resources/data_cna_discrete_import_test_with_wrong_entrez_and_correct_hugo.txt");
+        new ImportCnaDiscreteLongData(
+            file,
+            geneticProfile.getGeneticProfileId(),
+            genePanel,
+            DaoGeneOptimized.getInstance(),
+            DaoGeneticAlteration.getInstance(),
+            noNamespaces).importData();
+
+        // Test order of genetic alteration values:
+        TestGeneticAlteration geneticAlteration = getGeneticAlterationByEntrez(57670L);
+        assertEquals(geneticProfile.getGeneticProfileId(), geneticAlteration.geneticProfileId);
+        assertEquals("2,-2,", geneticAlteration.values);
+    }
+    
+    /**
      * Test genetic events are imported, even when not imported as cna event
      */
     @Test

--- a/core/src/test/java/org/mskcc/cbio/portal/scripts/TestImportCnaDiscreteLongData.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/scripts/TestImportCnaDiscreteLongData.java
@@ -241,6 +241,29 @@ public class TestImportCnaDiscreteLongData {
     }
 
     /**
+     * Test that entries are imported when valid entrez IDs are missing but Hugo IDs are provided
+     */
+    @Test
+    public void testImportCnaDiscreteLongDataHandlesEntriesWithoutEntrezButWithHugo() throws Exception {
+        List<TestGeneticAlteration> beforeGeneticAlterations = getAllGeneticAlterations();
+        assertEquals(beforeGeneticAlterations.size(), 42);
+
+        File file = new File("src/test/resources/data_cna_discrete_import_test_without_entrez_with_hugo.txt");
+        new ImportCnaDiscreteLongData(
+            file,
+            geneticProfile.getGeneticProfileId(),
+            genePanel,
+            DaoGeneOptimized.getInstance(),
+            DaoGeneticAlteration.getInstance(),
+            noNamespaces).importData();
+
+        // Test order of genetic alteration values:
+        TestGeneticAlteration geneticAlteration = getGeneticAlterationByEntrez(57670L);
+        assertEquals(geneticProfile.getGeneticProfileId(), geneticAlteration.geneticProfileId);
+        assertEquals("2,-2,", geneticAlteration.values);
+    }
+
+    /**
      * Test genetic events are imported, even when not imported as cna event
      */
     @Test

--- a/core/src/test/resources/data_cna_discrete_import_test_with_wrong_entrez_and_correct_hugo.txt
+++ b/core/src/test/resources/data_cna_discrete_import_test_with_wrong_entrez_and_correct_hugo.txt
@@ -1,0 +1,3 @@
+Hugo_Symbol	Entrez_Gene_Id	Sample_Id	Value	cbp_driver	cbp_driver_annotation	cbp_driver_tiers	cbp_driver_tiers_annotation
+KIAA1549	123456	TCGA-A1-A0SB-11	2				
+KIAA1549	123456	TCGA-A2-A04U-11	-2				

--- a/core/src/test/resources/data_cna_discrete_import_test_without_entrez_with_hugo.txt
+++ b/core/src/test/resources/data_cna_discrete_import_test_without_entrez_with_hugo.txt
@@ -1,0 +1,3 @@
+Hugo_Symbol	Entrez_Gene_Id	Sample_Id	Value	cbp_driver	cbp_driver_annotation	cbp_driver_tiers	cbp_driver_tiers_annotation
+KIAA1549	NA	TCGA-A1-A0SB-11	2				
+KIAA1549		TCGA-A2-A04U-11	-2				


### PR DESCRIPTION
# Bugs
1. CNA long format importer does not import an entry when only a hugo ID and no entrez ID is provided.
2. CNA long format importer does not import an entry when a correct hugo ID but a faulty entrez ID is provided.

# Solutions
1. Use the entrez ID that is linked to the provided hugo ID. This entrez ID lookup was already done, and it is now also used when creating a CnaEvent.
2. Try to find gene by entrez ID first, and if nothing found, try to find a gene by its hugo symbol.

# Notes
This PR contains regression tests.