### PR TITLE
Do not call next study view filter when no samples left

### DIFF
--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -273,7 +273,7 @@ public class StudyViewFilterApplier {
     
     private List<SampleIdentifier> chainSubFilters(StudyViewFilter studyViewFilter, List<SampleIdentifier> sampleIdentifiers) {
         for (StudyViewSubFilterApplier subFilterApplier : subFilterAppliers) {
-            if (subFilterApplier.shouldApplyFilter(studyViewFilter)) {
+            if (!sampleIdentifiers.isEmpty() && subFilterApplier.shouldApplyFilter(studyViewFilter)) {
                 sampleIdentifiers = subFilterApplier.filter(sampleIdentifiers, studyViewFilter);
             }
         }


### PR DESCRIPTION
# Problem
Study View filter Appliers are called on empty lists. This results in errors in some of the Filters.

# Solution
Do not call next filter when not needed.