### PR TITLE
Use commit hash for v5.4.3 frontend version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
   </profiles>
 
   <properties>
-    <frontend.version>5.4.3</frontend.version>
+    <frontend.version>912202642c6ab4fbbed53a13b8f71589d9846f70</frontend.version>
     <frontend.groupId>com.github.cbioportal</frontend.groupId>
     <spring.version>5.2.20.RELEASE</spring.version>
     <spring.integration.version>5.3.0.RELEASE</spring.integration.version>

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
   </profiles>
 
   <properties>
-    <frontend.version>v5.4.3</frontend.version>
+    <frontend.version>5.4.3</frontend.version>
     <frontend.groupId>com.github.cbioportal</frontend.groupId>
     <spring.version>5.2.20.RELEASE</spring.version>
     <spring.integration.version>5.3.0.RELEASE</spring.integration.version>


### PR DESCRIPTION
For some reason https://jitpack.io/com/github/cbioPortal/cbioportal-frontend/v5.4.3/build.log seems to be not working, so use hash commit instead: https://jitpack.io/com/github/cbioPortal/cbioportal-frontend/912202642c6ab4fbbed53a13b8f71589d9846f70/build.log