### PR TITLE
Add default parameters to DB schema migration script

### DIFF
--- a/docs/Updating-your-cBioPortal-installation.md
+++ b/docs/Updating-your-cBioPortal-installation.md
@@ -49,7 +49,7 @@ To run the migration script first go to the scripts folder
 `<your_cbioportal_dir>/core/src/main/scripts` 
 and then run the following command:
 ```console
-$ python migrate_db.py --properties-file <your_cbioportal_dir>/src/main/resources/portal.properties --sql <your_cbioportal_dir>/db-scripts/src/main/resources/migration.sql
+$ python migrate_db.py
 ```
 This should result in the following output:
 ```console


### PR DESCRIPTION
Both `--properties-file` and `--sql` properties can be inferred from the environment, so this PR proposes to use the default properties and sql files in the `migrate_db.py` script unless specified in the parameters.
