### PR TITLE
fix several bugs in oncokb annotation scripts and improve code robustness

### DIFF
--- a/core/src/main/scripts/importer/libImportOncokb.py
+++ b/core/src/main/scripts/importer/libImportOncokb.py
@@ -279,6 +279,8 @@ def interface():
                              'http://localhost:8080')
     parser.add_argument('-m', '--study_directory', type=str, required=True,
                         help='path to study directory.')
+    parser.add_argument('-p', '--portal-info-dir', help='Specify a directory of database export JSON files for validation.'
+                                                        'genes.json is used to resolved gene symbols/IDs')
     parser = parser.parse_args()
     return parser
 

--- a/core/src/main/scripts/importer/updateOncokbAnnotations.py
+++ b/core/src/main/scripts/importer/updateOncokbAnnotations.py
@@ -30,7 +30,6 @@ import argparse
 import importlib
 import logging.handlers
 import os
-import requests
 import sys
 import MySQLdb
 from pathlib import Path


### PR DESCRIPTION
I ran into several issues while using these scripts. Can now also use local `*.json` files for gene symbol resolving.
Code improvements to handle edge cases in the data.