### PR TITLE
Simplify clinical data binning related SQL

### DIFF
--- a/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
+++ b/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
@@ -8,6 +8,7 @@ import org.cbioportal.model.ClinicalDataCount;
 import org.cbioportal.model.CopyNumberCountByGene;
 import org.cbioportal.model.GenomicDataCount;
 import org.cbioportal.model.Sample;
+import org.cbioportal.web.parameter.ClinicalDataType;
 import org.cbioportal.web.parameter.StudyViewFilter;
 
 import java.util.List;
@@ -31,6 +32,8 @@ public interface StudyViewRepository {
     List<GenomicDataCount> getGenomicDataCounts(StudyViewFilter studyViewFilter);
     
     List<ClinicalAttribute> getClinicalAttributes();
+
+    Map<String, ClinicalDataType> getClinicalAttributeDatatypeMap();
 
     List<CaseListDataCount> getCaseListDataCounts(StudyViewFilter studyViewFilter);
 

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.java
@@ -32,12 +32,6 @@ public interface StudyViewMapper {
     List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter,
                                                 boolean applyPatientIdFilters, AlterationFilterHelper alterationFilterHelper);
     
-    List<ClinicalDataCount> getPatientClinicalDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter,
-                                                         boolean applyPatientIdFilters,  List<String> attributeIds, List<String> filteredAttributeValues);
-
-    List<ClinicalDataCount> getSampleClinicalDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter,
-                                                        boolean applyPatientIdFilters, List<String> attributeIds, List<String> filteredAttributeValues );
-    
     List<ClinicalDataCount> getClinicalDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter,
                                                   boolean applyPatientIdFilters, List<String> attributeIds, List<String> filteredAttributeValues);
 

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
@@ -12,6 +12,7 @@ import org.cbioportal.persistence.StudyViewRepository;
 import org.cbioportal.persistence.enums.ClinicalAttributeDataSource;
 import org.cbioportal.persistence.helper.AlterationFilterHelper;
 import org.cbioportal.web.parameter.CategorizedClinicalDataCountFilter;
+import org.cbioportal.web.parameter.ClinicalDataType;
 import org.cbioportal.web.parameter.StudyViewFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
@@ -81,6 +82,25 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     @Override
     public List<ClinicalAttribute> getClinicalAttributes() {
         return mapper.getClinicalAttributes();
+    }
+
+    @Override
+    public Map<String, ClinicalDataType> getClinicalAttributeDatatypeMap() {
+        if (clinicalAttributesMap.isEmpty()) {
+            buildClinicalAttributeNameMap();
+        }
+        
+        Map<String, ClinicalDataType> attributeDatatypeMap = new HashMap<>();
+
+        clinicalAttributesMap
+            .get(ClinicalAttributeDataSource.SAMPLE)
+            .forEach(attribute -> attributeDatatypeMap.put(attribute.getAttrId(), ClinicalDataType.SAMPLE));
+
+        clinicalAttributesMap
+            .get(ClinicalAttributeDataSource.PATIENT)
+            .forEach(attribute -> attributeDatatypeMap.put(attribute.getAttrId(), ClinicalDataType.PATIENT));
+        
+        return attributeDatatypeMap;
     }
 
     @Override

--- a/src/main/java/org/cbioportal/service/StudyViewColumnarService.java
+++ b/src/main/java/org/cbioportal/service/StudyViewColumnarService.java
@@ -7,9 +7,11 @@ import org.cbioportal.model.ClinicalDataCountItem;
 import org.cbioportal.model.GenomicDataCount;
 import org.cbioportal.model.CopyNumberCountByGene;
 import org.cbioportal.model.Sample;
+import org.cbioportal.web.parameter.ClinicalDataType;
 import org.cbioportal.web.parameter.StudyViewFilter;
 
 import java.util.List;
+import java.util.Map;
 
 public interface StudyViewColumnarService {
 
@@ -19,6 +21,8 @@ public interface StudyViewColumnarService {
     List<CopyNumberCountByGene> getCnaGenes(StudyViewFilter interceptedStudyViewFilter);
     List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilter studyViewFilter);
 
+    Map<String, ClinicalDataType> getClinicalAttributeDatatypeMap();
+    
     List<ClinicalDataCountItem> getClinicalDataCounts(StudyViewFilter studyViewFilter, List<String> filteredAttributes);
 
     List<CaseListDataCount> getCaseListDataCounts(StudyViewFilter studyViewFilter);
@@ -28,6 +32,5 @@ public interface StudyViewColumnarService {
     List<ClinicalData> getSampleClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds);
 
     List<GenomicDataCount> getGenomicDataCounts(StudyViewFilter studyViewFilter);
-
-
+    
 }

--- a/src/main/java/org/cbioportal/service/impl/StudyViewColumnarServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/impl/StudyViewColumnarServiceImpl.java
@@ -11,12 +11,14 @@ import org.cbioportal.model.Sample;
 import org.cbioportal.persistence.StudyViewRepository;
 import org.cbioportal.service.AlterationCountService;
 import org.cbioportal.service.StudyViewColumnarService;
+import org.cbioportal.web.parameter.ClinicalDataType;
 import org.cbioportal.web.parameter.StudyViewFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -59,6 +61,11 @@ public class StudyViewColumnarServiceImpl implements StudyViewColumnarService {
     }
 
     @Override
+    public Map<String, ClinicalDataType> getClinicalAttributeDatatypeMap() {
+        return studyViewRepository.getClinicalAttributeDatatypeMap();
+    }
+    
+    @Override
     public List<ClinicalDataCountItem> getClinicalDataCounts(StudyViewFilter studyViewFilter, List<String> filteredAttributes) {
         return studyViewRepository.getClinicalDataCounts(studyViewFilter, filteredAttributes)
             .stream().collect(Collectors.groupingBy(ClinicalDataCount::getAttributeId))
@@ -85,6 +92,4 @@ public class StudyViewColumnarServiceImpl implements StudyViewColumnarService {
     public List<ClinicalData> getSampleClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds) {
         return studyViewRepository.getSampleClinicalData(studyViewFilter, attributeIds);
     }
-
-
 }

--- a/src/main/java/org/cbioportal/web/columnar/ClinicalDataBinner.java
+++ b/src/main/java/org/cbioportal/web/columnar/ClinicalDataBinner.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Component
 public class ClinicalDataBinner {
@@ -27,6 +26,15 @@ public class ClinicalDataBinner {
         this.dataBinner = dataBinner;
     }
 
+    private List<ClinicalData> convertCountsToData(List<ClinicalDataCount> clinicalDataCounts)
+    {
+        return clinicalDataCounts
+            .stream()
+            .map(NewClinicalDataBinUtil::generateClinicalDataFromClinicalDataCount)
+            .flatMap(Collection::stream)
+            .toList();
+    }
+    
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     public List<ClinicalDataBin> fetchClinicalDataBinCounts(
         DataBinMethod dataBinMethod,
@@ -43,53 +51,30 @@ public class ClinicalDataBinner {
         List<String> attributeIds = attributes.stream().map(ClinicalDataBinFilter::getAttributeId).collect(Collectors.toList());
 
         // a new StudyView filter to partially filter by study and sample ids only
-        StudyViewFilter partialFilter = new StudyViewFilter();
-        partialFilter.setStudyIds(studyViewFilter.getStudyIds());
-        partialFilter.setSampleIdentifiers(studyViewFilter.getSampleIdentifiers());
-
-        // filter only by study id and sample identifiers, ignore rest
         // we need this additional partial filter because we always need to know the bins generated for the initial state
         // which allows us to keep the number of bins and bin ranges consistent even if there are additional data filters.
         // we only want to update the counts for each bin, we don't want to regenerate the bins for the filtered data.
         // NOTE: partial filter is only needed when dataBinMethod == DataBinMethod.STATIC but that's always the case
         // for the frontend implementation. we can't really use dataBinMethod == DataBinMethod.DYNAMIC because of the
         // complication it brings to the frontend visualization and filtering
-        List<Sample> unfilteredSamples = studyViewColumnarService.getFilteredSamples(partialFilter);
-        List<Sample> filteredSamples = studyViewColumnarService.getFilteredSamples(studyViewFilter);
+        StudyViewFilter partialFilter = new StudyViewFilter();
+        partialFilter.setStudyIds(studyViewFilter.getStudyIds());
+        partialFilter.setSampleIdentifiers(studyViewFilter.getSampleIdentifiers());
 
-        // TODO make sure unique sample and patient keys don't need to be distinct
-        List<String> unfilteredUniqueSampleKeys = unfilteredSamples.stream().map(Sample::getUniqueSampleKey).collect(Collectors.toList());
-        List<String> filteredUniqueSampleKeys = filteredSamples.stream().map(Sample::getUniqueSampleKey).collect(Collectors.toList());
-        List<String> unfilteredUniquePatientKeys = unfilteredSamples.stream().map(Sample::getUniquePatientKey).collect(Collectors.toList());
-        List<String> filteredUniquePatientKeys = filteredSamples.stream().map(Sample::getUniquePatientKey).collect(Collectors.toList());
-
-        // TODO make sure we don't need a distinction between sample vs patient attribute ids here
-        //  ideally we shouldn't because we have patient clinical data separated from sample clinical data in clickhouse
-        
         // we need the clinical data for the partial filter in order to generate the bins for initial state
-        // we use the filtered data to calculate the counts for each bin, we do not regenerate bins for the filtered data 
-        List<ClinicalData> unfilteredClinicalDataForSamples = studyViewColumnarService.getSampleClinicalData(partialFilter, attributeIds);
-        List<ClinicalData> filteredClinicalDataForSamples = studyViewColumnarService.getSampleClinicalData(studyViewFilter, attributeIds);
-        List<ClinicalData> unfilteredClinicalDataForPatients = studyViewColumnarService.getPatientClinicalData(partialFilter, attributeIds);
-        List<ClinicalData> filteredClinicalDataForPatients = studyViewColumnarService.getPatientClinicalData(studyViewFilter, attributeIds);
+        // we use the filtered data to calculate the counts for each bin, we do not regenerate bins for the filtered data
+        List<ClinicalDataCountItem> unfilteredClinicalDataCounts = studyViewColumnarService.getClinicalDataCounts(partialFilter, attributeIds);
+        List<ClinicalDataCountItem> filteredClinicalDataCounts = studyViewColumnarService.getClinicalDataCounts(studyViewFilter, attributeIds);
 
-        Map<String, ClinicalDataType> attributeDatatypeMap = NewClinicalDataBinUtil.toAttributeDatatypeMap(
-            unfilteredClinicalDataForSamples.stream().map(ClinicalData::getAttrId).collect(Collectors.toList()),
-            unfilteredClinicalDataForPatients.stream().map(ClinicalData::getAttrId).collect(Collectors.toList()),
-            Collections.emptyList() // TODO ignoring conflictingPatientAttributeIds for now
+        // TODO ignoring conflictingPatientAttributeIds for now
+        List<ClinicalData> unfilteredClinicalData = convertCountsToData(
+            unfilteredClinicalDataCounts.stream().flatMap(c -> c.getCounts().stream()).toList()
+        );
+        List<ClinicalData> filteredClinicalData = convertCountsToData(
+            filteredClinicalDataCounts.stream().flatMap(c -> c.getCounts().stream()).toList()
         );
 
-        List<Binnable> unfilteredClinicalData = Stream.of(
-            unfilteredClinicalDataForSamples,
-            unfilteredClinicalDataForPatients
-            // unfilteredClinicalDataForConflictingPatientAttributes /// TODO ignoring conflictingPatientAttributeIds for now
-        ).flatMap(Collection::stream).collect(Collectors.toList());
-
-        List<Binnable> filteredClinicalData = Stream.of(
-            filteredClinicalDataForSamples,
-            filteredClinicalDataForPatients
-            // filteredClinicalDataForConflictingPatientAttributes // TODO ignoring conflictingPatientAttributeIds for now
-        ).flatMap(Collection::stream).collect(Collectors.toList());
+        Map<String, ClinicalDataType> attributeDatatypeMap = studyViewColumnarService.getClinicalAttributeDatatypeMap();
 
         Map<String, List<Binnable>> unfilteredClinicalDataByAttributeId =
             unfilteredClinicalData.stream().collect(Collectors.groupingBy(Binnable::getAttrId));
@@ -100,17 +85,13 @@ public class ClinicalDataBinner {
         List<ClinicalDataBin> clinicalDataBins = Collections.emptyList();
 
         if (dataBinMethod == DataBinMethod.STATIC) {
-            if (!unfilteredSamples.isEmpty() && !unfilteredClinicalData.isEmpty()) {
+            if (!unfilteredClinicalData.isEmpty()) {
                 clinicalDataBins = NewClinicalDataBinUtil.calculateStaticDataBins(
                     dataBinner,
                     attributes,
                     attributeDatatypeMap,
                     unfilteredClinicalDataByAttributeId,
-                    filteredClinicalDataByAttributeId,
-                    unfilteredUniqueSampleKeys,
-                    unfilteredUniquePatientKeys,
-                    filteredUniqueSampleKeys,
-                    filteredUniquePatientKeys
+                    filteredClinicalDataByAttributeId
                 );
             }
         }
@@ -123,9 +104,7 @@ public class ClinicalDataBinner {
                     dataBinner,
                     attributes,
                     attributeDatatypeMap,
-                    filteredClinicalDataByAttributeId,
-                    filteredUniqueSampleKeys,
-                    filteredUniquePatientKeys
+                    filteredClinicalDataByAttributeId
                 );
             }
         }

--- a/src/main/java/org/cbioportal/web/columnar/util/NewClinicalDataBinUtil.java
+++ b/src/main/java/org/cbioportal/web/columnar/util/NewClinicalDataBinUtil.java
@@ -1,7 +1,9 @@
 package org.cbioportal.web.columnar.util;
 
 import org.cbioportal.model.Binnable;
+import org.cbioportal.model.ClinicalData;
 import org.cbioportal.model.ClinicalDataBin;
+import org.cbioportal.model.ClinicalDataCount;
 import org.cbioportal.model.DataBin;
 import org.cbioportal.web.parameter.ClinicalDataBinCountFilter;
 import org.cbioportal.web.parameter.ClinicalDataBinFilter;
@@ -15,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.toList;
 
 public class NewClinicalDataBinUtil {
     public static StudyViewFilter removeSelfFromFilter(ClinicalDataBinCountFilter dataBinCountFilter) {
@@ -70,33 +71,21 @@ public class NewClinicalDataBinUtil {
         List<ClinicalDataBinFilter> attributes,
         Map<String, ClinicalDataType> attributeDatatypeMap,
         Map<String, List<Binnable>> unfilteredClinicalDataByAttributeId,
-        Map<String, List<Binnable>> filteredClinicalDataByAttributeId,
-        List<String> unfilteredUniqueSampleKeys,
-        List<String> unfilteredUniquePatientKeys,
-        List<String> filteredUniqueSampleKeys,
-        List<String> filteredUniquePatientKeys
+        Map<String, List<Binnable>> filteredClinicalDataByAttributeId
     ) {
         List<ClinicalDataBin> clinicalDataBins = new ArrayList<>();
 
         for (ClinicalDataBinFilter attribute : attributes) {
             if (attributeDatatypeMap.containsKey(attribute.getAttributeId())) {
-                ClinicalDataType clinicalDataType = attributeDatatypeMap.get(attribute.getAttributeId());
-                List<String> filteredIds = clinicalDataType == ClinicalDataType.PATIENT ? filteredUniquePatientKeys
-                    : filteredUniqueSampleKeys;
-                List<String> unfilteredIds = clinicalDataType == ClinicalDataType.PATIENT
-                    ? unfilteredUniquePatientKeys
-                    : unfilteredUniqueSampleKeys;
-
                 List<ClinicalDataBin> dataBins = dataBinner
-                    .calculateClinicalDataBins(attribute, clinicalDataType,
-                        filteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(),
-                            emptyList()),
-                        unfilteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(),
-                            emptyList()),
-                        filteredIds, unfilteredIds)
+                    .calculateClinicalDataBins(
+                        attribute,
+                        filteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(), emptyList()),
+                        unfilteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(), emptyList())
+                    )
                     .stream()
                     .map(dataBin -> dataBinToClinicalDataBin(attribute, dataBin))
-                    .collect(toList());
+                    .toList();
 
                 clinicalDataBins.addAll(dataBins);
             }
@@ -109,9 +98,7 @@ public class NewClinicalDataBinUtil {
         DataBinner dataBinner,
         List<ClinicalDataBinFilter> attributes,
         Map<String, ClinicalDataType> attributeDatatypeMap,
-        Map<String, List<Binnable>> filteredClinicalDataByAttributeId,
-        List<String> filteredUniqueSampleKeys,
-        List<String> filteredUniquePatientKeys
+        Map<String, List<Binnable>> filteredClinicalDataByAttributeId
     ) {
         List<ClinicalDataBin> clinicalDataBins = new ArrayList<>();
 
@@ -119,23 +106,46 @@ public class NewClinicalDataBinUtil {
 
             // if there is clinical data for requested attribute
             if (attributeDatatypeMap.containsKey(attribute.getAttributeId())) {
-                ClinicalDataType clinicalDataType = attributeDatatypeMap.get(attribute.getAttributeId());
-                List<String> filteredIds = clinicalDataType == ClinicalDataType.PATIENT
-                    ? filteredUniquePatientKeys
-                    : filteredUniqueSampleKeys;
-
                 List<ClinicalDataBin> dataBins = dataBinner
-                    .calculateDataBins(attribute, clinicalDataType,
-                        filteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(),
-                            emptyList()),
-                        filteredIds)
+                    .calculateDataBins(
+                        attribute,
+                        filteredClinicalDataByAttributeId.getOrDefault(attribute.getAttributeId(), emptyList())
+                    )
                     .stream()
                     .map(dataBin -> dataBinToClinicalDataBin(attribute, dataBin))
-                    .collect(toList());
+                    .toList();
                 clinicalDataBins.addAll(dataBins);
             }
         }
 
         return clinicalDataBins;
+    }
+
+    /**
+     * Generate a list of ClinicalData from the given data count instance.
+     * Size of the generated list is equal to 'dataCount.count',
+     * and each ClinicalData in the list contains the same value 'dataCount.value'
+     * 
+     * This method improves the performance of the data binning because it allows us to fetch only
+     * the clinical data counts data which is a lot more compact and faster to generated than the actual clinical data.
+     * We only need the attribute id and the value of the clinical data to generate data bins.
+     * Constructing the clinical data in memory by using clinical data counts significantly improves the performance,
+     * and it also allows us to use the exact same SQL used by the clinical data counts endpoint. 
+     * 
+     * @param dataCount ClinicalDataCount instance containing the count and the value
+     * @return  a list of ClinicalData with size 'dataCount.count' and value 'dataCount.value'
+     */
+    public static List<ClinicalData> generateClinicalDataFromClinicalDataCount(ClinicalDataCount dataCount)
+    {
+        List<ClinicalData> data = new ArrayList<>(dataCount.getCount());
+        
+        for (int i=0; i < dataCount.getCount(); i++) {
+            ClinicalData d = new ClinicalData();
+            d.setAttrId(dataCount.getAttributeId());
+            d.setAttrValue(dataCount.getValue());
+            data.add(d);
+        }
+        
+        return data;
     }
 }

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
@@ -141,7 +141,10 @@
         <foreach item="dataFilterValue" collection="clinicalDataFilter.values" open=" AND ((" separator=") OR (" close="))">
             <trim prefix="" prefixOverrides="AND">
                 <if test="dataFilterValue.value eq 'NA'">
-                    AND attribute_value = ''
+                    AND
+                    <include refid="isAttributeValueNA">
+                        <property name="attribute_value" value="attribute_value"/>
+                    </include>
                 </if>
                 <choose>
                     <when test="dataFilterValue.start == dataFilterValue.end">

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
@@ -136,8 +136,7 @@
         SELECT ${unique_id}
         FROM ${table_name}
         WHERE attribute_name = '${clinicalDataFilter.attributeId}' AND
-        type='${type}' AND
-        (attribute_value = '' OR match(attribute_value, '^[\d\.]+$'))
+        type='${type}'
         <foreach item="dataFilterValue" collection="clinicalDataFilter.values" open=" AND ((" separator=") OR (" close="))">
             <trim prefix="" prefixOverrides="AND">
                 <if test="dataFilterValue.value eq 'NA'">
@@ -146,19 +145,22 @@
                         <property name="attribute_value" value="attribute_value"/>
                     </include>
                 </if>
-                <choose>
-                    <when test="dataFilterValue.start == dataFilterValue.end">
-                        AND abs(minus(cast(attribute_value as float), ${dataFilterValue.start})) &lt; exp(-11)
-                    </when>
-                    <otherwise>
-                        <if test="dataFilterValue.start != null">
-                            AND cast(attribute_value as float) &gt; ${dataFilterValue.start}
-                        </if>
-                        <if test="dataFilterValue.end != null">
-                            AND cast(attribute_value as float) &lt;= ${dataFilterValue.end}
-                        </if>
-                    </otherwise>
-                </choose>
+                <if test="dataFilterValue.start != null || dataFilterValue.end != null">
+                    AND match(attribute_value, '^[\d\.]+$')
+                    <choose>
+                        <when test="dataFilterValue.start == dataFilterValue.end">
+                            AND abs(minus(cast(attribute_value as float), ${dataFilterValue.start})) &lt; exp(-11)
+                        </when>
+                        <otherwise>
+                            <if test="dataFilterValue.start != null">
+                                AND cast(attribute_value as float) &gt; ${dataFilterValue.start}
+                            </if>
+                            <if test="dataFilterValue.end != null">
+                                AND cast(attribute_value as float) &lt;= ${dataFilterValue.end}
+                            </if>
+                        </otherwise>
+                    </choose>
+                </if>
             </trim>
         </foreach>
 

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -74,7 +74,6 @@
         GROUP BY hugo_gene_symbol;
     </select>
 
-    <!-- TODO only fetching from sample_clinical_attribute_numeric, need to support sample_clinical_attribute_categorical as well -->
     <select id="getSampleClinicalDataFromStudyViewFilter" resultType="org.cbioportal.model.ClinicalData">
         SELECT
             sample_unique_id as sampleId,
@@ -84,12 +83,11 @@
             cancer_study_identifier as studyId
         FROM clinical_data_derived
         <where>
-            type = 'sample' AND
             sample_unique_id IN (
-            <include refid="sampleUniqueIdsFromStudyViewFilter"/>
-            <if test="applyPatientIdFilters == true">
-                INTERSECT <include refid="getSampleIdsFromPatientIds"/>
-            </if>
+                <include refid="sampleUniqueIdsFromStudyViewFilter"/>
+                <if test="applyPatientIdFilters == true">
+                    INTERSECT <include refid="getSampleIdsFromPatientIds"/>
+                </if>
             )
         </where>
         <if test="attributeIds != null and !attributeIds.isEmpty()">
@@ -98,17 +96,17 @@
                 #{attributeId}
             </foreach>
         </if>
+        AND type = 'sample'
     </select>
-    
-    <!-- TODO only fetching from patient_clinical_attribute_numeric, need to support patient_clinical_attribute_categorical as well -->
+
     <select id="getPatientClinicalDataFromStudyViewFilter" resultType="org.cbioportal.model.ClinicalData">
         SELECT
             patient_unique_id as patientId,
             attribute_name as attrId,
             attribute_value as attrValue,
             cancer_study_identifier as studyId
-        FROM patient_clinical_attribute_numeric_mv
-        <where> 
+        FROM clinical_data_derived
+        <where>
             patient_unique_id IN (
                 <include refid="getPatientIdsFromSampleIdFilters"/>
                 <if test="applyPatientIdFilters == true">
@@ -122,19 +120,15 @@
                 #{attributeId}
             </foreach>
         </if>
+        AND type = 'patient'
     </select>
-   
+    
     <!-- for /clinical-data-counts/fetch (returns ClinicalData) which will then be converted to clinicalDataCountItems -->
     <select id="getClinicalDataCounts" resultType="org.cbioportal.model.ClinicalDataCount">
-        <include refid="getCategoricalClinicalDataCountsQuerySample">
-            <property name="table_name_prefix" value="sample"/>
-        </include>
+        <include refid="getClinicalDataCountsQuerySample" />
         UNION ALL
-        <include refid="getCategoricalClinicalDataCountsQueryPatient">
-            <property name="table_name_prefix" value="patient"/>
-        </include>
+        <include refid="getClinicalDataCountsQueryPatient" />
     </select>
-
 
     <!-- for /molecular-profile-sample-counts/fetch (returns GenomicDataCount) which will then be converted to clinicalDataCountItems -->
     <select id="getGenomicDataCounts" resultType="org.cbioportal.model.GenomicDataCount">
@@ -169,10 +163,13 @@
     </select>
     
 
-    <sql id="getCategoricalClinicalDataCountsQuerySample">
+    <sql id="getClinicalDataCountsQuerySample">
         SELECT
         attribute_name as attributeId,
-        if(attribute_value='', 'NA', attribute_value) AS value,
+        <include refid="normalizeAttributeValueNA">
+            <property name="attribute_value" value="attribute_value"/>
+            <property name="as_value" value="value"/>
+        </include>,
         count(value) as count
         FROM clinical_data_derived
         <where>
@@ -199,10 +196,13 @@
         value
     </sql>
 
-    <sql id="getCategoricalClinicalDataCountsQueryPatient">
+    <sql id="getClinicalDataCountsQueryPatient">
         SELECT
         attribute_name as attributeId,
-        if(attribute_value='', 'NA', attribute_value) AS value,
+        <include refid="normalizeAttributeValueNA">
+            <property name="attribute_value" value="attribute_value"/>
+            <property name="as_value" value="value"/>
+        </include>,
         count(value) as count
         FROM clinical_data_derived
         <where>
@@ -330,5 +330,24 @@
         <if test="applyPatientIdFilters == true">
             AND patient_unique_id IN (<include refid="patientUniqueIdsFromStudyViewFilter"/>)
         </if> 
+    </sql>
+    
+    <!-- This is to match actual NA values ('NA', 'NAN', and 'N/A') in addition to the empty string -->
+    <sql id="isAttributeValueNA">
+        ${attribute_value}=''
+        OR upperUTF8(${attribute_value})='NA'
+        OR upperUTF8(${attribute_value})='NAN'
+        OR upperUTF8(${attribute_value})='N/A'
+    </sql>
+    
+    <sql id="normalizeAttributeValueNA">
+        if(
+          <include refid="isAttributeValueNA">
+              <property name="attribute_value" value="${attribute_value}"/>
+          </include>,
+          'NA',
+          ${attribute_value}
+        )
+        AS ${as_value}
     </sql>
 </mapper>


### PR DESCRIPTION
- Use clinical data counts derived from the new `clinical_data_derived` table instead of fetching all the actual clinical data
- Simplify NA count logic. Now NA data is actually in the database, so we just need the get that NA count.