### PR TITLE
:bug: Fix RedisAutoConfig Exclusion logic to exclude if redis session…

### DIFF
--- a/src/main/java/org/cbioportal/security/config/AutoconfigureExcludeConfig.java
+++ b/src/main/java/org/cbioportal/security/config/AutoconfigureExcludeConfig.java
@@ -27,9 +27,11 @@ public class AutoconfigureExcludeConfig {
     @ConditionalOnProperty(name = "authenticate", havingValue = "oauth2")
     @EnableAutoConfiguration(exclude=Saml2RelyingPartyAutoConfiguration.class)
     public static class OAuth2 {}
-    
+
     @Configuration
-    @ConditionalOnProperty(name = "persistence.cache_type", havingValue = "redis", isNot = true)
+    @ConditionalOnExpression(
+        "T(org.apache.commons.lang3.StringUtils).isEmpty('${spring.data.redis.host:}')"
+    )
     @EnableAutoConfiguration(exclude=RedisAutoConfiguration.class)
     public static class Redis {}
 

--- a/src/main/java/org/cbioportal/security/config/AutoconfigureExcludeConfig.java
+++ b/src/main/java/org/cbioportal/security/config/AutoconfigureExcludeConfig.java
@@ -30,7 +30,7 @@ public class AutoconfigureExcludeConfig {
 
     @Configuration
     @ConditionalOnExpression(
-        "T(org.apache.commons.lang3.StringUtils).isEmpty('${spring.data.redis.host:}')"
+        "T(org.apache.commons.lang3.StringUtils).isEmpty('${spring.session.store-type:}')"
     )
     @EnableAutoConfiguration(exclude=RedisAutoConfiguration.class)
     public static class Redis {}

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -397,8 +397,6 @@ logging.level.root=INFO
 
 ## Redis HTTP Session Store
 # Redis Session
-## Comment out the line below to enable redis caching
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
 #spring.data.redis.host=localhost
 #spring.data.redis.port=6379
 


### PR DESCRIPTION
Currently If users wanted to just configure Spring Redis Session it was impossible with out enabling redis cache type.

Updated conditional logic to look at the presence of spring.data.redis.host instead