### PR TITLE
Remove spring-boot-starter-data-mongodb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,10 +191,6 @@
 			<version>${io-jsonwebtoken.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-mongodb</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.mongodb</groupId>
 			<artifactId>bson</artifactId>
 			<version>${mongodb_bson.version}</version>


### PR DESCRIPTION
Since 6.0.0 cBioPortal ships with spring-boot-starter-data-mongodb which includes the mongodb java client in currently version 4.9.1. 
cBioPortal still uses 3.12.14. The APIs of both are incompatible to each other. Depending on your java version and it's lib strategy this can cause a `Method not found` error. On my workstation I had no issues, but using a alpine-based docker image I ran into this issue.

So I suppose to remove the spring-boot one for now. In addition I think that using the version of mongodb that ships with spring-boot only makes sense if the spring-boot versions between cBioPortal and session-service are aligned (which they aren't at the moment).