### PR TITLE
Fixed an error in naming alleles for the mutation file checks in SNP, DNP, and TNP

### DIFF
--- a/core/src/main/scripts/importer/validateData.py
+++ b/core/src/main/scripts/importer/validateData.py
@@ -1928,7 +1928,7 @@ class MutationsExtendedValidator(CustomDriverAnnotationValidator, CustomNamespac
 
             if variant_type == "SNP":
                 # Expect alleles to have length 2 when variant type is SNP
-                if not (len(ref_allele) == 1 and len(tumor_seq_allele1) == 1 and len(tumor_seq_allele1) == 1):
+                if not (len(ref_allele) == 1 and len(tumor_seq_allele1) == 1 and len(tumor_seq_allele2) == 1):
                     log_message = "Variant_Type indicates a SNP, but length of Reference_Allele, Tumor_Seq_Allele1 " \
                                   "and/or Tumor_Seq_Allele2 do not equal 1."
                     extra_dict = {'line_number': self.line_number,
@@ -1936,7 +1936,7 @@ class MutationsExtendedValidator(CustomDriverAnnotationValidator, CustomNamespac
                     self.send_log_message(self.strict_maf_checks, log_message, extra_dict)
             if variant_type == "DNP":
                 # Expect alleles to have length 2 when variant type is DNP
-                if not (len(ref_allele) == 2 and len(tumor_seq_allele1) == 2 and len(tumor_seq_allele1) == 2):
+                if not (len(ref_allele) == 2 and len(tumor_seq_allele1) == 2 and len(tumor_seq_allele2) == 2):
                     log_message = "Variant_Type indicates a DNP, but length of Reference_Allele, Tumor_Seq_Allele1 " \
                                   "and/or Tumor_Seq_Allele2 do not equal 2."
                     extra_dict = {'line_number': self.line_number,
@@ -1944,7 +1944,7 @@ class MutationsExtendedValidator(CustomDriverAnnotationValidator, CustomNamespac
                     self.send_log_message(self.strict_maf_checks, log_message, extra_dict)
             if variant_type == "TNP":
                 # Expect alleles to have length 3 when variant type is TNP
-                if not (len(ref_allele) == 3 and len(tumor_seq_allele1) == 3 and len(tumor_seq_allele1) == 3):
+                if not (len(ref_allele) == 3 and len(tumor_seq_allele1) == 3 and len(tumor_seq_allele2) == 3):
                     log_message = "Variant_Type indicates a TNP, but length of Reference_Allele, Tumor_Seq_Allele1 " \
                                   "and/or Tumor_Seq_Allele2 do not equal 3."
                     extra_dict = {'line_number': self.line_number,


### PR DESCRIPTION
Fixed an error in naming alleles for the mutation file checks in SNP, DNP, and TNP. 

Describe changes proposed in this pull request:
- tumor_seq_allele1 was repeated twice, instead of tumor_seq_allele2. 

# Checks
- [ ] Runs on heroku
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
