### PR TITLE
Fix disabling SSL for MySQL connection

### DIFF
--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -1090,9 +1090,13 @@ def get_db_cursor(portal_properties: PortalProperties):
             "port": url_elements.port if url_elements.port is not None else 3306,
             "db": url_elements.paths[0],
             "user": portal_properties.database_user,
-            "passwd": portal_properties.database_pw,
-            "ssl": "useSSL" not in url_elements.query or url_elements.query["useSSL"] == "true"
+            "passwd": portal_properties.database_pw
         }
+        if url_elements.query["useSSL"] == "true":
+            connection_kwargs['ssl'] = {"ssl_mode": True}
+            connection_kwargs['ssl_mode'] = 'REQUIRED'
+        else:
+            connection_kwargs['ssl_mode'] = 'DISABLED'   
         connection = MySQLdb.connect(**connection_kwargs)
     except MySQLdb.Error as exception:
         print(exception, file=ERROR_FILE)


### PR DESCRIPTION
Copied from #10276 

Fix #10275

# Problem
When migrating the database the migration.py script tries to connect to the MySQL database over SSL, despite the _db.use_ssl_ property having value _false_.

# Analysis
The current and broken logic in migration.py to configure SSL is:

```
connection_kwargs = {here
if portal_properties.database_use_ssl == 'true':
    connection_kwargs['ssl'] = {"ssl_mode": True}
```

When I change this to the following, the _db.use_ssl_ property is respected:

```
connection_kwargs = {}
if portal_properties.database_use_ssl == 'true':
    connection_kwargs["ssl_mode"] = "REQUIRED"
else:
   connection_kwargs["ssl_mode"] = "DISABLED"
```

# Changes in this PR
This PR will add the _ssl_mode_ to the kwargs of the migration script.
