### PR TITLE
Revert original Study View endpoints

### DIFF
--- a/core/src/test/resources/applicationContext-dao.xml
+++ b/core/src/test/resources/applicationContext-dao.xml
@@ -80,7 +80,7 @@
     
     <!-- scan for mappers and let them be autowired -->
     <bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
-        <property name="basePackage" value="org.mskcc.cbio.portal.persistence,org.cbioportal.persistence.mybatis" />
+        <property name="basePackage" value="org.mskcc.cbio.portal.persistence,org.cbioportal.persistence.mybatis,org.cbioportal.persistence.mybatiscolumnstore" />
     </bean>
 
     <!-- enable component scanning (beware that this does not enable mapper scanning!) -->


### PR DESCRIPTION
- This fixes failing core tests
- We may need to rebase to latest master to fix failing integration tests
- We will also need a new frontend branch to use the new `column-store` endpoints.