### PR TITLE
Add dependency for SAML2 integration

### DIFF
--- a/security/security-spring/pom.xml
+++ b/security/security-spring/pom.xml
@@ -123,6 +123,10 @@
             <groupId>org.cbioportal</groupId>
             <artifactId>service</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-httpclient</groupId>
+            <artifactId>commons-httpclient</artifactId>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
Fixes integration with SAML2 IDP (e.g., Keycloak).