### PR TITLE
Configure database connection via db.connection_string param

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,10 +42,12 @@ jobs:
         working-directory: ./cbioportal-docker-compose
         run: |
           cd ./data && ./init.sh && rm -rf ./studies/* && cd ../config && \
-          cat $PORTAL_SOURCE_DIR/portal/target/portal/WEB-INF/classes/portal.properties | \
-              sed 's/db.host=.*/db.host=cbioportal-database:3306/g' | \
-              sed 's|db.connection_string=.*|db.connection_string=jdbc:mysql://cbioportal-database:3306/|g' \
-              > portal.properties
+          cat $PORTAL_SOURCE_DIR/portal/target/classes/portal.properties | \
+              sed 's|db.host=.*||' | \
+              sed 's|db.portal_db_name=.*||' | \
+              sed 's|db.use_ssl=.*||' | \
+              sed 's|db.connection_string=.*|db.connection_string=jdbc:mysql://cbioportal-database:3306/cbioportal?useSSL=false\&allowPublicKeyRetrieval=true|' \
+              > portal.properties && more portal.properties
       - name: 'Start cbioportal-docker-compose'
         working-directory: ./cbioportal-docker-compose
         run: |

--- a/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/dao/JdbcDataSource.java
@@ -3,28 +3,44 @@ package org.mskcc.cbio.portal.dao;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.mskcc.cbio.portal.util.DatabaseProperties;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.Assert;
 
 /**
  * Data source that self-initializes based on cBioPortal configuration.
  */
 public class JdbcDataSource extends BasicDataSource {
+
     public JdbcDataSource () {
         DatabaseProperties dbProperties = DatabaseProperties.getInstance();
+
         String host = dbProperties.getDbHost();
         String userName = dbProperties.getDbUser();
         String password = dbProperties.getDbPassword();
         String mysqlDriverClassName = dbProperties.getDbDriverClassName();
         String database = dbProperties.getDbName();
-        String useSSL = (!StringUtils.isBlank(dbProperties.getDbUseSSL())) ? dbProperties.getDbUseSSL() : "false";
         String enablePooling = (!StringUtils.isBlank(dbProperties.getDbEnablePooling())) ? dbProperties.getDbEnablePooling(): "false";
-        String url ="jdbc:mysql://" + host + "/" + database +
-                        "?user=" + userName + "&password=" + password +
-                        "&zeroDateTimeBehavior=convertToNull&useSSL=" + useSSL;
+        String connectionURL = dbProperties.getConnectionURL();
+        
+        Assert.isTrue(
+            !defined(host) && !defined(database) && !defined(dbProperties.getDbUseSSL()),
+            "\n----------------------------------------------------------------------------------------------------------------" +
+                "-- Connection error:\n" +
+                "-- You try to connect to the database using the deprecated 'db.host', 'db.portal_db_name' and 'db.use_ssl' properties.\n" +
+                "-- Please remove these properties and use the 'db.connection_string' property instead. See https://docs.cbioportal.org/deployment/customization/portal.properties-reference/\n" +
+                "-- for assistance on building a valid connection string.\n" +
+                "----------------------------------------------------------------------------------------------------------------\n"
+        );
+        
+        Assert.hasText(userName, errorMessage("username", "db.user"));
+        Assert.hasText(password, errorMessage("password", "db.password"));
+        Assert.hasText(mysqlDriverClassName, errorMessage("driver class name", "db.driver"));
+
+        this.setUrl(connectionURL);
+
         //  Set up poolable data source
         this.setDriverClassName(mysqlDriverClassName);
         this.setUsername(userName);
         this.setPassword(password);
-        this.setUrl(url);
         // Disable this to avoid caching statements
         this.setPoolPreparedStatements(Boolean.valueOf(enablePooling));
         // these are the values cbioportal has been using in their production
@@ -36,5 +52,13 @@ public class JdbcDataSource extends BasicDataSource {
         this.setTestOnBorrow(true);
         this.setValidationQuery("SELECT 1");
         this.setJmxName("org.cbioportal:DataSource=" + database);
+    }
+    
+    private String errorMessage(String displayName, String propertyName) {
+        return String.format("No %s provided for database connection. Please set '%s' in portal.properties.", displayName, propertyName);
+    }
+    
+    private boolean defined(String property) {
+        return property != null && !property.isEmpty();
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/portal/util/DatabaseProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/DatabaseProperties.java
@@ -47,6 +47,7 @@ public class DatabaseProperties {
     private String dbDriverClassName;
     private String dbUseSSL;
     private String dbEnablePooling;
+    private String connectionURL;
 
     // No production keys stored in filesystem or code: digest the key; put it in properties; load it into dbms on startup
     private static DatabaseProperties dbProperties;
@@ -63,6 +64,7 @@ public class DatabaseProperties {
             dbProperties.setDbDriverClassName(GlobalProperties.getProperty("db.driver"));
             dbProperties.setDbUseSSL(GlobalProperties.getProperty("db.use_ssl"));
             dbProperties.setDbEnablePooling(GlobalProperties.getProperty("db.enable_pooling"));
+            dbProperties.setConnectionURL(GlobalProperties.getProperty("db.connection_string"));
         }
         return dbProperties;
     }
@@ -134,4 +136,12 @@ public class DatabaseProperties {
         this.dbEnablePooling = dbEnablePooling;
     }
 
+    public String getConnectionURL() {
+        return connectionURL;
+    }
+
+    public void setConnectionURL(String connectionURL) {
+        this.connectionURL = connectionURL;
+    }
+    
 }

--- a/core/src/main/java/org/mskcc/cbio/portal/util/SpringUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/SpringUtil.java
@@ -38,17 +38,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.context.support.GenericXmlApplicationContext;
 import org.springframework.stereotype.Component;
 
 @Component
-public class SpringUtil
-{
+public class SpringUtil {
     private static final Logger log = LoggerFactory.getLogger(SpringUtil.class);
 
     private static AccessControl accessControl;
-    private static ApplicationContext context;
-    private static GenericXmlApplicationContext applicationContext;
+    private static ApplicationContext applicationContext;
 
     @Autowired
     public void setAccessControl(AccessControl accessControl) {
@@ -56,15 +53,13 @@ public class SpringUtil
         SpringUtil.accessControl = accessControl;
     }
 
-    public static AccessControl getAccessControl()
-    {
+    public static AccessControl getAccessControl() {
         return accessControl;
     }
 
-    public static synchronized void initDataSource()
-    {
-        if (SpringUtil.context == null) {
-            context = new ClassPathXmlApplicationContext("classpath:applicationContext-persistenceConnections.xml");
+    public static synchronized void initDataSource() {
+        if (SpringUtil.applicationContext == null) {
+            SpringUtil.applicationContext = new ClassPathXmlApplicationContext("classpath:applicationContext-persistenceConnections.xml");
         }
     }
 
@@ -74,7 +69,7 @@ public class SpringUtil
      * @return the Spring Framework application context
      */
     public static ApplicationContext getApplicationContext() {
-        return context;
+        return applicationContext;
     }
 
     /**
@@ -84,7 +79,7 @@ public class SpringUtil
      * @param context
      */
     public static void setApplicationContext(ApplicationContext context) {
-        SpringUtil.context = context;
+        SpringUtil.applicationContext = context;
     }
 
     /**
@@ -93,8 +88,7 @@ public class SpringUtil
      *
      * @param context
      */
-    public static synchronized void initDataSource(ApplicationContext context)
-    {
-        SpringUtil.context = context;
+    public static synchronized void initDataSource(ApplicationContext context) {
+        SpringUtil.applicationContext = context;
     }
 }

--- a/core/src/main/scripts/importer/cbioportalImporter.py
+++ b/core/src/main/scripts/importer/cbioportalImporter.py
@@ -419,8 +419,7 @@ def usage():
                            '--command [%s] --study_directory <path to directory> '
                            '--meta_filename <path to metafile>'
                            '--data_filename <path to datafile>'
-                           '--study_ids <cancer study ids for remove-study command, comma separated>'
-                           '--properties-filename <path to properties file> ' % (COMMANDS)), file=OUTPUT_FILE)
+                           '--study_ids <cancer study ids for remove-study command, comma separated>' % (COMMANDS)), file=OUTPUT_FILE)
 
 def check_args(command):
     if command not in COMMANDS:

--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -11,7 +11,9 @@ import csv
 import logging.handlers
 from collections import OrderedDict
 from subprocess import Popen, PIPE, STDOUT
-
+from typing import Dict, Optional
+import dsnparse
+import MySQLdb
 
 # ------------------------------------------------------------------------------
 # globals
@@ -36,6 +38,14 @@ IMPORT_CANCER_TYPE_CLASS = "org.mskcc.cbio.portal.scripts.ImportTypesOfCancers"
 IMPORT_CASE_LIST_CLASS = "org.mskcc.cbio.portal.scripts.ImportSampleList"
 ADD_CASE_LIST_CLASS = "org.mskcc.cbio.portal.scripts.AddCaseList"
 VERSION_UTIL_CLASS = "org.mskcc.cbio.portal.util.VersionUtil"
+
+PORTAL_PROPERTY_DATABASE_USER = 'db.user'
+PORTAL_PROPERTY_DATABASE_PW = 'db.password'
+PORTAL_PROPERTY_DATABASE_HOST = 'db.host'
+PORTAL_PROPERTY_DATABASE_NAME = 'db.portal_db_name'
+PORTAL_PROPERTY_DATABASE_URL = 'db.connection_string'
+PORTAL_PROPERTY_DATABASE_USESSL = 'db.use_ssl'
+REQUIRED_DATABASE_PROPERTIES = [PORTAL_PROPERTY_DATABASE_USER, PORTAL_PROPERTY_DATABASE_PW, PORTAL_PROPERTY_DATABASE_URL]
 
 # provides a key for data types to metafile specification dict.
 class MetaFileTypes(object):
@@ -1000,3 +1010,96 @@ def run_java(*args):
     elif process.returncode != 0:
         raise RuntimeError('Aborting due to error while executing step.')
     return ret
+
+
+def properties_error_message(display_name: str, property_name: str) -> str:
+    return f"No {display_name} provided for database connection. Please set '{property_name}' in portal.properties."
+
+
+class PortalProperties(object):
+    """ Properties object class, just has fields for db conn """
+
+    def __init__(self, database_user, database_pw, database_url):
+        self.database_user = database_user
+        self.database_pw = database_pw
+        self.database_url = database_url
+
+
+def get_database_properties(properties_filename: str) -> Optional[PortalProperties]:
+
+    properties = parse_properties_file(properties_filename)
+    
+    missing_properties = []
+    for required_property in REQUIRED_DATABASE_PROPERTIES:
+        if required_property not in properties or len(properties[required_property]) == 0:
+            missing_properties.append(required_property)
+    if missing_properties:
+        print(
+            'Missing required properties : (%s)' % (', '.join(missing_properties)),
+            file=ERROR_FILE)
+        return None
+
+    if properties.get(PORTAL_PROPERTY_DATABASE_HOST) is not None \
+        or properties.get(PORTAL_PROPERTY_DATABASE_NAME) is not None \
+        or properties.get(PORTAL_PROPERTY_DATABASE_USESSL) is not None:
+        print("""
+            ----------------------------------------------------------------------------------------------------------------
+            -- Connection error:
+            -- You try to connect to the database using the deprecated 'db.host', 'db.portal_db_name' and 'db.use_ssl' properties.
+            -- Please remove these properties and use the 'db.connection_string' property instead. See https://docs.cbioportal.org/deployment/customization/portal.properties-reference/
+            -- for assistance on building a valid connection string.
+            ------------------------------------------------------------f---------------------------------------------------
+        """, file=ERROR_FILE)
+        return None
+
+    return PortalProperties(properties[PORTAL_PROPERTY_DATABASE_USER],
+                            properties[PORTAL_PROPERTY_DATABASE_PW],
+                            properties[PORTAL_PROPERTY_DATABASE_URL])
+
+
+def parse_properties_file(properties_filename: str) -> Dict[str, str]:
+
+    if not os.path.exists(properties_filename):
+        print('properties file %s cannot be found' % properties_filename, file=ERROR_FILE)
+        sys.exit(2)
+        
+    properties = {}
+    with open(properties_filename, 'r') as properties_file:
+        for line in properties_file:
+            line = line.strip()
+            # skip line if its blank or a comment
+            if len(line) == 0 or line.startswith('#'):
+                continue
+            try:
+                name, value = line.split('=', maxsplit=1)
+            except ValueError:
+                print(
+                    'Skipping invalid entry in property file: %s' % line,
+                    file=ERROR_FILE)
+                continue
+            properties[name] = value.strip()
+    return properties
+
+
+def get_db_cursor(portal_properties: PortalProperties):
+
+    try:
+        url_elements = dsnparse.parse(portal_properties.database_url)
+        connection_kwargs = {
+            "host": url_elements.host,
+            "port": url_elements.port if url_elements.port is not None else 3306,
+            "db": url_elements.paths[0],
+            "user": portal_properties.database_user,
+            "passwd": portal_properties.database_pw,
+            "ssl": "useSSL" not in url_elements.query or url_elements.query["useSSL"] == "true"
+        }
+        connection = MySQLdb.connect(**connection_kwargs)
+    except MySQLdb.Error as exception:
+        print(exception, file=ERROR_FILE)
+        message = (
+            "--> Error connecting to server with URL"
+            + portal_properties.database_url)
+        print(message, file=ERROR_FILE)
+        raise ConnectionError(message) from exception
+    if connection is not None:
+        return connection, connection.cursor()

--- a/docker/web-and-data/docker-entrypoint.sh
+++ b/docker/web-and-data/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 shopt -s nullglob
 
 BAKED_IN_WAR_CONFIG_FILE=/cbioportal-webapp/WEB-INF/classes/portal.properties
-CUSTOM_PROPERTIES_FILE=/cbioportal/portal.properties
+CUSTOM_PROPERTIES_FILE=cbioportal/portal.properties
 
 # check to see if this file is being run or sourced from another script
 _is_sourced() {
@@ -23,19 +23,57 @@ parse_db_params_from_config_and_command_line() {
     else
         PROPERTIES_FILE=$BAKED_IN_WAR_CONFIG_FILE
     fi
-
-    for param in db.host db.user db.portal_db_name db.password; do
+    for param in db.host db.user db.portal_db_name db.password db.connection_string; do
         if $(parse_db_params_from_command_line $@ | grep -q $param); then
-            parse_db_params_from_command_line $@ | grep "^$param"
+            prop=$(parse_db_params_from_command_line $@ | grep "^$param" || [[ $? == 1 ]])
         else
-            grep -v '^#' $PROPERTIES_FILE | grep "^$param"
+            prop=$(grep -v '^#' $PROPERTIES_FILE | grep "^$param" || [[ $? == 1 ]])
+        fi
+        if [[ -n "$prop" ]]
+        then
+            # Replace dot in parameter name with underscore.
+            prop=$(sed "s/^db\./db_/" <<< $prop)
+            if [[ $param == db.connection_string ]]
+            then
+                # Remove the parameters (?...) from the connection URL.
+                echo $(sed -r "s/^([^=]+)=([^\?]+).*/\1=\2/" <<< $prop)
+            else 
+                echo $prop
+            fi
         fi
     done
 }
 
+parse_connection_string() {
+    # Adapted from: https://stackoverflow.com/a/45977232
+    readonly URI_REGEX='^(([^:/?#]+):)+?(//((([^:/?#]+)@)?([^:/?#]+)(:([0-9]+))?))?(/([^?#]*))(\?([^#]*))?(#(.*))?'
+    #                    ↑↑             ↑  ↑↑↑            ↑         ↑ ↑            ↑ ↑        ↑  ↑        ↑ ↑
+    #                    |2 scheme      |  ||6 userinfo   7 host    | 9 port       | 11 rpath |  13 query | 15 fragment
+    #                    1 scheme:      |  |5 userinfo@             8 :…           10 path    12 ?…       14 #…
+    #                                   |  4 authority
+    #                                   3 //…
+    echo db_host=$([[ "$1" =~ $URI_REGEX ]] && echo "${BASH_REMATCH[7]}")
+    echo db_port=$([[ "$1" =~ $URI_REGEX ]] && echo "${BASH_REMATCH[9]}")
+}
+
 check_db_connection() {
-    eval "$(parse_db_params_from_config_and_command_line $@ | sed 's/^db\./db_/g')"
-    POTENTIAL_DB_PARAMS=$@
+    eval $(parse_db_params_from_config_and_command_line $@)
+    
+    if [[ -n $db_host ]] || [[ -n $db_portal_db_name ]] || [[ -n $db_use_ssl ]]
+    then
+        echo "----------------------------------------------------------------------------------------------------------------"
+        echo "-- Connection error:"
+        echo "-- You try to connect to the database using the deprecated 'db.host', 'db.portal_db_name' and 'db.use_ssl' properties."
+        echo "-- Please remove these properties and use the 'db.connection_string' property instead. See https://docs.cbioportal.org/deployment/customization/portal.properties-reference/"
+        echo "-- for assistance on building a valid connection string."
+        echo "------------------------------------------------------------f---------------------------------------------------"
+        exit 1
+    fi
+
+    if [[ -n $db_connection_string ]]
+    then 
+        eval "$(parse_connection_string $db_connection_string)"
+    fi
 
     if [ -z ${db_port+x} ] # is $db_port unset?
     then 
@@ -45,7 +83,6 @@ check_db_connection() {
             db_port="3306" # use default port
         fi
     fi
-
 
     while ! mysqladmin ping -s -h$(echo ${db_host} | cut -d: -f1) -P${db_port} -u${db_user} -p${db_password};
     do

--- a/docs/Migration-Guide.md
+++ b/docs/Migration-Guide.md
@@ -2,7 +2,7 @@
 
 This page describes various changes deployers will need to make as they deploy newer versions of the portal. -
 
-## <v5.3.19 --> v5.3.20
+## <v5.3.19 --> v5.4.0
 
 - Remove `db.host` and `db.portal_db_name` and `db.use_ssl` properties from the _portal.properties_ file or JVM
   parameters. Update property `db.connection_string` to encode the hostname, port, database and other parameters

--- a/docs/Migration-Guide.md
+++ b/docs/Migration-Guide.md
@@ -1,22 +1,45 @@
 # Migration Guide
-This page describes various changes deployers will need to make as they deploy newer versions of the portal. 
+
+This page describes various changes deployers will need to make as they deploy newer versions of the portal. -
+
+## <v5.3.19 --> v5.3.20
+
+- Remove `db.host` and `db.portal_db_name` and `db.use_ssl` properties from the _portal.properties_ file or JVM
+  parameters. Update property `db.connection_string` to encode the hostname, port, database and other parameters
+  according to [Database Settings](portal.properties-Reference.md#Database-Settings) documentation and pass via
+  _portal.properties_ file or as JVM parameter.
 
 ## v4 -> v5
-- All fusion profiles are now required to be migrated to structural variant format. One can use this [migration tool](https://github.com/cBioPortal/datahub-study-curation-tools/tree/master/fusion-to-sv-converter) to migrate the fusion files.
-- All fusion files on [datahub](https://github.com/cBioPortal/datahub) were migrated to the structural variant format and their molecular profile ids were renamed from `{study_id}_fusion` to `{study_id}_structural_variants`. If you are using these datahub files one would need to re-import them.
-- Study view user setting will be outdated after migration, please follow `Clear Study View User settings` section in [Session Service Management](Session-Service-Management.md#Clear-Study-View-User-settings)
-- The new default set of transcripts for each gene has changed from `uniprot` to `mskcc`. See the [Mutation Data Annotation Section](./mutation-data-transcript-annotation.md) for more details. To keep the old set of default transcripts add the property `genomenexus.isoform_override_source=uniprot` to [the properties file](https://docs.cbioportal.org/deployment/customization/portal.properties-reference/#properties).
+
+- All fusion profiles are now required to be migrated to structural variant format. One can use
+  this [migration tool](https://github.com/cBioPortal/datahub-study-curation-tools/tree/master/fusion-to-sv-converter)
+  to migrate the fusion files.
+- All fusion files on [datahub](https://github.com/cBioPortal/datahub) were migrated to the structural variant format
+  and their molecular profile ids were renamed from `{study_id}_fusion` to `{study_id}_structural_variants`. If you are
+  using these datahub files one would need to re-import them.
+- Study view user setting will be outdated after migration, please follow `Clear Study View User settings` section
+  in [Session Service Management](Session-Service-Management.md#Clear-Study-View-User-settings)
+- The new default set of transcripts for each gene has changed from `uniprot` to `mskcc`. See
+  the [Mutation Data Annotation Section](./mutation-data-transcript-annotation.md) for more details. To keep the old set
+  of default transcripts add the property `genomenexus.isoform_override_source=uniprot`
+  to [the properties file](https://docs.cbioportal.org/deployment/customization/portal.properties-reference/#properties).
 
 See the [v5.0.0 release notes](https://github.com/cBioPortal/cbioportal/releases/tag/v5.0.0) for more details.
 
 ## v3 -> v4
+
 - Introduces `logback` package for logging. If you don't have any custom log4j.properties file, no changes are necessary
-- Cleans up several old databases ([PR](https://github.com/cBioPortal/cbioportal/pull/9360)). In theory the migration should be seamless, since the docker container detects an old database version and migrates it automatically.
+- Cleans up several old databases ([PR](https://github.com/cBioPortal/cbioportal/pull/9360)). In theory the migration
+  should be seamless, since the docker container detects an old database version and migrates it automatically.
 
 See the [v4.0.0 release notes](https://github.com/cBioPortal/cbioportal/releases/tag/v4.0.0) for more details.
 
 ## v2 -> v3
-- Session service is now required to be set up. You can't run it without session service. The recommended way to run cBioPortal is to use the Docker Compose instructions.
+
+- Session service is now required to be set up. You can't run it without session service. The recommended way to run
+  cBioPortal is to use the Docker Compose instructions.
 
 ## v1 -> v2
-- Changes cBioPortal to a Single Page App (SPA) written in React, Mobx and bootstrap that uses a REST API. It shouldn't change anything for a deployer.
+
+- Changes cBioPortal to a Single Page App (SPA) written in React, Mobx and bootstrap that uses a REST API. It shouldn't
+  change anything for a deployer.

--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -7,18 +7,25 @@ This page describes the main properties within portal.properties.
 ```
 db.user=
 db.password=
-db.host=[e.g. localhost to connect via socket, or e.g. 127.0.0.1:3307 to connect to a different port like 3307. Used by Java data import layer]
-db.portal_db_name=[the database name in mysql, e.g. cbiodb]
+db.connection_string=
 db.driver=[this is the name of your JDBC driver, e.g., com.mysql.jdbc.Driver]
 ```
 
-Include `db_connection_string` with the format specified below, and replace `localhost` by the value of `db.host`:
+The format of the `db.connection_string` is:
+```
+jdbc:mysql://<host>:<port>/<database name>?<parameter1>&<parameter2>&<parameter...>
+```
+
+For example:
 
 ```
-db.connection_string=jdbc:mysql://localhost/
+jdbc:mysql://localhost:3306/cbiodb?zeroDateTimeBehavior=convertToNull&useSSL=false
 ```
 
-db.tomcat\_resource\_name is required in order to work with the tomcat database connection pool and should have the default value jdbc/cbioportal in order to work correctly with the your WAR file.
+:warning: The fields `db.host` and `db.portal_db_name` and `db.use_ssl` are deprecated. It is required to configure the database connection using
+the `db.connection_string` instead.
+
+`db.tomcat_resource_name` is required in order to work with the tomcat database connection pool and should have the default value jdbc/cbioportal in order to work correctly with the your WAR file.
 
 ```
 db.tomcat_resource_name=jdbc/cbioportal

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
 
     <db.test.driver>com.mysql.jdbc.Driver</db.test.driver>
     <!-- For MySQL < 5.5 change 'default_storage_engine' to 'storage_engine' -->
-    <db.test.url>jdbc:mysql://127.0.0.1:3306/cgds_test?sessionVariables=default_storage_engine=InnoDB&amp;allowLoadLocalInfile=true</db.test.url>
+    <db.test.url>jdbc:mysql://127.0.0.1:3306/cgds_test?useSSL=false&amp;sessionVariables=default_storage_engine=InnoDB&amp;allowLoadLocalInfile=true&amp;allowPublicKeyRetrieval=true</db.test.url>
     <db.test.username>cbio_user</db.test.username>
     <db.test.password>somepassword</db.test.password>
 

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -215,8 +215,6 @@
             <!-- We neither create nor populate the database here. Instead we rely on DB created for the integration tests in the core module. -->
             <CBIO_TEST_DB_USR>${db.test.username}</CBIO_TEST_DB_USR>
             <CBIO_TEST_DB_PSW>${db.test.password}</CBIO_TEST_DB_PSW>
-            <CBIO_TEST_DB_HOST>127.0.0.1:3306</CBIO_TEST_DB_HOST>
-            <CBIO_TEST_DB_NAME>cgds_test</CBIO_TEST_DB_NAME>
             <CBIO_TEST_DB_CONNECTION_STRING>${db.test.url}</CBIO_TEST_DB_CONNECTION_STRING>
           </environmentVariables>
         </configuration>

--- a/portal/src/integration-tests/saml-oauth2-setup/pom.xml
+++ b/portal/src/integration-tests/saml-oauth2-setup/pom.xml
@@ -66,8 +66,6 @@
                             <!-- DB settings -->
                             <db.user>${env.CBIO_TEST_DB_USR}</db.user>
                             <db.password>${env.CBIO_TEST_DB_PSW}</db.password>
-                            <db.host>${env.CBIO_TEST_DB_HOST}</db.host>
-                            <db.portal_db_name>${env.CBIO_TEST_DB_NAME}</db.portal_db_name>
                             <db.connection_string>${env.CBIO_TEST_DB_CONNECTION_STRING}</db.connection_string>
                             <!-- SAML settings -->
                             <saml.keystore.location>file://${project.basedir}/testSamlKeystore.jks

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -4,10 +4,8 @@ app.name=cbioportal
 # database
 db.user=cbio_user
 db.password=somepassword
-db.host=localhost:3306
-db.portal_db_name=cbioportal
 db.driver=com.mysql.jdbc.Driver
-db.connection_string=jdbc:mysql://localhost:3306/
+db.connection_string=jdbc:mysql://localhost:3306/cbioportal?useSSL=false
 # set tomcat_resource_name when using dbconnector=jndi instead of the default
 # dbconnector=dbcp. Note that dbconnector needs to be set in CATLINA_OPTS when
 # using Tomcat (CATALINA_OPTS="-Ddbconnector=jndi"). It does not get picked up
@@ -18,7 +16,7 @@ db.connection_string=jdbc:mysql://localhost:3306/
 
 # this should normally be set to false. In some cases you could set this to true (e.g. for testing a feature of a newer release that is not related to the schema change in expected db version above):
 db.suppress_schema_version_mismatch_errors=false
-db.use_ssl=false
+
 # web page cosmetics
 skin.title=cBioPortal for Cancer Genomics
 skin.email_contact=cbioportal at googlegroups dot com

--- a/test/integration/docker-compose-localbuild.yml
+++ b/test/integration/docker-compose-localbuild.yml
@@ -10,6 +10,8 @@ services:
      - $PORTAL_INFO_DIR:/portalinfo/
      # make docker compose run the cbioportal version-under-test
      # by volume mounting the local portal source folder into the container
-     # and running 
+     # and running
      - $PORTAL_SOURCE_DIR:/cbioportal/
      - $PORTAL_SOURCE_DIR/portal/target/cbioportal.war:/app.war
+     # TODO: remove line below after upgrade of cbioportal-docker-compose to > v5.3.20
+     - $PORTAL_SOURCE_DIR/docker/web-and-data/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh

--- a/web/src/main/java/org/cbioportal/web/config/WebServletContextListener.java
+++ b/web/src/main/java/org/cbioportal/web/config/WebServletContextListener.java
@@ -47,12 +47,12 @@ public class WebServletContextListener implements ServletContextListener, Initia
 
     private void checkOncokbInfo() {
         if(StringUtils.isEmpty(this.oncokbToken) && (StringUtils.isEmpty(this.oncokbURL) || this.oncokbURL.equalsIgnoreCase(DEFAULT_ONCOKB_URL))) {
-            System.out.println("----------------------------------------------------------------------------------------------------------------");
+            System.out.println("\n----------------------------------------------------------------------------------------------------------------");
             // oncokb.org is deprecated, www.oncokb.org should be used
             System.out.println("-- You are connecting to the OncoKB public instance which does not include any therapeutic information.");
             System.out.println("-- Please consider obtaining a license to support future OncoKB development by following https://docs.cbioportal.org/2.4-integration-with-other-webservices/oncokb-data-access.");
             System.out.println("-- Thank you.");
-            System.out.println("----------------------------------------------------------------------------------------------------------------");
+            System.out.println("----------------------------------------------------------------------------------------------------------------\n");
         }
     }
     


### PR DESCRIPTION
This update is needed to allow connection parameters required to run MySQL8.

# Problem
In order to run MySQL 8 additional parameters must be provided to the database connection. At present similar parameters (e.g., _db.use_ssl_) are provided via dedicated properties in _portal.properties_ and, by extension, in java class _DatabaseProperties_. 

# Solution
In order to make it easier to provide custom database connection parameters, I propose in this PR to leverage the existing _db.connection_url_ parameter (that is unused as far as I can see) and make this the required way of configuring the connection. The _db.user_ , _db.password_ and _db.driver_ properties will still be used. The _db.host_, _db.database_, _db.port_ and _db.use_ssl_ properties become obsolete.

This PR will also update the python migration script to run migration using the _db.connection_string_ property. The python importer scripts all rely on confguration at the level of the Java code, and do not require update.

# Backward compatibility
This implementation is backwards compatible with configuring with the legacy _db.host_, _db.database_, _db.port_ and _db.use_ssl_ properties.

# Deprecation warning
A deprecation warning was added for the legacy style database connection params:
```
1:41:25.713 [RMI TCP Connection(2)-127.0.0.1] INFO  o.m.c.portal.util.GlobalProperties - Successfully read properties file

----------------------------------------------------------------------------------------------------------------
-- Deprecation warning:
-- You are connecting to the database using the deprecated 'db.host', 'db.portal_db_name' and 'db.use_ssl' properties.
-- Please use the 'db.connection_string' instead (see https://docs.cbioportal.org/deployment/customization/portal.properties-reference/).
----------------------------------------------------------------------------------------------------------------

11:41:25.718 [RMI TCP Connection(2)-127.0.0.1] INFO  o.s.c.s.PostProcessorRegistrationDelegate$BeanPostProcessorChecker - Bean 'businessDataSource' of type [org.mskcc.cbio.portal.dao.JdbcDataSource] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
...
11:41:29.012 [RMI TCP Connection(2)-127.0.0.1] INFO  o.s.web.context.ContextLoader - Root WebApplicationContext initialized in 6066 ms

----------------------------------------------------------------------------------------------------------------
-- You are connecting to the OncoKB public instance which does not include any therapeutic information.
-- Please consider obtaining a license to support future OncoKB development by following https://docs.cbioportal.org/2.4-integration-with-other-webservices/oncokb-data-access.
-- Thank you.
----------------------------------------------------------------------------------------------------------------

<6>Initializing Spring DispatcherServlet 'api'
11:41:29.079 [RMI TCP Connection(2)-127.0.0.1] INFO  o.s.web.servlet.DispatcherServlet - Initializing Servlet 'api'
```

# Verification
**MSK tasks:**
- [x] Java part 
  - [x] (backward compatible) importers
  - [x] (backward compatible) backend spring app database connection 
- [x] (backward compatible) local backend migration script
- [x] deployments ([beta portal](https://beta.cbioportal.org/))
- [ ] internal usage

**The Hyve tasks:**
- [ ] docker and docker-compose
  - [ ] backend database connection
  - [ ] migration script is still working

