### PR TITLE
:wrench: Add Configuration Properties for study view summary limits

### DIFF
--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -651,6 +651,15 @@ enable_cross_study_expression = (selectedStudies)=>{ [your logic] return true|fa
 enable_cross_study_expression = true|false
 ```
 
+## Combined Study View Summary Limits
+### Background
+A limit is added to prevent poor performance of Study View when selecting too large sample numbers.
+### Properties
+* `studyview.max_samples_selected`: Limit is disabled when not set
+
+### Behavior
+When these limits are exceeded the "Explore Selected Studies" button will be disabled on the Study View Page.
+
 ## Request Body Compression
 
 ### Background

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -132,6 +132,7 @@
             "enable_request_body_gzip_compression",
             "enable_treatment_groups",
             "query_product_limit",
+            "studyview.max_samples_selected",
             "clinical_attribute_product_limit",
             "saml.logout.local",
             "skin.citation_rule_text",

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -118,6 +118,9 @@ setting controlling which name should be used to display the authenticated user 
 # true | false | (studies)=>{ return true } 
 # enable_cross_study_expression=
 
+## Combined Study View Comparison Limits
+# Any Number | Disabled when not set
+# studyview.max_samples_selected=
 
 ## change the `-Dauthenticate=` JVM argument to configure
 ## which method of authentication to use (false, googleplus, social_auth_google, social_auth_microsoft, saml, openid, noauthsessionservice)


### PR DESCRIPTION
Fix #10125 

Added two new Properties to configure Combined Study View Summary Limits

## Combined Study View Summary Limits
### Background
A limit is added to prevent poor performance of Study View when selecting too large sample numbers.
### Properties
* `studyview.max_samples_selected`: default is `50000` samples