### PR TITLE
Feature/10133 exclude clinical attributes with low priority

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -2600,12 +2600,12 @@ class ClinicalValidator(Validator):
                         invalid_values = True
                 elif self.METADATA_LINES[line_index] == 'priority':
                     try:
-                        if int(value) < 0:
+                        if int(value) < -1:
                             raise ValueError()
                     except ValueError:
                         self.logger.error(
                             'Priority definition should be an integer, and should be '
-                            'greater than or equal to zero',
+                            'greater than or equal to -1',
                             extra={'line_number': line_index + 1,
                                    'column_number': col_index + 1,
                                    'cause': value})

--- a/docs/deployment/customization/Studyview.md
+++ b/docs/deployment/customization/Studyview.md
@@ -25,6 +25,8 @@ The higher the score, the higher priority it will be displayed in the study view
 If you want to hide chart, please set the priority to 0.
 For combination chart, as long as one of the clinical attributes has been set to 0, it will be hidden.
 
+To disable the chart, set the priority to -1.(Currently disables charts for single clinical attributes only)
+
 Currently, we preassigned priority to few charts, but as long as you assign a priority in the database except than 1, these preassigned priorities will be overwritten.
 
 | Chart name(clinical attribute ID)                          	| Frontend default priority 	| Additional Info                                   |


### PR DESCRIPTION
Fix #10133 
Describe changes proposed in this pull request:
Update Validator to allow priority values >= -1 and update documentation (This is to disable Clinical Attribute charts when priority is set to -1)