### PR TITLE
Fix custom MSK endpoints to include api-legacy

### DIFF
--- a/src/main/java/org/cbioportal/web/MskEntityTranslationController.java
+++ b/src/main/java/org/cbioportal/web/MskEntityTranslationController.java
@@ -91,7 +91,7 @@ public class MskEntityTranslationController {
     }
 
     @RequestMapping(
-        value={"/cis/{sampleID}", "/darwin/{sampleID}"},
+        value={"/api-legacy/cis/{sampleID}", "/api-legacy/darwin/{sampleID}"},
         method=RequestMethod.GET
     )
     public ModelAndView redirectIMPACT(@PathVariable String sampleID, ModelMap model) {
@@ -99,7 +99,7 @@ public class MskEntityTranslationController {
     }
 
     @RequestMapping(
-        value="/crdb/{sampleID}",
+        value="/api-legacy/crdb/{sampleID}",
         method=RequestMethod.GET
     )
     public ModelAndView redirectCRDB(@PathVariable String sampleID, ModelMap model) {
@@ -132,7 +132,7 @@ public class MskEntityTranslationController {
     }
 
     @RequestMapping(
-        value={"/cis/{sampleID}/exists", "/darwin/{sampleID}/exists", "/crdb/{sampleID}/exists"},
+        value={"/api-legacy/cis/{sampleID}/exists", "/api-legacy/darwin/{sampleID}/exists", "/api-legacy/crdb/{sampleID}/exists"},
         method=RequestMethod.GET
     )
     public @ResponseBody HashMap<String, Boolean> exists(@PathVariable String sampleID, ModelMap model) {


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/10649. Adds `/api-legacy/` to msk entity translation controller to move custom MSK endpoints like e.g. /api-legacy/cis/P-0047549-T01-IM6 to /cis/P-0047549-T01-IM6