### PR TITLE
Add studyId to CancerStudyTag entity

### DIFF
--- a/model/src/main/java/org/cbioportal/model/CancerStudyTags.java
+++ b/model/src/main/java/org/cbioportal/model/CancerStudyTags.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 public class CancerStudyTags implements Serializable {
 
     private Integer cancerStudyId;
+    private String studyId;
     private String tags;
 
     public Integer getCancerStudyId() {
@@ -21,5 +22,13 @@ public class CancerStudyTags implements Serializable {
 
     public void setTags(String tags) {
         this.tags = tags;
+    }
+
+    public String getStudyId() {
+        return studyId;
+    }
+
+    public void setStudyId(String studyId) {
+        this.studyId = studyId;
     }
 }

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
@@ -148,7 +148,8 @@
     <select id="getTagsForMultipleStudies" resultType="org.cbioportal.model.CancerStudyTags">
         SELECT
         cancer_study_tags.CANCER_STUDY_ID AS cancerStudyId,
-        cancer_study_tags.TAGS AS tags
+        cancer_study_tags.TAGS AS tags,
+        cancer_study.CANCER_STUDY_IDENTIFIER as studyId
         FROM cancer_study_tags
         JOIN cancer_study ON cancer_study_tags.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
         <where>

--- a/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepositoryTest.java
+++ b/persistence/persistence-mybatis/src/test/java/org/cbioportal/persistence/mybatis/StudyMyBatisRepositoryTest.java
@@ -222,6 +222,7 @@ public class StudyMyBatisRepositoryTest {
         Assert.assertEquals("{\"Analyst\": {\"Name\": \"Jack\", \"Email\": \"jack@something.com\"}, \"Load id\": 35}", result.getTags());
     }
     
+    @Test
     public void getMultipleTags() throws Exception {
 
         List<CancerStudyTags> result = studyMyBatisRepository.getTagsForMultipleStudies(Arrays.asList("study_tcga_pub", "acc_tcga"));
@@ -229,9 +230,11 @@ public class StudyMyBatisRepositoryTest {
         Assert.assertEquals(2, result.size());
         CancerStudyTags cancerStudyTags1 = result.get(1);
         Assert.assertEquals((Integer) 1, cancerStudyTags1.getCancerStudyId());
+        Assert.assertEquals("study_tcga_pub", cancerStudyTags1.getStudyId());
         Assert.assertEquals("{\"Analyst\": {\"Name\": \"Jack\", \"Email\": \"jack@something.com\"}, \"Load id\": 35}", cancerStudyTags1.getTags());
         CancerStudyTags cancerStudyTags2 = result.get(0);
         Assert.assertEquals((Integer) 2, cancerStudyTags2.getCancerStudyId());
-        Assert.assertEquals("{\"Load id\": 36}", cancerStudyTags2.getTags()); 
+        Assert.assertEquals("acc_tcga", cancerStudyTags2.getStudyId());
+        Assert.assertEquals("{\"Load id\": 36}", cancerStudyTags2.getTags());
     }
 }

--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -186,7 +186,8 @@ public class StudyController {
     @ApiOperation("Get the study tags by IDs")
     public ResponseEntity<List<CancerStudyTags>> getTagsForMultipleStudies(
         @ApiParam(required = true, value = "List of Study IDs")
-        @RequestBody List<String> studyIds) {
+        @RequestBody List<String> studyIds
+    ) {
 
         List<CancerStudyTags> cancerStudyTags = studyService.getTagsForMultipleStudies(studyIds);
 


### PR DESCRIPTION
This PR adds studyIds to CancerStudyTag entities.

At the moment only the (internal?) cancerStudyId is provided. However, when requesting all study tags in the frontend, the (human readable) studyIds are needed to match the tags with their studies.
