### PR TITLE
Update germline values in mutation status selector

### DIFF
--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/AlterationCountsMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/AlterationCountsMapper.xml
@@ -239,7 +239,7 @@
                 <trim prefix="AND (" suffix=")" prefixOverrides="OR">
                     <if test="includeGermline">
                         OR
-                        LOWER(mutation.MUTATION_STATUS) = 'germline'
+                        LOWER(mutation.MUTATION_STATUS) LIKE '%germline%'
                     </if>
                     <if test="includeSomatic">
                         OR
@@ -247,7 +247,7 @@
                     </if>
                     <if test="includeUnknownStatus">
                         OR
-                        LOWER(mutation.MUTATION_STATUS) NOT IN ('germline', 'somatic')
+                        (LOWER(mutation.MUTATION_STATUS) != 'somatic' AND LOWER(mutation.MUTATION_STATUS) NOT LIKE '%germline%')
                     </if>
                 </trim>
             </when>


### PR DESCRIPTION
We now have incoming new Germline values:

Germline
Germline - VUS
Germline - Pathogenic
Germline - Likely Pathogenic
So we need to update the filter logic to include updated values.

Changes in this pull request are backward compatible, old data won't see differences after deployment.