### PR TITLE
Fix validator bug with DFS_STATUS error log message

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -2941,7 +2941,6 @@ class PatientClinicalValidator(ClinicalValidator):
                     self.logger.error(
                             'Value in DFS_STATUS column is not 0:DiseaseFree, '
                             '1:Recurred/Progressed, 1:Recurred, 1:Progressed',
-                            'DiseaseFree, Recurred/Progressed, Recurred or Progressed',
                             extra={'line_number': self.line_number,
                                    'column_number': col_index + 1,
                                    'cause': value})


### PR DESCRIPTION
# Problem
The python validator throws a python error when there is a data-dependent error in the `DFS_STATUS` column.

# Solution
This is caused by the passing of a f-string variable where there is no need for string replacement (no `%` present in message string). Removal of the second argument corrects this problem.