### PR TITLE
Fix StructuralVariantMapper.xml

### DIFF
--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StructuralVariantMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StructuralVariantMapper.xml
@@ -160,7 +160,7 @@
 
     <sql id="whereStructuralVariantQueries">
         <if test="structuralVariantQueries != null and !structuralVariantQueries.isEmpty()">
-            (
+            OR (
                 <foreach item="item" collection="structuralVariantQueries" open="(" separator=") OR (" close=")">
                     <if test="item.gene1.entrezId != null">
                         structural_variant.SITE1_ENTREZ_GENE_ID=#{item.gene1.entrezId}

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/StructuralVariantMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/StructuralVariantMyBatisRepositoryTest.java
@@ -505,6 +505,34 @@ public class StructuralVariantMyBatisRepositoryTest {
         Assert.assertEquals((Integer) 238, structuralVariantFirstResult.getSite2EntrezGeneId());
         Assert.assertEquals("Fusion", structuralVariantFirstResult.getEventInfo());
     }
+
+    @Test
+    public void fetchStructuralVariantsWithStructuralVariantQueryAndGeneId() throws Exception {
+
+        List<String> molecularProfileIds = new ArrayList<>();
+        List<String> sampleIds = new ArrayList<>();
+
+        molecularProfileIds.add("study_tcga_pub_sv");
+
+        List<Integer> entrezGeneId = Arrays.asList(8031);
+        List<StructuralVariantQuery> singleStructVarQuery = new ArrayList<>();
+        singleStructVarQuery.add(new StructuralVariantQuery(
+            new StructuralVariantGeneSubQuery(27436),
+            new StructuralVariantGeneSubQuery(238)
+        ));
+
+        List<Integer> noEntrezIds = Collections.emptyList();
+
+        List<StructuralVariant> result =
+            structuralVariantMyBatisRepository.fetchStructuralVariants(
+                molecularProfileIds,
+                sampleIds,
+                entrezGeneId,
+                singleStructVarQuery
+            );
+
+        Assert.assertEquals(3,  result.size());
+    }
     
     @Test
     public void fetchStructuralVariantsWithMultipleStructuralVariantQueries() throws Exception {


### PR DESCRIPTION
# Problem
Sending both Entez Gene Ids and StructuralVariantQueries to the StructuralVariantMapper results in a syntax error. The cause is a missing `OR` connecting the queries.

# Solution
Add the missing `OR`.

# Tests
Regression test was added to confirm fix of the problem.