### PR TITLE
Add configuration to disable study tags

### DIFF
--- a/docs/deployment/customization/application.properties-Reference.md
+++ b/docs/deployment/customization/application.properties-Reference.md
@@ -790,3 +790,11 @@ By default, the studies loaded into a local cBioPortal instance are organized ba
 priority_studies=
 ```
 The value of this variable will create a custom category with studies on the top of the study selector view. The format for the string should be category1#study1a,study1b,study1c;category2#study2 (e.g., PanCancer Studies#msk_impact_2017), where the ``category`` can be any string and the ``study`` should be the study ID of the required uploaded study. 
+
+## Study Tag functionality
+Study Tags allow portal maintainers to define miscellaneous descriptive meta data to studies, which will be shown to users in tooltips and are also searchable. This feature
+is on by default but can be disabled using the following property.
+```
+//boolean
+enable_study_tags=true|false
+```

--- a/src/main/java/org/cbioportal/service/FrontendPropertiesServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/FrontendPropertiesServiceImpl.java
@@ -175,14 +175,17 @@ public class FrontendPropertiesServiceImpl implements FrontendPropertiesService 
         skin_patient_view_copy_number_table_columns_show_on_init("skin.patient_view.copy_number_table.columns.show_on_init", null),
         skin_patient_view_structural_variant_table_columns_show_on_init("skin.patient_view.structural_variant_table.columns.show_on_init", null),
         skin_results_view_tables_default_sort_column("skin.results_view.tables.default_sort_column", null),
+        
         skin_patient_view_tables_default_sort_column("skin.patient_view.tables.default_sort_column", null),
         enable_treatment_groups("enable_treatment_groups", null),
         comparison_categorical_na_values("comparison.categorical_na_values", null),
         clinical_attribute_product_limit("clinical_attribute_product_limit", null),
         skin_right_nav_show_web_tours("skin.right_nav.show_web_tours", "false"),
-        
+
+        enable_study_tags("enable_study_tags", null),
         enable_darwin("enable_darwin", null);
 
+      
         private final String propertyName;
         private final String defaultValue;
 

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -422,4 +422,8 @@ server.max-http-request-header-size=16384
 # Development Configuration
 spring.devtools.restart.enabled=false
 
+## Study Tag functionality
+#enable_study_tags=true|false
+
 # EOL - Do not delete the following lines
+


### PR DESCRIPTION
Configuration property allows portal maintainers to disable study tag functionality, which is enabled by default.   Study tags are miscellaneous meta data associated with individual cancer studies.