### PR TITLE
Remove demo-rfc72 reference from integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: cbioportal/cbioportal-docker-compose
-          ref: demo-rfc72
           path: ./cbioportal-docker-compose
       - name: 'Initialize cbioportal-docker-compose'
         working-directory: ./cbioportal-docker-compose


### PR DESCRIPTION
Since we merged the changes for v6, now it's time to remove outdated branch references in the integration test. `demo-rfc72` will be deleted