### PR TITLE
Add json prop for custom patient view sample type colors

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -183,6 +183,12 @@ public class GlobalProperties {
         oncoprintClinicalTracksConfigJson = property; 
     }
 
+    private static String skinPatientViewCustomSampleTypesJson;
+    @Value("${skin.patient_view.custom_sample_types_json:}") // default is empty string
+    public void setSkinPatientViewCustomSampleTypesJson(String property) {
+        skinPatientViewCustomSampleTypesJson = property; 
+    }
+
     // properties for showing the right logo in the header_bar and default logo
     public static final String SKIN_RIGHT_LOGO = "skin.right_logo";
 
@@ -1252,6 +1258,14 @@ public class GlobalProperties {
     public static String getOncoprintClinicalTracksConfigJson() {
         if (oncoprintClinicalTracksConfigJson.length() > 0) {
             return readFile(oncoprintClinicalTracksConfigJson);
+        } else {
+            return null;
+        }
+    }
+    
+    public static String getSkinPatientViewCustomSampleTypesJson() {
+        if (skinPatientViewCustomSampleTypesJson.length() > 0) {
+            return readFile(skinPatientViewCustomSampleTypesJson);
         } else {
             return null;
         }

--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -183,10 +183,10 @@ public class GlobalProperties {
         oncoprintClinicalTracksConfigJson = property; 
     }
 
-    private static String skinPatientViewCustomSampleTypesJson;
-    @Value("${skin.patient_view.custom_sample_types_json:}") // default is empty string
-    public void setSkinPatientViewCustomSampleTypesJson(String property) {
-        skinPatientViewCustomSampleTypesJson = property; 
+    private static String skinPatientViewCustomSampleTypeColorsJson;
+    @Value("${skin.patient_view.custom_sample_type_colors_json:}") // default is empty string
+    public void setSkinPatientViewCustomSampleTypeColorsJson(String property) {
+        skinPatientViewCustomSampleTypeColorsJson = property; 
     }
 
     // properties for showing the right logo in the header_bar and default logo
@@ -1263,9 +1263,9 @@ public class GlobalProperties {
         }
     }
     
-    public static String getSkinPatientViewCustomSampleTypesJson() {
-        if (skinPatientViewCustomSampleTypesJson.length() > 0) {
-            return readFile(skinPatientViewCustomSampleTypesJson);
+    public static String getSkinPatientViewCustomSampleTypeColorsJson() {
+        if (skinPatientViewCustomSampleTypeColorsJson.length() > 0) {
+            return readFile(skinPatientViewCustomSampleTypeColorsJson);
         } else {
             return null;
         }

--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -223,6 +223,13 @@ Define the colors of custom sample types in the patient view using a json object
 ```
 skin.patient_view.custom_sample_type_colors_json=classpath:/skin-patient-view-custom-sample-type-colors.json
 ```
+Example of json file contents:
+```json
+{
+    "Primary": "green",
+    "Biopsy 3": "#00c040ff"
+}
+```
 
 ### Choose the display name for authenticated users
 

--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -218,6 +218,12 @@ skin.patient_view.copy_number_table.columns.show_on_init=
 skin.patient_view.structural_variant_table.columns.show_on_init=
 ```
 
+### Define custom sample type colors
+Define the colors of custom sample types in the patient view using a json object with for each sample type a color:
+```
+skin.patient_view.custom_sample_types_json=classpath:/skin-patient-view-custom-sample-types.json
+```
+
 ### Choose the display name for authenticated users
 
 By default the display name for authenticated users is email, but it can be changed for the user name:

--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -221,7 +221,7 @@ skin.patient_view.structural_variant_table.columns.show_on_init=
 ### Define custom sample type colors
 Define the colors of custom sample types in the patient view using a json object with for each sample type a color:
 ```
-skin.patient_view.custom_sample_types_json=classpath:/skin-patient-view-custom-sample-types.json
+skin.patient_view.custom_sample_type_colors_json=classpath:/skin-patient-view-custom-sample-type-colors.json
 ```
 
 ### Choose the display name for authenticated users

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -185,7 +185,7 @@
 
         obj.put("oncoprint_clinical_tracks_config_json",GlobalProperties.getOncoprintClinicalTracksConfigJson());
 
-        obj.put("skin_patient_view_custom_sample_types_json", GlobalProperties.getSkinPatientViewCustomSampleTypesJson());
+        obj.put("skin_patient_view_custom_sample_type_colors_json", GlobalProperties.getSkinPatientViewCustomSampleTypeColorsJson());
 
         obj.put("authenticationMethod",GlobalProperties.authenticationMethod());
 

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -185,6 +185,8 @@
 
         obj.put("oncoprint_clinical_tracks_config_json",GlobalProperties.getOncoprintClinicalTracksConfigJson());
 
+        obj.put("skin_patient_view_custom_sample_types_json", GlobalProperties.getSkinPatientViewCustomSampleTypesJson());
+
         obj.put("authenticationMethod",GlobalProperties.authenticationMethod());
 
         obj.put("mskWholeSlideViewerToken", GlobalProperties.getMskWholeSlideViewerToken());


### PR DESCRIPTION
Extend the legend colors of sample types in the patient view by configuring custom sample types from a json file on the classpath. 
Applies the same mechanism that is used to configure default clinical tracks in the oncoprint.
See also the frontend PR: https://github.com/cBioPortal/cbioportal-frontend/pull/4704