### PR TITLE
Enable server public key retrieval in python scripts

### DIFF
--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -1092,16 +1092,20 @@ def get_db_cursor(portal_properties: PortalProperties):
             "user": portal_properties.database_user,
             "passwd": portal_properties.database_pw
         }
-        if url_elements.query["useSSL"] == "true":
-            connection_kwargs['ssl'] = {"ssl_mode": True}
+        if url_elements.query.get("useSSL") == "true":
             connection_kwargs['ssl_mode'] = 'REQUIRED'
+            connection_kwargs['ssl'] = {"ssl_mode": True}
         else:
-            connection_kwargs['ssl_mode'] = 'DISABLED'   
+            connection_kwargs['ssl_mode'] = 'DISABLED'  
+            if url_elements.query.get("get-server-public-key") == "true":
+                connection_kwargs['ssl'] = {
+                    'MYSQL_OPT_GET_SERVER_PUBLIC_KEY': True
+                }
         connection = MySQLdb.connect(**connection_kwargs)
     except MySQLdb.Error as exception:
         print(exception, file=ERROR_FILE)
         message = (
-            "--> Error connecting to server with URL"
+            "--> Error connecting to server with URL: "
             + portal_properties.database_url)
         print(message, file=ERROR_FILE)
         raise ConnectionError(message) from exception


### PR DESCRIPTION
# Problem
When using an un-encrypted connection MySQL 8 by default requires password encryption that uses the server public key. The client enables retrieval of the server public key by passing 'get-server-public-key' in the connection URL. The migration step that is mediated by Python scripts fails with the following error because it does not correctly request retrieval of the server public key:

```
ERROR 2061 (HY000): Authentication plugin 'caching_sha2_password'
reported error: Authentication requires secure connection.
```

# Solution
This PR will make sure the python mysqlclient library passes 'get-server-public-key=true' as a parameter named  'MYSQL_OPT_GET_SERVER_PUBLIC_KEY' to the MySQL C-library.
