### PR TITLE
Added setting for python-specific connection URL 

### DIFF
--- a/core/src/main/scripts/importer/cbioportal_common.py
+++ b/core/src/main/scripts/importer/cbioportal_common.py
@@ -44,6 +44,7 @@ PORTAL_PROPERTY_DATABASE_PW = 'db.password'
 PORTAL_PROPERTY_DATABASE_HOST = 'db.host'
 PORTAL_PROPERTY_DATABASE_NAME = 'db.portal_db_name'
 PORTAL_PROPERTY_DATABASE_URL = 'db.connection_string'
+PORTAL_PROPERTY_DATABASE_URL_PYTHON = 'db.connection_string_python'
 PORTAL_PROPERTY_DATABASE_USESSL = 'db.use_ssl'
 REQUIRED_DATABASE_PROPERTIES = [PORTAL_PROPERTY_DATABASE_USER, PORTAL_PROPERTY_DATABASE_PW, PORTAL_PROPERTY_DATABASE_URL]
 
@@ -1051,7 +1052,8 @@ def get_database_properties(properties_filename: str) -> Optional[PortalProperti
             ------------------------------------------------------------f---------------------------------------------------
         """, file=ERROR_FILE)
         return None
-
+    if python_url := properties.get(PORTAL_PROPERTY_DATABASE_URL_PYTHON):
+        properties[PORTAL_PROPERTY_DATABASE_URL] = python_url
     return PortalProperties(properties[PORTAL_PROPERTY_DATABASE_USER],
                             properties[PORTAL_PROPERTY_DATABASE_PW],
                             properties[PORTAL_PROPERTY_DATABASE_URL])

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -1150,6 +1150,10 @@ Example column:
 
 SOME_HYPERLINK: ```[Link text Here](https://link-url-here.org)```
 
+The external link can be opened in a new tab, instead of an IFRAME within the same window/tab. To do this, the string `:blank` is to be added as a suffix at the end of the URL.
+
+HYPERLINK_OPEN_IN_NEWTAB: ```[Link text Here](https://link-url-here.org/path:blank)```
+
 ### Event Types
 As previously mentioned, the EVENT_TYPE can be anything. However, several event types have columns with special effects. Furthermore, for some event types cBioPortal has column naming suggestions.
 

--- a/docs/deployment/customization/portal.properties-Reference.md
+++ b/docs/deployment/customization/portal.properties-Reference.md
@@ -31,6 +31,17 @@ the `db.connection_string` instead.
 db.tomcat_resource_name=jdbc/cbioportal
 ```
 
+### Python-specific connection URL (internal use only)
+
+``` 
+db.connection_string_python= 
+
+``` 
+
+Setting that allows a python-specific database connection URL which is different from the connection URL used by Java. This allows, for instance, to migrate the database with different connection properties in the docker entry point script. If provided, the python-specific connection URL takes precedence over the standard connection string. 
+
+The format of the `db.connection_string_python` is identical to `db.connection_string`
+
 ## cBioPortal Customization
 
 ### Hide tabs (pages)

--- a/src/main/resources/portal.properties.EXAMPLE
+++ b/src/main/resources/portal.properties.EXAMPLE
@@ -6,6 +6,8 @@ db.user=cbio_user
 db.password=somepassword
 db.driver=com.mysql.jdbc.Driver
 db.connection_string=jdbc:mysql://localhost:3306/cbioportal?useSSL=false
+# Connection string for when both python and java connections are used in the docker entrypoint. When a connection URL is given for python, it will be used to form a connection to the mySQL database instead of the standard connection string. This allows for different connection properties to be used (like ssl connection for example). 
+# db.connection_string_python= jdbc:mysql://cbioDB:3306/cbioportal
 # set tomcat_resource_name when using dbconnector=jndi instead of the default
 # dbconnector=dbcp. Note that dbconnector needs to be set in CATLINA_OPTS when
 # using Tomcat (CATALINA_OPTS="-Ddbconnector=jndi"). It does not get picked up


### PR DESCRIPTION
### Problem:

Standard database connection string does not work when using MySQL python connector for migration. For example, ssl connection is disabled for the standard connection URL, but ssl connection is required for python MySQL connection. 

### Fix: 

Added Python-specific connection URL, and implemented it in the get_database_properties function, so the correct URL is selected for the migration script.

Input URL is given in the portal.properties:

`db.connection_string_python=`
