### PR TITLE
Binning of custom data

### DIFF
--- a/model/src/main/java/org/cbioportal/model/Binnable.java
+++ b/model/src/main/java/org/cbioportal/model/Binnable.java
@@ -1,0 +1,13 @@
+package org.cbioportal.model;
+
+/**
+ * Data that can be binned, clinical or custom
+ */
+public interface Binnable {
+    String getAttrId();
+    String getAttrValue();
+    String getSampleId();
+    String getPatientId();
+    String getStudyId();
+    Boolean isPatientAttribute();
+}

--- a/model/src/main/java/org/cbioportal/model/ClinicalData.java
+++ b/model/src/main/java/org/cbioportal/model/ClinicalData.java
@@ -2,7 +2,7 @@ package org.cbioportal.model;
 
 import javax.validation.constraints.NotNull;
 
-public class ClinicalData  extends UniqueKeyBase implements Binnable  {
+public class ClinicalData extends UniqueKeyBase implements Binnable  {
 
     private Integer internalId;
     private String sampleId;

--- a/model/src/main/java/org/cbioportal/model/ClinicalData.java
+++ b/model/src/main/java/org/cbioportal/model/ClinicalData.java
@@ -2,7 +2,7 @@ package org.cbioportal.model;
 
 import javax.validation.constraints.NotNull;
 
-public class ClinicalData extends UniqueKeyBase {
+public class ClinicalData  extends UniqueKeyBase implements Binnable  {
 
     private Integer internalId;
     private String sampleId;
@@ -49,6 +49,13 @@ public class ClinicalData extends UniqueKeyBase {
 
     public String getAttrId() {
         return attrId;
+    }
+
+    public Boolean isPatientAttribute() {
+        if(clinicalAttribute == null) {
+            return null;
+        }
+        return this.clinicalAttribute.getPatientAttribute();
     }
 
     public void setAttrId(String attrId) {

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -25,6 +25,29 @@
             <artifactId>permission-evaluator</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.cbioportal</groupId>
+            <artifactId>session-service</artifactId>
+            <classifier>model</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-boot-starter-web</artifactId>
+                    <groupId>org.springframework.boot</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-boot-starter-data-mongodb</artifactId>
+                    <groupId>org.springframework.boot</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
@@ -56,6 +79,10 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/service/src/main/java/org/cbioportal/service/AttributeByStudyService.java
+++ b/service/src/main/java/org/cbioportal/service/AttributeByStudyService.java
@@ -1,0 +1,9 @@
+package org.cbioportal.service;
+
+import org.cbioportal.model.ClinicalAttribute;
+
+import java.util.List;
+
+public interface AttributeByStudyService {
+    List<ClinicalAttribute> getClinicalAttributesByStudyIdsAndAttributeIds(List<String> studyIds, List<String> attributeIds);
+}

--- a/service/src/main/java/org/cbioportal/service/ClinicalAttributeService.java
+++ b/service/src/main/java/org/cbioportal/service/ClinicalAttributeService.java
@@ -8,7 +8,7 @@ import org.cbioportal.service.exception.StudyNotFoundException;
 
 import java.util.List;
 
-public interface ClinicalAttributeService {
+public interface ClinicalAttributeService extends AttributeByStudyService {
 
     List<ClinicalAttribute> getAllClinicalAttributes(String projection, Integer pageSize, Integer pageNumber,
                                                      String sortBy, String direction);
@@ -31,5 +31,4 @@ public interface ClinicalAttributeService {
 
     List<ClinicalAttributeCount> getClinicalAttributeCountsBySampleListId(String sampleListId);
     
-    List<ClinicalAttribute> getClinicalAttributesByStudyIdsAndAttributeIds(List<String> studyIds, List<String> attributeIds);
 }

--- a/service/src/main/java/org/cbioportal/service/CustomDataService.java
+++ b/service/src/main/java/org/cbioportal/service/CustomDataService.java
@@ -1,0 +1,10 @@
+package org.cbioportal.service;
+
+import org.cbioportal.service.util.CustomDataSession;
+
+import java.util.List;
+import java.util.Map;
+
+public interface CustomDataService {
+    Map<String, CustomDataSession> getCustomDataSessions(List<String> attributes);
+}

--- a/service/src/main/java/org/cbioportal/service/impl/CustomDataServiceImpl.java
+++ b/service/src/main/java/org/cbioportal/service/impl/CustomDataServiceImpl.java
@@ -1,0 +1,58 @@
+package org.cbioportal.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cbioportal.service.CustomDataService;
+import org.cbioportal.service.util.CustomDataSession;
+import org.cbioportal.service.util.SessionServiceRequestHandler;
+import org.cbioportal.session_service.domain.SessionType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+@Service
+public class CustomDataServiceImpl implements CustomDataService {
+    @Autowired
+    private SessionServiceRequestHandler sessionServiceRequestHandler;
+    
+    @Autowired
+    private ObjectMapper sessionServiceObjectMapper;
+
+    /**
+     * Retrieve CustomDataSession from session service for custom data attributes. 
+     * @param customAttributeIds - attribute id/hash of custom data used as session service key.
+     * @return Map of custom data attribute id to the CustomDataSession
+     */
+    @Override
+    public Map<String, CustomDataSession> getCustomDataSessions(List<String> customAttributeIds) {
+        Map<String, CompletableFuture<CustomDataSession>> postFuturesMap = customAttributeIds.stream()
+            .collect(Collectors.toMap(
+                attributeId -> attributeId,
+                attributeId -> CompletableFuture.supplyAsync(() -> {
+                    try {
+                        String customDataSessionJson = sessionServiceRequestHandler.getSessionDataJson(
+                            SessionType.custom_data,
+                            attributeId
+                        );
+                        return sessionServiceObjectMapper.readValue(customDataSessionJson, CustomDataSession.class);
+                    } catch (Exception e) {
+                        return null;
+                    }
+                })
+            ));
+
+        CompletableFuture.allOf(postFuturesMap.values().toArray(new CompletableFuture[postFuturesMap.size()])).join();
+
+        Map<String, CustomDataSession> customDataSessions = postFuturesMap.entrySet().stream()
+            .filter(entry -> entry.getValue().join() != null)
+            .collect(Collectors.toMap(
+                entry -> entry.getKey(),
+                entry -> entry.getValue().join()
+            ));
+
+        return customDataSessions;
+    }
+}

--- a/service/src/main/java/org/cbioportal/service/util/BinnableCustomDataValue.java
+++ b/service/src/main/java/org/cbioportal/service/util/BinnableCustomDataValue.java
@@ -1,0 +1,49 @@
+package org.cbioportal.service.util;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.cbioportal.model.Binnable;
+
+import java.io.Serializable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BinnableCustomDataValue implements Binnable, Serializable {
+
+    private final CustomDataValue customDataValue;
+    private final String attrId;
+    private final Boolean patientAttribute;
+
+    public BinnableCustomDataValue(
+        CustomDataValue customDataValue,
+        String attributeId,
+        Boolean patientAttribute
+    ) {
+        this.customDataValue = customDataValue;
+        this.attrId = attributeId;
+        this.patientAttribute = patientAttribute;
+    }
+
+    public String getSampleId() {
+        return customDataValue.getSampleId();
+    }
+
+    public String getPatientId() {
+        return customDataValue.getPatientId();
+    }
+
+    public String getStudyId() {
+        return customDataValue.getStudyId();
+    }
+
+    public String getAttrId() {
+        return attrId;
+    }
+
+    public Boolean isPatientAttribute() {
+        return patientAttribute;
+    }
+    
+    public String getAttrValue() {
+        return customDataValue.getValue();
+    }
+
+}

--- a/service/src/main/java/org/cbioportal/service/util/ClinicalAttributeUtil.java
+++ b/service/src/main/java/org/cbioportal/service/util/ClinicalAttributeUtil.java
@@ -11,17 +11,24 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ClinicalAttributeUtil {
-    public void extractCategorizedClinicalAttributes(List<ClinicalAttribute> clinicalAttributes,
-            List<String> sampleAttributeIds, List<String> patientAttributeIds,
-            List<String> conflictingPatientAttributeIds) {
-        
+
+    public void extractCategorizedClinicalAttributes(
+        List<ClinicalAttribute> clinicalAttributes,
+        List<String> sampleAttributeIds, 
+        List<String> patientAttributeIds,
+        List<String> conflictingPatientAttributeIds
+    ) {
+
         Set<String> sampleAttributeIdsSet = new HashSet<String>();
         Set<String> patientAttributeIdsSet = new HashSet<String>();
         Set<String> conflictingPatientAttributeIdsSet = new HashSet<String>();
 
-        Map<String, Map<Boolean, List<ClinicalAttribute>>> groupedAttributesByIdAndType = clinicalAttributes.stream()
-                .collect(Collectors.groupingBy(ClinicalAttribute::getAttrId,
-                        Collectors.groupingBy(ClinicalAttribute::getPatientAttribute)));
+        Map<String, Map<Boolean, List<ClinicalAttribute>>> groupedAttributesByIdAndType = clinicalAttributes
+            .stream()
+            .collect(Collectors.groupingBy(
+                ClinicalAttribute::getAttrId,
+                Collectors.groupingBy(ClinicalAttribute::getPatientAttribute)
+            ));
 
         groupedAttributesByIdAndType.entrySet().forEach(entry -> {
             if (entry.getValue().keySet().size() == 1) {
@@ -42,7 +49,7 @@ public class ClinicalAttributeUtil {
                 });
             }
         });
-        
+
         sampleAttributeIds.addAll(sampleAttributeIdsSet);
         patientAttributeIds.addAll(patientAttributeIdsSet);
         conflictingPatientAttributeIds.addAll(conflictingPatientAttributeIdsSet);

--- a/service/src/main/java/org/cbioportal/service/util/CustomAttributeWithData.java
+++ b/service/src/main/java/org/cbioportal/service/util/CustomAttributeWithData.java
@@ -1,18 +1,18 @@
-package org.cbioportal.web;
+package org.cbioportal.service.util;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
-
-import org.cbioportal.web.parameter.CustomDataValue;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class CustomAttributeWithData implements Serializable{
+public class CustomAttributeWithData implements Serializable {
 
     private String owner = "anonymous";
     private Set<String> origin = new HashSet<>();

--- a/service/src/main/java/org/cbioportal/service/util/CustomDataSession.java
+++ b/service/src/main/java/org/cbioportal/service/util/CustomDataSession.java
@@ -1,4 +1,4 @@
-package org.cbioportal.web.parameter;
+package org.cbioportal.service.util;
 
 import java.io.IOException;
 
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.cbioportal.session_service.domain.Session;
 import org.cbioportal.session_service.domain.SessionType;
-import org.cbioportal.web.CustomAttributeWithData;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/service/src/main/java/org/cbioportal/service/util/CustomDataValue.java
+++ b/service/src/main/java/org/cbioportal/service/util/CustomDataValue.java
@@ -1,4 +1,4 @@
-package org.cbioportal.web.parameter;
+package org.cbioportal.service.util;
 
 import java.io.Serializable;
 

--- a/service/src/main/java/org/cbioportal/service/util/SessionServiceConfig.java
+++ b/service/src/main/java/org/cbioportal/service/util/SessionServiceConfig.java
@@ -1,0 +1,16 @@
+package org.cbioportal.service.util;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SessionServiceConfig {
+
+    @Bean
+    public ObjectMapper sessionServiceObjectMapper() {
+        return new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+    
+}

--- a/service/src/main/java/org/cbioportal/service/util/SessionServiceRequestHandler.java
+++ b/service/src/main/java/org/cbioportal/service/util/SessionServiceRequestHandler.java
@@ -1,15 +1,10 @@
-package org.cbioportal.web.util;
+package org.cbioportal.service.util;
 
 import java.nio.charset.Charset;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
-import org.cbioportal.session_service.domain.Session;
 import org.cbioportal.session_service.domain.SessionType;
-import org.cbioportal.web.parameter.CustomDataSession;
-import org.cbioportal.web.parameter.CustomGeneList;
-import org.cbioportal.web.parameter.PageSettings;
-import org.cbioportal.web.parameter.VirtualStudy;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -17,9 +12,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Component
 public class SessionServiceRequestHandler {
@@ -56,32 +48,16 @@ public class SessionServiceRequestHandler {
         };
     }
 
-    public Session getSession(SessionType type, String id) throws Exception {
+    public String getSessionDataJson(SessionType type, String id) throws Exception {
 
         RestTemplate restTemplate = new RestTemplate();
 
         // add basic authentication in header
-        HttpEntity<String> headers = new HttpEntity<String>(getHttpHeaders());
+        HttpEntity<String> headers = new HttpEntity<>(getHttpHeaders());
         ResponseEntity<String> responseEntity = restTemplate.exchange(sessionServiceURL + type + "/" + id,
                 HttpMethod.GET, headers, String.class);
 
-        ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
-        Session session;
-
-        if (type.equals(SessionType.virtual_study) || type.equals(SessionType.group)) {
-            session = mapper.readValue(responseEntity.getBody(), VirtualStudy.class);
-        } else if (type.equals(SessionType.settings)) {
-            session = mapper.readValue(responseEntity.getBody(), PageSettings.class);
-        } else if (type.equals(SessionType.custom_data)) {
-            session = mapper.readValue(responseEntity.getBody(), CustomDataSession.class);
-        } else if (type.equals(SessionType.custom_gene_list)) {
-            session = mapper.readValue(responseEntity.getBody(), CustomGeneList.class);
-        } else {
-            session = mapper.readValue(responseEntity.getBody(), Session.class);
-        }
-
-        return session;
+        return responseEntity.getBody();
     }
 
 }

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -97,29 +97,6 @@
       <artifactId>mongo-java-driver</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.github.cbioportal</groupId>
-        <artifactId>session-service</artifactId>
-        <classifier>model</classifier>
-        <exclusions>
-            <exclusion>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-to-slf4j</artifactId>
-            </exclusion>
-            <exclusion>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-            </exclusion>
-            <exclusion>
-                <artifactId>spring-boot-starter-web</artifactId>
-                <groupId>org.springframework.boot</groupId>
-            </exclusion>
-            <exclusion>
-                <artifactId>spring-boot-starter-data-mongodb</artifactId>
-                <groupId>org.springframework.boot</groupId>
-            </exclusion>
-        </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/web/src/main/java/org/cbioportal/web/config/CustomObjectMapper.java
+++ b/web/src/main/java/org/cbioportal/web/config/CustomObjectMapper.java
@@ -98,13 +98,13 @@ import org.cbioportal.web.mixin.SessionDataMixin;
 import org.cbioportal.web.mixin.SessionMixin;
 import org.cbioportal.web.mixin.StructuralVariantMixin;
 import org.cbioportal.web.mixin.TypeOfCancerMixin;
-import org.cbioportal.web.parameter.CustomDataSession;
+import org.cbioportal.service.util.CustomDataSession;
 import org.cbioportal.web.parameter.PageSettings;
 import org.cbioportal.web.parameter.PageSettingsData;
 import org.cbioportal.web.parameter.StudyPageSettings;
 import org.cbioportal.web.parameter.VirtualStudy;
 import org.cbioportal.web.parameter.VirtualStudyData;
-import org.cbioportal.web.CustomAttributeWithData;
+import org.cbioportal.service.util.CustomAttributeWithData;
 
 public class CustomObjectMapper extends ObjectMapper {
 

--- a/web/src/main/java/org/cbioportal/web/parameter/DataBinMethod.java
+++ b/web/src/main/java/org/cbioportal/web/parameter/DataBinMethod.java
@@ -1,7 +1,19 @@
 package org.cbioportal.web.parameter;
 
+/**
+ *  STATIC and DYNAMIC binning relate to the way bin boundaries are derived from numerical data of a sample cohort
+ *  defined by a Study View Filter (SVF).
+ *  
+ *  When binning in STATIC mode, the binning ignores any filter in the SVF on the attribute that is the subject of 
+ *  binning. In effect, it bins all values of the cohort. This mode is important to drive frontend behavior where
+ *  histograms show bins related to the entire data range, but highlight the currently selected/filtered data in blue 
+ *  (non-selected data bins in grey). In effect, this way the non-selected data influences the boundaries of the data
+ *  bins, irrespective of the selected attribute range. 
+ *  
+ *  When binning in DYNAMIC mode, only the attribute data is binned that is defined by the SVF. The non-selected 
+ *  rest of the data does not influence the bin boundaries.
+ */
 public enum DataBinMethod {
-
     STATIC,
     DYNAMIC
 }

--- a/web/src/main/java/org/cbioportal/web/util/BinningData.java
+++ b/web/src/main/java/org/cbioportal/web/util/BinningData.java
@@ -1,0 +1,39 @@
+package org.cbioportal.web.util;
+
+import com.google.common.collect.ImmutableList;
+import org.cbioportal.model.Binnable;
+import org.cbioportal.model.ClinicalData;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Collections.unmodifiableList;
+
+public class BinningData<T extends Binnable> {
+    public final List<T> samples;
+    public final List<T> patients;
+    public final List<T> conflictingPatientAttributes;
+    private final List<T> allData;
+
+    public BinningData(
+        List<T> samples, 
+        List<T> patients, 
+        List<T> conflictingPatientAttributes
+    ) {
+        this.samples = unmodifiableList(samples);
+        this.patients = unmodifiableList(patients);
+        this.conflictingPatientAttributes = unmodifiableList(conflictingPatientAttributes);
+        this.allData = Stream.of(
+            this.samples,
+            this.patients,
+            this.conflictingPatientAttributes
+        ).flatMap(Collection::stream).collect(Collectors.toList());
+    }
+    
+    public List<T> getAllData() {
+        return allData;
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/web/util/BinningIds.java
+++ b/web/src/main/java/org/cbioportal/web/util/BinningIds.java
@@ -1,0 +1,91 @@
+package org.cbioportal.web.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.unmodifiableList;
+
+/**
+ * All IDs relevant for binning of clinical (and custom clinical) data
+ */
+public class BinningIds {
+    private List<String> studyIds = new ArrayList<>();
+    private List<String> sampleIds = new ArrayList<>();
+    private List<String> patientIds = new ArrayList<>();
+    private List<String> studyIdsOfPatients = new ArrayList<>();
+    private List<String> uniqueSampleKeys = new ArrayList<>();
+    private List<String> uniquePatientKeys = new ArrayList<>();
+    private List<String> sampleAttributeIds = new ArrayList<>();
+    private List<String> patientAttributeIds = new ArrayList<>();
+    private List<String> conflictingPatientAttributeIds = new ArrayList<>();
+
+    public BinningIds() {}
+
+    /**
+     * Create shallow clone
+     */
+    public BinningIds(BinningIds toClone) {
+        this();
+        this.studyIds = new ArrayList<>(toClone.getStudyIds());
+        this.sampleIds = new ArrayList<>(toClone.getSampleIds());
+        this.patientIds = new ArrayList<>(toClone.getPatientIds());
+        this.studyIdsOfPatients = new ArrayList<>(toClone.getStudyIdsOfPatients());
+        this.uniqueSampleKeys = new ArrayList<>(toClone.getUniqueSampleKeys());
+        this.uniquePatientKeys = new ArrayList<>(toClone.getUniquePatientKeys());
+        this.sampleAttributeIds = new ArrayList<>(toClone.getSampleAttributeIds());
+        this.patientAttributeIds = new ArrayList<>(toClone.getPatientAttributeIds());
+        this.conflictingPatientAttributeIds = new ArrayList<>(toClone.getConflictingPatientAttributeIds());
+    }
+
+    /**
+     * Convert lists into unmodifiable lists 
+     * to prevent unknown side effects
+     */
+    public void toImmutable() {
+        this.studyIds = unmodifiableList(this.getStudyIds());
+        this.sampleIds = unmodifiableList(this.getSampleIds());
+        this.patientIds = unmodifiableList(this.getPatientIds());
+        this.studyIdsOfPatients = unmodifiableList(this.getStudyIdsOfPatients());
+        this.uniqueSampleKeys = unmodifiableList(this.getUniqueSampleKeys());
+        this.uniquePatientKeys = unmodifiableList(this.getUniquePatientKeys());
+        this.sampleAttributeIds = unmodifiableList(this.getSampleAttributeIds());
+        this.patientAttributeIds = unmodifiableList(this.getPatientAttributeIds());
+        this.conflictingPatientAttributeIds = unmodifiableList(this.getConflictingPatientAttributeIds());
+    }
+
+    public List<String> getStudyIds() {
+        return studyIds;
+    }
+
+    public List<String> getSampleIds() {
+        return sampleIds;
+    }
+
+    public List<String> getPatientIds() {
+        return patientIds;
+    }
+
+    public List<String> getStudyIdsOfPatients() {
+        return studyIdsOfPatients;
+    }
+
+    public List<String> getUniqueSampleKeys() {
+        return uniqueSampleKeys;
+    }
+
+    public List<String> getUniquePatientKeys() {
+        return uniquePatientKeys;
+    }
+
+    public List<String> getSampleAttributeIds() {
+        return sampleAttributeIds;
+    }
+
+    public List<String> getPatientAttributeIds() {
+        return patientAttributeIds;
+    }
+
+    public List<String> getConflictingPatientAttributeIds() {
+        return conflictingPatientAttributeIds;
+    }
+}

--- a/web/src/main/java/org/cbioportal/web/util/BinningIds.java
+++ b/web/src/main/java/org/cbioportal/web/util/BinningIds.java
@@ -37,22 +37,6 @@ public class BinningIds {
         this.conflictingPatientAttributeIds = new ArrayList<>(toClone.getConflictingPatientAttributeIds());
     }
 
-    /**
-     * Convert lists into unmodifiable lists 
-     * to prevent unknown side effects
-     */
-    public void toImmutable() {
-        this.studyIds = unmodifiableList(this.getStudyIds());
-        this.sampleIds = unmodifiableList(this.getSampleIds());
-        this.patientIds = unmodifiableList(this.getPatientIds());
-        this.studyIdsOfPatients = unmodifiableList(this.getStudyIdsOfPatients());
-        this.uniqueSampleKeys = unmodifiableList(this.getUniqueSampleKeys());
-        this.uniquePatientKeys = unmodifiableList(this.getUniquePatientKeys());
-        this.sampleAttributeIds = unmodifiableList(this.getSampleAttributeIds());
-        this.patientAttributeIds = unmodifiableList(this.getPatientAttributeIds());
-        this.conflictingPatientAttributeIds = unmodifiableList(this.getConflictingPatientAttributeIds());
-    }
-
     public List<String> getStudyIds() {
         return studyIds;
     }

--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataBinUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataBinUtil.java
@@ -1,22 +1,32 @@
 package org.cbioportal.web.util;
 
+import org.cbioportal.model.Binnable;
 import org.cbioportal.model.ClinicalAttribute;
 import org.cbioportal.model.ClinicalData;
 import org.cbioportal.model.ClinicalDataBin;
-import org.cbioportal.service.ClinicalAttributeService;
-import org.cbioportal.service.PatientService;
-import org.cbioportal.service.util.ClinicalAttributeUtil;
+import org.cbioportal.service.AttributeByStudyService;
+import org.cbioportal.service.CustomDataService;
+import org.cbioportal.service.util.BinnableCustomDataValue;
+import org.cbioportal.service.util.CustomAttributeWithData;
+import org.cbioportal.service.util.CustomDataSession;
+import org.cbioportal.service.util.CustomDataValue;
 import org.cbioportal.web.parameter.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 @Component
 public class ClinicalDataBinUtil {
 
+    @Autowired
+    private AttributeByStudyService clinicalAttributeService;
     @Autowired
     private StudyViewFilterApplier studyViewFilterApplier;
     @Autowired
@@ -26,12 +36,10 @@ public class ClinicalDataBinUtil {
     @Autowired
     private StudyViewFilterUtil studyViewFilterUtil;
     @Autowired
-    private ClinicalAttributeService clinicalAttributeService;
+    private CustomDataService customDataService;
     @Autowired
-    private ClinicalAttributeUtil clinicalAttributeUtil;
-    @Autowired
-    private PatientService patientService;
-    
+    private IdPopulator idPopulator;
+
     public StudyViewFilter removeSelfFromFilter(ClinicalDataBinCountFilter dataBinCountFilter) {
         List<ClinicalDataBinFilter> attributes = dataBinCountFilter.getAttributes();
         StudyViewFilter studyViewFilter = dataBinCountFilter.getStudyViewFilter();
@@ -39,7 +47,7 @@ public class ClinicalDataBinUtil {
         if (attributes.size() == 1) {
             studyViewFilterUtil.removeSelfFromFilter(attributes.get(0).getAttributeId(), studyViewFilter);
         }
-        
+
         return studyViewFilter;
     }
 
@@ -48,230 +56,261 @@ public class ClinicalDataBinUtil {
         ClinicalDataBinCountFilter dataBinCountFilter
     ) {
         return this.fetchClinicalDataBinCounts(
-            dataBinMethod, 
-            dataBinCountFilter, 
+            dataBinMethod,
+            dataBinCountFilter,
             // by default call the method to remove self from filter
             true
         );
     }
-    
+
     public List<ClinicalDataBin> fetchClinicalDataBinCounts(
         DataBinMethod dataBinMethod,
         ClinicalDataBinCountFilter dataBinCountFilter,
         boolean shouldRemoveSelfFromFilter
     ) {
+        StudyViewFilter studyViewFilter = toStudyViewFilter(dataBinCountFilter, shouldRemoveSelfFromFilter);
+        List<SampleIdentifier> unfilteredSamples = filterByStudyAndSample(studyViewFilter);
+        List<String> attributeIds = toAttributeIds(dataBinCountFilter.getAttributes());
+        List<ClinicalAttribute> clinicalAttributes = fetchClinicalAttributes(attributeIds, unfilteredSamples);
+        BinningIds binningIds = idPopulator.populateIdLists(unfilteredSamples, clinicalAttributes);
+        Map<String, ClinicalDataType> attributeByDatatype = toAttributeDatatypeMap(binningIds);
+        BinningData<Binnable> unfilteredData = (BinningData<Binnable>) (BinningData<? extends Binnable>) fetchBinningData(binningIds);
+        return createBins(
+            dataBinMethod, 
+            dataBinCountFilter, 
+            studyViewFilter,
+            attributeByDatatype, 
+            clinicalAttributes,
+            binningIds, 
+            unfilteredSamples,
+            unfilteredData
+        );
+    }
+
+    public List<ClinicalDataBin> fetchCustomDataBinCounts(
+        DataBinMethod dataBinMethod,
+        ClinicalDataBinCountFilter dataBinCountFilter,
+        boolean shouldRemoveSelfFromFilter
+    ) {
+        List<String> attributeIds = toAttributeIds(dataBinCountFilter.getAttributes());
+        Map<String, CustomDataSession> customDataSessions = customDataService.getCustomDataSessions(attributeIds);
+        Map<String, List<Binnable>> customDataByAttributeId = createCustomDataByAttributeId(customDataSessions);
+        Map<String, ClinicalDataType> customAttributeByDatatype = createCustomAttributeDatatypeMap(customDataSessions);
+
+        StudyViewFilter studyViewFilter = toStudyViewFilter(dataBinCountFilter, shouldRemoveSelfFromFilter);
+        List<SampleIdentifier> unfilteredSamples = filterByStudyAndSample(studyViewFilter);
+        List<ClinicalAttribute> customDataAttributes = toCustomAttributes(customDataSessions);
+            
+        BinningIds unfilteredIds = idPopulator.populateIdLists(unfilteredSamples, customDataAttributes);
+        BinningData<Binnable> unfilteredData = fetchCustomBinningData(customDataByAttributeId, unfilteredIds);
+
+        return createBins(
+            dataBinMethod, 
+            dataBinCountFilter, 
+            studyViewFilter,
+            customAttributeByDatatype, 
+            customDataAttributes, 
+            unfilteredIds, 
+            unfilteredSamples,
+            unfilteredData
+        );
+    }
+
+    private List<ClinicalDataBin> createBins(
+        DataBinMethod dataBinMethod,
+        ClinicalDataBinCountFilter dataBinCountFilter,
+        StudyViewFilter studyViewFilter,
+        Map<String, ClinicalDataType> clinicalDataAttributeDatatypeMap,
+        List<ClinicalAttribute> clinicalAttributes,
+        BinningIds unfilteredIds,
+        List<SampleIdentifier> unfilteredSampleIds,
+        BinningData<Binnable> unfilteredData
+    ) {
+        List<SampleIdentifier> filteredSampleIds = filterSampleIds(studyViewFilter, unfilteredSampleIds);
+
+        BinningIds filteredIds;
+        List<Binnable> filteredClinicalData;
+        if (filteredSampleIds.equals(unfilteredSampleIds)) {
+            // if filtered and unfiltered samples are exactly the same, no need to fetch clinical data again:
+            filteredIds = new BinningIds(unfilteredIds);
+            filteredClinicalData = unfilteredData.getAllData();
+        } else {
+            filteredIds = idPopulator.populateIdLists(filteredSampleIds, clinicalAttributes);
+            filteredClinicalData = filterClinicalData(unfilteredData, filteredIds);
+        }
+
         List<ClinicalDataBinFilter> attributes = dataBinCountFilter.getAttributes();
+        if (dataBinMethod == DataBinMethod.STATIC) {
+            if (unfilteredSampleIds.isEmpty() || unfilteredData.getAllData().isEmpty()) {
+                return emptyList();
+            }
+            return calculateStaticDataBins(
+                attributes,
+                clinicalDataAttributeDatatypeMap,
+                toClinicalDataByAttributeId(unfilteredData.getAllData()),
+                toClinicalDataByAttributeId(filteredClinicalData),
+                unfilteredIds.getUniqueSampleKeys(),
+                unfilteredIds.getUniquePatientKeys(),
+                filteredIds.getUniqueSampleKeys(),
+                filteredIds.getUniquePatientKeys()
+            );
+        } else { // dataBinMethod == DataBinMethod.DYNAMIC
+            if (filteredClinicalData.isEmpty()) {
+                return emptyList();
+            }
+            return calculateDynamicDataBins(
+                attributes,
+                clinicalDataAttributeDatatypeMap,
+                toClinicalDataByAttributeId(filteredClinicalData),
+                filteredIds.getUniqueSampleKeys(),
+                filteredIds.getUniquePatientKeys()
+            );
+        }
+    }
+
+    private List<ClinicalAttribute> toCustomAttributes(
+        Map<String, CustomDataSession> customDataSessions
+    ) {
+        return customDataSessions
+            .entrySet()
+            .stream()
+            .map(e -> toClinicalAttribute(e.getKey(), e.getValue().getData()))
+            .collect(toList());
+    }
+
+    private ClinicalAttribute toClinicalAttribute(String key, CustomAttributeWithData data) {
+        ClinicalAttribute result = new ClinicalAttribute();
+        result.setPatientAttribute(data.getPatientAttribute());
+        result.setAttrId(key);
+        result.setDatatype(data.getDatatype());
+        return result;
+    }
+
+    private Map<String, List<Binnable>> toClinicalDataByAttributeId(List<Binnable> unfilteredData) {
+        return unfilteredData.stream().collect(Collectors.groupingBy(Binnable::getAttrId));
+    }
+
+    private List<Binnable> filterClinicalData(
+        BinningData<Binnable> unfilteredData, 
+        BinningIds filteredIds
+    ) {
+        return studyViewFilterUtil.filterClinicalData(
+            unfilteredData.samples,
+            unfilteredData.patients,
+            unfilteredData.conflictingPatientAttributes,
+            filteredIds.getStudyIds(),
+            filteredIds.getSampleIds(),
+            filteredIds.getStudyIdsOfPatients(),
+            filteredIds.getPatientIds(),
+            filteredIds.getSampleAttributeIds(),
+            filteredIds.getPatientAttributeIds(),
+            filteredIds.getConflictingPatientAttributeIds()
+        );
+    }
+
+    private List<SampleIdentifier> filterSampleIds(StudyViewFilter studyViewFilter, List<SampleIdentifier> unfilteredSampleIds) {
+        return studyViewFilterUtil.shouldSkipFilterForClinicalDataBins(studyViewFilter)
+            ? unfilteredSampleIds
+            : studyViewFilterApplier.apply(studyViewFilter);
+    }
+
+    private List<String> toAttributeIds(List<ClinicalDataBinFilter> dataBinCountFilter) {
+        return dataBinCountFilter.stream()
+            .map(ClinicalDataBinFilter::getAttributeId).collect(toList());
+    }
+
+    private StudyViewFilter toStudyViewFilter(ClinicalDataBinCountFilter dataBinCountFilter, boolean shouldRemoveSelfFromFilter) {
         StudyViewFilter studyViewFilter = dataBinCountFilter.getStudyViewFilter();
 
         if (shouldRemoveSelfFromFilter) {
             studyViewFilter = removeSelfFromFilter(dataBinCountFilter);
         }
+        return studyViewFilter;
+    }
 
-        List<String> attributeIds = attributes.stream().map(ClinicalDataBinFilter::getAttributeId).collect(Collectors.toList());
+    private Map<String, List<Binnable>> createCustomDataByAttributeId(Map<String, CustomDataSession> customDataSessions) {
+        return customDataSessions.entrySet().stream()
+            .collect(toMap(
+                Map.Entry::getKey,
+                entry -> entry
+                    .getValue()
+                    .getData()
+                    .getData()
+                    .stream()
+                    .map(mapCustomToBinnable(entry))
+                    .collect(toList())
+            ));
+    }
 
-        // filter only by study id and sample identifiers, ignore rest
-        List<SampleIdentifier> unfilteredSampleIdentifiers = filterByStudyAndSample(studyViewFilter);
-
-        List<String> unfilteredStudyIds = new ArrayList<>();
-        List<String> unfilteredSampleIds = new ArrayList<>();
-        List<String> unfilteredPatientIds = new ArrayList<>();
-        List<String> studyIdsOfUnfilteredPatients = new ArrayList<>();
-        List<String> unfilteredUniqueSampleKeys = new ArrayList<>();
-        List<String> unfilteredUniquePatientKeys = new ArrayList<>();
-        List<String> unfilteredSampleAttributeIds = new ArrayList<>();
-        List<String> unfilteredPatientAttributeIds = new ArrayList<>();
-        // patient attributes which are also sample attributes in other studies
-        List<String> unfilteredConflictingPatientAttributeIds = new ArrayList<>();
-
-        populateIdLists(
-            // input
-            unfilteredSampleIdentifiers,
-            attributeIds,
-
-            // output
-            unfilteredStudyIds,
-            unfilteredSampleIds,
-            unfilteredPatientIds,
-            studyIdsOfUnfilteredPatients,
-            unfilteredUniqueSampleKeys,
-            unfilteredUniquePatientKeys,
-            unfilteredSampleAttributeIds,
-            unfilteredPatientAttributeIds,
-            unfilteredConflictingPatientAttributeIds
+    private BinningData<ClinicalData> fetchBinningData(BinningIds binningIds) {
+        List<ClinicalData> samples = clinicalDataFetcher.fetchClinicalDataForSamples(
+            binningIds.getStudyIds(),
+            binningIds.getSampleIds(),
+            binningIds.getSampleAttributeIds()
         );
 
-        Map<String, ClinicalDataType> attributeDatatypeMap = constructAttributeDataMap(
-            unfilteredSampleAttributeIds,
-            unfilteredPatientAttributeIds,
-            unfilteredConflictingPatientAttributeIds
+        List<ClinicalData> patients = clinicalDataFetcher.fetchClinicalDataForPatients(
+            binningIds.getStudyIdsOfPatients(),
+            binningIds.getPatientIds(),
+            binningIds.getPatientAttributeIds()
         );
 
-        List<ClinicalData> unfilteredClinicalDataForSamples = clinicalDataFetcher.fetchClinicalDataForSamples(
-            unfilteredStudyIds,
-            unfilteredSampleIds,
-            new ArrayList<>(unfilteredSampleAttributeIds)
+        List<ClinicalData> conflictingPatientAttributes = clinicalDataFetcher.fetchClinicalDataForConflictingPatientAttributes(
+            binningIds.getStudyIdsOfPatients(),
+            binningIds.getPatientIds(),
+            binningIds.getConflictingPatientAttributeIds()
         );
-
-        List<ClinicalData> unfilteredClinicalDataForPatients = clinicalDataFetcher.fetchClinicalDataForPatients(
-            studyIdsOfUnfilteredPatients,
-            unfilteredPatientIds,
-            new ArrayList<>(unfilteredPatientAttributeIds)
-        );
-
-        List<ClinicalData> unfilteredClinicalDataForConflictingPatientAttributes = clinicalDataFetcher.fetchClinicalDataForConflictingPatientAttributes(
-            studyIdsOfUnfilteredPatients,
-            unfilteredPatientIds,
-            new ArrayList<>(unfilteredConflictingPatientAttributeIds)
-        );
-
-        List<ClinicalData> unfilteredClinicalData = Stream.of(
-            unfilteredClinicalDataForSamples,
-            unfilteredClinicalDataForPatients,
-            unfilteredClinicalDataForConflictingPatientAttributes
-        ).flatMap(Collection::stream).collect(Collectors.toList());
-
-        // if filters are practically the same no need to re-apply them
-        List<SampleIdentifier> filteredSampleIdentifiers =
-            studyViewFilterUtil.shouldSkipFilterForClinicalDataBins(studyViewFilter) ?
-                unfilteredSampleIdentifiers : studyViewFilterApplier.apply(studyViewFilter);
-
-        List<String> filteredUniqueSampleKeys;
-        List<String> filteredUniquePatientKeys;
-        List<ClinicalData> filteredClinicalData;
-
-        // if filtered and unfiltered samples are exactly the same, no need to fetch clinical data again
-        if (filteredSampleIdentifiers.equals(unfilteredSampleIdentifiers)) {
-            filteredUniqueSampleKeys = unfilteredUniqueSampleKeys;
-            filteredUniquePatientKeys = unfilteredUniquePatientKeys;
-            filteredClinicalData = unfilteredClinicalData;
-        }
-        else {
-            List<String> filteredStudyIds = new ArrayList<>();
-            List<String> filteredSampleIds = new ArrayList<>();
-            List<String> filteredPatientIds = new ArrayList<>();
-            List<String> studyIdsOfFilteredPatients = new ArrayList<>();
-            filteredUniqueSampleKeys = new ArrayList<>();
-            filteredUniquePatientKeys = new ArrayList<>();
-            List<String> filteredSampleAttributeIds = new ArrayList<>();
-            List<String> filteredPatientAttributeIds = new ArrayList<>();
-            // patient attributes which are also sample attributes in other studies
-            List<String> filteredConflictingPatientAttributeIds = new ArrayList<>();
-
-            populateIdLists(
-                // input
-                filteredSampleIdentifiers,
-                attributeIds,
-
-                // output
-                filteredStudyIds,
-                filteredSampleIds,
-                filteredPatientIds,
-                studyIdsOfFilteredPatients,
-                filteredUniqueSampleKeys,
-                filteredUniquePatientKeys,
-                filteredSampleAttributeIds,
-                filteredPatientAttributeIds,
-                filteredConflictingPatientAttributeIds
-            );
-
-            filteredClinicalData = studyViewFilterUtil.filterClinicalData(
-                unfilteredClinicalDataForSamples,
-                unfilteredClinicalDataForPatients,
-                unfilteredClinicalDataForConflictingPatientAttributes,
-                filteredStudyIds,
-                filteredSampleIds,
-                studyIdsOfFilteredPatients,
-                filteredPatientIds,
-                filteredSampleAttributeIds,
-                filteredPatientAttributeIds,
-                filteredConflictingPatientAttributeIds
-            );
-        }
-
-        Map<String, List<ClinicalData>> unfilteredClinicalDataByAttributeId =
-            unfilteredClinicalData.stream().collect(Collectors.groupingBy(ClinicalData::getAttrId));
-
-        Map<String, List<ClinicalData>> filteredClinicalDataByAttributeId =
-            filteredClinicalData.stream().collect(Collectors.groupingBy(ClinicalData::getAttrId));
-
-        List<ClinicalDataBin> clinicalDataBins = Collections.emptyList();
-
-        if (dataBinMethod == DataBinMethod.STATIC) {
-            if (!unfilteredSampleIdentifiers.isEmpty() && !unfilteredClinicalData.isEmpty()) {
-                clinicalDataBins = calculateStaticDataBins(
-                    attributes,
-                    attributeDatatypeMap,
-                    unfilteredClinicalDataByAttributeId,
-                    filteredClinicalDataByAttributeId,
-                    unfilteredUniqueSampleKeys,
-                    unfilteredUniquePatientKeys,
-                    filteredUniqueSampleKeys,
-                    filteredUniquePatientKeys
-                );
-            }
-        }
-        else { // dataBinMethod == DataBinMethod.DYNAMIC
-            if (!filteredClinicalData.isEmpty()) {
-                clinicalDataBins = calculateDynamicDataBins(
-                    attributes,
-                    attributeDatatypeMap,
-                    filteredClinicalDataByAttributeId,
-                    filteredUniqueSampleKeys,
-                    filteredUniquePatientKeys
-                );
-            }
-        }
-        
-        return clinicalDataBins;
+        return new BinningData<>(samples, patients, conflictingPatientAttributes);
     }
     
-    public void populateIdLists(
-        // input lists
-        List<SampleIdentifier> sampleIdentifiers,
-        List<String> attributeIds,
-        // lists to get populated
-        List<String> studyIds,
-        List<String> sampleIds,
-        List<String> patientIds,
-        List<String> studyIdsOfPatients,
-        List<String> uniqueSampleKeys,
-        List<String> uniquePatientKeys,
-        List<String> sampleAttributeIds,
-        List<String> patientAttributeIds,
-        List<String> conflictingPatientAttributeIds
+    private BinningData<Binnable> fetchCustomBinningData(
+        Map<String, List<Binnable>> clinicalDataByAttributeId, 
+        BinningIds binningIds
     ) {
-        studyViewFilterUtil.extractStudyAndSampleIds(
-            sampleIdentifiers,
-            studyIds,
-            sampleIds
+        List<Binnable> clinicalDataForPatients = clinicalDataByAttributeId
+            .values()
+            .stream()
+            .filter(e -> e.get(0).isPatientAttribute())
+            .flatMap(List::stream)
+            .collect(toList());
+
+        List<Binnable> clinicalDataForSamples = clinicalDataByAttributeId
+            .values()
+            .stream()
+            .filter(e -> !e.get(0).isPatientAttribute())
+            .flatMap(List::stream)
+            .collect(toList());
+
+        List<ClinicalData> unfilteredClinicalDataForConflictingPatientAttributes = clinicalDataFetcher.fetchClinicalDataForConflictingPatientAttributes(
+            binningIds.getStudyIdsOfPatients(),
+            binningIds.getPatientIds(),
+            binningIds.getConflictingPatientAttributeIds()
         );
+        return new BinningData<>(
+            clinicalDataForSamples,
+            clinicalDataForPatients,
+            (List<Binnable>) (List<? extends Binnable>) unfilteredClinicalDataForConflictingPatientAttributes
+        );
+    }
 
-        patientService.getPatientsOfSamples(studyIds, sampleIds).stream().forEach(patient -> {
-            patientIds.add(patient.getStableId());
-            studyIdsOfPatients.add(patient.getCancerStudyIdentifier());
-        });
 
-        uniqueSampleKeys.addAll(studyViewFilterApplier.getUniqkeyKeys(studyIds, sampleIds));
-        uniquePatientKeys.addAll(studyViewFilterApplier.getUniqkeyKeys(studyIdsOfPatients, patientIds));
-
-        if (attributeIds != null) {
-            List<ClinicalAttribute> clinicalAttributes = clinicalAttributeService
-                .getClinicalAttributesByStudyIdsAndAttributeIds(studyIds, attributeIds);
-
-            clinicalAttributeUtil.extractCategorizedClinicalAttributes(
-                clinicalAttributes,
-                sampleAttributeIds,
-                patientAttributeIds,
-                conflictingPatientAttributeIds
+    private Function<CustomDataValue, Binnable> mapCustomToBinnable(Map.Entry<String, CustomDataSession> entry) {
+        return customDataValue -> {
+            final String attributeId = entry.getKey();
+            final Boolean patientAttribute = entry.getValue().getData().getPatientAttribute();
+            return new BinnableCustomDataValue(
+                customDataValue, 
+                attributeId, 
+                patientAttribute
             );
-        }
+        };
     }
 
     public List<ClinicalDataBin> calculateStaticDataBins(
-        List<ClinicalDataBinFilter> attributes,
+        List<ClinicalDataBinFilter> attributes, 
         Map<String, ClinicalDataType> attributeDatatypeMap,
-        Map<String, List<ClinicalData>> unfilteredClinicalDataByAttributeId,
-        Map<String, List<ClinicalData>> filteredClinicalDataByAttributeId,
+        Map<String, List<Binnable>> unfilteredClinicalDataByAttributeId,
+        Map<String, List<Binnable>> filteredClinicalDataByAttributeId,
         List<String> unfilteredUniqueSampleKeys,
         List<String> unfilteredUniquePatientKeys,
         List<String> filteredUniqueSampleKeys,
@@ -291,13 +330,13 @@ public class ClinicalDataBinUtil {
                 List<ClinicalDataBin> dataBins = dataBinner
                     .calculateClinicalDataBins(attribute, clinicalDataType,
                         filteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(),
-                            Collections.emptyList()),
+                            emptyList()),
                         unfilteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(),
-                            Collections.emptyList()),
+                            emptyList()),
                         filteredIds, unfilteredIds)
                     .stream()
                     .map(dataBin -> studyViewFilterUtil.dataBinToClinicalDataBin(attribute, dataBin))
-                    .collect(Collectors.toList());
+                    .collect(toList());
 
                 clinicalDataBins.addAll(dataBins);
             }
@@ -309,7 +348,7 @@ public class ClinicalDataBinUtil {
     public List<ClinicalDataBin> calculateDynamicDataBins(
         List<ClinicalDataBinFilter> attributes,
         Map<String, ClinicalDataType> attributeDatatypeMap,
-        Map<String, List<ClinicalData>> filteredClinicalDataByAttributeId,
+        Map<String, List<Binnable>> filteredClinicalDataByAttributeId,
         List<String> filteredUniqueSampleKeys,
         List<String> filteredUniquePatientKeys
     ) {
@@ -317,6 +356,7 @@ public class ClinicalDataBinUtil {
 
         for (ClinicalDataBinFilter attribute : attributes) {
 
+            // if there is clinical data for requested attribute
             if (attributeDatatypeMap.containsKey(attribute.getAttributeId())) {
                 ClinicalDataType clinicalDataType = attributeDatatypeMap.get(attribute.getAttributeId());
                 List<String> filteredIds = clinicalDataType == ClinicalDataType.PATIENT
@@ -326,36 +366,51 @@ public class ClinicalDataBinUtil {
                 List<ClinicalDataBin> dataBins = dataBinner
                     .calculateDataBins(attribute, clinicalDataType,
                         filteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(),
-                            Collections.emptyList()),
+                            emptyList()),
                         filteredIds)
                     .stream()
                     .map(dataBin -> studyViewFilterUtil.dataBinToClinicalDataBin(attribute, dataBin))
-                    .collect(Collectors.toList());
+                    .collect(toList());
                 clinicalDataBins.addAll(dataBins);
             }
         }
 
         return clinicalDataBins;
     }
-
-    public Map<String, ClinicalDataType> constructAttributeDataMap(
+    private Map<String, ClinicalDataType> toAttributeDatatypeMap(BinningIds binningIds) {
+        return toAttributeDatatypeMap(
+            binningIds.getSampleAttributeIds(),
+            binningIds.getPatientAttributeIds(),
+            binningIds.getConflictingPatientAttributeIds()
+        );
+    }
+    public Map<String, ClinicalDataType> toAttributeDatatypeMap(
         List<String> sampleAttributeIds,
         List<String> patientAttributeIds,
         List<String> conflictingPatientAttributeIds
     ) {
         Map<String, ClinicalDataType> attributeDatatypeMap = new HashMap<>();
 
-        sampleAttributeIds.forEach(attribute->{
+        sampleAttributeIds.forEach(attribute -> {
             attributeDatatypeMap.put(attribute, ClinicalDataType.SAMPLE);
         });
-        patientAttributeIds.forEach(attribute->{
+        patientAttributeIds.forEach(attribute -> {
             attributeDatatypeMap.put(attribute, ClinicalDataType.PATIENT);
         });
-        conflictingPatientAttributeIds.forEach(attribute->{
+        conflictingPatientAttributeIds.forEach(attribute -> {
             attributeDatatypeMap.put(attribute, ClinicalDataType.SAMPLE);
         });
 
         return attributeDatatypeMap;
+    }
+
+    private Map<String, ClinicalDataType> createCustomAttributeDatatypeMap(
+        Map<String, CustomDataSession> customDataSessions
+    ) {
+        return customDataSessions.entrySet().stream().collect(toMap(
+            Map.Entry::getKey,
+            ClinicalDataBinUtil::getDataType
+        ));
     }
 
     public List<SampleIdentifier> filterByStudyAndSample(
@@ -372,4 +427,22 @@ public class ClinicalDataBinUtil {
 
         return studyViewFilterApplier.apply(filter);
     }
+
+    private static ClinicalDataType getDataType(Map.Entry<String, CustomDataSession> entry) {
+        return entry.getValue().getData().getPatientAttribute() ? ClinicalDataType.PATIENT : ClinicalDataType.SAMPLE;
+    }
+    
+    private List<ClinicalAttribute> fetchClinicalAttributes(List<String> attributeIds, List<SampleIdentifier> unfilteredSamples) {
+
+        List<String> studyIds = new ArrayList<>();
+        List<String> sampleIds = new ArrayList<>();
+        studyViewFilterUtil.extractStudyAndSampleIds(
+            unfilteredSamples,
+            studyIds,
+            sampleIds
+        );
+        
+       return clinicalAttributeService.getClinicalAttributesByStudyIdsAndAttributeIds(studyIds, attributeIds);
+    }
+    
 }

--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataEqualityFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataEqualityFilterApplier.java
@@ -26,7 +26,8 @@ public class ClinicalDataEqualityFilterApplier extends ClinicalDataFilterApplier
                          MultiKeyMap clinicalDataMap,
                          String entityId,
                          String studyId,
-                         Boolean negateFilters) {
+                         Boolean negateFilters
+    ) {
         return studyViewFilterUtil.getFilteredCountByDataEquality(attributes, clinicalDataMap, entityId, studyId, negateFilters);
     }
 }

--- a/web/src/main/java/org/cbioportal/web/util/ClinicalDataFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/ClinicalDataFilterApplier.java
@@ -13,22 +13,27 @@ import org.cbioportal.web.parameter.ClinicalDataFilter;
 import org.cbioportal.web.parameter.Projection;
 import org.cbioportal.web.parameter.SampleIdentifier;
 
-public abstract class ClinicalDataFilterApplier {
+public abstract class ClinicalDataFilterApplier implements DataFilterApplier<ClinicalDataFilter> {
     private PatientService patientService;
     private ClinicalDataService clinicalDataService;
     protected StudyViewFilterUtil studyViewFilterUtil;
 
-    public ClinicalDataFilterApplier(PatientService patientService,
-                                     ClinicalDataService clinicalDataService,
-                                     StudyViewFilterUtil studyViewFilterUtil) {
+    public ClinicalDataFilterApplier(
+        PatientService patientService,
+        ClinicalDataService clinicalDataService,
+        StudyViewFilterUtil studyViewFilterUtil
+    ) {
         this.patientService = patientService;
         this.clinicalDataService = clinicalDataService;
         this.studyViewFilterUtil = studyViewFilterUtil;
     }
 
-    public List<SampleIdentifier> apply(List<SampleIdentifier> sampleIdentifiers,
-                                        List<ClinicalDataFilter> clinicalDataFilters,
-                                        Boolean negateFilters) {
+    @Override
+    public List<SampleIdentifier> apply(
+        List<SampleIdentifier> sampleIdentifiers,
+        List<ClinicalDataFilter> clinicalDataFilters,
+        Boolean negateFilters
+    ) {
         if (!clinicalDataFilters.isEmpty() && !sampleIdentifiers.isEmpty()) {
             List<String> studyIds = new ArrayList<>();
             List<String> sampleIds = new ArrayList<>();

--- a/web/src/main/java/org/cbioportal/web/util/CustomDataDatatype.java
+++ b/web/src/main/java/org/cbioportal/web/util/CustomDataDatatype.java
@@ -1,0 +1,13 @@
+package org.cbioportal.web.util;
+
+public enum CustomDataDatatype {
+    /**
+     * Categorical data
+     */
+    STRING,
+
+    /**
+     * Numerical data
+     */
+    NUMBER
+}

--- a/web/src/main/java/org/cbioportal/web/util/CustomDataFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/CustomDataFilterApplier.java
@@ -105,7 +105,7 @@ public class CustomDataFilterApplier implements DataFilterApplier<ClinicalDataFi
                 .get(attributeId)
                 .getData()
                 .getDatatype()
-                .equals(CustomDataDatatype.STRING.name())
+                .equals(CustomDatatype.STRING.name())
             ) {
                 equalityFilters.add(filter);
             } else {

--- a/web/src/main/java/org/cbioportal/web/util/CustomDatatype.java
+++ b/web/src/main/java/org/cbioportal/web/util/CustomDatatype.java
@@ -1,6 +1,6 @@
 package org.cbioportal.web.util;
 
-public enum CustomDataDatatype {
+public enum CustomDatatype {
     /**
      * Categorical data
      */

--- a/web/src/main/java/org/cbioportal/web/util/DataFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/DataFilterApplier.java
@@ -1,0 +1,15 @@
+package org.cbioportal.web.util;
+
+import org.cbioportal.web.parameter.DataFilter;
+import org.cbioportal.web.parameter.SampleIdentifier;
+
+import java.util.List;
+
+public interface DataFilterApplier<T extends DataFilter> {
+
+    List<SampleIdentifier> apply(
+        List<SampleIdentifier> sampleIdentifiers,
+        List<T> dataFilters,
+        Boolean negateFilters
+    );
+}

--- a/web/src/main/java/org/cbioportal/web/util/IdPopulator.java
+++ b/web/src/main/java/org/cbioportal/web/util/IdPopulator.java
@@ -54,7 +54,7 @@ public class IdPopulator {
         uniqueSampleKeys.addAll(studyViewFilterApplier.getUniqkeyKeys(studyIds, sampleIds));
         uniquePatientKeys.addAll(studyViewFilterApplier.getUniqkeyKeys(studyIdsOfPatients, patientIds));
 
-        if (clinicalAttributes != null && ! clinicalAttributes.isEmpty()) {
+        if (clinicalAttributes != null && !clinicalAttributes.isEmpty()) {
             clinicalAttributeUtil.extractCategorizedClinicalAttributes(
                 clinicalAttributes,
                 sampleAttributeIds,
@@ -62,7 +62,6 @@ public class IdPopulator {
                 conflictingPatientAttributeIds
             );
         }
-        binningIds.toImmutable();
         return binningIds;
     }
 

--- a/web/src/main/java/org/cbioportal/web/util/IdPopulator.java
+++ b/web/src/main/java/org/cbioportal/web/util/IdPopulator.java
@@ -1,0 +1,69 @@
+package org.cbioportal.web.util;
+
+import org.cbioportal.model.ClinicalAttribute;
+import org.cbioportal.service.AttributeByStudyService;
+import org.cbioportal.service.PatientService;
+import org.cbioportal.service.util.ClinicalAttributeUtil;
+import org.cbioportal.web.parameter.SampleIdentifier;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class IdPopulator {
+    
+    @Autowired
+    private ClinicalAttributeUtil clinicalAttributeUtil;
+    @Autowired
+    private StudyViewFilterApplier studyViewFilterApplier;
+    @Autowired
+    private StudyViewFilterUtil studyViewFilterUtil;
+    @Autowired
+    private PatientService patientService;
+    
+    public IdPopulator() {}
+
+    public BinningIds populateIdLists(
+        List<SampleIdentifier> samples,
+        List<ClinicalAttribute> clinicalAttributes
+    ) {
+        BinningIds binningIds = new BinningIds();
+        List<String> studyIds = binningIds.getStudyIds();
+        List<String> sampleIds = binningIds.getSampleIds();
+        List<String> patientIds = binningIds.getPatientIds();
+        List<String> studyIdsOfPatients = binningIds.getStudyIdsOfPatients();
+        List<String> uniqueSampleKeys = binningIds.getUniqueSampleKeys();
+        List<String> uniquePatientKeys = binningIds.getUniquePatientKeys();
+        List<String> sampleAttributeIds = binningIds.getSampleAttributeIds();
+        List<String> patientAttributeIds = binningIds.getPatientAttributeIds();
+        List<String> conflictingPatientAttributeIds = binningIds.getConflictingPatientAttributeIds();
+
+        studyViewFilterUtil.extractStudyAndSampleIds(
+            samples,
+            studyIds,
+            sampleIds
+        );
+
+        patientService.getPatientsOfSamples(studyIds, sampleIds).forEach(patient -> {
+            patientIds.add(patient.getStableId());
+            studyIdsOfPatients.add(patient.getCancerStudyIdentifier());
+        });
+
+        uniqueSampleKeys.addAll(studyViewFilterApplier.getUniqkeyKeys(studyIds, sampleIds));
+        uniquePatientKeys.addAll(studyViewFilterApplier.getUniqkeyKeys(studyIdsOfPatients, patientIds));
+
+        if (clinicalAttributes != null && ! clinicalAttributes.isEmpty()) {
+            clinicalAttributeUtil.extractCategorizedClinicalAttributes(
+                clinicalAttributes,
+                sampleAttributeIds,
+                patientAttributeIds,
+                conflictingPatientAttributeIds
+            );
+        }
+        binningIds.toImmutable();
+        return binningIds;
+    }
+
+}

--- a/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
+++ b/web/src/main/java/org/cbioportal/web/util/InvolvedCancerStudyExtractorInterceptor.java
@@ -73,6 +73,7 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
     public static final String MUTATION_MULTIPLE_STUDY_FETCH_PATH = "/mutations/fetch";
     public static final String COPY_NUMBER_SEG_FETCH_PATH = "/copy-number-segments/fetch";
     public static final String STUDY_VIEW_CLINICAL_DATA_BIN_COUNTS_PATH = "/clinical-data-bin-counts/fetch";
+    public static final String STUDY_VIEW_CUSTOM_DATA_BIN_COUNTS_PATH = "/custom-data-bin-counts/fetch";
     public static final String STUDY_VIEW_GENOMICL_DATA_BIN_COUNTS_PATH = "/genomic-data-bin-counts/fetch";
     public static final String STUDY_VIEW_GENERIC_ASSAY_DATA_BIN_COUNTS_PATH = "/generic-assay-data-bin-counts/fetch";
     public static final String STUDY_VIEW_GENERIC_ASSAY_DATA_COUNTS_PATH = "/generic-assay-data-counts/fetch";
@@ -124,7 +125,7 @@ public class InvolvedCancerStudyExtractorInterceptor extends HandlerInterceptorA
             return extractAttributesFromMutationMultipleStudyFilter(request);
         } else if (requestPathInfo.equals(COPY_NUMBER_SEG_FETCH_PATH)) {
             return extractAttributesFromSampleIdentifiers(request);
-        } else if (requestPathInfo.equals(STUDY_VIEW_CLINICAL_DATA_BIN_COUNTS_PATH)) {
+        } else if (Arrays.asList(STUDY_VIEW_CLINICAL_DATA_BIN_COUNTS_PATH, STUDY_VIEW_CUSTOM_DATA_BIN_COUNTS_PATH).contains(requestPathInfo)) {
             return extractAttributesFromClinicalDataBinCountFilter(request);
         } else if (requestPathInfo.equals(STUDY_VIEW_GENOMICL_DATA_BIN_COUNTS_PATH)) {
             return extractAttributesFromGenomicDataBinCountFilter(request);

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -53,6 +53,8 @@ public class StudyViewFilterApplier {
     @Autowired
     private ClinicalDataIntervalFilterApplier clinicalDataIntervalFilterApplier;
     @Autowired
+    private CustomDataFilterApplier customDataFilterApplier;
+    @Autowired
     private StudyViewFilterUtil studyViewFilterUtil;
     @Autowired
     private GeneService geneService;
@@ -68,8 +70,6 @@ public class StudyViewFilterApplier {
     private DataBinner dataBinner;
     @Autowired
     private StructuralVariantService structuralVariantService;
-    @Autowired
-    private CustomDataFilterApplier customDataFilterApplier;
     @Autowired
     private MolecularProfileUtil molecularProfileUtil;
 
@@ -568,16 +568,16 @@ public class StudyViewFilterApplier {
             removeSelfFromFilter(dataBinFilters.get(0), studyViewFilter);
         }
 
-        List<U> resultDataBins = new ArrayList<>();
+        List<U> resultDataBins;
         List<String> filteredSampleIds = new ArrayList<>();
         List<String> filteredStudyIds = new ArrayList<>();
-        List<ClinicalData> filteredData = fetchData(dataBinCountFilter, studyViewFilter, filteredSampleIds,
+        List<Binnable> filteredData = fetchData(dataBinCountFilter, studyViewFilter, filteredSampleIds,
                 filteredStudyIds);
 
         List<String> filteredUniqueSampleKeys = getUniqkeyKeys(filteredStudyIds, filteredSampleIds);
 
-        Map<String, List<ClinicalData>> filteredClinicalDataByAttributeId = filteredData.stream()
-                .collect(Collectors.groupingBy(ClinicalData::getAttrId));
+        Map<String, List<Binnable>> filteredClinicalDataByAttributeId = filteredData.stream()
+                .collect(Collectors.groupingBy(Binnable::getAttrId));
 
         if (dataBinMethod == DataBinMethod.STATIC) {
 
@@ -589,15 +589,15 @@ public class StudyViewFilterApplier {
 
             List<String> unfilteredSampleIds = new ArrayList<>();
             List<String> unfilteredStudyIds = new ArrayList<>();
-            List<ClinicalData> unfilteredData = fetchData(dataBinCountFilter, filter, unfilteredSampleIds,
+            List<Binnable> unfilteredData = fetchData(dataBinCountFilter, filter, unfilteredSampleIds,
                     unfilteredStudyIds);
 
             List<String> unFilteredUniqueSampleKeys = getUniqkeyKeys(unfilteredSampleIds, unfilteredStudyIds);
 
-            Map<String, List<ClinicalData>> unfilteredDataByAttributeId = unfilteredData.stream()
-                    .collect(Collectors.groupingBy(ClinicalData::getAttrId));
+            Map<String, List<Binnable>> unfilteredDataByAttributeId = unfilteredData.stream()
+                    .collect(Collectors.groupingBy(Binnable::getAttrId));
 
-            resultDataBins = (List<U>) dataBinFilters.stream().flatMap(dataBinFilter -> {
+            resultDataBins = dataBinFilters.stream().flatMap(dataBinFilter -> {
                 String attributeId = getAttributeUniqueKey(dataBinFilter);
                 return dataBinner
                         .calculateClinicalDataBins(dataBinFilter, ClinicalDataType.SAMPLE,
@@ -622,8 +622,12 @@ public class StudyViewFilterApplier {
         return resultDataBins;
     }
 
-    private <S extends DataBinCountFilter> List<ClinicalData> fetchData(S dataBinCountFilter,
-            StudyViewFilter studyViewFilter, List<String> sampleIds, List<String> studyIds) {
+    private <S extends DataBinCountFilter> List<Binnable> fetchData(
+        S dataBinCountFilter,
+        StudyViewFilter studyViewFilter, 
+        List<String> sampleIds, 
+        List<String> studyIds
+    ) {
 
         List<SampleIdentifier> filteredSampleIdentifiers = apply(studyViewFilter);
         studyViewFilterUtil.extractStudyAndSampleIds(filteredSampleIdentifiers, studyIds, sampleIds);

--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
@@ -5,14 +5,15 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.map.MultiKeyMap;
-import org.cbioportal.model.ClinicalData;
+import org.cbioportal.model.Binnable;
 import org.cbioportal.model.ClinicalDataBin;
 import org.cbioportal.model.ClinicalDataCount;
 import org.cbioportal.model.ClinicalDataCountItem;
 import org.cbioportal.model.DataBin;
-import org.cbioportal.model.MolecularProfile;
 import org.cbioportal.model.Patient;
 import org.cbioportal.model.SampleList;
+import org.cbioportal.service.util.CustomDataSession;
+import org.cbioportal.service.util.CustomDataValue;
 import org.cbioportal.service.util.MolecularProfileUtil;
 import org.cbioportal.web.parameter.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +24,11 @@ public class StudyViewFilterUtil {
     @Autowired
     private MolecularProfileUtil molecularProfileUtil;
     
-    public void extractStudyAndSampleIds(List<SampleIdentifier> sampleIdentifiers, List<String> studyIds, List<String> sampleIds) {
+    public void extractStudyAndSampleIds(
+        List<SampleIdentifier> sampleIdentifiers, 
+        List<String> studyIds, 
+        List<String> sampleIds
+    ) {
         for (SampleIdentifier sampleIdentifier : sampleIdentifiers) {
             studyIds.add(sampleIdentifier.getStudyId());
             sampleIds.add(sampleIdentifier.getSampleId());
@@ -103,7 +108,7 @@ public class StudyViewFilterUtil {
         return count;
     }
 
-    public List<ClinicalDataCountItem> getClinicalDataCountsFromCustomData(List<CustomDataSession> customDataSessions,
+    public List<ClinicalDataCountItem> getClinicalDataCountsFromCustomData(Collection<CustomDataSession> customDataSessions,
             Map<String, SampleIdentifier> filteredSamplesMap, List<Patient> patients) {
         int totalSamplesCount = filteredSamplesMap.keySet().size();
         int totalPatientsCount = patients.size();
@@ -111,10 +116,9 @@ public class StudyViewFilterUtil {
         return customDataSessions.stream().map(customDataSession -> {
 
             Map<String, List<CustomDataValue>> groupedDatabyValue = customDataSession.getData().getData().stream()
-                    .filter(datum -> {
-                        return filteredSamplesMap
-                                .containsKey(getCaseUniqueKey(datum.getStudyId(), datum.getSampleId()));
-                    }).collect(Collectors.groupingBy(CustomDataValue::getValue));
+                .filter(datum -> filteredSamplesMap
+                    .containsKey(getCaseUniqueKey(datum.getStudyId(), datum.getSampleId()))
+                ).collect(Collectors.groupingBy(CustomDataValue::getValue));
 
             ClinicalDataCountItem clinicalDataCountItem = new ClinicalDataCountItem();
             clinicalDataCountItem.setAttributeId(customDataSession.getId());
@@ -188,10 +192,10 @@ public class StudyViewFilterUtil {
         );
     }
     
-    public List<ClinicalData> filterClinicalData(
-        List<ClinicalData> unfilteredClinicalDataForSamples,
-        List<ClinicalData> unfilteredClinicalDataForPatients,
-        List<ClinicalData> unfilteredClinicalDataForConflictingPatientAttributes,
+    public List<Binnable> filterClinicalData(
+        List<Binnable> unfilteredClinicalDataForSamples,
+        List<Binnable> unfilteredClinicalDataForPatients,
+        List<Binnable> unfilteredClinicalDataForConflictingPatientAttributes,
         List<String> studyIds,
         List<String> sampleIds,
         List<String> studyIdsOfPatients,
@@ -200,7 +204,7 @@ public class StudyViewFilterUtil {
         List<String> patientAttributeIds,
         List<String> conflictingPatientAttributes
     ) {
-        List<ClinicalData> combinedResult = new ArrayList<>();
+        List<Binnable> combinedResult = new ArrayList<>();
         
         Map<String, String> patientIdToStudyId = null;
             
@@ -251,8 +255,8 @@ public class StudyViewFilterUtil {
         return combinedResult;
     }
     
-    private List<ClinicalData> filterClinicalDataByStudyAndSampleAndAttribute(
-        List<ClinicalData> clinicalData,
+    private List<Binnable> filterClinicalDataByStudyAndSampleAndAttribute(
+        List<Binnable> clinicalData,
         Map<String, String> sampleToStudyId,
         Map<String, Boolean> attributeIdLookup
     ) {
@@ -265,8 +269,8 @@ public class StudyViewFilterUtil {
             .collect(Collectors.toList());
     }
 
-    private List<ClinicalData> filterClinicalDataByStudyAndPatientAndAttribute(
-        List<ClinicalData> clinicalData,
+    private List<Binnable> filterClinicalDataByStudyAndPatientAndAttribute(
+        List<Binnable> clinicalData,
         Map<String, String> patientToStudyId,
         Map<String, Boolean> attributeIdLookup
     ) {
@@ -296,11 +300,11 @@ public class StudyViewFilterUtil {
         return caseToStudy;
     }
 
-    private String generateSampleToStudyKey(ClinicalData clinicalData) {
+    private String generateSampleToStudyKey(Binnable clinicalData) {
         return generateCaseToStudyKey(clinicalData.getStudyId(), clinicalData.getSampleId());
     }
     
-    private String generatePatientToStudyKey(ClinicalData clinicalData) {
+    private String generatePatientToStudyKey(Binnable clinicalData) {
         return generateCaseToStudyKey(clinicalData.getStudyId(), clinicalData.getPatientId());
     }
     

--- a/web/src/test/java/org/cbioportal/web/ClinicalDataEnrichmentControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/ClinicalDataEnrichmentControllerTest.java
@@ -37,7 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@ContextConfiguration("/applicationContext-web.xml")
+@ContextConfiguration("/applicationContext-web-test.xml")
 @Configuration
 public class ClinicalDataEnrichmentControllerTest {
 

--- a/web/src/test/java/org/cbioportal/web/DataAccessTokenControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/DataAccessTokenControllerTest.java
@@ -47,7 +47,7 @@ import org.springframework.web.context.WebApplicationContext;
 import javax.servlet.http.HttpSession;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations={"/applicationContext-web.xml", "/applicationContext-security-test.xml"})
+@ContextConfiguration(locations={"/applicationContext-web-test.xml", "/applicationContext-security-test.xml"})
 @WebAppConfiguration
 public class DataAccessTokenControllerTest {
 

--- a/web/src/test/java/org/cbioportal/web/GenericAssayControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GenericAssayControllerTest.java
@@ -34,7 +34,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@ContextConfiguration("/applicationContext-web.xml")
+@ContextConfiguration("/applicationContext-web-test.xml")
 @Configuration
 public class GenericAssayControllerTest {
 

--- a/web/src/test/java/org/cbioportal/web/GenericAssayDataControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/GenericAssayDataControllerTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@ContextConfiguration("/applicationContext-web.xml")
+@ContextConfiguration("/applicationContext-web-test.xml")
 @Configuration
 public class GenericAssayDataControllerTest {
 

--- a/web/src/test/java/org/cbioportal/web/StructuralVariantControllerTest.java
+++ b/web/src/test/java/org/cbioportal/web/StructuralVariantControllerTest.java
@@ -58,7 +58,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@ContextConfiguration("/applicationContext-web.xml")
+@ContextConfiguration("/applicationContext-web-test.xml")
 @Configuration
 public class StructuralVariantControllerTest {
 

--- a/web/src/test/java/org/cbioportal/web/util/ClinicalDataBinUtilTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/ClinicalDataBinUtilTest.java
@@ -179,6 +179,8 @@ public class ClinicalDataBinUtilTest {
         
         
         // assert function calls
+        verify(idPopulator, times(1))
+                    .populateIdLists(any(), any());
         
         // we don't expect filterClinicalData to be called for an unfiltered query
         verify(studyViewFilterUtil, never())

--- a/web/src/test/java/org/cbioportal/web/util/ClinicalDataBinUtilTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/ClinicalDataBinUtilTest.java
@@ -1,15 +1,24 @@
 package org.cbioportal.web.util;
 
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cbioportal.model.ClinicalAttribute;
 import org.cbioportal.model.ClinicalData;
 import org.cbioportal.model.ClinicalDataBin;
 import org.cbioportal.model.Patient;
 import org.cbioportal.service.ClinicalAttributeService;
 import org.cbioportal.service.PatientService;
+import org.cbioportal.service.impl.CustomDataServiceImpl;
 import org.cbioportal.service.util.ClinicalAttributeUtil;
+import org.cbioportal.service.util.CustomAttributeWithData;
+import org.cbioportal.service.util.CustomDataSession;
+import org.cbioportal.service.util.CustomDataValue;
+import org.cbioportal.service.util.SessionServiceRequestHandler;
 import org.cbioportal.web.parameter.*;
-import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -19,13 +28,19 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.util.ResourceUtils;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -44,6 +59,13 @@ public class ClinicalDataBinUtilTest {
     private ClinicalAttributeService clinicalAttributeService;
     @Mock
     private PatientService patientService;
+    @Mock
+    private SessionServiceRequestHandler sessionServiceRequestHandler;
+    @Spy
+    private ObjectMapper sessionServiceObjectMapper = new ObjectMapper();
+    @Spy
+    @InjectMocks
+    private CustomDataServiceImpl customDataService;
     @Spy
     private StudyViewFilterUtil studyViewFilterUtil;
     @Spy
@@ -61,11 +83,19 @@ public class ClinicalDataBinUtilTest {
     @Spy
     @InjectMocks
     private ScientificSmallDataBinner scientificSmallDataBinner;
+
+    @Spy
+    @InjectMocks
+    private IdPopulator idPopulator;
+    
     @Spy
     @InjectMocks
     private LogScaleDataBinner logScaleDataBinner;
     @Spy
     private DataBinHelper dataBinHelper;
+    private final String testDataAttributeId = "test";
+    private final ObjectMapper customDatasetMapper = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @Before
     public void setup() {
@@ -84,68 +114,68 @@ public class ClinicalDataBinUtilTest {
         
         // assert data bin counts
         
-        Assert.assertEquals(33, dataBins.size());
+        assertEquals(33, dataBins.size());
         
         List<ClinicalDataBin> mutationCountBins = 
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("MUTATION_COUNT")).collect(Collectors.toList());
-        Assert.assertEquals(6, mutationCountBins.size());
-        Assert.assertEquals(2, mutationCountBins.get(0).getCount().intValue());
-        Assert.assertEquals(1, mutationCountBins.get(1).getCount().intValue());
-        Assert.assertEquals(1, mutationCountBins.get(2).getCount().intValue());
-        Assert.assertEquals(1, mutationCountBins.get(3).getCount().intValue());
-        Assert.assertEquals(1, mutationCountBins.get(4).getCount().intValue());
-        Assert.assertEquals(1, mutationCountBins.get(5).getCount().intValue());
+        assertEquals(6, mutationCountBins.size());
+        assertEquals(2, mutationCountBins.get(0).getCount().intValue());
+        assertEquals(1, mutationCountBins.get(1).getCount().intValue());
+        assertEquals(1, mutationCountBins.get(2).getCount().intValue());
+        assertEquals(1, mutationCountBins.get(3).getCount().intValue());
+        assertEquals(1, mutationCountBins.get(4).getCount().intValue());
+        assertEquals(1, mutationCountBins.get(5).getCount().intValue());
 
         List<ClinicalDataBin> fractionGenomeAlteredBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("FRACTION_GENOME_ALTERED")).collect(Collectors.toList());
-        Assert.assertEquals(7, fractionGenomeAlteredBins.size());
-        Assert.assertEquals(1, fractionGenomeAlteredBins.get(0).getCount().intValue());
-        Assert.assertEquals(1, fractionGenomeAlteredBins.get(1).getCount().intValue());
-        Assert.assertEquals(1, fractionGenomeAlteredBins.get(2).getCount().intValue());
-        Assert.assertEquals(1, fractionGenomeAlteredBins.get(3).getCount().intValue());
-        Assert.assertEquals(1, fractionGenomeAlteredBins.get(4).getCount().intValue());
-        Assert.assertEquals(1, fractionGenomeAlteredBins.get(5).getCount().intValue());
-        Assert.assertEquals(1, fractionGenomeAlteredBins.get(6).getCount().intValue());
+        assertEquals(7, fractionGenomeAlteredBins.size());
+        assertEquals(1, fractionGenomeAlteredBins.get(0).getCount().intValue());
+        assertEquals(1, fractionGenomeAlteredBins.get(1).getCount().intValue());
+        assertEquals(1, fractionGenomeAlteredBins.get(2).getCount().intValue());
+        assertEquals(1, fractionGenomeAlteredBins.get(3).getCount().intValue());
+        assertEquals(1, fractionGenomeAlteredBins.get(4).getCount().intValue());
+        assertEquals(1, fractionGenomeAlteredBins.get(5).getCount().intValue());
+        assertEquals(1, fractionGenomeAlteredBins.get(6).getCount().intValue());
 
         List<ClinicalDataBin> ageAtSeqReportedYearsBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("AGE_AT_SEQ_REPORTED_YEARS")).collect(Collectors.toList());
-        Assert.assertEquals(6, ageAtSeqReportedYearsBins.size());
-        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(0).getCount().intValue());
-        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(1).getCount().intValue());
-        Assert.assertEquals(2, ageAtSeqReportedYearsBins.get(2).getCount().intValue());
-        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(3).getCount().intValue());
-        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(4).getCount().intValue());
-        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(5).getCount().intValue());
+        assertEquals(6, ageAtSeqReportedYearsBins.size());
+        assertEquals(1, ageAtSeqReportedYearsBins.get(0).getCount().intValue());
+        assertEquals(1, ageAtSeqReportedYearsBins.get(1).getCount().intValue());
+        assertEquals(2, ageAtSeqReportedYearsBins.get(2).getCount().intValue());
+        assertEquals(1, ageAtSeqReportedYearsBins.get(3).getCount().intValue());
+        assertEquals(1, ageAtSeqReportedYearsBins.get(4).getCount().intValue());
+        assertEquals(1, ageAtSeqReportedYearsBins.get(5).getCount().intValue());
         
         List<ClinicalDataBin> caAgeBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("CA_AGE")).collect(Collectors.toList());
-        Assert.assertEquals(5, caAgeBins.size());
-        Assert.assertEquals(1, caAgeBins.get(0).getCount().intValue());
-        Assert.assertEquals(1, caAgeBins.get(1).getCount().intValue());
-        Assert.assertEquals(1, caAgeBins.get(2).getCount().intValue());
-        Assert.assertEquals(1, caAgeBins.get(3).getCount().intValue());
-        Assert.assertEquals(1, caAgeBins.get(4).getCount().intValue());
+        assertEquals(5, caAgeBins.size());
+        assertEquals(1, caAgeBins.get(0).getCount().intValue());
+        assertEquals(1, caAgeBins.get(1).getCount().intValue());
+        assertEquals(1, caAgeBins.get(2).getCount().intValue());
+        assertEquals(1, caAgeBins.get(3).getCount().intValue());
+        assertEquals(1, caAgeBins.get(4).getCount().intValue());
 
         List<ClinicalDataBin> cptSeqBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("CPT_SEQ_DATE")).collect(Collectors.toList());
-        Assert.assertEquals(3, cptSeqBins.size());
-        Assert.assertEquals(1, cptSeqBins.get(0).getCount().intValue());
-        Assert.assertEquals(3, cptSeqBins.get(1).getCount().intValue());
-        Assert.assertEquals(3, cptSeqBins.get(2).getCount().intValue());
+        assertEquals(3, cptSeqBins.size());
+        assertEquals(1, cptSeqBins.get(0).getCount().intValue());
+        assertEquals(3, cptSeqBins.get(1).getCount().intValue());
+        assertEquals(3, cptSeqBins.get(2).getCount().intValue());
         
         List<ClinicalDataBin> cptOrderIntBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("CPT_ORDER_INT")).collect(Collectors.toList());
-        Assert.assertEquals(1, cptOrderIntBins.size());
-        Assert.assertEquals(7, cptOrderIntBins.get(0).getCount().intValue());
+        assertEquals(1, cptOrderIntBins.size());
+        assertEquals(7, cptOrderIntBins.get(0).getCount().intValue());
         
         List<ClinicalDataBin> hybridDeathIntBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("HYBRID_DEATH_INT")).collect(Collectors.toList());
-        Assert.assertEquals(5, hybridDeathIntBins.size());
-        Assert.assertEquals(1, hybridDeathIntBins.get(0).getCount().intValue());
-        Assert.assertEquals(1, hybridDeathIntBins.get(1).getCount().intValue());
-        Assert.assertEquals(1, hybridDeathIntBins.get(2).getCount().intValue());
-        Assert.assertEquals(1, hybridDeathIntBins.get(3).getCount().intValue());
-        Assert.assertEquals(1, hybridDeathIntBins.get(4).getCount().intValue());
+        assertEquals(5, hybridDeathIntBins.size());
+        assertEquals(1, hybridDeathIntBins.get(0).getCount().intValue());
+        assertEquals(1, hybridDeathIntBins.get(1).getCount().intValue());
+        assertEquals(1, hybridDeathIntBins.get(2).getCount().intValue());
+        assertEquals(1, hybridDeathIntBins.get(3).getCount().intValue());
+        assertEquals(1, hybridDeathIntBins.get(4).getCount().intValue());
         
         
         // assert function calls
@@ -157,10 +187,6 @@ public class ClinicalDataBinUtilTest {
         // study view filter should be applied only once
         verify(studyViewFilterApplier, times(1)).apply(any());
         
-        // ids should be populated only once
-        verify(clinicalDataBinUtil, times(1))
-            .populateIdLists(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
-
         // should call the correct bin calculate method only once for the given binning method
         verify(clinicalDataBinUtil, times(1))
             .calculateStaticDataBins(any(), any(), any(), any(), any(), any(), any(), any());
@@ -178,71 +204,70 @@ public class ClinicalDataBinUtilTest {
             mockQueryFilter()
         );
 
-        
         // assert data bin counts
         
-        Assert.assertEquals(33, dataBins.size());
+        assertEquals(33, dataBins.size());
 
         List<ClinicalDataBin> mutationCountBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("MUTATION_COUNT")).collect(Collectors.toList());
-        Assert.assertEquals(6, mutationCountBins.size());
-        Assert.assertEquals(0, mutationCountBins.get(0).getCount().intValue());
-        Assert.assertEquals(0, mutationCountBins.get(1).getCount().intValue());
-        Assert.assertEquals(0, mutationCountBins.get(2).getCount().intValue());
-        Assert.assertEquals(1, mutationCountBins.get(3).getCount().intValue());
-        Assert.assertEquals(1, mutationCountBins.get(4).getCount().intValue());
-        Assert.assertEquals(0, mutationCountBins.get(5).getCount().intValue());
+        assertEquals(6, mutationCountBins.size());
+        assertEquals(0, mutationCountBins.get(0).getCount().intValue());
+        assertEquals(0, mutationCountBins.get(1).getCount().intValue());
+        assertEquals(0, mutationCountBins.get(2).getCount().intValue());
+        assertEquals(1, mutationCountBins.get(3).getCount().intValue());
+        assertEquals(1, mutationCountBins.get(4).getCount().intValue());
+        assertEquals(0, mutationCountBins.get(5).getCount().intValue());
 
         List<ClinicalDataBin> fractionGenomeAlteredBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("FRACTION_GENOME_ALTERED")).collect(Collectors.toList());
-        Assert.assertEquals(7, fractionGenomeAlteredBins.size());
-        Assert.assertEquals(1, fractionGenomeAlteredBins.get(0).getCount().intValue());
-        Assert.assertEquals(0, fractionGenomeAlteredBins.get(1).getCount().intValue());
-        Assert.assertEquals(1, fractionGenomeAlteredBins.get(2).getCount().intValue());
-        Assert.assertEquals(0, fractionGenomeAlteredBins.get(3).getCount().intValue());
-        Assert.assertEquals(0, fractionGenomeAlteredBins.get(4).getCount().intValue());
-        Assert.assertEquals(0, fractionGenomeAlteredBins.get(5).getCount().intValue());
-        Assert.assertEquals(0, fractionGenomeAlteredBins.get(6).getCount().intValue());
+        assertEquals(7, fractionGenomeAlteredBins.size());
+        assertEquals(1, fractionGenomeAlteredBins.get(0).getCount().intValue());
+        assertEquals(0, fractionGenomeAlteredBins.get(1).getCount().intValue());
+        assertEquals(1, fractionGenomeAlteredBins.get(2).getCount().intValue());
+        assertEquals(0, fractionGenomeAlteredBins.get(3).getCount().intValue());
+        assertEquals(0, fractionGenomeAlteredBins.get(4).getCount().intValue());
+        assertEquals(0, fractionGenomeAlteredBins.get(5).getCount().intValue());
+        assertEquals(0, fractionGenomeAlteredBins.get(6).getCount().intValue());
 
         List<ClinicalDataBin> ageAtSeqReportedYearsBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("AGE_AT_SEQ_REPORTED_YEARS")).collect(Collectors.toList());
-        Assert.assertEquals(6, ageAtSeqReportedYearsBins.size());
-        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(0).getCount().intValue());
-        Assert.assertEquals(1, ageAtSeqReportedYearsBins.get(1).getCount().intValue());
-        Assert.assertEquals(0, ageAtSeqReportedYearsBins.get(2).getCount().intValue());
-        Assert.assertEquals(0, ageAtSeqReportedYearsBins.get(3).getCount().intValue());
-        Assert.assertEquals(0, ageAtSeqReportedYearsBins.get(4).getCount().intValue());
-        Assert.assertEquals(0, ageAtSeqReportedYearsBins.get(5).getCount().intValue());
+        assertEquals(6, ageAtSeqReportedYearsBins.size());
+        assertEquals(1, ageAtSeqReportedYearsBins.get(0).getCount().intValue());
+        assertEquals(1, ageAtSeqReportedYearsBins.get(1).getCount().intValue());
+        assertEquals(0, ageAtSeqReportedYearsBins.get(2).getCount().intValue());
+        assertEquals(0, ageAtSeqReportedYearsBins.get(3).getCount().intValue());
+        assertEquals(0, ageAtSeqReportedYearsBins.get(4).getCount().intValue());
+        assertEquals(0, ageAtSeqReportedYearsBins.get(5).getCount().intValue());
 
         List<ClinicalDataBin> caAgeBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("CA_AGE")).collect(Collectors.toList());
-        Assert.assertEquals(5, caAgeBins.size());
-        Assert.assertEquals(1, caAgeBins.get(0).getCount().intValue());
-        Assert.assertEquals(1, caAgeBins.get(1).getCount().intValue());
-        Assert.assertEquals(0, caAgeBins.get(2).getCount().intValue());
-        Assert.assertEquals(0, caAgeBins.get(3).getCount().intValue());
-        Assert.assertEquals(0, caAgeBins.get(4).getCount().intValue());
+        assertEquals(5, caAgeBins.size());
+        assertEquals(1, caAgeBins.get(0).getCount().intValue());
+        assertEquals(1, caAgeBins.get(1).getCount().intValue());
+        assertEquals(0, caAgeBins.get(2).getCount().intValue());
+        assertEquals(0, caAgeBins.get(3).getCount().intValue());
+        assertEquals(0, caAgeBins.get(4).getCount().intValue());
 
         List<ClinicalDataBin> cptSeqBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("CPT_SEQ_DATE")).collect(Collectors.toList());
-        Assert.assertEquals(3, cptSeqBins.size());
-        Assert.assertEquals(0, cptSeqBins.get(0).getCount().intValue());
-        Assert.assertEquals(2, cptSeqBins.get(1).getCount().intValue());
-        Assert.assertEquals(0, cptSeqBins.get(2).getCount().intValue());
+        assertEquals(3, cptSeqBins.size());
+        assertEquals(0, cptSeqBins.get(0).getCount().intValue());
+        assertEquals(2, cptSeqBins.get(1).getCount().intValue());
+        assertEquals(0, cptSeqBins.get(2).getCount().intValue());
 
         List<ClinicalDataBin> cptOrderIntBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("CPT_ORDER_INT")).collect(Collectors.toList());
-        Assert.assertEquals(1, cptOrderIntBins.size());
-        Assert.assertEquals(2, cptOrderIntBins.get(0).getCount().intValue());
+        assertEquals(1, cptOrderIntBins.size());
+        assertEquals(2, cptOrderIntBins.get(0).getCount().intValue());
 
         List<ClinicalDataBin> hybridDeathIntBins =
             dataBins.stream().filter(bin -> bin.getAttributeId().equals("HYBRID_DEATH_INT")).collect(Collectors.toList());
-        Assert.assertEquals(5, hybridDeathIntBins.size());
-        Assert.assertEquals(1, hybridDeathIntBins.get(0).getCount().intValue());
-        Assert.assertEquals(0, hybridDeathIntBins.get(1).getCount().intValue());
-        Assert.assertEquals(0, hybridDeathIntBins.get(2).getCount().intValue());
-        Assert.assertEquals(1, hybridDeathIntBins.get(3).getCount().intValue());
-        Assert.assertEquals(0, hybridDeathIntBins.get(4).getCount().intValue());
+        assertEquals(5, hybridDeathIntBins.size());
+        assertEquals(1, hybridDeathIntBins.get(0).getCount().intValue());
+        assertEquals(0, hybridDeathIntBins.get(1).getCount().intValue());
+        assertEquals(0, hybridDeathIntBins.get(2).getCount().intValue());
+        assertEquals(1, hybridDeathIntBins.get(3).getCount().intValue());
+        assertEquals(0, hybridDeathIntBins.get(4).getCount().intValue());
         
         
         // assert function calls
@@ -253,18 +278,120 @@ public class ClinicalDataBinUtilTest {
 
         // study view filter should be applied twice
         verify(studyViewFilterApplier, times(2)).apply(any());
-
-        // ids should be populated twice
-        verify(clinicalDataBinUtil, times(2))
-            .populateIdLists(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
-
+        
         // should call the correct bin calculate method only once for the given binning method
         verify(clinicalDataBinUtil, times(1))
             .calculateStaticDataBins(any(), any(), any(), any(), any(), any(), any(), any());
         verify(clinicalDataBinUtil, never())
             .calculateDynamicDataBins(any(), any(), any(), any(), any());
-    }
+    }    
     
+    @Test
+    public void fetchCustomDataBinCountsWithStaticBinningMethod() throws Exception {
+        String customDataset = getFileContents("classpath:custom-dataset.json");
+        
+        mockCustomDataService(customDataset);
+        mockStudyViewFilterApplier(customDataset);
+        ClinicalDataBinCountFilter filter = createClinicalDataBinCountFilter();
+        
+        List<ClinicalDataBin> bins = clinicalDataBinUtil.fetchCustomDataBinCounts(
+            DataBinMethod.STATIC,
+            filter,
+            false
+        );
+        
+        // Total number of bins:
+        assertEquals(11, bins.size());
+
+        // All bins should have the custom data set name as attribute:
+        List<ClinicalDataBin> customDatasetAttributeBins = bins
+            .stream()
+            .filter(bin -> bin.getAttributeId().equals(testDataAttributeId))
+            .collect(Collectors.toList());
+        assertEquals(11, customDatasetAttributeBins.size());
+
+        assertEquals("<=", bins.get(0).getSpecialValue());
+        assertEquals(3, bins.get(0).getCount().intValue());
+
+        // Bin size should be five:
+        assertEquals(5, bins.get(1).getEnd().intValue() - bins.get(1).getStart().intValue());
+        assertEquals(5, bins.get(1).getCount().intValue());
+
+        assertEquals(8, bins.get(2).getCount().intValue());
+        assertEquals(5, bins.get(3).getCount().intValue());
+        assertEquals(8, bins.get(4).getCount().intValue());
+        assertEquals(5, bins.get(5).getCount().intValue());
+        assertEquals(8, bins.get(6).getCount().intValue());
+        assertEquals(5, bins.get(7).getCount().intValue());
+        assertEquals(6, bins.get(8).getCount().intValue());
+        assertEquals(2, bins.get(9).getCount().intValue());
+        
+        assertEquals(">", bins.get(10).getSpecialValue());
+        assertEquals(1, bins.get(10).getCount().intValue());
+    }
+
+    @Test
+    public void fetchCustomDataBinCountsWithStaticBinningMethod_minimalExample() throws Exception {
+        String customDataset = getFileContents("classpath:custom-dataset-minimal.json");
+        
+        mockCustomDataService(customDataset);
+        mockStudyViewFilterApplier(customDataset);
+        ClinicalDataBinCountFilter filter = createClinicalDataBinCountFilter();
+        
+        List<ClinicalDataBin> bins = clinicalDataBinUtil.fetchCustomDataBinCounts(
+            DataBinMethod.STATIC,
+            filter,
+            false
+        );
+        
+        // Total number of bins:
+        assertEquals(13, bins.size());
+
+        // All bins should have the custom data set name as attribute:
+        List<ClinicalDataBin> customDatasetAttributeBins = bins
+            .stream()
+            .filter(bin -> bin.getAttributeId().equals(testDataAttributeId))
+            .collect(Collectors.toList());
+        assertEquals(13, customDatasetAttributeBins.size());
+        
+        // Start bin:
+        assertEquals("<=", bins.get(0).getSpecialValue());
+        assertEquals(1, bins.get(0).getCount().intValue());
+        assertEquals(-1.0, bins.get(0).getEnd().intValue(), 0);
+
+        // Size of next bins should be 1:
+        assertEquals(1, bins.get(1).getEnd().intValue() - bins.get(1).getStart().intValue(), 0);
+        assertEquals(1, bins.get(1).getCount().intValue());
+
+        assertEquals(1, bins.get(2).getCount().intValue());
+        assertEquals(2, bins.get(3).getCount().intValue());
+        assertEquals(2, bins.get(4).getCount().intValue());
+        assertEquals(1, bins.get(5).getCount().intValue());
+        assertEquals(0, bins.get(6).getCount().intValue());
+        assertEquals(1, bins.get(7).getCount().intValue());
+        assertEquals(1, bins.get(8).getCount().intValue());
+        assertEquals(1, bins.get(9).getCount().intValue());
+        assertEquals(1, bins.get(10).getCount().intValue());
+        assertEquals(1, bins.get(11).getCount().intValue());
+        assertEquals(1, bins.get(12).getCount().intValue());
+        
+    }
+
+    private void mockStudyViewFilterApplier(String customDataset) throws IOException {
+        TreeNode path = customDatasetMapper.readTree(customDataset).path("data").path("data");
+
+        TypeReference<List<SampleIdentifier>> type = new TypeReference<List<SampleIdentifier>>() {};
+        List<SampleIdentifier> customIDs = customDatasetMapper.readValue(customDatasetMapper.treeAsTokens(path), type);
+
+        when(
+            studyViewFilterApplier.apply(any())
+        ).thenReturn(customIDs);
+    }
+
+    private String getFileContents(String resourceLocation) throws IOException {
+        return new String(Files.readAllBytes(ResourceUtils.getFile(resourceLocation).toPath()));
+    }
+
     private void mockUnfilteredQuery()
     {
         mockMethods(
@@ -306,7 +433,17 @@ public class ClinicalDataBinUtilTest {
             mockFilteredClinicalAttributes()
         );
     }
-    
+
+    private static final String sessionTestKey = "testkey";
+
+    @Value("classpath:state.json") Resource stateFile;
+
+    private void mockCustomDataService(String customDataset) throws Exception {
+        when(
+            sessionServiceRequestHandler.getSessionDataJson(any(), any())
+        ).thenReturn(customDataset);
+    }
+
     private void mockMethods(
         List<SampleIdentifier> sampleIdentifiers,
         List<String> sampleIds,
@@ -330,7 +467,6 @@ public class ClinicalDataBinUtilTest {
         when(
             clinicalAttributeService.getClinicalAttributesByStudyIdsAndAttributeIds(eq(studyIds), eq(attributeIds))
         ).thenReturn(clinicalAttributes);
-
         when(
             studyViewFilterApplier.apply(argThat(new StudyViewFilterMatcher(studyViewFilter)))
         ).thenReturn(sampleIdentifiers);
@@ -348,7 +484,7 @@ public class ClinicalDataBinUtilTest {
             clinicalDataFetcher.fetchClinicalDataForPatients(eq(studyIdsOfPatients), eq(patientIds), eq(patientAttributeIds))
         ).thenReturn(clinicalDataForPatients);
     }
-    
+
     private ClinicalDataBinCountFilter mockBaseFilter() {
         ClinicalDataBinCountFilter filter = new ClinicalDataBinCountFilter();
         
@@ -366,7 +502,7 @@ public class ClinicalDataBinUtilTest {
 
         return filter;
     }
-    
+
     private List<String> mockUnfilteredStudySampleUniqueKeys() {
         List<String> keys = new ArrayList<>();
         
@@ -380,7 +516,7 @@ public class ClinicalDataBinUtilTest {
         
         return keys;
     }
-    
+
     private List<String> mockFilteredStudySampleUniqueKeys() {
         List<String> keys = new ArrayList<>();
         
@@ -389,7 +525,7 @@ public class ClinicalDataBinUtilTest {
         
         return keys;
     }
-    
+
     private List<String> mockUnfilteredStudyPatientUniqueKeys() {
         List<String> keys = new ArrayList<>();
         
@@ -401,7 +537,7 @@ public class ClinicalDataBinUtilTest {
         
         return keys;
     }
-    
+
     private List<String> mockFilteredStudyPatientUniqueKeys() {
         List<String> keys = new ArrayList<>();
         
@@ -410,7 +546,7 @@ public class ClinicalDataBinUtilTest {
         
         return keys;
     }
-    
+
     private List<String> mockUnfilteredSampleIds() {
         List<String> sampleIds = new ArrayList<>();
 
@@ -424,7 +560,7 @@ public class ClinicalDataBinUtilTest {
 
         return sampleIds;
     }
-    
+
     private List<String> mockFilteredSampleIds() {
         List<String> sampleIds = new ArrayList<>();
 
@@ -445,7 +581,7 @@ public class ClinicalDataBinUtilTest {
 
         return patientIds;
     }
-    
+
     private List<String> mockFilteredPatientIds() {
         List<String> patientIds = new ArrayList<>();
 
@@ -454,7 +590,7 @@ public class ClinicalDataBinUtilTest {
 
         return patientIds;
     }
-    
+
     private List<Patient> mockUnfilteredPatients() {
         return mockPatients(mockUnfilteredPatientIds());
     }
@@ -462,7 +598,7 @@ public class ClinicalDataBinUtilTest {
     private List<Patient> mockFilteredPatients() {
         return mockPatients(mockFilteredPatientIds());
     }
-    
+
     private List<Patient> mockPatients(List<String> patientIds) {
         List<Patient> patients = new ArrayList<>();
         
@@ -479,7 +615,7 @@ public class ClinicalDataBinUtilTest {
     private List<String> mockUnfilteredStudyIds() {
         return Collections.nCopies(7, STUDY_ID);
     }
-    
+
     private List<String> mockFilteredStudyIds() {
         return Collections.nCopies(2, STUDY_ID);
     }
@@ -487,11 +623,11 @@ public class ClinicalDataBinUtilTest {
     private List<String> mockUnfilteredStudyIdsOfPatients() {
         return Collections.nCopies(5, STUDY_ID);
     }
-    
+
     private List<String> mockFilteredStudyIdsOfPatients() {
         return Collections.nCopies(2, STUDY_ID);
     }
-    
+
     private List<SampleIdentifier> mockUnfilteredSampleIdentifiers() {
         return mockSampleIdentifiers(mockUnfilteredSampleIds());
     }
@@ -512,7 +648,7 @@ public class ClinicalDataBinUtilTest {
 
         return sampleIdentifiers;
     }
-    
+
     private List<String> mockUnfilteredAttributeIds() {
         List<String> attributeIds = new ArrayList<>();
         
@@ -542,7 +678,7 @@ public class ClinicalDataBinUtilTest {
 
         return attributeIds;
     }
-    
+
     private List<ClinicalDataBinFilter> mockUnfilteredAttributes() {
         List<ClinicalDataBinFilter> attributes = new ArrayList<>();
         List<String> attributeIds = mockUnfilteredAttributeIds();
@@ -555,7 +691,7 @@ public class ClinicalDataBinUtilTest {
         
         return attributes;
     }
-    
+
     private ClinicalAttribute mockClinicalAttribute(String attrId, String displayName, boolean isPatientAttribute) {
         ClinicalAttribute attr = new ClinicalAttribute();
         
@@ -568,7 +704,7 @@ public class ClinicalDataBinUtilTest {
         
         return attr;
     }
-    
+
     private List<ClinicalAttribute> mockUnfilteredClinicalAttributes() {
         List<ClinicalAttribute> clinicalAttributes = new ArrayList<>();
         
@@ -595,7 +731,7 @@ public class ClinicalDataBinUtilTest {
 
         return clinicalAttributes;
     }
-    
+
     private ClinicalData mockClinicalData(String id, String value, String patientId, String sampleId)
     {
         ClinicalData data = new ClinicalData();
@@ -608,7 +744,7 @@ public class ClinicalDataBinUtilTest {
         
         return data;
     }
-    
+
     private List<ClinicalData> mockUnfilteredClinicalDataForSamples() {
         List<ClinicalData> data = new ArrayList<>();
         
@@ -659,7 +795,7 @@ public class ClinicalDataBinUtilTest {
 
         return data;
     }
-    
+
     private StudyViewFilter mockUnfilteredStudyViewFilter() {
         StudyViewFilter studyViewFilter = new StudyViewFilter();
 
@@ -669,7 +805,7 @@ public class ClinicalDataBinUtilTest {
         
         return studyViewFilter;
     }
-    
+
     private StudyViewFilter mockFilteredStudyViewFilter() {
         StudyViewFilter studyViewFilter = mockUnfilteredStudyViewFilter();
         
@@ -699,8 +835,8 @@ public class ClinicalDataBinUtilTest {
     }
 
     private class StudyViewFilterMatcher implements ArgumentMatcher<StudyViewFilter> {
-        private StudyViewFilter source;
 
+        private StudyViewFilter source;
         public StudyViewFilterMatcher(StudyViewFilter source) {
             this.source = source;
         }
@@ -714,7 +850,7 @@ public class ClinicalDataBinUtilTest {
                 equalClinicalDataFilters(source.getClinicalDataFilters(), target.getClinicalDataFilters())
             );
         }
-        
+
         private boolean equalClinicalDataFilters(List<ClinicalDataFilter> sourceFilters, List<ClinicalDataFilter> targetFilters) {
             if (sourceFilters == null && targetFilters == null) {
                 return true;
@@ -736,7 +872,7 @@ public class ClinicalDataBinUtilTest {
             
             return true;
         }
-        
+
         private boolean equalDataFilterValues(List<DataFilterValue> sourceValues, List<DataFilterValue> targetValues)
         {
             if (sourceValues == null && targetValues == null) {
@@ -760,5 +896,22 @@ public class ClinicalDataBinUtilTest {
 
             return true;
         }
+
+    }
+
+    private ClinicalDataBinCountFilter createClinicalDataBinCountFilter() {
+        ClinicalDataBinCountFilter clinicalDataBinCountFilter = new ClinicalDataBinCountFilter();
+        List<ClinicalDataBinFilter> attributes = new ArrayList<>();
+        ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
+        clinicalDataBinFilter.setAttributeId(testDataAttributeId);
+        clinicalDataBinFilter.setBinMethod(DataBinFilter.BinMethod.CUSTOM);
+        StudyViewFilter studyViewFilter = new StudyViewFilter();
+        ArrayList<String> studyIds = new ArrayList<>();
+        studyIds.add("study_es_0");
+        studyViewFilter.setStudyIds(studyIds);
+        clinicalDataBinCountFilter.setStudyViewFilter(studyViewFilter);
+        attributes.add(clinicalDataBinFilter);
+        clinicalDataBinCountFilter.setAttributes(attributes);
+        return clinicalDataBinCountFilter;
     }
 }

--- a/web/src/test/java/org/cbioportal/web/util/DataBinnerTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/DataBinnerTest.java
@@ -4,6 +4,8 @@ import static org.cbioportal.web.parameter.DataBinFilter.*;
 
 
 import java.util.stream.IntStream;
+
+import org.cbioportal.model.Binnable;
 import org.cbioportal.model.ClinicalData;
 import org.cbioportal.model.DataBin;
 import org.cbioportal.web.parameter.BinsGeneratorConfig;
@@ -57,7 +59,7 @@ public class DataBinnerTest {
         MockitoAnnotations.initMocks(this);
     }
 
-    private List<String> getCaseIds(List<ClinicalData> unfilteredClinicalData, boolean getPatientIds) {
+    private List<String> getCaseIds(List<Binnable> unfilteredClinicalData, boolean getPatientIds) {
         return unfilteredClinicalData
                 .stream()
                 .map(datum -> studyViewFilterUtil.getCaseUniqueKey(datum.getStudyId(),
@@ -73,7 +75,7 @@ public class DataBinnerTest {
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
         
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -136,7 +138,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setStart(new BigDecimal("39.5"));
         clinicalDataBinFilter.setEnd(new BigDecimal("80.5"));
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -171,7 +173,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setStart(new BigDecimal("39.5"));
         clinicalDataBinFilter.setEnd(new BigDecimal("80.5"));
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -205,7 +207,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setStart(new BigDecimal("39.5"));
         clinicalDataBinFilter.setEnd(new BigDecimal("81.5"));
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -245,7 +247,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setBinMethod(BinMethod.CUSTOM);
         clinicalDataBinFilter.setCustomBins(Arrays.asList(50.0, 60.0, 70.0).stream().map(item -> BigDecimal.valueOf(item)).collect(Collectors.toList()));
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -278,13 +280,13 @@ public class DataBinnerTest {
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
 
-        List<ClinicalData> unfilteredClinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> unfilteredClinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> unfilteredPatientIds =
             getCaseIds(unfilteredClinicalData, true);
         List<DataBin> unfilteredDataBins = dataBinner.calculateDataBins(
             clinicalDataBinFilter, ClinicalDataType.PATIENT, unfilteredClinicalData, unfilteredPatientIds);
         
-        List<ClinicalData> filteredClinicalData = unfilteredClinicalData.subList(0, 108); // (0, 60] interval
+        List<Binnable> filteredClinicalData = unfilteredClinicalData.subList(0, 108); // (0, 60] interval
         List<String> filteredPatientIds =
             getCaseIds(filteredClinicalData, true);
         List<DataBin> filteredDataBins = dataBinner.calculateClinicalDataBins(clinicalDataBinFilter,
@@ -365,7 +367,7 @@ public class DataBinnerTest {
         String attributeId = "N_SCANS_PET_CT_PT";
         String[] values = mockData.get("genie_N_SCANS_PET_CT_PT");
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
@@ -395,7 +397,7 @@ public class DataBinnerTest {
         String attributeId = "N_SCANS_BONE_PT";
         String[] values = mockData.get("genie_N_SCANS_BONE_PT");
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
@@ -433,7 +435,7 @@ public class DataBinnerTest {
         String attributeId = "AGE_AT_WHICH_SEQUENCING_WAS_REPORTED";
         String[] values = mockData.get("genie_public_AGE_AT_WHICH_SEQUENCING_WAS_REPORTED");
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
         
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
@@ -530,7 +532,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setBinMethod(BinMethod.CUSTOM);
         clinicalDataBinFilter.setCustomBins(Arrays.asList(18.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0).stream().map(item -> BigDecimal.valueOf(item)).collect(Collectors.toList()));
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
         patientIds.addAll(Arrays.asList(patientsWithNoClinicalData));
 
@@ -591,7 +593,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setBinMethod(BinMethod.CUSTOM);
         clinicalDataBinFilter.setCustomBins(Arrays.asList(18.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0).stream().map(item -> BigDecimal.valueOf(item)).collect(Collectors.toList()));
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
         patientIds.addAll(Arrays.asList(patientsWithNoClinicalData));
 
@@ -626,7 +628,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setBinMethod(BinMethod.CUSTOM);
         clinicalDataBinFilter.setCustomBins(Arrays.asList(18.0, 25.0, 30.0, 35.0).stream().map(item -> BigDecimal.valueOf(item)).collect(Collectors.toList()));
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
         patientIds.addAll(Arrays.asList(patientsWithNoClinicalData));
 
@@ -658,7 +660,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setBinMethod(BinMethod.CUSTOM);
         clinicalDataBinFilter.setCustomBins(Arrays.asList(30.0).stream().map(item -> BigDecimal.valueOf(item)).collect(Collectors.toList()));
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
         patientIds.addAll(Arrays.asList(patientsWithNoClinicalData));
 
@@ -688,7 +690,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setBinMethod(BinMethod.CUSTOM);
         clinicalDataBinFilter.setCustomBins(Arrays.asList(20.0, 50.0).stream().map(item -> BigDecimal.valueOf(item)).collect(Collectors.toList()));
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
         patientIds.addAll(Arrays.asList(patientsWithNoClinicalData));
 
@@ -722,7 +724,7 @@ public class DataBinnerTest {
         generateBins.setAnchorValue(new BigDecimal(50));
         clinicalDataBinFilter.setBinsGeneratorConfig(generateBins);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
         patientIds.addAll(Arrays.asList(patientsWithNoClinicalData));
 
@@ -756,7 +758,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setAttributeId(attributeId);
         clinicalDataBinFilter.setBinMethod(BinMethod.MEDIAN);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
         patientIds.addAll(Arrays.asList(patientsWithNoClinicalData));
 
@@ -784,7 +786,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setAttributeId(attributeId);
         clinicalDataBinFilter.setBinMethod(BinMethod.QUARTILE);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
         patientIds.addAll(Arrays.asList(patientsWithNoClinicalData));
 
@@ -811,7 +813,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setAttributeId(attributeId);
         clinicalDataBinFilter.setBinMethod(BinMethod.QUARTILE);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -833,7 +835,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setAttributeId(attributeId);
         clinicalDataBinFilter.setBinMethod(BinMethod.QUARTILE);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -854,7 +856,7 @@ public class DataBinnerTest {
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -879,7 +881,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setBinMethod(BinMethod.CUSTOM);
         clinicalDataBinFilter.setCustomBins(Arrays.asList(1.0, 2.0, 5.0, 10.0, 30.0).stream().map(item -> BigDecimal.valueOf(item)).collect(Collectors.toList()));
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> sampleIds = getCaseIds(clinicalData, false);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.SAMPLE, clinicalData, sampleIds);
@@ -905,7 +907,7 @@ public class DataBinnerTest {
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -939,7 +941,7 @@ public class DataBinnerTest {
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> sampleIds = getCaseIds(clinicalData, false);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.SAMPLE, clinicalData, sampleIds);
@@ -964,7 +966,7 @@ public class DataBinnerTest {
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> sampleIds = getCaseIds(clinicalData, false);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.SAMPLE, clinicalData, sampleIds, 5);
@@ -985,7 +987,7 @@ public class DataBinnerTest {
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> sampleIds = getCaseIds(clinicalData, false);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.SAMPLE, clinicalData, sampleIds);
@@ -1024,7 +1026,7 @@ public class DataBinnerTest {
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> sampleIds = getCaseIds(clinicalData, false);
         sampleIds.addAll(Arrays.asList(samplesWithNoClinicalData));
 
@@ -1060,7 +1062,7 @@ public class DataBinnerTest {
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> sampleIds = getCaseIds(clinicalData, false);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.SAMPLE, clinicalData, sampleIds);
@@ -1108,7 +1110,7 @@ public class DataBinnerTest {
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -1153,7 +1155,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setAttributeId(attributeId);
         clinicalDataBinFilter.setDisableLogScale(true);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -1181,7 +1183,7 @@ public class DataBinnerTest {
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -1205,7 +1207,7 @@ public class DataBinnerTest {
         ClinicalDataBinFilter clinicalDataBinFilter = new ClinicalDataBinFilter();
         clinicalDataBinFilter.setAttributeId(attributeId);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -1239,7 +1241,7 @@ public class DataBinnerTest {
         clinicalDataBinFilter.setAttributeId(attributeId);
         clinicalDataBinFilter.setDisableLogScale(true);
 
-        List<ClinicalData> clinicalData = mockClinicalData(attributeId, studyId, values);
+        List<Binnable> clinicalData = mockClinicalData(attributeId, studyId, values);
         List<String> patientIds = getCaseIds(clinicalData, true);
 
         List<DataBin> dataBins = dataBinner.calculateDataBins(clinicalDataBinFilter, ClinicalDataType.PATIENT, clinicalData, patientIds);
@@ -1253,8 +1255,8 @@ public class DataBinnerTest {
         Assert.assertEquals(">", dataBins.get(13).getSpecialValue());
     }
 
-    private List<ClinicalData> mockClinicalData(String attributeId, String studyId, String[] values) {
-        List<ClinicalData> clinicalDataList =  new ArrayList<>();
+    private List<Binnable> mockClinicalData(String attributeId, String studyId, String[] values) {
+        List<Binnable> clinicalDataList =  new ArrayList<>();
 
         for (int index = 0; index < values.length; index++)
         {

--- a/web/src/test/java/org/cbioportal/web/util/StudyViewFilterApplierTest.java
+++ b/web/src/test/java/org/cbioportal/web/util/StudyViewFilterApplierTest.java
@@ -1,5 +1,6 @@
 package org.cbioportal.web.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cbioportal.model.*;
 import org.cbioportal.model.MolecularProfile.MolecularAlterationType;
 import org.cbioportal.model.util.Select;
@@ -16,7 +17,9 @@ import org.cbioportal.service.PatientService;
 import org.cbioportal.service.SampleListService;
 import org.cbioportal.service.SampleService;
 import org.cbioportal.service.StructuralVariantService;
+import org.cbioportal.service.impl.CustomDataServiceImpl;
 import org.cbioportal.service.util.MolecularProfileUtil;
+import org.cbioportal.service.util.SessionServiceRequestHandler;
 import org.cbioportal.web.parameter.ClinicalDataFilter;
 import org.cbioportal.web.parameter.DataFilterValue;
 import org.cbioportal.web.parameter.GeneIdType;
@@ -24,25 +27,27 @@ import org.cbioportal.web.parameter.GenericAssayDataFilter;
 import org.cbioportal.web.parameter.Projection;
 import org.cbioportal.web.parameter.SampleIdentifier;
 import org.cbioportal.web.parameter.StudyViewFilter;
-import org.cbioportal.web.util.appliers.*;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.context.ApplicationContext;
+import org.springframework.util.ResourceUtils;
 
+import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.file.Files;
 import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableList.of;
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.stream.Collectors.*;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class StudyViewFilterApplierTest {
@@ -60,6 +65,7 @@ public class StudyViewFilterApplierTest {
     public static final String CLINICAL_ATTRIBUTE_ID_1 = "attribute_id1";
     public static final String CLINICAL_ATTRIBUTE_ID_2 = "attribute_id2";
     public static final String CLINICAL_ATTRIBUTE_ID_3 = "attribute_id3";
+    public static final String CUSTOM_DATASET_ID = "custom_dataset_id";
     public static final Integer ENTREZ_GENE_ID_1 = 1;
     public static final Integer ENTREZ_GENE_ID_2 = 2;
     public static final String HUGO_GENE_SYMBOL_1 = "HUGO_GENE_SYMBOL_1";
@@ -115,6 +121,19 @@ public class StudyViewFilterApplierTest {
     @Spy
     @InjectMocks
     private MolecularProfileUtil molecularProfileUtil;
+
+    @Mock
+    private SessionServiceRequestHandler sessionServiceRequestHandler;
+    @Spy
+    private ObjectMapper sessionServiceObjectMapper = new ObjectMapper();
+
+    @Spy
+    @InjectMocks
+    private CustomDataServiceImpl customDataService;
+
+    @Spy
+    @InjectMocks
+    private CustomDataFilterApplier customDataFilterApplier;
 
     @Before
     public void setup() {
@@ -261,8 +280,8 @@ public class StudyViewFilterApplierTest {
         patient4.setCancerStudyIdentifier(STUDY_ID);
         patients.add(patient4);
 
-        Mockito.when(sampleService.fetchSamples(studyIds, sampleIds, "ID")).thenReturn(samples);
-        Mockito.when(patientService.getPatientsOfSamples(studyIds, sampleIds)).thenReturn(patients);
+        when(sampleService.fetchSamples(studyIds, sampleIds, "ID")).thenReturn(samples);
+        when(patientService.getPatientsOfSamples(studyIds, sampleIds)).thenReturn(patients);
 
         List<ClinicalData> patientClinicalDataList = new ArrayList<>();
         ClinicalData patientClinicalData1 = new ClinicalData();
@@ -287,7 +306,7 @@ public class StudyViewFilterApplierTest {
         patientClinicalData3.setStudyId(STUDY_ID);
         patientClinicalDataList.add(patientClinicalData3);
 
-        Mockito.when(clinicalDataService.getPatientClinicalDataDetailedToSample(
+        when(clinicalDataService.getPatientClinicalDataDetailedToSample(
                 Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID), patientIds,
                 Arrays.asList(CLINICAL_ATTRIBUTE_ID_1, CLINICAL_ATTRIBUTE_ID_2))).thenReturn(patientClinicalDataList);
 
@@ -302,7 +321,7 @@ public class StudyViewFilterApplierTest {
         updatedSamples.add(sample4);
         updatedSamples.add(sample5);
 
-        Mockito.when(sampleService.getSamplesOfPatientsInMultipleStudies(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID),
+        when(sampleService.getSamplesOfPatientsInMultipleStudies(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID),
                 updatedPatientIds, "ID")).thenReturn(updatedSamples);
 
         List<ClinicalData> sampleClinicalDataList = new ArrayList<>();
@@ -343,7 +362,7 @@ public class StudyViewFilterApplierTest {
         updatedSampleIds.add(SAMPLE_ID4);
         updatedSampleIds.add(SAMPLE_ID5);
 
-        Mockito.when(
+        when(
                 clinicalDataService.fetchClinicalData(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID),
                         Arrays.asList(SAMPLE_ID1, SAMPLE_ID2, SAMPLE_ID3, SAMPLE_ID4, SAMPLE_ID5),
                         Arrays.asList(CLINICAL_ATTRIBUTE_ID_1, CLINICAL_ATTRIBUTE_ID_2), "SAMPLE", "SUMMARY"))
@@ -363,7 +382,7 @@ public class StudyViewFilterApplierTest {
         updatedPatient3.setCancerStudyIdentifier(STUDY_ID);
         updatedPatients.add(updatedPatient3);
 
-        Mockito.when(
+        when(
                 patientService.getPatientsOfSamples(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID),
                         Arrays.asList(SAMPLE_ID1, SAMPLE_ID2, SAMPLE_ID3, SAMPLE_ID4, SAMPLE_ID5)))
                 .thenReturn(updatedPatients);
@@ -379,7 +398,7 @@ public class StudyViewFilterApplierTest {
         molecularProfile2.setMolecularAlterationType(MolecularAlterationType.COPY_NUMBER_ALTERATION);
         molecularProfile2.setDatatype("DISCRETE");
 
-        Mockito.when(molecularProfileService.getMolecularProfilesInStudies(Arrays.asList(STUDY_ID), "SUMMARY"))
+        when(molecularProfileService.getMolecularProfilesInStudies(Arrays.asList(STUDY_ID), "SUMMARY"))
                 .thenReturn(Arrays.asList(molecularProfile1, molecularProfile2));
 
         List<Mutation> mutations = new ArrayList<>();
@@ -403,9 +422,9 @@ public class StudyViewFilterApplierTest {
         Gene gene1 = new Gene();
         gene1.setEntrezGeneId(ENTREZ_GENE_ID_1);
         gene1.setHugoGeneSymbol(HUGO_GENE_SYMBOL_1);
-        Mockito.when(geneService.fetchGenes(Arrays.asList(HUGO_GENE_SYMBOL_1), GeneIdType.HUGO_GENE_SYMBOL.name(),
+        when(geneService.fetchGenes(Arrays.asList(HUGO_GENE_SYMBOL_1), GeneIdType.HUGO_GENE_SYMBOL.name(),
                 Projection.SUMMARY.name())).thenReturn(Arrays.asList(gene1));
-        Mockito.when(mutationService.getMutationsInMultipleMolecularProfilesByGeneQueries(
+        when(mutationService.getMutationsInMultipleMolecularProfilesByGeneQueries(
             anyList(), anyList(), anyList(), anyString(), isNull(), isNull(), isNull(), isNull())).thenReturn(mutations);
 
         updatedSampleIds = new ArrayList<>();
@@ -427,7 +446,7 @@ public class StudyViewFilterApplierTest {
         profileCaseIdentifier3.setMolecularProfileId(MOLECULAR_PROFILE_ID_2);
         molecularProfileCaseIdentifiers.add(profileCaseIdentifier3);
 
-        Mockito.when(molecularProfileService.getFirstDiscreteCNAProfileCaseIdentifiers(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID),
+        when(molecularProfileService.getFirstDiscreteCNAProfileCaseIdentifiers(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID),
                 updatedSampleIds))
                 .thenReturn(molecularProfileCaseIdentifiers);
 
@@ -448,10 +467,10 @@ public class StudyViewFilterApplierTest {
         Gene gene2 = new Gene();
         gene2.setEntrezGeneId(ENTREZ_GENE_ID_2);
         gene2.setHugoGeneSymbol(HUGO_GENE_SYMBOL_2);
-        Mockito.when(geneService.fetchGenes(Arrays.asList(HUGO_GENE_SYMBOL_2), GeneIdType.HUGO_GENE_SYMBOL.name(),
+        when(geneService.fetchGenes(Arrays.asList(HUGO_GENE_SYMBOL_2), GeneIdType.HUGO_GENE_SYMBOL.name(),
             Projection.SUMMARY.name())).thenReturn(Arrays.asList(gene2));
 
-        Mockito.when(discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
+        when(discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
             anyList(), anyList(), anyList(), anyString())).thenReturn(discreteCopyNumberDataList);
 
         List<ClinicalAttribute> clinicalAttributeList = new ArrayList<>();
@@ -464,7 +483,7 @@ public class StudyViewFilterApplierTest {
         clinicalAttribute2.setDatatype("STRING");
         clinicalAttributeList.add(clinicalAttribute2);
 
-        Mockito.when(clinicalAttributeService.getClinicalAttributesByStudyIdsAndAttributeIds(Arrays.asList(STUDY_ID),
+        when(clinicalAttributeService.getClinicalAttributesByStudyIdsAndAttributeIds(Arrays.asList(STUDY_ID),
                 Arrays.asList(CLINICAL_ATTRIBUTE_ID_1, CLINICAL_ATTRIBUTE_ID_2))).thenReturn(clinicalAttributeList);
 
         List<SampleIdentifier> result = studyViewFilterApplier.apply(studyViewFilter);
@@ -555,8 +574,8 @@ public class StudyViewFilterApplierTest {
         patient4.setCancerStudyIdentifier(STUDY_ID);
         patients.add(patient4);
 
-        Mockito.when(sampleService.fetchSamples(studyIds, sampleIds, "ID")).thenReturn(samples);
-        Mockito.when(patientService.getPatientsOfSamples(studyIds, sampleIds)).thenReturn(patients);
+        when(sampleService.fetchSamples(studyIds, sampleIds, "ID")).thenReturn(samples);
+        when(patientService.getPatientsOfSamples(studyIds, sampleIds)).thenReturn(patients);
 
         List<ClinicalData> sampleClinicalDataList = new ArrayList<>();
         ClinicalData sampleClinicalData1 = new ClinicalData();
@@ -590,12 +609,12 @@ public class StudyViewFilterApplierTest {
         sampleClinicalData5.setStudyId(STUDY_ID);
         sampleClinicalDataList.add(sampleClinicalData5);
 
-        Mockito.when(
+        when(
                 clinicalDataService.fetchClinicalData(Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID),
                         sampleIds, Arrays.asList(CLINICAL_ATTRIBUTE_ID_3), "SAMPLE", "SUMMARY"))
                 .thenReturn(sampleClinicalDataList);
 
-        Mockito.when(clinicalDataService.getPatientClinicalDataDetailedToSample(
+        when(clinicalDataService.getPatientClinicalDataDetailedToSample(
                 Arrays.asList(STUDY_ID, STUDY_ID, STUDY_ID, STUDY_ID), sampleIds,
                 Arrays.asList(CLINICAL_ATTRIBUTE_ID_3))).thenReturn(new ArrayList<ClinicalData>());
 
@@ -615,7 +634,7 @@ public class StudyViewFilterApplierTest {
         clinicalAttribute1.setDatatype("NUMBER");
         clinicalAttributeList.add(clinicalAttribute1);
 
-        Mockito.when(clinicalAttributeService.getClinicalAttributesByStudyIdsAndAttributeIds(Arrays.asList(STUDY_ID),
+        when(clinicalAttributeService.getClinicalAttributesByStudyIdsAndAttributeIds(Arrays.asList(STUDY_ID),
                 Arrays.asList(CLINICAL_ATTRIBUTE_ID_3))).thenReturn(clinicalAttributeList);
 
         List<SampleIdentifier> result1 = studyViewFilterApplier.apply(studyViewFilter);
@@ -728,8 +747,8 @@ public class StudyViewFilterApplierTest {
         patient4.setCancerStudyIdentifier(STUDY_ID);
         patients.add(patient4);
 
-        Mockito.when(sampleService.fetchSamples(studyIds, sampleIds, "ID")).thenReturn(samples);
-        Mockito.when(patientService.getPatientsOfSamples(studyIds, sampleIds)).thenReturn(patients);
+        when(sampleService.fetchSamples(studyIds, sampleIds, "ID")).thenReturn(samples);
+        when(patientService.getPatientsOfSamples(studyIds, sampleIds)).thenReturn(patients);
         
         List<MolecularProfile> molecularProfiles = new ArrayList<>();
         MolecularProfile molecularProfile1 = new MolecularProfile();
@@ -738,7 +757,7 @@ public class StudyViewFilterApplierTest {
         molecularProfile1.setPatientLevel(true);
         molecularProfiles.add(molecularProfile1);
         
-        Mockito.when(molecularProfileService.getMolecularProfilesInStudies(Arrays.asList(STUDY_ID), "SUMMARY")).thenReturn(molecularProfiles);
+        when(molecularProfileService.getMolecularProfilesInStudies(Arrays.asList(STUDY_ID), "SUMMARY")).thenReturn(molecularProfiles);
 
         List<GenericAssayData> genericAssayDataList = new ArrayList<>();
         
@@ -787,7 +806,7 @@ public class StudyViewFilterApplierTest {
         genericAssayData5.setValue("100");
         genericAssayDataList.add(genericAssayData5);
 
-        Mockito.when(genericAssayService
+        when(genericAssayService
             .fetchGenericAssayData(Arrays.asList(MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1, MOLECULAR_PROFILE_ID_1), sampleIds, Arrays.asList(CLINICAL_ATTRIBUTE_ID_3), "SUMMARY")).thenReturn(genericAssayDataList);
         
         GenericAssayDataFilter genericAssayDataFilter = new GenericAssayDataFilter();
@@ -805,4 +824,122 @@ public class StudyViewFilterApplierTest {
         // And sample1 sample2 belong to patient1
         Assert.assertEquals(4, result.size());
     }
+    
+    @Test
+    public void applyNumericalCustomDataFilter() throws Exception {
+        // Create samples:
+        List<SampleIdentifier> sampleIdentifiers = new ArrayList<>();
+        sampleIdentifiers.add(createSampleIdentifier(SAMPLE_ID1));
+        sampleIdentifiers.add(createSampleIdentifier(SAMPLE_ID2));
+        sampleIdentifiers.add(createSampleIdentifier(SAMPLE_ID3));
+        StudyViewFilter studyViewFilter = new StudyViewFilter();
+        studyViewFilter.setSampleIdentifiers(sampleIdentifiers);
+        List<String> sampleIds = sampleIdentifiers
+            .stream()
+            .map(SampleIdentifier::getSampleId)
+            .collect(toList());
+        List<String> studyIds = sampleIdentifiers
+            .stream()
+            .map(SampleIdentifier::getStudyId)
+            .collect(toList());
+        List<Sample> samples = sampleIdentifiers
+            .stream()
+            .map(si -> createSample(si.getSampleId()))
+            .collect(toList());
+
+        // Create custom dataset interval filter: sample value must be between 0 and 10
+        ClinicalDataFilter customDataFilter = new ClinicalDataFilter();
+        customDataFilter.setAttributeId(CUSTOM_DATASET_ID);
+        DataFilterValue intervalFilter = new DataFilterValue();
+        intervalFilter.setStart(new BigDecimal("0"));
+        intervalFilter.setEnd(new BigDecimal("10"));
+        customDataFilter.setValues(of(intervalFilter));
+        List<ClinicalDataFilter> customDataFilters = new ArrayList<>();
+        customDataFilters.add(customDataFilter);
+        studyViewFilter.setCustomDataFilters(customDataFilters);
+        
+        // Mock sample service:
+        when(sampleService.fetchSamples(eq(studyIds), eq(sampleIds), eq("ID"))).thenReturn(samples);
+        
+        // Load custom dataset:
+        String customDataset = getFileContents("classpath:numerical-custom-dataset-filter-applier.json");
+        mockCustomDataService(customDataset);
+
+        List<SampleIdentifier> result = studyViewFilterApplier.apply(studyViewFilter);
+
+        Assert.assertEquals(1, result.size());
+    }
+
+    @Test
+    public void applyCategoricalCustomDataFilter() throws Exception {
+        // Create samples:
+        List<SampleIdentifier> sampleIdentifiers = new ArrayList<>();
+        sampleIdentifiers.add(createSampleIdentifier(SAMPLE_ID1));
+        sampleIdentifiers.add(createSampleIdentifier(SAMPLE_ID2));
+        sampleIdentifiers.add(createSampleIdentifier(SAMPLE_ID3));
+        StudyViewFilter studyViewFilter = new StudyViewFilter();
+        studyViewFilter.setSampleIdentifiers(sampleIdentifiers);
+        List<String> sampleIds = sampleIdentifiers
+            .stream()
+            .map(SampleIdentifier::getSampleId)
+            .collect(toList());
+        List<String> studyIds = sampleIdentifiers
+            .stream()
+            .map(SampleIdentifier::getStudyId)
+            .collect(toList());
+        List<Sample> samples = sampleIdentifiers
+            .stream()
+            .map(si -> createSample(si.getSampleId()))
+            .collect(toList());
+        
+        // Create custom dataset equality filter: sample value must be value2
+        ClinicalDataFilter customDataFilter = new ClinicalDataFilter();
+        customDataFilter.setAttributeId(CUSTOM_DATASET_ID);
+        customDataFilter.setValues(of(createDataFilterValue("value2")));
+        List<ClinicalDataFilter> customDataFilters = new ArrayList<>();
+        customDataFilters.add(customDataFilter);
+        studyViewFilter.setCustomDataFilters(customDataFilters);
+        
+        // Mock sample service:
+        when(sampleService.fetchSamples(eq(studyIds), eq(sampleIds), eq("ID"))).thenReturn(samples);
+        
+        // Load custom dataset:
+        String customDataset = getFileContents("classpath:categorical-custom-dataset-filter-applier.json");
+        mockCustomDataService(customDataset);
+
+        List<SampleIdentifier> result = studyViewFilterApplier.apply(studyViewFilter);
+
+        Assert.assertEquals(1, result.size());
+    }
+
+    private DataFilterValue createDataFilterValue(String value) {
+        DataFilterValue equalityFilter = new DataFilterValue();
+        equalityFilter.setValue(value);
+        return equalityFilter;
+    }
+
+    private Sample createSample(String sampleId) {
+        Sample sample1 = new Sample();
+        sample1.setStableId(sampleId);
+        sample1.setCancerStudyIdentifier(STUDY_ID);
+        return sample1;
+    }
+
+    private SampleIdentifier createSampleIdentifier(String sampleId) {
+        SampleIdentifier sampleIdentifier1 = new SampleIdentifier();
+        sampleIdentifier1.setSampleId(sampleId);
+        sampleIdentifier1.setStudyId(STUDY_ID);
+        return sampleIdentifier1;
+    }
+
+    private void mockCustomDataService(String customDatasetFile) throws Exception {
+        when(
+            sessionServiceRequestHandler.getSessionDataJson(any(), any())
+        ).thenReturn(customDatasetFile);
+    }
+    
+    private String getFileContents(String resourceLocation) throws IOException {
+        return new String(Files.readAllBytes(ResourceUtils.getFile(resourceLocation).toPath()));
+    }
+    
 }

--- a/web/src/test/resources/applicationContext-web-test.xml
+++ b/web/src/test/resources/applicationContext-web-test.xml
@@ -13,6 +13,10 @@
 
     <!-- load beans from shared test configuration -->
     <bean class="org.cbioportal.web.config.CacheMapUtilConfig"/>
+    
+    <bean class="org.cbioportal.service.impl.CustomDataServiceImpl"/>
+    <bean class="org.cbioportal.service.util.SessionServiceRequestHandler"/>
+    <bean class="com.fasterxml.jackson.databind.ObjectMapper"/>
 
     <bean
         class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">

--- a/web/src/test/resources/categorical-custom-dataset-filter-applier.json
+++ b/web/src/test/resources/categorical-custom-dataset-filter-applier.json
@@ -1,0 +1,26 @@
+{
+    "id": "custom_dataset_id",
+    "data": {
+        "owner": "custom_dataset_owner",
+        "origin": [
+            "test"
+        ],
+        "created": 1674657017813,
+        "lastUpdated": 1674657017813,
+        "users": [
+            "test"
+        ],
+        "displayName": "test",
+        "description": "test",
+        "datatype": "STRING",
+        "patientAttribute": false,
+        "priority": "0",
+        "data": [
+            {"sampleId": "sample_id1", "patientId": "test_patient", "studyId": "study_id", "value": "value1"},
+            {"sampleId": "sample_id2", "patientId": "test_patient", "studyId": "study_id", "value": "value2"},
+            {"sampleId": "sample_id3", "patientId": "test_patient", "studyId": "study_id", "value": "value3"}
+        ]
+    },
+    "source": "test",
+    "type": "custom_data"
+}

--- a/web/src/test/resources/custom-dataset-minimal.json
+++ b/web/src/test/resources/custom-dataset-minimal.json
@@ -1,0 +1,48 @@
+{
+    "id": "test",
+    "data": {
+        "owner": "test",
+        "origin": [
+            "test"
+        ],
+        "created": 1674657017813,
+        "lastUpdated": 1674657017813,
+        "users": [
+            "test"
+        ],
+        "displayName": "test",
+        "description": "test",
+        "datatype": "NUMBER",
+        "patientAttribute": false,
+        "priority": "0",
+        "data": [
+            {"sampleId": "test-0-01", "patientId": "test-A", "studyId": "test", "value": "-1.1"},
+            
+            {"sampleId": "test-0-01", "patientId": "test-A", "studyId": "test", "value": "0"},
+            
+            {"sampleId": "test-1-same-patient-01", "patientId": "test-1-same-patient", "studyId": "test", "value": "1"},
+
+            {"sampleId": "test-1-same-patient-02", "patientId": "test-1-same-patient", "studyId": "test", "value": "1.1"},
+            {"sampleId": "test-2-01", "patientId": "test-2", "studyId": "test", "value": "2"},
+            
+            {"sampleId": "test-3-01", "patientId": "test-3", "studyId": "test", "value": "3"},
+            {"sampleId": "test-other-patient-same-bin-01", "patientId": "test-other-patient-same-bin", "studyId": "test", "value": "3"},
+            
+            {"sampleId": "test-5-01", "patientId": "test-5", "studyId": "test", "value": "4"},
+            
+            {"sampleId": "test-6-01", "patientId": "test-6", "studyId": "test", "value": "6"},
+
+            {"sampleId": "test-7-01", "patientId": "test-7", "studyId": "test", "value": "7"},
+
+            {"sampleId": "test-8-01", "patientId": "test-8", "studyId": "test", "value": "8"},
+
+            {"sampleId": "test-9-01", "patientId": "test-9", "studyId": "test", "value": "9"},
+            
+            {"sampleId": "test-9-01", "patientId": "test-9", "studyId": "test", "value": "10"},
+            
+            {"sampleId": "test-9-01", "patientId": "test-9", "studyId": "test", "value": "11"}
+        ]
+    },
+    "source": "test",
+    "type": "custom_data"
+}

--- a/web/src/test/resources/custom-dataset.json
+++ b/web/src/test/resources/custom-dataset.json
@@ -1,0 +1,359 @@
+{
+    "id": "test",
+    "data": {
+        "owner": "foo@bar.com",
+        "origin": [
+            "none"
+        ],
+        "created": 1674657017813,
+        "lastUpdated": 1674657017813,
+        "users": [
+            "foo@bar.com"
+        ],
+        "displayName": "Foo",
+        "description": "Bar",
+        "datatype": "NUMBER",
+        "patientAttribute": false,
+        "priority": "0",
+        "data": [
+            {
+                "sampleId": "TCGA-A1-A0SB-01",
+                "patientId": "TCGA-A1-A0SB",
+                "studyId": "study_es_0",
+                "value": "23"
+            },
+            {
+                "sampleId": "TCGA-A2-A04P-01",
+                "patientId": "TCGA-A2-A04P",
+                "studyId": "study_es_0",
+                "value": "1"
+            },
+            {
+                "sampleId": "TCGA-A2-A0CV-01",
+                "patientId": "TCGA-A2-A0CV",
+                "studyId": "study_es_0",
+                "value": "5"
+            },
+            {
+                "sampleId": "TCGA-A2-A0ET-01",
+                "patientId": "TCGA-A2-A0ET",
+                "studyId": "study_es_0",
+                "value": "7"
+            },
+            {
+                "sampleId": "TCGA-A2-A0T4-01",
+                "patientId": "TCGA-A2-A0T4",
+                "studyId": "study_es_0",
+                "value": "7"
+            },
+            {
+                "sampleId": "TCGA-A2-A1FV-01",
+                "patientId": "TCGA-A2-A1FV",
+                "studyId": "study_es_0",
+                "value": "6.7"
+            },
+            {
+                "sampleId": "TCGA-A7-A0CE-01",
+                "patientId": "TCGA-A7-A0CE",
+                "studyId": "study_es_0",
+                "value": "5"
+            },
+            {
+                "sampleId": "TCGA-A7-A26I-01",
+                "patientId": "TCGA-A7-A26I",
+                "studyId": "study_es_0",
+                "value": "9"
+            },
+            {
+                "sampleId": "TCGA-A8-A07C-01",
+                "patientId": "TCGA-A8-A07C",
+                "studyId": "study_es_0",
+                "value": "11"
+            },
+            {
+                "sampleId": "TCGA-A8-A083-01",
+                "patientId": "TCGA-A8-A083",
+                "studyId": "study_es_0",
+                "value": "11"
+            },
+            {
+                "sampleId": "TCGA-A8-A08S-01",
+                "patientId": "TCGA-A8-A08S",
+                "studyId": "study_es_0",
+                "value": "10.7"
+            },
+            {
+                "sampleId": "TCGA-A8-A09D-01",
+                "patientId": "TCGA-A8-A09D",
+                "studyId": "study_es_0",
+                "value": "9"
+            },
+            {
+                "sampleId": "TCGA-A8-A0A4-01",
+                "patientId": "TCGA-A8-A0A4",
+                "studyId": "study_es_0",
+                "value": "13"
+            },
+            {
+                "sampleId": "TCGA-AN-A0AL-01",
+                "patientId": "TCGA-AN-A0AL",
+                "studyId": "study_es_0",
+                "value": "15"
+            },
+            {
+                "sampleId": "TCGA-AN-A0FY-01",
+                "patientId": "TCGA-AN-A0FY",
+                "studyId": "study_es_0",
+                "value": "15"
+            },
+            {
+                "sampleId": "TCGA-AO-A03O-01",
+                "patientId": "TCGA-AO-A03O",
+                "studyId": "study_es_0",
+                "value": "14.7"
+            },
+            {
+                "sampleId": "TCGA-AO-A0JC-01",
+                "patientId": "TCGA-AO-A0JC",
+                "studyId": "study_es_0",
+                "value": "13"
+            },
+            {
+                "sampleId": "TCGA-AO-A12C-01",
+                "patientId": "TCGA-AO-A12C",
+                "studyId": "study_es_0",
+                "value": "17"
+            },
+            {
+                "sampleId": "TCGA-AQ-A1H2-01",
+                "patientId": "TCGA-AQ-A1H2",
+                "studyId": "study_es_0",
+                "value": "19"
+            },
+            {
+                "sampleId": "TCGA-AR-A0U3-01",
+                "patientId": "TCGA-AR-A0U3",
+                "studyId": "study_es_0",
+                "value": "19"
+            },
+            {
+                "sampleId": "TCGA-AR-A1AW-01",
+                "patientId": "TCGA-AR-A1AW",
+                "studyId": "study_es_0",
+                "value": "18.7"
+            },
+            {
+                "sampleId": "TCGA-AR-A24W-01",
+                "patientId": "TCGA-AR-A24W",
+                "studyId": "study_es_0",
+                "value": "17"
+            },
+            {
+                "sampleId": "TCGA-B6-A0IC-01",
+                "patientId": "TCGA-B6-A0IC",
+                "studyId": "study_es_0",
+                "value": "21"
+            },
+            {
+                "sampleId": "TCGA-B6-A0RM-01",
+                "patientId": "TCGA-B6-A0RM",
+                "studyId": "study_es_0",
+                "value": "23"
+            },
+            {
+                "sampleId": "TCGA-B6-A0X0-01",
+                "patientId": "TCGA-B6-A0X0",
+                "studyId": "study_es_0",
+                "value": "23"
+            },
+            {
+                "sampleId": "TCGA-BH-A0B2-01",
+                "patientId": "TCGA-BH-A0B2",
+                "studyId": "study_es_0",
+                "value": "22.7"
+            },
+            {
+                "sampleId": "TCGA-BH-A0BP-01",
+                "patientId": "TCGA-BH-A0BP",
+                "studyId": "study_es_0",
+                "value": "21"
+            },
+            {
+                "sampleId": "TCGA-BH-A0DI-01",
+                "patientId": "TCGA-BH-A0DI",
+                "studyId": "study_es_0",
+                "value": "25"
+            },
+            {
+                "sampleId": "TCGA-BH-A0E9-01",
+                "patientId": "TCGA-BH-A0E9",
+                "studyId": "study_es_0",
+                "value": "27"
+            },
+            {
+                "sampleId": "TCGA-BH-A0HI-01",
+                "patientId": "TCGA-BH-A0HI",
+                "studyId": "study_es_0",
+                "value": "27"
+            },
+            {
+                "sampleId": "TCGA-BH-A0WA-01",
+                "patientId": "TCGA-BH-A0WA",
+                "studyId": "study_es_0",
+                "value": "26.7"
+            },
+            {
+                "sampleId": "TCGA-BH-A18V-01",
+                "patientId": "TCGA-BH-A18V",
+                "studyId": "study_es_0",
+                "value": "25"
+            },
+            {
+                "sampleId": "TCGA-BH-A1FC-01",
+                "patientId": "TCGA-BH-A1FC",
+                "studyId": "study_es_0",
+                "value": "29"
+            },
+            {
+                "sampleId": "TCGA-BH-A209-01",
+                "patientId": "TCGA-BH-A209",
+                "studyId": "study_es_0",
+                "value": "31"
+            },
+            {
+                "sampleId": "TCGA-C8-A130-01",
+                "patientId": "TCGA-C8-A130",
+                "studyId": "study_es_0",
+                "value": "31"
+            },
+            {
+                "sampleId": "TCGA-C8-A1HN-01",
+                "patientId": "TCGA-C8-A1HN",
+                "studyId": "study_es_0",
+                "value": "30.7"
+            },
+            {
+                "sampleId": "TCGA-D8-A141-01",
+                "patientId": "TCGA-D8-A141",
+                "studyId": "study_es_0",
+                "value": "29"
+            },
+            {
+                "sampleId": "TCGA-D8-A1JI-01",
+                "patientId": "TCGA-D8-A1JI",
+                "studyId": "study_es_0",
+                "value": "33"
+            },
+            {
+                "sampleId": "TCGA-D8-A1XB-01",
+                "patientId": "TCGA-D8-A1XB",
+                "studyId": "study_es_0",
+                "value": "35"
+            },
+            {
+                "sampleId": "TCGA-D8-A1XW-01",
+                "patientId": "TCGA-D8-A1XW",
+                "studyId": "study_es_0",
+                "value": "35"
+            },
+            {
+                "sampleId": "TCGA-D8-A27P-01",
+                "patientId": "TCGA-D8-A27P",
+                "studyId": "study_es_0",
+                "value": "34.7"
+            },
+            {
+                "sampleId": "TCGA-E2-A14O-01",
+                "patientId": "TCGA-E2-A14O",
+                "studyId": "study_es_0",
+                "value": "33"
+            },
+            {
+                "sampleId": "TCGA-E2-A156-01",
+                "patientId": "TCGA-E2-A156",
+                "studyId": "study_es_0",
+                "value": "37"
+            },
+            {
+                "sampleId": "TCGA-E2-A15O-01",
+                "patientId": "TCGA-E2-A15O",
+                "studyId": "study_es_0",
+                "value": "39"
+            },
+            {
+                "sampleId": "TCGA-E2-A1IH-01",
+                "patientId": "TCGA-E2-A1IH",
+                "studyId": "study_es_0",
+                "value": "39"
+            },
+            {
+                "sampleId": "TCGA-E2-A1LH-01",
+                "patientId": "TCGA-E2-A1LH",
+                "studyId": "study_es_0",
+                "value": "38.7"
+            },
+            {
+                "sampleId": "TCGA-E9-A1NG-01",
+                "patientId": "TCGA-E9-A1NG",
+                "studyId": "study_es_0",
+                "value": "37"
+            },
+            {
+                "sampleId": "TCGA-E9-A1RF-01",
+                "patientId": "TCGA-E9-A1RF",
+                "studyId": "study_es_0",
+                "value": "41"
+            },
+            {
+                "sampleId": "TCGA-E9-A245-01",
+                "patientId": "TCGA-E9-A245",
+                "studyId": "study_es_0",
+                "value": "43"
+            },
+            {
+                "sampleId": "TCGA-EW-A1OW-01",
+                "patientId": "TCGA-EW-A1OW",
+                "studyId": "study_es_0",
+                "value": "43"
+            },
+            {
+                "sampleId": "TCGA-EW-A1PF-01",
+                "patientId": "TCGA-EW-A1PF",
+                "studyId": "study_es_0",
+                "value": "42.7"
+            },
+            {
+                "sampleId": "TCGA-GM-A2DL-01",
+                "patientId": "TCGA-GM-A2DL",
+                "studyId": "study_es_0",
+                "value": "41"
+            },
+            {
+                "sampleId": "TEST_SAMPLE_14",
+                "patientId": "TEST_PATIENT_14",
+                "studyId": "study_es_0",
+                "value": "45"
+            },
+            {
+                "sampleId": "TEST_SAMPLE_15",
+                "patientId": "TEST_PATIENT_15",
+                "studyId": "study_es_0",
+                "value": "46"
+            },
+            {
+                "sampleId": "TEST_SAMPLE_2",
+                "patientId": "TEST_PATIENT_2",
+                "studyId": "study_es_0",
+                "value": "49"
+            },
+            {
+                "sampleId": "TEST_SAMPLE_SOMATIC_HETEROZYGOUS",
+                "patientId": "TEST_PATIENT_NAMESPACE",
+                "studyId": "study_es_0",
+                "value": "54"
+            }
+        ]
+    },
+    "source": "my_portal",
+    "type": "custom_data"
+}

--- a/web/src/test/resources/numerical-custom-dataset-filter-applier.json
+++ b/web/src/test/resources/numerical-custom-dataset-filter-applier.json
@@ -1,0 +1,26 @@
+{
+    "id": "custom_dataset_id",
+    "data": {
+        "owner": "custom_dataset_owner",
+        "origin": [
+            "test"
+        ],
+        "created": 1674657017813,
+        "lastUpdated": 1674657017813,
+        "users": [
+            "test"
+        ],
+        "displayName": "test",
+        "description": "test",
+        "datatype": "NUMBER",
+        "patientAttribute": false,
+        "priority": "0",
+        "data": [
+            {"sampleId": "sample_id1", "patientId": "test_patient", "studyId": "study_id", "value": "-2"},
+            {"sampleId": "sample_id2", "patientId": "test_patient", "studyId": "study_id", "value": "2"},
+            {"sampleId": "sample_id3", "patientId": "test_patient", "studyId": "study_id", "value": "12"}
+        ]
+    },
+    "source": "test",
+    "type": "custom_data"
+}


### PR DESCRIPTION
Allow users to bin and filter their own custom (numerical and categorical) datasets using a new endpoint.

These changes will be used in a front end PR.

## Changes
- Add new endpoint `/custom-data-bin-counts/fetch` to `StudyViewController` to bin custom datasets
- Isolate retrieval of custom data from session service in new `CustomDataServiceImpl`, and share functionality at relevant places
- Filter by both categorical and numerical custom data using `CustomDataFilterApplier`
- Refactor `ClinicalDataBinUtil` to bin both clinical and custom data.
 
## Tests
- Filtering is tested in `StudyViewFilterApplierTest`
- Binning is tested in  `ClinicalDataBinUtilTest`
- Use `applicationContext-web-test.xml` in integration tests to fix missing `CustomDataServiceImpl` (and related) beans