### PR TITLE
Add defaults for genomic evolution tab in patient view

### DIFF
--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -153,6 +153,13 @@ Different samples of a patient may have been analyzed with different gene panels
 skin.patientview.filter_genes_profiled_all_samples=
 ```
 
+### Control default settings of the VAF line chart in the genomic evolution tab of patient view
+If you want to enablelog scale and sequential mode by default, set this property to `true`:
+```
+vaf.log_scale.default=true|false
+vaf.sequential_mode.default=true|false
+```
+
 ### Control unauthorized studies to be displayed on the home page
 
 By default, on an authenticated portal the home page will only show studies for which the current user is authorized. By setting the _skin.home\_page.show\_unauthorized\_studies_ property to _true_ the home page will also show unauthorized studies. The unauthorized studies will appear greyed out and cannot be selected for downstream analysis in Results View or Study View.
@@ -434,6 +441,11 @@ If you want to disable the automatic selection of OncoKB and hotspots as annotat
 ```
 oncoprint.oncokb.default=true|false
 oncoprint.hotspots.default=true|false
+```
+
+If you want to enable oncoprint heatmap clustering by default, set this property to `true`:
+```
+oncoprint.clustered.default=true|false
 ```
 
 **Automatic hiding of variants of unknown significance (VUS)**

--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -154,7 +154,7 @@ skin.patientview.filter_genes_profiled_all_samples=
 ```
 
 ### Control default settings of the VAF line chart in the genomic evolution tab of patient view
-If you want to enablelog scale and sequential mode by default, set this property to `true`:
+If you want to enable log scale and sequential mode by default, set this property to `true`:
 ```
 vaf.log_scale.default=true|false
 vaf.sequential_mode.default=true|false

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -38,6 +38,7 @@
             "oncoprint.custom_driver_annotation.binary.default",
             "oncoprint.oncokb.default",
             "oncoprint.hotspots.default",
+            "oncoprint.clustered.default",
             "genomenexus.url",
             "genomenexus.url.grch38",
             "google_analytics_profile_id",
@@ -147,7 +148,9 @@
             "skin.patient_view.structural_variant_table.columns.show_on_init",
             "comparison.categorical_na_values",
             "study_download_url",
-            "skin.home_page.show_reference_genome"
+            "skin.home_page.show_reference_genome",
+            "vaf.sequential_mode.default",
+            "vaf.log_scale.default"
         };
 
 

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -316,6 +316,7 @@ oncoprint.oncokb.default=true
 oncoprint.hotspots.default=true
 # oncoprint.hide_vus.default=true
 # oncoprint.clinical_tracks.config_json=classpath:/oncoprint-default-tracks.json
+# oncoprint.clustered.default=true
 
 # Custom gene sets
 # querypage.setsofgenes.location=file:/<path>
@@ -436,3 +437,6 @@ persistence.cache_type=no-cache
 # study_download_url=
 
 # download_group=
+
+# vaf.sequential_mode.default=false
+# vaf.log_scale.default=false


### PR DESCRIPTION
Add three properties for mutation heatmap and line chart checkboxes in the genomic evolution tab of the patient view:

- Linechart log scale: 
  - `vaf.log_scale.default`
- Linechart sequentical mode: 
  - `vaf.sequential_mode.default` 
- Mutation oncoprint heatmap clustering: 
  - `oncoprint.clustered.default`

See also the front-end PR https://github.com/cBioPortal/cbioportal-frontend/pull/4680
