### PR TITLE
Use RSA256 algorithm for SAML2 authN statement singing

### DIFF
--- a/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/saml/SAMLBootstrapRSA256.java
+++ b/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/saml/SAMLBootstrapRSA256.java
@@ -1,0 +1,18 @@
+package org.cbioportal.security.spring.authentication.saml;
+
+import org.opensaml.Configuration;
+import org.opensaml.xml.security.BasicSecurityConfiguration;
+import org.opensaml.xml.signature.SignatureConstants;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.security.saml.SAMLBootstrap;
+
+public class SAMLBootstrapRSA256 extends SAMLBootstrap {
+        @Override
+        public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+            super.postProcessBeanFactory(beanFactory);
+            BasicSecurityConfiguration config = (BasicSecurityConfiguration) Configuration.getGlobalSecurityConfiguration();
+            config.registerSignatureAlgorithmURI("RSA", SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
+            config.setSignatureReferenceDigestMethod(SignatureConstants.ALGO_ID_DIGEST_SHA256);
+        }
+}

--- a/security/security-spring/src/main/resources/applicationContext-security.xml
+++ b/security/security-spring/src/main/resources/applicationContext-security.xml
@@ -349,6 +349,7 @@
                     <b:bean class="org.springframework.security.saml.metadata.ExtendedMetadata">
                         <b:property name="idpDiscoveryEnabled" value="true"/>
                         <b:property name="signMetadata" value="false"/>
+                        <b:property name="signingAlgorithm" value="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
                     </b:bean>
                 </b:property>
             </b:bean>
@@ -498,7 +499,7 @@
     </b:bean>
 
     <!-- Initialization of OpenSAML library-->
-    <b:bean class="org.springframework.security.saml.SAMLBootstrap"/>
+    <b:bean class="org.cbioportal.security.spring.authentication.saml.SAMLBootstrapRSA256"/>
 
     <!-- Initialization of the velocity engine -->
     <b:bean id="velocityEngine" class="org.springframework.security.saml.util.VelocityFactory" factory-method="getEngine"/>


### PR DESCRIPTION
# Problem
Keycloak 22 does not allow login from cBioPortal because the authN request is signed with SHA1 algorithm. Keycloak dropped support for SHA1 because it is insecure.

# Solution
Configure cBioPortal to sign with RSA-256 algorithm.

This PR will reconfigure cBioPortal to use RSA-256 according to this [blogpost](https://myshittycode.com/2016/02/23/spring-security-saml-replacing-sha-1-with-sha-256-on-signature-and-digest-algorithms/). 