### PR TITLE
Add documentation for quick select on homepage

### DIFF
--- a/docs/deployment/customization/application.properties-Reference.md
+++ b/docs/deployment/customization/application.properties-Reference.md
@@ -162,18 +162,18 @@ Prevent users from saving data by removing all Download tabs and download and co
 skin.hide_download_controls=
 ```
 
-### Quick select buttons 
+### Quick select buttons
 
-This feature allows you to generate a Quick Select button on the top of your query page. The button, when clicked on, will automatically select the studies mentioned after the '#`. 
+This feature allows you to generate a Quick Select button on the top of your query page. The button, when clicked on, will automatically select the studies mentioned after the '#`.
 
 ```
 skin.quick_select_buttons=
 ```
 
 The format for the string should be ``<Button name>|<Mouse-over text>#study1a,study1b,....`` where:
-- <Button name> will be the label on the button (for e.g. TCGA PanCancer Atlas Studies, Curated set of non-redundant studies)
-- <Mouse-over text> will be the text that is displayed when you hover over the button (for e.g. 218 studies that are manually curated including TCGA and non-TCGA studies with no overlapping samples) 
-- study1a,study1b,.... are the study IDs of the loaded studies that should be selected when the button is clicked. (for e.g. acbc_mskcc_2015,acc_tcga_pan_can_atlas_2018)
+- `<Button name>` will be the label on the button (for e.g. TCGA PanCancer Atlas Studies, Curated set of non-redundant studies)
+- `<Mouse-over text>` will be the text that is displayed when you hover over the button (for e.g. 218 studies that are manually curated including TCGA and non-TCGA studies with no overlapping samples)
+- `study1a,study1b,....` are the study IDs of the loaded studies that should be selected when the button is clicked. (for e.g. acbc_mskcc_2015,acc_tcga_pan_can_atlas_2018)
 
 
 ### Control default setting for filtering of genes in mutation and CNA tables of patient view

--- a/docs/deployment/customization/application.properties-Reference.md
+++ b/docs/deployment/customization/application.properties-Reference.md
@@ -162,6 +162,18 @@ Prevent users from saving data by removing all Download tabs and download and co
 skin.hide_download_controls=
 ```
 
+### Quick select buttons 
+
+This feature allows you to generate a Quick Select button on the top of your query page. The button, when clicked on, will automatically select the studies mentioned after the '#`. 
+
+```
+skin.quick_select_buttons=
+```
+
+The format for the string should be ``<Button name>|<Mouse-over text>#study1a,study1b,....`` where:
+- <Button name> will be the label on the button (for e.g. TCGA PanCancer Atlas Studies, Curated set of non-redundant studies)
+- <Mouse-over text> will be the text that is displayed when you hover over the button (for e.g. 218 studies that are manually curated including TCGA and non-TCGA studies with no overlapping samples) 
+- study1a,study1b,.... are the study IDs of the loaded studies that should be selected when the button is clicked. (for e.g. acbc_mskcc_2015,acc_tcga_pan_can_atlas_2018)
 
 
 ### Control default setting for filtering of genes in mutation and CNA tables of patient view


### PR DESCRIPTION
Add docs for quick select button on homepage:

<img width="518" alt="image" src="https://github.com/user-attachments/assets/ef0a69d7-651a-499d-89c6-b4145ebea299" />
