### PR TITLE
Fix disabling SSL for MySQL connection

### DIFF
--- a/core/src/main/scripts/migrate_db.py
+++ b/core/src/main/scripts/migrate_db.py
@@ -61,6 +61,9 @@ def get_db_cursor(portal_properties):
         connection_kwargs['db'] = portal_properties.database_name
         if portal_properties.database_use_ssl == 'true':
             connection_kwargs['ssl'] = {"ssl_mode": True}
+            connection_kwargs['ssl_mode'] = 'REQUIRED'
+        else:
+            connection_kwargs['ssl_mode'] = 'DISABLED'          
         
         connection = MySQLdb.connect(**connection_kwargs)
     except MySQLdb.Error as exception:


### PR DESCRIPTION
Fix #10275

# Problem
When migrating the database the migration.py script tries to connect to the MySQL database over SSL, despite the _db.use_ssl_ property having value _false_.

# Analysis
The current and broken logic in migration.py to configure SSL is:

```
connection_kwargs = {here
if portal_properties.database_use_ssl == 'true':
    connection_kwargs['ssl'] = {"ssl_mode": True}
```

When I change this to the following, the _db.use_ssl_ property is respected:

```
connection_kwargs = {}
if portal_properties.database_use_ssl == 'true':
    connection_kwargs["ssl_mode"] = "REQUIRED"
else:
   connection_kwargs["ssl_mode"] = "DISABLED"
```

# Changes in this PR
This PR will add the _ssl_mode_ to the kwargs of the migration script.
