### PR TITLE
Remove servlet-api dependency from mockserver-client-java

### DIFF
--- a/docs/deployment/standalone/README.md
+++ b/docs/deployment/standalone/README.md
@@ -55,7 +55,7 @@ services:
     networks:
      - cbio-internal
      - cbio-bridge
-    command: /bin/sh -c "/cbioportal_ipblock.sh && rm -rf /cbioportal-webapp/lib/servlet-api-2.5.jar && java -Xms2g -Xmx4g -cp '/cbioportal-webapp:/cbioportal-webapp/lib/*' org.cbioportal.PortalApplication --spring.config.location=/cbioportal-webapp/application.properties --session.service.url=http://cbioportal-session:5000/api/sessions/portal/"
+    command: /bin/sh -c "/cbioportal_ipblock.sh && java -Xms2g -Xmx4g -cp '/cbioportal-webapp:/cbioportal-webapp/lib/*' org.cbioportal.PortalApplication --spring.config.location=/cbioportal-webapp/application.properties --session.service.url=http://cbioportal-session:5000/api/sessions/portal/"
   cbioportal-database:
     restart: unless-stopped
     image: mysql:5.7

--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,12 @@
             <artifactId>mockserver-client-java</artifactId>
             <version>${mockserver.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.github.dasniko</groupId>


### PR DESCRIPTION
Fix #10838 

`servlet-api` is being used by `mockserver-client-java`, we need to exclude this from dependency instead of doing this manually when starting the service