### PR TITLE
Add bean for CancerStudyPermissionEvaluator

### DIFF
--- a/src/main/java/org/cbioportal/security/CancerStudyPermissionEvaluator.java
+++ b/src/main/java/org/cbioportal/security/CancerStudyPermissionEvaluator.java
@@ -44,7 +44,6 @@ import org.cbioportal.persistence.cachemaputil.CacheMapUtil;
 import org.cbioportal.utils.security.AccessLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.*;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;

--- a/src/main/java/org/cbioportal/security/config/MethodSecurityConfig.java
+++ b/src/main/java/org/cbioportal/security/config/MethodSecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -32,7 +33,12 @@ public class MethodSecurityConfig {
     public MethodSecurityExpressionHandler createExpressionHandler() {
         DefaultMethodSecurityExpressionHandler expressionHandler =
             new DefaultMethodSecurityExpressionHandler();
-        expressionHandler.setPermissionEvaluator(new CancerStudyPermissionEvaluator(appName, doFilterGroupsByAppName, alwaysShowCancerStudyGroup, cacheMapUtil));
+        expressionHandler.setPermissionEvaluator(cancerStudyPermissionEvaluator());
         return expressionHandler;
+    }
+    
+    @Bean
+    public CancerStudyPermissionEvaluator cancerStudyPermissionEvaluator() {
+        return new CancerStudyPermissionEvaluator(appName, doFilterGroupsByAppName, alwaysShowCancerStudyGroup, cacheMapUtil);
     }
 }


### PR DESCRIPTION
Add a bean for `CancerStudyPermissionEvaluator` instead of instantiating directly within `createExpressionHandler`
