### PR TITLE
Improve Generic Assay Meta performance

### DIFF
--- a/model/src/main/java/org/cbioportal/model/GenericAssayAdditionalProperty.java
+++ b/model/src/main/java/org/cbioportal/model/GenericAssayAdditionalProperty.java
@@ -1,6 +1,7 @@
 package org.cbioportal.model;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class GenericAssayAdditionalProperty implements Serializable {
     private String name;
@@ -35,5 +36,21 @@ public class GenericAssayAdditionalProperty implements Serializable {
 
     public void setStableId(String stableId) {
         this.stableId = stableId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof GenericAssayAdditionalProperty)) {
+            return false;
+        }
+        GenericAssayAdditionalProperty that = (GenericAssayAdditionalProperty) o;
+        return getName().equals(that.getName()) &&
+            getValue().equals(that.getName()) &&
+            getStableId().equals(that.getStableId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(), getValue(), getStableId());
     }
 }

--- a/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenericAssayRepository.java
+++ b/persistence/persistence-api/src/main/java/org/cbioportal/persistence/GenericAssayRepository.java
@@ -15,5 +15,8 @@ public interface GenericAssayRepository {
     List<GenericAssayAdditionalProperty> getGenericAssayAdditionalproperties(List<String> stableIds);
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
+    List<GenericAssayAdditionalProperty> getGenericAssayAdditionalpropertiesByMolecularProfileId(String molecularProfileId);
+    
+    @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<String> getGenericAssayStableIdsByMolecularIds(List<String> molecularProfileIds);
 }

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenericAssayMapper.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenericAssayMapper.java
@@ -12,6 +12,8 @@ public interface GenericAssayMapper {
 
     List<GenericAssayAdditionalProperty> getGenericAssayAdditionalproperties(List<String> stableIds);
 
+    List<GenericAssayAdditionalProperty> getGenericAssayAdditionalpropertiesByMolecularProfileId(String molecularProfileId);
+
     List<Integer> getMolecularProfileInternalIdsByMolecularProfileIds(List<String> molecularProfileIds);
 
     List<Integer> getGeneticEntityIdsByMolecularProfileInternalIds(List<Integer> molecularProfileInternalIds);

--- a/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenericAssayMyBatisRepository.java
+++ b/persistence/persistence-mybatis/src/main/java/org/cbioportal/persistence/mybatis/GenericAssayMyBatisRepository.java
@@ -34,6 +34,12 @@ public class GenericAssayMyBatisRepository implements GenericAssayRepository {
 
     @Override
     @Cacheable(cacheResolver = "staticRepositoryCacheOneResolver", condition = "@cacheEnabledConfig.getEnabled()")
+    public List<GenericAssayAdditionalProperty> getGenericAssayAdditionalpropertiesByMolecularProfileId(String molecularProfileId) {
+        return genericAssayMapper.getGenericAssayAdditionalpropertiesByMolecularProfileId(molecularProfileId);
+    }
+
+    @Override
+    @Cacheable(cacheResolver = "staticRepositoryCacheOneResolver", condition = "@cacheEnabledConfig.getEnabled()")
     public List<String> getGenericAssayStableIdsByMolecularIds(List<String> molecularProfileIds) {
         
         List<Integer> molecularProfileInternalIds = genericAssayMapper.getMolecularProfileInternalIdsByMolecularProfileIds(molecularProfileIds);

--- a/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenericAssayMapper.xml
+++ b/persistence/persistence-mybatis/src/main/resources/org/cbioportal/persistence/mybatis/GenericAssayMapper.xml
@@ -37,6 +37,18 @@
             )
     </select>
 
+    <select id="getGenericAssayAdditionalpropertiesByMolecularProfileId" resultType="org.cbioportal.model.GenericAssayAdditionalProperty">
+        SELECT generic_entity_properties.NAME as name,
+        generic_entity_properties.VALUE as value,
+        genetic_entity.STABLE_ID as stableId
+        FROM generic_entity_properties
+        INNER JOIN genetic_entity ON genetic_entity.ID = generic_entity_properties.GENETIC_ENTITY_ID
+        INNER JOIN genetic_alteration ON genetic_alteration.GENETIC_ENTITY_ID = genetic_entity.ID
+        INNER JOIN genetic_profile ON genetic_profile.GENETIC_PROFILE_ID = genetic_alteration.GENETIC_PROFILE_ID
+        WHERE
+            genetic_profile.STABLE_ID = #{molecularProfileId}
+    </select>
+
     <select id="getMolecularProfileInternalIdsByMolecularProfileIds" resultType="int">
         SELECT genetic_profile.GENETIC_PROFILE_ID
         FROM genetic_profile

--- a/service/src/test/java/org/cbioportal/service/impl/GenericAssayServiceImpTest.java
+++ b/service/src/test/java/org/cbioportal/service/impl/GenericAssayServiceImpTest.java
@@ -261,9 +261,6 @@ public class GenericAssayServiceImpTest extends BaseServiceImplTest {
 
     @Test
     public void getGenericAssayMetaByStableIdsAndMolecularIds() throws GenericAssayNotFoundException {
-        Mockito.when(genericAssayRepository.getGenericAssayMeta(idList))
-        .thenReturn(mockGenericAssayMetaList);
-
         Mockito.when(genericAssayRepository.getGenericAssayStableIdsByMolecularIds(PROFILE_ID_LIST))
         .thenReturn(idList);
 
@@ -282,18 +279,52 @@ public class GenericAssayServiceImpTest extends BaseServiceImplTest {
         Assert.assertEquals(mockGenericAssayMetaList.get(1).getGenericEntityMetaProperties(), meta2.getGenericEntityMetaProperties());
     }
 
+    @Test
+    public void getGenericAssayMetaByMolecularIds() throws GenericAssayNotFoundException {
+        Mockito.when(genericAssayRepository.getGenericAssayAdditionalpropertiesByMolecularProfileId(PROFILE_ID))
+            .thenReturn(mockGenericAssayAdditionalPropertyList);
+
+        List<GenericAssayMeta> result = genericAssayService.getGenericAssayMetaByStableIdsAndMolecularIds(null, PROFILE_ID_LIST, PersistenceConstants.SUMMARY_PROJECTION);
+        GenericAssayMeta meta1 = result.get(0);
+        GenericAssayMeta meta2 = result.get(1);
+        Assert.assertEquals(mockGenericAssayMetaList.get(0).getEntityType(), meta1.getEntityType());
+        Assert.assertEquals(mockGenericAssayMetaList.get(0).getStableId(), meta1.getStableId());
+        Assert.assertEquals(mockGenericAssayMetaList.get(0).getGenericEntityMetaProperties(), meta1.getGenericEntityMetaProperties());
+
+        Assert.assertEquals(mockGenericAssayMetaList.get(1).getEntityType(), meta2.getEntityType());
+        Assert.assertEquals(mockGenericAssayMetaList.get(1).getStableId(), meta2.getStableId());
+        Assert.assertEquals(mockGenericAssayMetaList.get(1).getGenericEntityMetaProperties(), meta2.getGenericEntityMetaProperties());
+    }
+
+    @Test
+    public void getGenericAssayMetaByStableIds() throws GenericAssayNotFoundException {
+        Mockito.when(genericAssayRepository.getGenericAssayAdditionalproperties(idList))
+            .thenReturn(mockGenericAssayAdditionalPropertyList);
+
+        List<GenericAssayMeta> result = genericAssayService.getGenericAssayMetaByStableIdsAndMolecularIds(idList, null, PersistenceConstants.SUMMARY_PROJECTION);
+        GenericAssayMeta meta1 = result.get(0);
+        GenericAssayMeta meta2 = result.get(1);
+        Assert.assertEquals(mockGenericAssayMetaList.get(0).getEntityType(), meta1.getEntityType());
+        Assert.assertEquals(mockGenericAssayMetaList.get(0).getStableId(), meta1.getStableId());
+        Assert.assertEquals(mockGenericAssayMetaList.get(0).getGenericEntityMetaProperties(), meta1.getGenericEntityMetaProperties());
+
+        Assert.assertEquals(mockGenericAssayMetaList.get(1).getEntityType(), meta2.getEntityType());
+        Assert.assertEquals(mockGenericAssayMetaList.get(1).getStableId(), meta2.getStableId());
+        Assert.assertEquals(mockGenericAssayMetaList.get(1).getGenericEntityMetaProperties(), meta2.getGenericEntityMetaProperties());
+    }
+
     private static List<GenericAssayMeta> createGenericAssayMetaList() {
 
         List<GenericAssayMeta> genericAssayMetaList = new ArrayList<>();
 
 
-        GenericAssayMeta meta1 = new GenericAssayMeta(GENERIC_ASSAY_ID_1,ENTITY_TYPE);
+        GenericAssayMeta meta1 = new GenericAssayMeta(ENTITY_TYPE, GENERIC_ASSAY_ID_1);
         HashMap<String, String> map1 = new HashMap<String, String>();
         map1.put(PROPERTY_NAME_1, PROPERTY_VALUE_1);
         meta1.setGenericEntityMetaProperties(map1);
         genericAssayMetaList.add(meta1);
 
-        GenericAssayMeta meta2 = new GenericAssayMeta(GENERIC_ASSAY_ID_2,ENTITY_TYPE);
+        GenericAssayMeta meta2 = new GenericAssayMeta(ENTITY_TYPE, GENERIC_ASSAY_ID_2);
         HashMap<String, String> map2 = new HashMap<String, String>();
         map2.put(PROPERTY_NAME_2, PROPERTY_VALUE_2);
         meta2.setGenericEntityMetaProperties(map2);


### PR DESCRIPTION
Partial Fix cBioPortal/icebox#570 

Describe changes proposed in this pull request:
- Adding a new repository function: `getGenericAssayAdditionalpropertiesByMolecularProfileId`, this function will reduce the ids in the SQL query and in some cases (query that requires too much data), this can avoid the database crash because there are too many ids in the query.
- `getGenericAssayAdditionalpropertiesByMolecularProfileId` is also been cached in the static cache, this will improve the fetching speed too
- Adding unit tests for generic essay service
