### PR TITLE
Fix: groups and authorities filter issue

### DIFF
--- a/src/main/java/org/cbioportal/security/CancerStudyPermissionEvaluator.java
+++ b/src/main/java/org/cbioportal/security/CancerStudyPermissionEvaluator.java
@@ -284,7 +284,9 @@ public class CancerStudyPermissionEvaluator implements PermissionEvaluator {
         // check if user is in study groups
         // performance now takes precedence over group accuracy (minimal risk to caching cancer study groups)
         // need to filter out empty groups, this can cause issue if grantedAuthorities and groups both contain empty string
-        Set<String> groups = Arrays.stream(cancerStudy.getGroups().split(";")).filter(String::isEmpty).collect(Collectors.toSet());
+        Set<String> groups = Arrays.stream(cancerStudy.getGroups().split(";"))
+            .filter(g -> !g.isEmpty())
+            .collect(Collectors.toSet());
         if (!Collections.disjoint(groups, grantedAuthorities)) {
             if (log.isDebugEnabled()) {
                 log.debug("hasAccessToCancerStudy(), user has access by groups return true");
@@ -368,7 +370,7 @@ public class CancerStudyPermissionEvaluator implements PermissionEvaluator {
         Set<String> allAuthorities = AuthorityUtils.authorityListToSet(authentication.getAuthorities())
             .stream()
             .map(authority -> authority.replaceAll("^ROLE_", ""))
-            .filter(String::isEmpty)
+            .filter(a -> !a.isEmpty())
             .collect(Collectors.toSet());
         Set<String> grantedAuthorities = new HashSet<>();
         if (filterGroupsByAppName()) {

--- a/src/main/java/org/cbioportal/security/CancerStudyPermissionEvaluator.java
+++ b/src/main/java/org/cbioportal/security/CancerStudyPermissionEvaluator.java
@@ -283,7 +283,8 @@ public class CancerStudyPermissionEvaluator implements PermissionEvaluator {
         }
         // check if user is in study groups
         // performance now takes precedence over group accuracy (minimal risk to caching cancer study groups)
-        Set<String> groups = new HashSet(Arrays.asList(cancerStudy.getGroups().split(";")));
+        // need to filter out empty groups, this can cause issue if grantedAuthorities and groups both contain empty string
+        Set<String> groups = Arrays.stream(cancerStudy.getGroups().split(";")).filter(String::isEmpty).collect(Collectors.toSet());
         if (!Collections.disjoint(groups, grantedAuthorities)) {
             if (log.isDebugEnabled()) {
                 log.debug("hasAccessToCancerStudy(), user has access by groups return true");
@@ -363,9 +364,11 @@ public class CancerStudyPermissionEvaluator implements PermissionEvaluator {
 
     private Set<String> getGrantedAuthorities(Authentication authentication) {
         String appName = getAppName().toUpperCase();
+        // need to filter out empty authorities, this can cause issue if grantedAuthorities and groups both contain empty string
         Set<String> allAuthorities = AuthorityUtils.authorityListToSet(authentication.getAuthorities())
             .stream()
             .map(authority -> authority.replaceAll("^ROLE_", ""))
+            .filter(String::isEmpty)
             .collect(Collectors.toSet());
         Set<String> grantedAuthorities = new HashSet<>();
         if (filterGroupsByAppName()) {


### PR DESCRIPTION
Filtering out empty groups and grantedAuthorities, it can cause issues if grantedAuthorities and groups both contain an empty string
