### PR TITLE
Filter out unauthorized studies when fetching study tags

### DIFF
--- a/web/src/main/java/org/cbioportal/web/StudyController.java
+++ b/web/src/main/java/org/cbioportal/web/StudyController.java
@@ -22,6 +22,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreFilter;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -180,7 +181,7 @@ public class StudyController {
         return new ResponseEntity<>(map, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasPermission(#studyIds, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
+    @PreFilter("hasPermission(#studyIds, 'Collection<CancerStudyId>', T(org.cbioportal.utils.security.AccessLevel).READ)")
     @RequestMapping(value = "/studies/tags/fetch", method = RequestMethod.POST,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation("Get the study tags by IDs")


### PR DESCRIPTION
This PR filters out unauthorized studies by adding the `@PreFilter` annotation to the `/studies/tags/fetch` endpoint.

Depends on fixing authorization in `/studies` (see https://github.com/cBioPortal/cbioportal/pull/10267).

At the moment a user with unauthorized studies gets an error screen on the index page. This is because the tags of all studies are fetched. However, you cannot fetch the study tags of unauthorized studies, resulting in a 403 and an error screen (see https://github.com/cBioPortal/cbioportal/issues/10221) .

By filtering the studies in the backend, the frontend does not need to have any knowledge of authorized studies (see also https://github.com/cBioPortal/cbioportal-frontend/pull/4653). 

