### PR TITLE
Do not call next study view filter when no samples left

### DIFF
--- a/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -296,6 +296,10 @@ public class StudyViewFilterApplier {
     private List<SampleIdentifier> filterMutatedGenes(List<GeneFilter> mutatedGenefilters,
             Map<String, MolecularProfile> molecularProfileMap, List<SampleIdentifier> sampleIdentifiers) {
 
+        if (sampleIdentifiers == null || sampleIdentifiers.isEmpty()) {
+            return new ArrayList<>();
+        }
+
         for (GeneFilter genefilter : mutatedGenefilters) {
 
             List<MolecularProfile> filteredMolecularProfiles = genefilter
@@ -364,6 +368,10 @@ public class StudyViewFilterApplier {
 
     private List<SampleIdentifier> filterStructuralVariantGenes(List<GeneFilter> svGenefilters,
             Map<String, MolecularProfile> molecularProfileMap, List<SampleIdentifier> sampleIdentifiers) {
+            
+        if (sampleIdentifiers == null || sampleIdentifiers.isEmpty()) {
+            return new ArrayList<>();
+        }
 
         for (GeneFilter genefilter : svGenefilters) {
 
@@ -433,6 +441,10 @@ public class StudyViewFilterApplier {
 
     private List<SampleIdentifier> filterCNAGenes(List<GeneFilter> cnaGeneFilters,
             Map<String, MolecularProfile> molecularProfileMap, List<SampleIdentifier> sampleIdentifiers) {
+        
+        if (sampleIdentifiers == null || sampleIdentifiers.isEmpty()) {
+            return new ArrayList<>();
+        }
 
         for (GeneFilter geneFilter : cnaGeneFilters) {
 

--- a/web/src/main/java/org/cbioportal/web/util/appliers/AbstractPatientTreatmentFilter.java
+++ b/web/src/main/java/org/cbioportal/web/util/appliers/AbstractPatientTreatmentFilter.java
@@ -8,6 +8,7 @@ import org.cbioportal.web.parameter.StudyViewFilter;
 import org.cbioportal.web.parameter.filter.AndedPatientTreatmentFilters;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,6 +26,11 @@ public abstract class AbstractPatientTreatmentFilter implements StudyViewSubFilt
         List<SampleIdentifier> identifiers,
         StudyViewFilter filter
     ) {
+
+        if (identifiers == null || identifiers.isEmpty()) {
+            return new ArrayList<>();
+        }
+        
         AndedPatientTreatmentFilters filters = getFilters(filter);
 
         List<String> sampleIds = identifiers.stream()

--- a/web/src/main/java/org/cbioportal/web/util/appliers/AbstractSampleTreatmentFilter.java
+++ b/web/src/main/java/org/cbioportal/web/util/appliers/AbstractSampleTreatmentFilter.java
@@ -8,6 +8,7 @@ import org.cbioportal.web.parameter.StudyViewFilter;
 import org.cbioportal.web.parameter.filter.AndedSampleTreatmentFilters;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,6 +26,11 @@ public abstract class AbstractSampleTreatmentFilter implements StudyViewSubFilte
         List<SampleIdentifier> identifiers,
         StudyViewFilter filter
     ) {
+    
+        if (identifiers == null || identifiers.isEmpty()) {
+            return new ArrayList<>();
+        }
+
         AndedSampleTreatmentFilters filters = getFilters(filter);
 
         List<String> sampleIds = identifiers.stream()

--- a/web/src/main/java/org/cbioportal/web/util/appliers/ClinicalEventFilterApplier.java
+++ b/web/src/main/java/org/cbioportal/web/util/appliers/ClinicalEventFilterApplier.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +26,11 @@ public final class ClinicalEventFilterApplier implements StudyViewSubFilterAppli
     
     @Override
     public List<SampleIdentifier> filter(@NonNull List<SampleIdentifier> toFilter, @NonNull StudyViewFilter filters) {
-       
+
+       if (toFilter == null || toFilter.isEmpty()) {
+           return new ArrayList<>();
+       }
+        
        List<String> studyIds = toFilter.stream()
            .map(SampleIdentifier::getStudyId)
            .collect(Collectors.toList());


### PR DESCRIPTION
This PR will fix MySQL query errors when the _manual submit_ mode of Study View is active and subsequent filters act on a  list of zero samples due to previous filters. 