### PR TITLE
Two sided fishers test

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/CalcFisherExactTest.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/CalcFisherExactTest.java
@@ -90,6 +90,7 @@ public class CalcFisherExactTest extends HttpServlet  {
                 int c = Integer.parseInt(dataSet.split(" ")[2]);
                 int d = Integer.parseInt(dataSet.split(" ")[3]);    
                 FisherExact fisher = new FisherExact(a + b + c + d);
+                // We generally use the two tailed Fisher's exact test for calculations
                 double pValue = fisher.getTwoTailedP(a, b, c, d);
                 result = result.concat(String.valueOf(pValue) + " ");                
             }

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/CalcFisherExactTest.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/CalcFisherExactTest.java
@@ -44,16 +44,20 @@ import javax.servlet.http.HttpServletResponse;
 import org.mskcc.cbio.portal.stats.FisherExact;
 
 /**
- * Calculate the cumulative (one-tail) p-value out of fisher exact test
+ * Calculate the cumulative (two-tail) p-value out of fisher exact test
  * 
  * @param a a, b, c, d are the four cells in a 2x2 matrix
  * @param b
  * @param c
  * @param d
- * @return one-tailed P-value (right or left, whichever is smallest)
+ * @return two-tailed P-value (right or left, whichever is smallest)
  * 
  */
 public class CalcFisherExactTest extends HttpServlet  {
+    /**
+     * Note: currently no front-end component makes request for fisher's exact test
+     * However, it was discussed that it's helpful to keep this around for future developers
+     */
 
     /**
      * Handles HTTP GET Request.
@@ -86,7 +90,7 @@ public class CalcFisherExactTest extends HttpServlet  {
                 int c = Integer.parseInt(dataSet.split(" ")[2]);
                 int d = Integer.parseInt(dataSet.split(" ")[3]);    
                 FisherExact fisher = new FisherExact(a + b + c + d);
-                double pValue = fisher.getCumlativeP(a, b, c, d);
+                double pValue = fisher.getTwoTailedP(a, b, c, d);
                 result = result.concat(String.valueOf(pValue) + " ");                
             }
         }

--- a/core/src/main/java/org/mskcc/cbio/portal/stats/FisherExact.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/stats/FisherExact.java
@@ -235,7 +235,9 @@ public class FisherExact {
      * @param b
      * @param c
      * @param d
-     * @return two-tailed P-value
+     * @return two-tailed P-value, 
+     * we generally prefer to use this value for research purposes
+     * consult with statisticians on if a new feature is going to use a one-sided Fisher's test value
      */
     public final double getTwoTailedP(int a, int b, int c, int d) {
         int min, i;

--- a/core/src/main/java/org/mskcc/cbio/portal/stats/OddsRatio.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/stats/OddsRatio.java
@@ -87,7 +87,7 @@ public class OddsRatio {
 
         oddsRatio = ((double) (a * d)) / ((double) (b * c));
         FisherExact fisher = new FisherExact(a + b + c + d);
-        pValue = fisher.getCumlativeP(a, b, c, d);
+        pValue = fisher.getTwoTailedP(a, b, c, d);
         lowerConfidenceInterval = Math.exp(Math.log(oddsRatio) - 1.96 * (Math.sqrt(1 / (double) a
                 + 1 / (double) b + 1 / (double) c + 1 / (double) d)));
         upperConfidenceInterval = Math.exp(Math.log(oddsRatio) + 1.96 * (Math.sqrt(1 / (double) a

--- a/core/src/main/java/org/mskcc/cbio/portal/util/EnrichmentsAnalysisUtil.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/EnrichmentsAnalysisUtil.java
@@ -652,7 +652,7 @@ public class EnrichmentsAnalysisUtil implements DaoGeneticAlteration.AlterationP
             }
         }
         FisherExact fisher = new FisherExact(a + b + c + d);
-        return fisher.getCumlativeP(a, b, c, d);
+        return fisher.getTwoTailedP(a, b, c, d);
     }
 
     private String getCytoband(int geneticEntityId, String geneticProfileStableId) {

--- a/web/src/test/resources/applicationContext-web-test.xml
+++ b/web/src/test/resources/applicationContext-web-test.xml
@@ -27,7 +27,7 @@
         </property>
         <property name="ignoreUnresolvablePlaceholders" value="true" />
     </bean>
-    
-    <!-- load the beans from the prodution configuration xml file -->
+
+    <!-- load the beans from the production configuration xml file -->
     <import resource="classpath:applicationContext-web.xml" />
 </beans>


### PR DESCRIPTION
Partially addresses cBioPortal/cbioportal#9943 (group comparison)

Describe changes proposed in this pull request:
- Changed CalcFisherExactTest.java to use the two-sided Fisher's exact test value
- Also changed OddsRatio.java, EnrichmentsAnalysisUtil.java to use the two-sided Fisher's exact test value
- Documented reasoning behind change in CalcFisherExactTest.java and FisherExact.java so future developers know that in general we prefer the two-sided Fisher's exact test

# Checks
- [x] Runs on heroku
- [x] Has tests or has a separate issue that describes the types of test that should be created.  (Going to create a separate issue about testing, there's a lack of testing for FisherExact.java functions in general)
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)! (This PR is not adding logic based on one or more clinical attributes)

# Notify reviewers
Notifying team members on Slack. 
