### PR TITLE
Update SQL to fix incompatibility with sqlmode OnlyFullGroupBy

### DIFF
--- a/core/src/test/resources/applicationContext-dao.xml
+++ b/core/src/test/resources/applicationContext-dao.xml
@@ -67,7 +67,16 @@
 		<property name="maxTotal" value="100" />
 		<property name="poolPreparedStatements" value="true" />
 	</bean>
-	
+
+    <bean id="databaseIdProvider" class="org.apache.ibatis.mapping.VendorDatabaseIdProvider">
+        <property name="properties">
+            <props>
+                <prop key="MySQL">mysql</prop>
+                <prop key="H2">h2</prop>
+            </props>
+        </property>
+    </bean>
+    
     <!-- define the SqlSessionFactory -->
     <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
         <property name="dataSource" ref="businessDataSource" />
@@ -76,6 +85,7 @@
         <!-- mapper locations is set here to support interdependency between mappers without -->
         <!-- having to autowire repositories into java classes that do not make direct uses of them -->
         <property name="mapperLocations" value="classpath*:org/cbioportal/persistence/mybatis/**/*.xml"/>
+        <property name="databaseIdProvider" ref="databaseIdProvider"/>
     </bean>
     
     <!-- scan for mappers and let them be autowired -->

--- a/persistence/persistence-connections/src/main/resources/applicationContext-persistenceConnections.xml
+++ b/persistence/persistence-connections/src/main/resources/applicationContext-persistenceConnections.xml
@@ -44,7 +44,15 @@
         </bean>
 
         <bean id="customObjectFactory" class="org.cbioportal.persistence.mybatis.util.CustomMyBatisObjectFactory" />
-
+        
+        <bean id="databaseIdProvider" class="org.apache.ibatis.mapping.VendorDatabaseIdProvider">
+            <property name="properties">
+                <props>
+                    <prop key="MySQL">mysql</prop>
+                    <prop key="H2">h2</prop>
+                </props>
+            </property>
+        </bean> 
         <!-- define the SqlSessionFactory -->
         <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
             <property name="dataSource" ref="businessDataSource" />
@@ -60,6 +68,7 @@
             <!-- mapper locations is set here to support interdependency between mappers without -->
             <!-- having to autowire repositories into java classes that do not make direct use of them -->
             <property name="mapperLocations" value="classpath*:org/cbioportal/persistence/mybatis/**/*.xml" />
+            <property name="databaseIdProvider" ref="databaseIdProvider"/>
         </bean>
     </beans>
   

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalEventMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalEventMapper.xml
@@ -142,7 +142,14 @@
 
     <select id="getPatientsDistinctClinicalEventInStudies" resultType="org.cbioportal.model.ClinicalEvent">
         SELECT
-        clinical_event.CLINICAL_EVENT_ID AS clinicalEventId,
+        <choose>
+            <when test="_databaseId == 'mysql'">
+                ANY_VALUE(clinical_event.CLINICAL_EVENT_ID) AS clinicalEventId,
+            </when>
+            <when test="_databaseId == 'h2'">
+                clinical_event.CLINICAL_EVENT_ID AS clinicalEventId,
+            </when>
+        </choose>
         clinical_event.EVENT_TYPE AS eventType,
         patient.STABLE_ID AS patientId
         <include refid="from"/>

--- a/persistence/persistence-mybatis/src/test/resources/testContextDatabase.xml
+++ b/persistence/persistence-mybatis/src/test/resources/testContextDatabase.xml
@@ -45,10 +45,20 @@
         <property name="url" value="jdbc:h2:mem:;MODE=MySQL;DATABASE_TO_UPPER=false;INIT=RUNSCRIPT FROM 'classpath:cgds-test.sql'\;RUNSCRIPT FROM 'classpath:testSql.sql'"/>
     </bean>
 
+    <bean id="databaseIdProvider" class="org.apache.ibatis.mapping.VendorDatabaseIdProvider">
+        <property name="properties">
+            <props>
+                <prop key="MySQL">mysql</prop>
+                <prop key="H2">h2</prop>
+            </props>
+        </property>
+    </bean>
+    
     <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
         <property name="dataSource" ref="dbcpDataSource"/>
         <property name="typeAliasesPackage" value="org.mskcc.cbio.portal.model"/>
         <property name="typeHandlersPackage" value="org.cbioportal.persistence.mybatis.typehandler"/>
+        <property name="databaseIdProvider" ref="databaseIdProvider"/>
     </bean>
 
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">


### PR DESCRIPTION
Fix #10080 

After MySQL 5.7.5 ONLY_FULL_GROUP_BY mode was added, which rejects queries which select list refer to non-aggregated columns that are neither named in the group by clause. 

https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_only_full_group_by

Describe changes proposed in this pull request:
Updated Query to utilize ANY_VALUE() 
https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value

## MySQL vs H2 compatibility
Integration tests run agains a H2 in-memory database that does not support the `ANY_VALUE` statement. To solve this, knowledge of the database type is passed to MyBatis using the [MyBatis DatabaseIdProvider mechanism](https://mybatis.org/mybatis-3/apidocs/reference/org/apache/ibatis/mapping/DatabaseIdProvider.html) that will use `ANY_VALUE` statements only when MySQL database is used.
