### PR TITLE
[RFC68] Add 'skin.study_view.show_sv_table' property

### DIFF
--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -272,6 +272,21 @@ installation_map_url=https://installationmap.netlify.app/
 
 To set up an installation map instance, one may consult the source code for the installation map [here](https://github.com/cbioportal/installation-map).
 
+
+### Show structural variants table on study view
+
+The structural variants table widget on study view allows users to define cohorts based on gene-orientation specific structural variant data format (see [here](/File-Formats.md#structural-variant-data)).
+The structural variants table widget supports cohort selection based on _gene1_, _gene2_ and _gene1/gene2_ orientation specific genomic events.
+This property enables the structural variants table widget on Study View.
+
+:warning: Although _gene1_ and _gene2_ specific queries may be used to investigate up- and downstream fusion partners, respectively, the validity of this
+depends on supports for this interpretation in the underlying data.
+
+```
+skin.study_view.show_sv_table=true
+```
+
+
 ## Ensembl transcript lookup URL
 
 The Mutations tab contains various links, redirecting the user to external information resources regarding the displayed transcript. The Ensembl template URL can be customized by modifying the property:

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -146,6 +146,7 @@
             "skin.results_view.mutation_table.columns.show_on_init",
             "skin.patient_view.copy_number_table.columns.show_on_init",
             "skin.patient_view.structural_variant_table.columns.show_on_init",
+            "skin.study_view.show_sv_table",
             "comparison.categorical_na_values",
             "study_download_url",
             "skin.home_page.show_reference_genome",

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -79,6 +79,9 @@ skin.right_nav.show_whats_new=true
 # settings controlling what to show in the right navigation bar
 skin.study_view.link_text=To build your own case set, try out our enhanced Study View.
 
+# setting controlling whether to show the structural variants table widget on study view
+skin.study_view.show_sv_table=false
+
 # setting controlling the default setting for filtering genes in patient view
 # skin.patientview.filter_genes_profiled_all_samples=false
 


### PR DESCRIPTION
# Background
The Structural Variant table feature is currently under a feature flag. This feature is not ready for public release because of concerns about the correct interpretation of gene1/gene2 relationships with the data that is in cbioportal.org. It is decided to control this feature with a portal.property instead, so that it can be used on private instances.

# Solution
This PR will implement a new property `skin.study_view.show_sv_table` that will be used by _cbioportal-frontend_ to conditionally render the widget. 