### PR TITLE
Fix context initialization when property 'dat.method' is missing

### DIFF
--- a/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/token/config/DataAccessTokenConfig.java
+++ b/security/security-spring/src/main/java/org/cbioportal/security/spring/authentication/token/config/DataAccessTokenConfig.java
@@ -48,7 +48,7 @@ public class DataAccessTokenConfig {
     }
 
     @Bean("dataAccessTokenService")
-    @ConditionalOnProperty(name = "dat.method", havingValue = "none")
+    @ConditionalOnProperty(name = "dat.method", havingValue = "none", matchIfMissing = true)
     public UnauthDataAccessTokenServiceImpl unauthDataAccessTokenService() {
         return new UnauthDataAccessTokenServiceImpl();
     }


### PR DESCRIPTION
# a Problem
When property _dat.method_ is not defined in portal.properties, context initialization complains about a missing TokenService bean. The cause of this error is that TokenService initialization does not include a default.

# Solution
This PR will set the 'none' value as the default when the property is undefined.