### PR TITLE
Changes Immutable List to Mutable List

### DIFF
--- a/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -165,8 +165,8 @@ public class StudyViewFilterApplier {
             sampleIdentifiers = sampleService.fetchSamples(studyIds, sampleIds, Projection.ID.name()).stream()
                 .map(sampleToSampleIdentifier).toList();
         } else {
-            sampleIdentifiers = sampleService.getAllSamplesInStudies(studyViewFilter.getStudyIds(), Projection.ID.name(),
-                null, null, null, null).stream().map(sampleToSampleIdentifier).toList();
+            sampleIdentifiers = sampleService.getAllSamplesInStudies(studyViewFilter.getStudyIds(), Projection.ID.name(), 
+            		null, null, null, null).stream().map(sampleToSampleIdentifier).collect(Collectors.toList());
         }
 
         List<String> studyIds = sampleIdentifiers.stream().map(SampleIdentifier::getStudyId).distinct()
@@ -320,7 +320,7 @@ public class StudyViewFilterApplier {
                         profileValue -> molecularProfileSet.getOrDefault(profileValue, new ArrayList<>()).stream())
                         .collect(Collectors.toMap(MolecularProfile::getStableId, Function.identity()));
 
-                Set<SampleIdentifier> filteredSampleIdentifiers = new HashSet<>();
+                Set<SampleIdentifier> filteredSampleIdentifiers = new HashSet<SampleIdentifier>();
                 genePanelData.forEach(datum -> {
                     if (datum.getProfiled() && profileMap.containsKey(datum.getMolecularProfileId())) {
                         SampleIdentifier sampleIdentifier = 

--- a/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
+++ b/src/main/java/org/cbioportal/web/util/StudyViewFilterApplier.java
@@ -320,7 +320,7 @@ public class StudyViewFilterApplier {
                         profileValue -> molecularProfileSet.getOrDefault(profileValue, new ArrayList<>()).stream())
                         .collect(Collectors.toMap(MolecularProfile::getStableId, Function.identity()));
 
-                Set<SampleIdentifier> filteredSampleIdentifiers = new HashSet<SampleIdentifier>();
+                Set<SampleIdentifier> filteredSampleIdentifiers = new HashSet<>();
                 genePanelData.forEach(datum -> {
                     if (datum.getProfiled() && profileMap.containsKey(datum.getMolecularProfileId())) {
                         SampleIdentifier sampleIdentifier = 


### PR DESCRIPTION
#10618 was caused by issues with retainAll trying to mutate an immutable object.

This fix changes sampleIdentifiers to a mutable object and allows the retainAll function to work (i.e., remove which is part of retainAll only works on mutable lists).