### PR TITLE
Fix: Allow ProfiledCasesCounter to add counts to empty alteration count list

### DIFF
--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/AlterationMyBatisRepository.java
@@ -36,8 +36,10 @@ public class AlterationMyBatisRepository implements AlterationRepository {
             || (molecularProfileCaseIdentifiers == null || molecularProfileCaseIdentifiers.isEmpty())
             || allAlterationsExcludedDriverAnnotation(alterationFilter)
             || allAlterationsExcludedMutationStatus(alterationFilter)
-            || allAlterationsExcludedDriverTierAnnotation(alterationFilter)) {
-            return Collections.emptyList();
+            || allAlterationsExcludedDriverTierAnnotation(alterationFilter)
+        ) {
+            // We want a mutable empty list:
+            return new ArrayList<>();
         }
 
         Set<String> molecularProfileIds = molecularProfileCaseIdentifiers.stream()


### PR DESCRIPTION
This PR fixes a 5xx response from the backend when there are no sample alteration gene counts to filter by.

When the sample alteration gene counts were queried from the database, and there was nothing to fetch, an immutable `EmptyList` was returned. This resulted in an exception later on when other counts were added to this list. 

Now a mutable empty `ArrayList` is returned.
