### PR TITLE
Fix study tag search when no studies available

### DIFF
--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/StudyMapper.xml
@@ -153,10 +153,12 @@
         FROM cancer_study_tags
         JOIN cancer_study ON cancer_study_tags.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
         <where>
+            <if test="studyIds != null and studyIds.size > 0">
                 cancer_study.CANCER_STUDY_IDENTIFIER IN
-                <foreach item="item" collection="list" open="(" separator="," close=")">
+                <foreach item="item" collection="studyIds" open="(" separator="," close=")">
                     #{item}
                 </foreach>
+            </if>
         </where>
     </select>
 


### PR DESCRIPTION
Fix `getTagsForMultipleStudies` query: it now handles studyId lists that are null or empty.

Fixes issue https://github.com/cBioPortal/cbioportal/issues/10163
