### PR TITLE
Label checker action reruns when needed

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -8,6 +8,9 @@ on:
     types:
       - opened
       - synchronize
+      - reopened
+      - labeled
+      - unlabeled
 
 jobs:
   label-check:


### PR DESCRIPTION
- The label checker GH action currently runs when a PR is posted, but not when labels are added
- Since most people add labels _after_ they post a PR, this makes the action mostly useless
- Fix: rerun action on add/remove label
- If this works, you could start making label checker a required check, which would make your release process a little cleaner, I think