### PR TITLE
Optimize study view clinical data search with denormalized view 

### DIFF
--- a/src/main/java/org/cbioportal/persistence/mybatis/ClinicalDataMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/persistence/mybatis/ClinicalDataMyBatisRepository.java
@@ -148,11 +148,18 @@ public class ClinicalDataMyBatisRepository implements ClinicalDataRepository {
         Integer offset = PaginationCalculator.offset(pageSize, pageNumber);
         Boolean sortAttrIsNumber = null;
         Boolean sortIsPatientAttr = null;
-        if (sortAttrId != null && ! sortAttrId.isEmpty()) {
-            ClinicalAttribute clinicalAttributeMeta = getClinicalAttributeMeta(studyIds, sortAttrId);
-            sortAttrIsNumber = clinicalAttributeMeta.getDatatype().equals("NUMBER");
-            sortIsPatientAttr = clinicalAttributeMeta.getPatientAttribute();
+        
+        if (sortAttrId != null) {
+            if (sortAttrId.equals("patientId") || sortAttrId.equals("sampleId")) {
+                sortAttrIsNumber = false;
+                sortIsPatientAttr = false;
+            } else {
+                ClinicalAttribute clinicalAttributeMeta = getClinicalAttributeMeta(studyIds, sortAttrId);
+                sortAttrIsNumber = clinicalAttributeMeta.getDatatype().equals("NUMBER");
+                sortIsPatientAttr = clinicalAttributeMeta.getPatientAttribute();
+            }
         }
+        
         return clinicalDataMapper.getVisibleSampleInternalIdsForClinicalTable(studyIds, sampleIds,"SUMMARY", pageSize, 
             offset, searchTerm, sortAttrId, sortAttrIsNumber, sortIsPatientAttr, direction);
     }

--- a/src/main/resources/db-scripts/migration.sql
+++ b/src/main/resources/db-scripts/migration.sql
@@ -1030,7 +1030,7 @@ CREATE INDEX idx_sample_stable_id ON sample (`STABLE_ID`);
 UPDATE `info` SET `DB_SCHEMA_VERSION`="2.13.1";
 
 ##version: 2.13.2
-CREATE TABLE clinical_data_search_mv (
+CREATE TABLE clinical_data_search_derived (
                                          ATTR_VALUE varchar(255),
                                          PATIENT_INTERNAL_ID varchar(255),
                                          SAMPLE_INTERNAL_ID varchar(255),
@@ -1040,7 +1040,7 @@ CREATE TABLE clinical_data_search_mv (
 );
 
 #populate table with data
-INSERT INTO clinical_data_search_mv (
+INSERT INTO clinical_data_search_derived (
     ATTR_VALUE, PATIENT_INTERNAL_ID, SAMPLE_INTERNAL_ID, PATIENT_STABLE_ID, SAMPLE_STABLE_ID, CANCER_STUDY_IDENTIFIER
 )
 (SELECT DISTINCT cp.ATTR_VALUE           as ATTR_VALUE,
@@ -1069,10 +1069,10 @@ WHERE NOT REGEXP_LIKE(cs.ATTR_VALUE, '^-?[0-9.]+$')
 );
 
 #create necessary indexes
-CREATE FULLTEXT INDEX clinical_data_search_mv_ATTR_VALUE_index
-    ON clinical_data_search_mv (ATTR_VALUE);
+CREATE FULLTEXT INDEX clinical_data_search_derived_ATTR_VALUE_index
+    ON clinical_data_search_derived (ATTR_VALUE);
 
-CREATE INDEX clinical_data_search_mv_CANCER_STUDY_IDENTIFIER_index
-    ON clinical_data_search_mv (CANCER_STUDY_IDENTIFIER);
+CREATE INDEX clinical_data_search_derived_CANCER_STUDY_IDENTIFIER_index
+    ON clinical_data_search_derived (CANCER_STUDY_IDENTIFIER);
     
 UPDATE `info` SET `DB_SCHEMA_VERSION`="2.13.2";

--- a/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalDataMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalDataMapper.xml
@@ -295,7 +295,7 @@
     <sql id="searchedAttributeData">
         SELECT
             DISTINCT SAMPLE_INTERNAL_ID sampleInternalId
-        FROM clinical_data_search_mv    
+        FROM clinical_data_search_derived    
         <where>
             <if test="sampleIds == null">
                 CANCER_STUDY_IDENTIFIER = #{studyIds[0]}

--- a/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalDataMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalDataMapper.xml
@@ -296,8 +296,6 @@
         SELECT
             DISTINCT SAMPLE_INTERNAL_ID sampleInternalId
         FROM clinical_data_search_mv    
-<!--                <include refid="whereSample"/>-->
-
         <where>
             <if test="sampleIds == null">
                 CANCER_STUDY_IDENTIFIER = #{studyIds[0]}
@@ -319,7 +317,6 @@
             </if>
         </where>
          AND
-         --Note that the following line requires a fulltext index on ATTR_VALUE COLUMN
          MATCH(ATTR_VALUE) AGAINST(#{searchTerm} IN NATURAL LANGUAGE MODE)
     </sql>
     

--- a/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalDataMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatis/ClinicalDataMapper.xml
@@ -294,19 +294,33 @@
 
     <sql id="searchedAttributeData">
         SELECT
-            DISTINCT sample.INTERNAL_ID sampleInternalId
-        FROM sample
-            INNER JOIN patient ON patient.INTERNAL_ID = sample.PATIENT_ID 
-            INNER JOIN cancer_study ON patient.CANCER_STUDY_ID = cancer_study.CANCER_STUDY_ID
-            INNER JOIN clinical_sample cs on sample.INTERNAL_ID = cs.INTERNAL_ID
-            INNER JOIN clinical_patient cp on patient.INTERNAL_ID = cp.INTERNAL_ID
-            <include refid="whereSample"/>
-                AND (
-                  cs.ATTR_VALUE LIKE CONCAT('%', #{searchTerm}, '%')
-                  OR cp.ATTR_VALUE LIKE CONCAT('%', #{searchTerm}, '%')
-                  OR sample.STABLE_ID LIKE CONCAT('%', #{searchTerm}, '%')
-                  OR patient.STABLE_ID LIKE CONCAT('%', #{searchTerm}, '%')
-            )
+            DISTINCT SAMPLE_INTERNAL_ID sampleInternalId
+        FROM clinical_data_search_mv    
+<!--                <include refid="whereSample"/>-->
+
+        <where>
+            <if test="sampleIds == null">
+                CANCER_STUDY_IDENTIFIER = #{studyIds[0]}
+            </if>
+            <if test="sampleIds != null">
+                <if test="@java.util.Arrays@stream(studyIds.toArray()).distinct().count() == 1">
+                   CANCER_STUDY_IDENTIFIER = #{studyIds[0]} AND
+                    SAMPLE_STABLE_ID IN
+                    <foreach item="item" collection="sampleIds" open="(" separator="," close=")">
+                        #{item}
+                    </foreach>
+                </if>
+                <if test="@java.util.Arrays@stream(studyIds.toArray()).distinct().count() > 1">
+                    (CANCER_STUDY_IDENTIFIER, SAMPLE_STABLE_ID) IN
+                    <foreach index="i" collection="sampleIds" open="(" separator="," close=")">
+                        (#{studyIds[${i}]}, #{sampleIds[${i}]})
+                    </foreach>
+                </if>
+            </if>
+        </where>
+         AND
+         --Note that the following line requires a fulltext index on ATTR_VALUE COLUMN
+         MATCH(ATTR_VALUE) AGAINST(#{searchTerm} IN NATURAL LANGUAGE MODE)
     </sql>
     
     <sql id="sortAttributeData">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -32,7 +32,7 @@
         window.netlify = localStorage.netlify;
 
         if (window.localdev || window.localdist) {
-            window.frontendConfig.frontendUrl = "//localhost:3000/"
+            window.frontendConfig.frontendUrl = "https://localhost:3000/"
             localStorage.setItem("e2etest", "true");
         } else if (window.netlify) {
             window.frontendConfig.frontendUrl = ['//',localStorage.netlify,'.netlify.app','/'].join('');


### PR DESCRIPTION
The main bottlenecks for clinical data tab are
1. live JOINs
2. search

On genie dataset (190k samples), a search takes ~30s.  These optimizations bring that down to 6s. 

This PR addresses these bottlenecks by 
1. Adding a new table (spec below) which precomputes joins.
2. Adding indexes (spec below) and using fulltext index on ATTR_VALUE and corresponding 



```
CREATE TABLE clinical_data_search_mv (
                                         ATTR_VALUE varchar(255),
                                         PATIENT_INTERNAL_ID varchar(255),
                                         SAMPLE_INTERNAL_ID varchar(255),
                                         PATIENT_STABLE_ID varchar(255),
                                         SAMPLE_STABLE_ID varchar(255),
                                         CANCER_STUDY_IDENTIFIER varchar(255)
);



#populate table with data
INSERT INTO clinical_data_search_mv (
    ATTR_VALUE, PATIENT_INTERNAL_ID, SAMPLE_INTERNAL_ID, PATIENT_STABLE_ID, SAMPLE_STABLE_ID, CANCER_STUDY_IDENTIFIER
)
    (SELECT DISTINCT cp.ATTR_VALUE           as ATTR_VALUE,
                     p.INTERNAL_ID           as PATIENT_INTERNAL_ID,
                     s.INTERNAL_ID           as SAMPLE_INTERNAL_ID,
                     p.STABLE_ID             as PATIENT_STABLE_ID,
                     s.STABLE_ID             as SAMPLE_STABLE_ID,
                     CANCER_STUDY_IDENTIFIER as CANCER_STUDY_IDENTIFIER
     FROM clinical_patient cp
              JOIN patient p on cp.INTERNAL_ID = p.INTERNAL_ID
              JOIN sample s on s.PATIENT_ID = p.INTERNAL_ID
              JOIN cancer_study cs on p.CANCER_STUDY_ID = cs.CANCER_STUDY_ID
     WHERE NOT REGEXP_LIKE(cp.ATTR_VALUE, '^-?[0-9.]+$')
     UNION
     SELECT DISTINCT cs.ATTR_VALUE             as ATTR_VALUE,
                     p.INTERNAL_ID             as PATIENT_INTERNAL_ID,
                     s.INTERNAL_ID             as SAMPLE_INTERNAL_ID,
                     p.STABLE_ID               as PATIENT_INTERNAL_ID,
                     s.STABLE_ID               as SAMPLE_STABLE_ID,
                     c.CANCER_STUDY_IDENTIFIER as CANCER_STUDY_IDENTIFIER
     FROM clinical_sample cs
              LEFT JOIN sample s on cs.INTERNAL_ID = s.INTERNAL_ID
              LEFT JOIN patient p on s.PATIENT_ID = p.INTERNAL_ID
              JOIN cancer_study c on p.CANCER_STUDY_ID = c.CANCER_STUDY_ID
     WHERE NOT REGEXP_LIKE(cs.ATTR_VALUE, '^-?[0-9.]+$')


    );




#create necessary indexes
create fulltext index clinical_data_search_mv_ATTR_VALUE_index
    on clinical_data_search_mv (ATTR_VALUE);

create index clinical_data_search_mv_CANCER_STUDY_IDENTIFIER_index
    on clinical_data_search_mv (CANCER_STUDY_IDENTIFIER);

```