### PR TITLE
Add dsnparse Python requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ markupsafe==2.0.1
 Jinja2==2.11.3
 mysqlclient==2.1.0
 PyYAML==5.4
+dsnparse==0.1.15


### PR DESCRIPTION
Needed for future PR concerning using db.connection_string to connect to the database (#10036) . By merging it prior to the resp. PR we make sure integration tests can run for that PR.
