### PR TITLE
Set download button visibility in UI based on user role/group

### DIFF
--- a/docs/deployment/customization/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/deployment/customization/Customizing-your-instance-of-cBioPortal.md
@@ -247,6 +247,13 @@ Below you can find the complete list of all the available skin properties.
             <td>false</td>
             <td>true / false / data</td>
         </tr>
+		<tr>
+            <td>download_group</td>
+            <td>controls download options in UI for each user. If present and user is authenticated, this value is checked against user roles.
+If the download_group is present in user groups then download options are shown in UI, else it fallback to **skin.hide_download_controls**</td>
+            <td></td>
+            <td>text</td>
+        </tr>
         <tr>
             <td>skin.show_settings_menu</td>
             <td>controls the appearance of the settings menu in study view and group comparison that controls annotation-based filtering.</td>

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -202,7 +202,7 @@
         obj.put("oncoKbTokenDefined", !StringUtils.isEmpty(GlobalProperties.getOncoKbToken()));
 
         obj.put("sessionServiceEnabled", !StringUtils.isEmpty(GlobalProperties.getSessionServiceUrl()));
-        
+
         obj.put("skin_hide_download_controls", GlobalProperties.getDownloadControl());
 
         out.println(obj.toJSONString());

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -434,3 +434,5 @@ persistence.cache_type=no-cache
 # Set StudyDownloadLinkUrl
 # Allows download links within DataSets Tab (See Portal.Properties documentation for more info)
 # study_download_url=
+
+# download_group=


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/10248

**RFC**: https://docs.google.com/document/d/19KV2Yplzxl1wnUc5bJDeysGX8vmL24UNi41NlIkX44s/edit

Implements below logic
<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-8d623e9d-7fff-2b95-ab64-f9babcc3c965"><div dir="ltr" style="margin-left:0pt;" align="left">

skin.hide_download_controls | Download group in user role | hide_download_controls to UI
-- | -- | --
TRUE | Yes | FALSE
TRUE | No | TRUE
FALSE | Yes | FALSE
FALSE | No | FALSE
data | Yes | FALSE
data | No | data

</div></b>