### PR TITLE
setup redirect to tutorials page

### DIFF
--- a/src/main/java/org/cbioportal/WebAppConfig.java
+++ b/src/main/java/org/cbioportal/WebAppConfig.java
@@ -22,6 +22,9 @@ public class WebAppConfig implements WebMvcConfigurer {
 	@Value("${springdoc.swagger-ui.path:/swagger-ui.html}")
 	private String swaggerRedirectUrl;
 
+	@Value("${skin.documentation.tutorial-url:https://docs.cbioportal.org/user-guide/overview/#tutorial-slides}")
+	private String tutorialRedirecUrl;
+
 	@Override
 	public void addResourceHandlers(ResourceHandlerRegistry registry) {
 		registry.addResourceHandler("/images/**").addResourceLocations("classpath:/webapp/images/");
@@ -32,6 +35,7 @@ public class WebAppConfig implements WebMvcConfigurer {
 	@Override
 	public void addViewControllers(ViewControllerRegistry registry) {
 		registry.addRedirectViewController("/api", swaggerRedirectUrl);
+		registry.addRedirectViewController("/tutorials", tutorialRedirecUrl);
 
 		// Redirects for single page app
 		registry.addViewController("/results/*").setViewName(SINGLE_PAGE_APP_ROOT);


### PR DESCRIPTION
Fix #10584  (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- Add redirect for tutorials back

# Checks
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
