### PR TITLE
Set default API springdoc properties to match those prior to v6

### DIFF
--- a/src/main/java/org/cbioportal/PortalApplication.java
+++ b/src/main/java/org/cbioportal/PortalApplication.java
@@ -15,7 +15,8 @@ import org.springframework.context.annotation.PropertySources;
     @PropertySource(ignoreResourceNotFound = true, value = "classpath:application.properties"),
     @PropertySource(ignoreResourceNotFound = true, value = "classpath:security.properties"),
     @PropertySource(ignoreResourceNotFound = true, value = "classpath:maven.properties"),
-    @PropertySource(ignoreResourceNotFound = true, value = "classpath:git.properties")
+    @PropertySource(ignoreResourceNotFound = true, value = "classpath:git.properties"),
+    @PropertySource(ignoreResourceNotFound = true, value = "classpath:springdoc.properties")
 })
 public class PortalApplication {
     public static void main(String[] args) {

--- a/src/main/resources/springdoc.properties
+++ b/src/main/resources/springdoc.properties
@@ -1,0 +1,1 @@
+springdoc.swagger-ui.urlsPrimaryName=public

--- a/src/main/resources/springdoc.properties
+++ b/src/main/resources/springdoc.properties
@@ -1,1 +1,4 @@
 springdoc.swagger-ui.urlsPrimaryName=public
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.path=/api/swagger-ui
+springdoc.api-docs.path=/api/v3/api-docs

--- a/src/main/resources/springfox.properties
+++ b/src/main/resources/springfox.properties
@@ -1,1 +1,0 @@
-springfox.documentation.swagger.v2.path=/api-docs


### PR DESCRIPTION
Adds several defaults for springdoc to match configuration of the cBioPortal API prior to the v6 release:

- Fix https://github.com/cBioPortal/cbioportal/issues/10554. Default listing is alphabetical (so `internal` was shown first). This makes `public` always show up by default. Also remove old springfox properties file and replace it with a springdoc properties file to include defaults of the swagger UI page
- Also add [these parameters](https://github.com/knowledgesystems/knowledgesystems-k8s-deployment/blob/dd92c2cfe31b8e465eb845d2844a5f4ba6fa963b/public-eks/cbioportal-prod/cbioportal_spring_boot.yaml#L183-L186) that allow for backwards compatibility with v2 api-docs locations