### PR TITLE
Add `show_web_tours` for Interactive Web Tour

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -122,6 +122,7 @@ public class GlobalProperties {
     public static final String SKIN_RIGHT_NAV_SHOW_EXAMPLES = "skin.right_nav.show_examples";
     public static final String SKIN_RIGHT_NAV_SHOW_TESTIMONIALS = "skin.right_nav.show_testimonials";
     public static final String SKIN_RIGHT_NAV_SHOW_WHATS_NEW = "skin.right_nav.show_whats_new";
+    public static final String SKIN_RIGHT_NAV_SHOW_WEB_TOURS = "skin.right_nav.show_web_tours";
     private static String skinAuthorizationMessage;
     @Value("${skin.authorization_message:Access to this portal is only available to authorized users.}")
     public void setSkinAuthorizationMessage(String property) { skinAuthorizationMessage = property; }
@@ -802,6 +803,12 @@ public class GlobalProperties {
     public static boolean showRightNavWhatsNew()
     {
         String showFlag = portalProperties.getProperty(SKIN_RIGHT_NAV_SHOW_WHATS_NEW);
+        return showFlag == null || Boolean.parseBoolean(showFlag);
+    }
+
+    public static boolean showRightNavWebTours()
+    {
+        String showFlag = portalProperties.getProperty(SKIN_RIGHT_NAV_SHOW_WEB_TOURS);
         return showFlag == null || Boolean.parseBoolean(showFlag);
     }
 

--- a/docs/deployment/customization/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/deployment/customization/Customizing-your-instance-of-cBioPortal.md
@@ -145,6 +145,12 @@ Below you can find the complete list of all the available skin properties.
 			<td>Text for public cBioPortal.org.</td>
 			<td>Any HTML text</td>
 		</tr>
+        <tr>
+			<td>skin.right_nav.show_web_tours</td>
+			<td>set the "Interactive Tours" section in the right navigation bar</td>
+			<td>true</td>
+			<td>true / false</td>
+		</tr>
 		<tr>
 			<td>skin.show_about_tab</td>
 			<td>show the "ABOUT" tab in the header</td>

--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -100,6 +100,9 @@ skin.right_nav.show_whats_new=
 skin.right_nav.show_twitter=
 ```
 
+#Interactive tours section
+skin.right_nav.show_web_tours=
+
 ### Control the content of specific sections
 
 Setting controlling the blurb: you can add any HTML code here that you want to visualize. This will be shown between the cBioPortal menu and the Query selector in the main page.

--- a/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/frontend_config.jsp
@@ -30,6 +30,7 @@ window.legacySupportFrontendConfig = {
     skinRightNavShowExamples : <%=GlobalProperties.showRightNavExamples()%>,
     skinRightNavShowTestimonials : <%=GlobalProperties.showRightNavTestimonials()%>,
     skinRightNavShowWhatsNew : <%=GlobalProperties.showRightNavWhatsNew()%>,
+    skinRightNavShowWebTours: <%=GlobalProperties.showRightNavInteractiveTour()%>,
     skinRightNavExamplesHTML : '<%=GlobalProperties.getExamplesRightColumnHtml()%>',
     skinRightNavExamplesHTML : '<%=GlobalProperties.getExamplesRightColumnHtml()%>',
     skinRightNavWhatsNewBlurb : '<%=GlobalProperties.getRightNavWhatsNewBlurb()%>',

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -98,6 +98,7 @@
             "skin.right_nav.show_whats_new",
             "skin.right_nav.show_twitter",
             "skin.right_nav.whats_new_blurb",
+            "skin.right_nav.show_web_tours",
             "skin.show_about_tab",
             "skin.show_data_tab",
             "skin.show_faqs_tab",


### PR DESCRIPTION
Student Name: [Biqing (Gloria) Su](https://github.com/Beking0912)
Mentors: [Jeremy R. Easton-Marks](https://github.com/JREastonMarks), [Ryan Fu](https://github.com/fuzhaoyuan)

## Description
This pull request introduces the property `show_web_tours` for displaying interactive tours in the frontend. 
**This change is required for e2e testing of interactive tours running on port 8080.**
See the related comment: https://github.com/cBioPortal/cbioportal-frontend/pull/4687#discussion_r1293579826
See the related commit on frontend side: https://github.com/cBioPortal/cbioportal-frontend/pull/4687/commits/8408eae02a56418e703f2c9c8b920a9e42570128

## Related Issue
- Interactive Web Tour code: https://github.com/cBioPortal/cbioportal-frontend/pull/4687
- Interactive Web Tour e2e testing: https://github.com/cBioPortal/cbioportal-frontend/pull/4700
- GSoC project description: https://github.com/cBioPortal/GSoC/issues/86