### PR TITLE
update cosmic importer for new cosmic datafiles

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/MutationKeywordUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/MutationKeywordUtils.java
@@ -150,7 +150,7 @@ public final class MutationKeywordUtils {
      * @return 
      */
     public static String guessCosmicKeyword(String aminoAcidChange) {
-        if (aminoAcidChange.matches("\\(?[A-Z\\*]?[0-9]+\\)?fs\\*?>?\\??[0-9]*") // frameshift
+        if (aminoAcidChange.matches("\\(?[A-Z\\*]?[0-9]+[A-Z\\*]?\\)?fs\\*?>?\\??[0-9]*") // frameshift
                 || aminoAcidChange.equals("?fs") // frameshift
                 || aminoAcidChange.matches("[A-Z][0-9]+>?\\*") // non sense
                 || aminoAcidChange.matches("M1>?[A-LN-Z]") // non start
@@ -166,7 +166,7 @@ public final class MutationKeywordUtils {
             return "truncating";
         }
         
-        Pattern p = Pattern.compile("(([A-Z\\*])[0-9]+)>?\\2");
+        Pattern p = Pattern.compile("(([A-Z\\*])[0-9]+)>?((\\2)|(=)|(%3D))");  // cosmic encodes = as %3D
         Matcher m = p.matcher(aminoAcidChange);
         if (m.matches()) {
             return m.group(1)+" silent";
@@ -181,10 +181,22 @@ public final class MutationKeywordUtils {
             return m.group(1)+" missense";
         }
         
-        p = Pattern.compile("[A-Z]?([0-9]+)_[A-Z]?[0-9]+ins(([A-Z]+)|([0-9]+))");
+        p = Pattern.compile("[A-Z]?([0-9]+)_[A-Z\\*]?[0-9]+ins(([A-Z]+)|([0-9]+))"); //incl. ins before stop codon
         m = p.matcher(aminoAcidChange);
         if (m.matches()) {
             return m.group(1)+" insertion";
+        }
+
+        p = Pattern.compile("\\*([0-9]+)[A-Z]?ext\\*(([0-9]+)|(\\?))"); //extension of stop codon
+        m = p.matcher(aminoAcidChange);
+        if (m.matches()) {
+            return m.group(1)+" insertion";
+        }
+
+        p = Pattern.compile("[A-Z*]([0-9]+)(_[A-Z*][0-9]+)?dup"); //duplication treated as insertion
+        m = p.matcher(aminoAcidChange);
+        if (m.matches()) {
+            return m.group(1)+" insertion";  
         }
         
         p = Pattern.compile("[A-Z]?([0-9]+)>[A-Z][A-Z]+");
@@ -211,11 +223,11 @@ public final class MutationKeywordUtils {
             return m.group(1) + "-" + m.group(2) + " deletion";
         }
         
-        p = Pattern.compile("[A-Z]([0-9]+)_[A-Z]([0-9]+)>([A-Z]+)"); // this is actually similar to missense mutation for more than 1 amino acid
+        p = Pattern.compile("[A-Z]([0-9]+)_[A-Z*]([0-9]+)((>)|(delins))([A-Z*]+)"); // this is actually similar to missense mutation for more than 1 amino acid
         m = p.matcher(aminoAcidChange);
         if (m.matches()) {
             int n1 = Integer.parseInt(m.group(2)) - Integer.parseInt(m.group(1)) + 1;
-            int n2 = m.group(3).length();
+            int n2 = m.group(6).length();
             if (n1==n2) {
                 return m.group(1) + "-" + m.group(2) + " missense";
             }
@@ -225,6 +237,27 @@ public final class MutationKeywordUtils {
             }
             
             return m.group(1) + " insertion";
+        }
+
+        p = Pattern.compile("[A-Z*]([0-9]+)delins[A-Z*]+[0-9]*"); //delins with 1 del & >1 ins
+        m = p.matcher(aminoAcidChange);
+        if (m.matches()) {
+            return m.group(1)+" insertion";
+        }
+
+        p = Pattern.compile("([A-Z*]+)([0-9]+)delext\\*([0-9]+)"); //delext
+        m = p.matcher(aminoAcidChange);
+        if (m.matches()) {
+            int n1 = m.group(1).length(); // no. of AA deleted
+            int n2 = Integer.parseInt(m.group(3));  // no. of AA added
+            int n3 = Integer.parseInt(m.group(2)); // location of AA1
+            if (n1==n2) {
+                return m.group(2) + "-" + Integer.toString(n3 + n2 - 1) + " missense";
+            }
+
+            if (n1 < n2) {
+                return m.group(2) + " insertion";
+            }
         }
         
         return null;

--- a/core/src/test/java/org/mskcc/cbio/portal/util/TestMutationKeywordUtils.java
+++ b/core/src/test/java/org/mskcc/cbio/portal/util/TestMutationKeywordUtils.java
@@ -107,11 +107,15 @@ public class TestMutationKeywordUtils {
         assertNull(MutationKeywordUtils.guessCosmicKeyword("K267_D268ins?"));
         assertNull(MutationKeywordUtils.guessCosmicKeyword("WQQQSYLD25?"));
         assertNull(MutationKeywordUtils.guessCosmicKeyword("M1>?"));
-        
+        assertNull(MutationKeywordUtils.guessCosmicKeyword("PCRF*177delext*4")); //delext deletion should be Null
+
+
         // silent
         assertEquals("*803 silent", MutationKeywordUtils.guessCosmicKeyword("*803*"));
         assertEquals("A803 silent", MutationKeywordUtils.guessCosmicKeyword("A803A"));
         assertEquals("A803 silent", MutationKeywordUtils.guessCosmicKeyword("A803>A"));
+        assertEquals("A803 silent", MutationKeywordUtils.guessCosmicKeyword("A803="));
+        assertEquals("A803 silent", MutationKeywordUtils.guessCosmicKeyword("A803%3D"));
         
         // missense
         assertEquals("A2 missense", MutationKeywordUtils.guessCosmicKeyword("A2S"));
@@ -127,8 +131,30 @@ public class TestMutationKeywordUtils {
         assertEquals("630 insertion", MutationKeywordUtils.guessCosmicKeyword("D630_I631insRG"));
         assertEquals("299 insertion", MutationKeywordUtils.guessCosmicKeyword("299_300insGRS"));
         assertEquals("976 insertion", MutationKeywordUtils.guessCosmicKeyword("V976_C977ins3"));
+        assertEquals("172 insertion", MutationKeywordUtils.guessCosmicKeyword("D172_*173insCTSTDGS"));
         assertEquals("452 insertion", MutationKeywordUtils.guessCosmicKeyword("Y452_Q455>SGGSRIK")); // this is actually missense?
         assertEquals("475 insertion", MutationKeywordUtils.guessCosmicKeyword("Q475_E476>VLQ")); // this is actually missense?
+        
+        // extension (treated as insertion)
+        assertEquals("1001 insertion", MutationKeywordUtils.guessCosmicKeyword("*1001Rext*22"));
+        
+        // duplication (treated as insertion)
+        assertEquals("100 insertion", MutationKeywordUtils.guessCosmicKeyword("A100dup"));
+        assertEquals("102 insertion", MutationKeywordUtils.guessCosmicKeyword("A102_A104dup"));
+        
+        // delins (treated as insertion/missense/deletion)
+        assertEquals("1038-1041 deletion", MutationKeywordUtils.guessCosmicKeyword("A1038_R1041delinsCFC"));
+        assertEquals("102-104 deletion", MutationKeywordUtils.guessCosmicKeyword("A102_L104delinsV"));
+        assertEquals("106 insertion", MutationKeywordUtils.guessCosmicKeyword("A106delinsGRLS"));
+        assertEquals("106 insertion", MutationKeywordUtils.guessCosmicKeyword("A106_A107delinsGRLS"));
+        assertEquals("107-108 missense", MutationKeywordUtils.guessCosmicKeyword("A107_L108delinsSD"));
+
+        
+        // delext (treated as insertion/missense), logically it should only be insertion
+        assertEquals("125 insertion", MutationKeywordUtils.guessCosmicKeyword("*125delext*8"));
+        assertEquals("177 insertion", MutationKeywordUtils.guessCosmicKeyword("PCRF*177delext*64"));
+        assertEquals("177-181 missense", MutationKeywordUtils.guessCosmicKeyword("PCRF*177delext*5"));
+        
         
         // deletion
         assertEquals("738-738 deletion", MutationKeywordUtils.guessCosmicKeyword("G738delG"));
@@ -156,6 +182,7 @@ public class TestMutationKeywordUtils {
         assertEquals("truncating", MutationKeywordUtils.guessCosmicKeyword("*257fs*>4"));
         assertEquals("truncating", MutationKeywordUtils.guessCosmicKeyword("557fs*?"));
         assertEquals("truncating", MutationKeywordUtils.guessCosmicKeyword("?fs"));
+        assertEquals("truncating", MutationKeywordUtils.guessCosmicKeyword("*100Ifs*4"));
         assertEquals("truncating", MutationKeywordUtils.guessCosmicKeyword("R412_*413delR*"));
         assertEquals("truncating", MutationKeywordUtils.guessCosmicKeyword("(P1249)fs*?"));
         


### PR DESCRIPTION
Update Cosmic data importer to parse Legacy ID and recognise new HGSVp nomenclature

`ImportCosmicData.java`
COSV identifiers do not map to the COSMIC webpage correctly, COSM identifiers are still present in INFO string, take these as COSMIC IDs.

`MutationKeywordUtils.java`
Line 153 - Frameshift was not recognised when starting at stop codon.
Line 169 - Add other silent mutation options
Line 184 - Insertion just before stop codon not recognised (A101_*102insAA)
Line 189-194 - New HGSVp keyword `ext`, implemented as insertion
Line 196-200 - New HGSVp keyword `dup`, implemented as insertion
Line 226 - New HGSVp keyword `delins`, added to existing `delins`-like structure
- Line 230 - Edited matching group to reflect new changes at line 226
Line 242-246 - New HGSVp keyword `delins` with 1 del and >1 ins, not captured by an earlier regex
Line 248-261 - New HGSVp keyword `delext` implemented in a similar structure as delins, excluding n1 > n2 option, as this would not be a delext

`TestMutationKeywordUtils.java`
Added tests for new implementations.

# Checks
- [ ] Runs on heroku
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
