### PR TITLE
Add 'skin.left_logo' property

### DIFF
--- a/docs/deployment/customization/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/deployment/customization/Customizing-your-instance-of-cBioPortal.md
@@ -116,9 +116,15 @@ Below you can find the complete list of all the available skin properties.
 			<td>Any HTML text</td>
 		</tr>
 		<tr>
+			<td>skin.left_logo</td>
+			<td>sets the left logo in the header. Logo should be placed in the images directory or in a subdirectory of the images directory. If placed in a subfolder, the skin.left_logo value has to contain the folder, e.g. skin.right_logo = myFolder/myImage.jpg</td>
+			<td>cBioPortal Logo</td>
+			<td>text</td>
+		</tr>
+		<tr>
 			<td>skin.right_logo</td>
-			<td>sets the right logo in the header. Logo should be placed in the images directory or in a subdirectory of the images directory. If placed in a subfolder, the skin.right_logo value has to contain the folder, e.g. skin.right_logo = myFolder/myImage.jpg</td>
-			<td>MSKCC Logo</td>
+			<td>sets the right institute logo in the header. Logo should be placed in the images directory or in a subdirectory of the images directory. If placed in a subfolder, the skin.right_logo value has to contain the folder, e.g. skin.right_logo = myFolder/myImage.jpg</td>
+			<td>no logo</td>
 			<td>text</td>
 		</tr>
 		<tr>

--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -142,9 +142,10 @@ Settings controlling the "What's New" blurb in the right navigation bar: you can
 skin.right_nav.whats_new_blurb=
 ```
 
-Add a custom logo in the right side of the menu. Place here the full name of the logo file (e.g. `logo.png`). This file should be saved in `$PORTAL_HOME/portal/images/`.
+Add custom logos to the left or right side of the header section. Place here the full name of the logo file (e.g. `logo.png`). This file should be present in `$PORTAL_HOME/portal/images/`.
 
 ```
+skin.left_logo=
 skin.right_logo=
 ```
 

--- a/portal/src/main/webapp/config_service.jsp
+++ b/portal/src/main/webapp/config_service.jsp
@@ -92,6 +92,7 @@
             "skin.query.max_tree_depth",
             "skin.quick_select_buttons",
             "skin.right_logo",
+            "skin.left_logo",
             "skin.right_nav.show_data_sets",
             "skin.right_nav.show_examples",
             "skin.right_nav.show_testimonials",

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -37,6 +37,7 @@ skin.documentation.dat=Authenticating-Users-via-Tokens.md
 
 # setting controlling the logos
 skin.right_logo=
+skin.left_logo=
 skin.tag_line_image=tag_line.png
 
 # setting controlling which tabs to hide.


### PR DESCRIPTION
This PR will implement a new property `skin.left_logo` that will be used by cbioportal-frontend to render a custom logo at the left side of the header.