### PR TITLE
Allow Redis service unavailable when Redis is enabled

### DIFF
--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/config/RedisConfig.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/config/RedisConfig.java
@@ -2,14 +2,17 @@ package org.cbioportal.persistence.config;
 
 import org.cbioportal.persistence.util.CustomKeyGenerator;
 import org.cbioportal.persistence.util.CustomRedisCachingProvider;
+import org.cbioportal.persistence.util.LoggingCacheErrorHandler;
 import org.cbioportal.utils.config.annotation.ConditionalOnProperty;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachingConfigurerSupport;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
 import org.springframework.cache.interceptor.CacheResolver;
 import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.cache.interceptor.NamedCacheResolver;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -27,6 +30,11 @@ public class RedisConfig extends CachingConfigurerSupport {
         return customRedisCachingProvider().getCacheManager(
             customRedisCachingProvider().getRedissonClient()
         );
+    }
+
+    @Override
+    public CacheErrorHandler errorHandler() {
+        return new LoggingCacheErrorHandler();
     }
 
     @Bean

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/LoggingCacheErrorHandler.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/util/LoggingCacheErrorHandler.java
@@ -1,0 +1,43 @@
+package org.cbioportal.persistence.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+
+/**
+ * Implementation of org.springframework.cache.interceptor.CacheErrorHandler
+ * that logs the error messages when performing Redis operations.
+ * Redis will throw a RuntimeException causing our APIs to return HTTP 500 responses, so we defined
+ * this class to just log the errors and allow our app fallback to the non-cached version.
+ */
+
+public class LoggingCacheErrorHandler implements CacheErrorHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LoggingCacheErrorHandler.class);
+
+    @Override
+    public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
+        LOG.error(String.format("Cache '%s' failed to get entry with key '%s'", cache.getName(), key), exception);
+        LOG.error(String.format("Cache error message: '%s'", exception.getMessage()));
+    }
+
+    @Override
+    public void handleCachePutError(RuntimeException exception, Cache cache, Object key, Object value) {
+        LOG.error(String.format("Cache '%s' failed to put entry with key '%s'", cache.getName(), key), exception);
+        LOG.error(String.format("Cache error message: '%s'", exception.getMessage()));
+    }
+
+    @Override
+    public void handleCacheEvictError(RuntimeException exception, Cache cache, Object key) {
+        LOG.error(String.format("Cache '%s' failed to evict entry with key '%s'", cache.getName(), key), exception);
+        LOG.error(String.format("Cache error message: '%s'", exception.getMessage()));
+    }
+
+    @Override
+    public void handleCacheClearError(RuntimeException exception, Cache cache) {
+        LOG.error(String.format("Cache '%s' failed to clear entries", cache.getName()), exception);
+        LOG.error(String.format("Cache error message: '%s'", exception.getMessage()));
+    }
+
+}


### PR DESCRIPTION
Fix #10287 

Describe changes proposed in this pull request:
- Adding `LoggingCacheErrorHandler` to log errors and override default `CacheErrorHandler` to avoid app crash