### PR TITLE
Get mutation data from genomic event table instead of mutation table

### DIFF
--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatiscolumnstore/StudyViewMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatiscolumnstore/StudyViewMapper.xml
@@ -31,14 +31,15 @@
             COUNT(DISTINCT sample_unique_id) as numberOfProfiledCases,
             COUNT(DISTINCT sample_unique_id) as numberOfAlteredCases,
             COUNT(*) as totalCount
-        FROM mutation
+        FROM genomic_event
         <where>
-           sample_unique_id IN ( <include refid="sampleUniqueIdsFromStudyViewFilter"/>
+            variant_type = 'mutation'
+            AND
+            sample_unique_id IN ( <include refid="sampleUniqueIdsFromStudyViewFilter"/>
             <if test="applyPatientIdFilters == true">
                 INTERSECT <include refid="getSampleIdsFromPatientIds"/>
             </if> 
             )
-
         </where>
         GROUP BY hugo_gene_symbol
         ORDER BY totalCount DESC;


### PR DESCRIPTION
We need to merge https://github.com/pvannierop/cbioportal-clickhouse-pilot/pull/5 first, and then regenerate and reimport the data.

We could rely on a partial string match in the `genetic_profile_stable_id` as an alternative solution, but that would come with the requirement that every mutation profile has to contain the string `mutation` as part of its stable id.