### PR TITLE
10584 fix tutorials

### DIFF
--- a/src/main/java/org/cbioportal/WebAppConfig.java
+++ b/src/main/java/org/cbioportal/WebAppConfig.java
@@ -35,7 +35,6 @@ public class WebAppConfig implements WebMvcConfigurer {
 	@Override
 	public void addViewControllers(ViewControllerRegistry registry) {
 		registry.addRedirectViewController("/api", swaggerRedirectUrl);
-		registry.addRedirectViewController("/tutorials", tutorialRedirecUrl);
 		registry.addRedirectViewController("/installations", "https://installationmap.netlify.app/");
 
 		// Redirects anything that doesn't start with /api or /proxy to the Javascript frontend

--- a/src/main/java/org/cbioportal/WebAppConfig.java
+++ b/src/main/java/org/cbioportal/WebAppConfig.java
@@ -22,6 +22,9 @@ public class WebAppConfig implements WebMvcConfigurer {
 	@Value("${springdoc.swagger-ui.path:/swagger-ui.html}")
 	private String swaggerRedirectUrl;
 
+	@Value("${skin.documentation.tutorial-url:https://docs.cbioportal.org/user-guide/overview/#tutorial-slides}")
+	private String tutorialRedirecUrl;
+
 	@Override
 	public void addResourceHandlers(ResourceHandlerRegistry registry) {
 		registry.addResourceHandler("/images/**").addResourceLocations("classpath:/webapp/images/");
@@ -32,6 +35,7 @@ public class WebAppConfig implements WebMvcConfigurer {
 	@Override
 	public void addViewControllers(ViewControllerRegistry registry) {
 		registry.addRedirectViewController("/api", swaggerRedirectUrl);
+		registry.addRedirectViewController("/tutorials", tutorialRedirecUrl);
 
 		// Redirects for single page app
 		registry.addViewController("/results/*").setViewName(SINGLE_PAGE_APP_ROOT);

--- a/src/main/java/org/cbioportal/WebAppConfig.java
+++ b/src/main/java/org/cbioportal/WebAppConfig.java
@@ -36,28 +36,10 @@ public class WebAppConfig implements WebMvcConfigurer {
 	public void addViewControllers(ViewControllerRegistry registry) {
 		registry.addRedirectViewController("/api", swaggerRedirectUrl);
 		registry.addRedirectViewController("/tutorials", tutorialRedirecUrl);
-
-		// Redirects for single page app
-		registry.addViewController("/results/*").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/results**").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/patient/*").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/patient**").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/study/*").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/study").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/mutation_mapper/*").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/mutation_mapper").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/index.do/*").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/case.do/*").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/loading/*").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/comparison").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/comparison/*").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/restore").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/index.do**").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/oncoprinter**").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/encodedRedirect").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/datasets**").setViewName(SINGLE_PAGE_APP_ROOT);
-		registry.addViewController("/ln**").setViewName(SINGLE_PAGE_APP_ROOT);
 		registry.addRedirectViewController("/installations", "https://installationmap.netlify.app/");
+
+		// Redirects anything that doesn't start with /api or /proxy to the Javascript frontend
+		registry.addViewController("/{path:^(?!api|proxy$).*$}").setViewName(SINGLE_PAGE_APP_ROOT);
 	}
 
 	@Bean

--- a/src/main/java/org/cbioportal/WebAppConfig.java
+++ b/src/main/java/org/cbioportal/WebAppConfig.java
@@ -22,9 +22,6 @@ public class WebAppConfig implements WebMvcConfigurer {
 	@Value("${springdoc.swagger-ui.path:/swagger-ui.html}")
 	private String swaggerRedirectUrl;
 
-	@Value("${skin.documentation.tutorial-url:https://docs.cbioportal.org/user-guide/overview/#tutorial-slides}")
-	private String tutorialRedirecUrl;
-
 	@Override
 	public void addResourceHandlers(ResourceHandlerRegistry registry) {
 		registry.addResourceHandler("/images/**").addResourceLocations("classpath:/webapp/images/");


### PR DESCRIPTION
Fix #10584  (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- Fix /tutorial path
- Refactor ViewControllerRegistry to forward everything besides /api and /proxy to the frontend
- Paths that don't exist still return a "page doesn't exist" page, although it returns a 200 instead of a 404 HTTP code (see image). **We should discuss this in standup.**

# Checks
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
<img width="1098" alt="Screenshot 2024-02-07 at 2 34 21 PM" src="https://github.com/cBioPortal/cbioportal/assets/6611791/01d42ce2-7f11-432d-a3c0-43d8698e7b36">


# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
