### PR TITLE
Do not use clinical data MVs

### DIFF
--- a/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
+++ b/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
@@ -1,6 +1,7 @@
 package org.cbioportal.persistence;
 
 import org.cbioportal.model.AlterationCountByGene;
+import org.cbioportal.model.ClinicalAttribute;
 import org.cbioportal.model.ClinicalData;
 import org.cbioportal.model.ClinicalDataCount;
 import org.cbioportal.model.CopyNumberCountByGene;
@@ -35,7 +36,7 @@ public interface StudyViewRepository {
     
     List<GenomicDataCount> getGenomicDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
     
-    List<String> getClinicalDataAttributeNames(ClinicalAttributeDataSource clinicalAttributeDataSource, ClinicalAttributeDataType dataType);
+    List<ClinicalAttribute> getClinicalAttributes();
 
     Map<String, AlterationCountByGene> getTotalProfiledCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, String alterationType);
     

--- a/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
+++ b/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
@@ -7,8 +7,6 @@ import org.cbioportal.model.ClinicalDataCount;
 import org.cbioportal.model.CopyNumberCountByGene;
 import org.cbioportal.model.GenomicDataCount;
 import org.cbioportal.model.Sample;
-import org.cbioportal.persistence.enums.ClinicalAttributeDataSource;
-import org.cbioportal.persistence.enums.ClinicalAttributeDataType;
 import org.cbioportal.web.parameter.CategorizedClinicalDataCountFilter;
 import org.cbioportal.web.parameter.StudyViewFilter;
 
@@ -29,10 +27,6 @@ public interface StudyViewRepository {
     List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
     
     List<ClinicalDataCount> getClinicalDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, List<String> filteredAttributes);
-    
-    List<ClinicalDataCount> getSampleClinicalDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, List<String> filteredAttributes);
-    
-    List<ClinicalDataCount> getPatientClinicalDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, List<String> filteredAttributes);
     
     List<GenomicDataCount> getGenomicDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
     

--- a/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
+++ b/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
@@ -15,28 +15,28 @@ import java.util.Map;
 import java.util.Set;
 
 public interface StudyViewRepository {
-    List<Sample> getFilteredSamples(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
+    List<Sample> getFilteredSamples(StudyViewFilter studyViewFilter);
 
-    List<ClinicalData> getSampleClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
+    List<ClinicalData> getSampleClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds);
     
-    List<ClinicalData> getPatientClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
+    List<ClinicalData> getPatientClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds);
     
-    List<AlterationCountByGene> getMutatedGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
+    List<AlterationCountByGene> getMutatedGenes(StudyViewFilter studyViewFilter);
     
-    List<CopyNumberCountByGene> getCnaGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
-    List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
+    List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilter studyViewFilter);
+    List<CopyNumberCountByGene> getCnaGenes(StudyViewFilter studyViewFilter);
     
-    List<ClinicalDataCount> getClinicalDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, List<String> filteredAttributes);
+    List<ClinicalDataCount> getClinicalDataCounts(StudyViewFilter studyViewFilter, List<String> filteredAttributes);
     
-    List<GenomicDataCount> getGenomicDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
+    List<GenomicDataCount> getGenomicDataCounts(StudyViewFilter studyViewFilter);
     
     List<ClinicalAttribute> getClinicalAttributes();
 
-    Map<String, AlterationCountByGene> getTotalProfiledCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, String alterationType);
+    Map<String, AlterationCountByGene> getTotalProfiledCounts(StudyViewFilter studyViewFilter, String alterationType);
     
-    int getFilteredSamplesCount(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
+    int getFilteredSamplesCount(StudyViewFilter studyViewFilter);
     
-    Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, String alterationType);
+    Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilter studyViewFilter, String alterationType);
     
-    int getTotalProfiledCountsByAlterationType(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, String alterationType);
+    int getTotalProfiledCountsByAlterationType(StudyViewFilter studyViewFilter, String alterationType);
 }

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.java
@@ -37,7 +37,7 @@ public interface StudyViewMapper {
     List<ClinicalDataCount> getClinicalDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter,
                                                   boolean applyPatientIdFilters, List<String> attributeIds, List<String> filteredAttributeValues);
     
-    List<String> getClinicalAttributeNames(String tableName);
+    List<ClinicalAttribute> getClinicalAttributes();
     
     List<ClinicalData> getSampleClinicalDataFromStudyViewFilter(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, boolean applyPatientIdFilters, List<String> attributeIds);
     

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
@@ -65,6 +65,7 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
             AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()));
     }
 
+    @Override
     public List<ClinicalDataCount> getClinicalDataCounts(StudyViewFilter studyViewFilter, List<String> filteredAttributes) {
         CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getClinicalDataCounts(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter),
@@ -77,6 +78,7 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
         return mapper.getGenomicDataCounts(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter));
     }
     
+    @Override
     public List<ClinicalAttribute> getClinicalAttributes() {
         return mapper.getClinicalAttributes();
     }
@@ -93,16 +95,19 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
             || categorizedClinicalDataCountFilter.getPatientNumericalClinicalDataFilters() != null && !categorizedClinicalDataCountFilter.getPatientNumericalClinicalDataFilters().isEmpty();
     }
 
+    @Override
     public List<ClinicalData> getSampleClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds) {
         CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getSampleClinicalDataFromStudyViewFilter(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter), attributeIds);
     }
     
+    @Override
     public List<ClinicalData> getPatientClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds) {
         CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getPatientClinicalDataFromStudyViewFilter(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter), attributeIds);
     }
     
+    @Override
     public Map<String, AlterationCountByGene> getTotalProfiledCounts(StudyViewFilter studyViewFilter, String alterationType) {
         CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getTotalProfiledCounts(studyViewFilter, categorizedClinicalDataCountFilter,

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
@@ -1,5 +1,6 @@
 package org.cbioportal.persistence.mybatisclickhouse;
 import org.cbioportal.model.AlterationCountByGene;
+import org.cbioportal.model.ClinicalAttribute;
 import org.cbioportal.model.ClinicalData;
 import org.cbioportal.model.ClinicalDataCount;
 import org.cbioportal.model.GenePanelToGene;
@@ -81,11 +82,9 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
         return mapper.getPatientClinicalDataCounts(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter),
             filteredAttributes, FILTERED_CLINICAL_ATTR_VALUES);
     }
-
-    @Override
-    public List<String> getClinicalDataAttributeNames(ClinicalAttributeDataSource clinicalAttributeDataSource, ClinicalAttributeDataType dataType) {
-        String tableName = clinicalAttributeDataSource.getValue().toLowerCase() + "_clinical_attribute_" + dataType.getValue().toLowerCase() + "_mv";
-        return mapper.getClinicalAttributeNames(tableName);
+    
+    public List<ClinicalAttribute> getClinicalAttributes() {
+        return mapper.getClinicalAttributes();
     }
 
     private boolean shouldApplyPatientIdFilters(CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter) {

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
@@ -9,13 +9,13 @@ import org.cbioportal.model.CopyNumberCountByGene;
 import org.cbioportal.model.Sample;
 import org.cbioportal.persistence.StudyViewRepository;
 import org.cbioportal.persistence.enums.ClinicalAttributeDataSource;
-import org.cbioportal.persistence.enums.ClinicalAttributeDataType;
 import org.cbioportal.persistence.helper.AlterationFilterHelper;
 import org.cbioportal.web.parameter.CategorizedClinicalDataCountFilter;
 import org.cbioportal.web.parameter.StudyViewFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -23,6 +23,9 @@ import java.util.stream.Collectors;
 
 @Repository
 public class StudyViewMyBatisRepository implements StudyViewRepository {
+
+    private Map<ClinicalAttributeDataSource, List<ClinicalAttribute>> clinicalAttributesMap = new HashMap<>();
+
 
     private static final List<String> FILTERED_CLINICAL_ATTR_VALUES = Collections.emptyList();
     private final StudyViewMapper mapper;
@@ -32,40 +35,44 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
         this.mapper = mapper;    
     }
     @Override
-    public List<Sample> getFilteredSamples(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter) {
-        
+    public List<Sample> getFilteredSamples(StudyViewFilter studyViewFilter) {
+        CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getFilteredSamples(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter));
     }
     
     @Override
-    public List<AlterationCountByGene> getMutatedGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter) {
+    public List<AlterationCountByGene> getMutatedGenes(StudyViewFilter studyViewFilter) {
+        CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getMutatedGenes(studyViewFilter, categorizedClinicalDataCountFilter,
             shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter),
             AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()));
     }
 
     @Override
-    public List<CopyNumberCountByGene> getCnaGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter) {
+    public List<CopyNumberCountByGene> getCnaGenes(StudyViewFilter studyViewFilter) {
+        CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getCnaGenes(studyViewFilter, categorizedClinicalDataCountFilter,
             shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter),
             AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()));
     }
 
     @Override
-    public List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter) {
+    public List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilter studyViewFilter) {
+        CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getStructuralVariantGenes(studyViewFilter, categorizedClinicalDataCountFilter,
             shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter),
             AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()));
     }
 
-    @Override
-    public List<ClinicalDataCount> getClinicalDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, List<String> filteredAttributes) {
+    public List<ClinicalDataCount> getClinicalDataCounts(StudyViewFilter studyViewFilter, List<String> filteredAttributes) {
+        CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getClinicalDataCounts(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter),
             filteredAttributes, FILTERED_CLINICAL_ATTR_VALUES );
     }
 
     @Override
-    public List<GenomicDataCount> getGenomicDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter) {
+    public List<GenomicDataCount> getGenomicDataCounts(StudyViewFilter studyViewFilter) {
+        CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getGenomicDataCounts(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter));
     }
     
@@ -78,27 +85,32 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
             || categorizedClinicalDataCountFilter.getPatientNumericalClinicalDataFilters() != null && !categorizedClinicalDataCountFilter.getPatientNumericalClinicalDataFilters().isEmpty();
     }
 
-    public List<ClinicalData> getSampleClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter) {
+    public List<ClinicalData> getSampleClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds) {
+        CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getSampleClinicalDataFromStudyViewFilter(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter), attributeIds);
     }
     
-    public List<ClinicalData> getPatientClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter) {
+    public List<ClinicalData> getPatientClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds) {
+        CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getPatientClinicalDataFromStudyViewFilter(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter), attributeIds);
     }
     
-    public Map<String, AlterationCountByGene> getTotalProfiledCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, String alterationType) {
+    public Map<String, AlterationCountByGene> getTotalProfiledCounts(StudyViewFilter studyViewFilter, String alterationType) {
+        CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getTotalProfiledCounts(studyViewFilter, categorizedClinicalDataCountFilter,
             shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter), alterationType);
     }
 
     @Override
-    public int getFilteredSamplesCount(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter) {
+    public int getFilteredSamplesCount(StudyViewFilter studyViewFilter) {
+        CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getFilteredSamplesCount(studyViewFilter, categorizedClinicalDataCountFilter,
             shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter));
     }
 
     @Override
-    public Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, String alterationType) {
+    public Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilter studyViewFilter, String alterationType) {
+        CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
         return mapper.getMatchingGenePanelIds(studyViewFilter, categorizedClinicalDataCountFilter,
             shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter), alterationType)
             .stream()
@@ -107,9 +119,62 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     }
 
     @Override
-    public int getTotalProfiledCountsByAlterationType(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, String alterationType) {
+    public int getTotalProfiledCountsByAlterationType(StudyViewFilter studyViewFilter, String alterationType) {
+        CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter = extractClinicalDataCountFilters(studyViewFilter);
        return mapper.getTotalProfiledCountByAlterationType(studyViewFilter, categorizedClinicalDataCountFilter,
            shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter), alterationType); 
     }
+
+    private void buildClinicalAttributeNameMap() {
+        clinicalAttributesMap = this.getClinicalAttributes()
+            .stream()
+            .collect(Collectors.groupingBy(ca -> ca.getPatientAttribute() ? ClinicalAttributeDataSource.PATIENT : ClinicalAttributeDataSource.SAMPLE));
+    }
+    
+    private CategorizedClinicalDataCountFilter extractClinicalDataCountFilters(final StudyViewFilter studyViewFilter) {
+        if (clinicalAttributesMap.isEmpty()) {
+            buildClinicalAttributeNameMap();
+        }
+
+        if (studyViewFilter.getClinicalDataFilters() == null) {
+            return CategorizedClinicalDataCountFilter.getBuilder().build();
+        }
+        
+        List<String> patientCategoricalAttributes = clinicalAttributesMap.get(ClinicalAttributeDataSource.PATIENT)
+            .stream().filter(ca -> ca.getDatatype().equals("STRING"))
+            .map(ClinicalAttribute::getAttrId)
+            .toList();
+
+        List<String> patientNumericalAttributes = clinicalAttributesMap.get(ClinicalAttributeDataSource.PATIENT)
+            .stream().filter(ca -> ca.getDatatype().equals("NUMBER"))
+            .map(ClinicalAttribute::getAttrId)
+            .toList();
+
+        List<String> sampleCategoricalAttributes = clinicalAttributesMap.get(ClinicalAttributeDataSource.SAMPLE)
+            .stream().filter(ca -> ca.getDatatype().equals("STRING"))
+            .map(ClinicalAttribute::getAttrId)
+            .toList();
+
+        List<String> sampleNumericalAttributes = clinicalAttributesMap.get(ClinicalAttributeDataSource.SAMPLE)
+            .stream().filter(ca -> ca.getDatatype().equals("NUMBER"))
+            .map(ClinicalAttribute::getAttrId)
+            .toList();
+        
+        return CategorizedClinicalDataCountFilter.getBuilder()
+            .setPatientCategoricalClinicalDataFilters(studyViewFilter.getClinicalDataFilters()
+                .stream().filter(clinicalDataFilter -> patientCategoricalAttributes.contains(clinicalDataFilter.getAttributeId()))
+                .collect(Collectors.toList()))
+            .setPatientNumericalClinicalDataFilters(studyViewFilter.getClinicalDataFilters().stream()
+                .filter(clinicalDataFilter -> patientNumericalAttributes.contains(clinicalDataFilter.getAttributeId()))
+                .collect(Collectors.toList()))
+            .setSampleCategoricalClinicalDataFilters(studyViewFilter.getClinicalDataFilters().stream()
+                .filter(clinicalDataFilter -> sampleCategoricalAttributes.contains(clinicalDataFilter.getAttributeId()))
+                .collect(Collectors.toList()))
+            .setSampleNumericalClinicalDataFilters(studyViewFilter.getClinicalDataFilters().stream()
+                .filter(clinicalDataFilter -> sampleNumericalAttributes.contains(clinicalDataFilter.getAttributeId()))
+                .collect(Collectors.toList()))
+            .build();
+    }
+    
 
 }

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
@@ -69,20 +69,6 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
         return mapper.getGenomicDataCounts(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter));
     }
     
-    
-
-    @Override
-    public List<ClinicalDataCount> getSampleClinicalDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, List<String> filteredAttributes) {
-        return mapper.getSampleClinicalDataCounts(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter),
-           filteredAttributes, FILTERED_CLINICAL_ATTR_VALUES );
-    }
-    
-    @Override
-    public List<ClinicalDataCount> getPatientClinicalDataCounts(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter, List<String> filteredAttributes) {
-        return mapper.getPatientClinicalDataCounts(studyViewFilter, categorizedClinicalDataCountFilter, shouldApplyPatientIdFilters(categorizedClinicalDataCountFilter),
-            filteredAttributes, FILTERED_CLINICAL_ATTR_VALUES);
-    }
-    
     public List<ClinicalAttribute> getClinicalAttributes() {
         return mapper.getClinicalAttributes();
     }

--- a/src/main/java/org/cbioportal/service/AlterationCountService.java
+++ b/src/main/java/org/cbioportal/service/AlterationCountService.java
@@ -77,9 +77,9 @@ public interface AlterationCountService {
                                                                     boolean includeMissingAlterationsFromGenePanel,
                                                                     AlterationFilter alterationFilter);
     
-    List<AlterationCountByGene> getMutatedGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
-    List<CopyNumberCountByGene> getCnaGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
+    List<AlterationCountByGene> getMutatedGenes(StudyViewFilter studyViewFilter);
+    List<CopyNumberCountByGene> getCnaGenes(StudyViewFilter studyViewFilter);
     
-    List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter);
+    List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilter studyViewFilter);
     
 }

--- a/src/main/java/org/cbioportal/service/impl/AlterationCountServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/impl/AlterationCountServiceImpl.java
@@ -16,7 +16,6 @@ import org.cbioportal.persistence.MolecularProfileRepository;
 import org.cbioportal.persistence.StudyViewRepository;
 import org.cbioportal.service.AlterationCountService;
 import org.cbioportal.service.util.AlterationEnrichmentUtil;
-import org.cbioportal.web.parameter.CategorizedClinicalDataCountFilter;
 import org.cbioportal.web.parameter.StudyViewFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
@@ -256,33 +255,30 @@ public class AlterationCountServiceImpl implements AlterationCountService {
     }
 
     @Override
-    public List<AlterationCountByGene> getMutatedGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter) {
-        var alterationCountByGenes = studyViewRepository.getMutatedGenes(studyViewFilter, categorizedClinicalDataCountFilter);
-        return populateAlterationCounts(alterationCountByGenes, studyViewFilter, categorizedClinicalDataCountFilter, AlterationType.MUTATION_EXTENDED);
+    public List<AlterationCountByGene> getMutatedGenes(StudyViewFilter studyViewFilter) {
+        var alterationCountByGenes = studyViewRepository.getMutatedGenes(studyViewFilter);
+        return populateAlterationCounts(alterationCountByGenes, studyViewFilter, AlterationType.MUTATION_EXTENDED);
     }
     
-    public List<CopyNumberCountByGene> getCnaGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter) {
-        var copyNumberCountByGenes = studyViewRepository.getCnaGenes(studyViewFilter, categorizedClinicalDataCountFilter);
-        return populateAlterationCounts(copyNumberCountByGenes, studyViewFilter, categorizedClinicalDataCountFilter, AlterationType.COPY_NUMBER_ALTERATION);
+    public List<CopyNumberCountByGene> getCnaGenes(StudyViewFilter studyViewFilter) {
+        var copyNumberCountByGenes = studyViewRepository.getCnaGenes(studyViewFilter);
+        return populateAlterationCounts(copyNumberCountByGenes, studyViewFilter, AlterationType.COPY_NUMBER_ALTERATION);
     }
 
     @Override
-    public List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilter studyViewFilter, CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter) {
-        var alterationCountByGenes = studyViewRepository.getStructuralVariantGenes(studyViewFilter, categorizedClinicalDataCountFilter);
-        return populateAlterationCounts(alterationCountByGenes, studyViewFilter, categorizedClinicalDataCountFilter, AlterationType.STRUCTURAL_VARIANT);
+    public List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilter studyViewFilter) {
+        var alterationCountByGenes = studyViewRepository.getStructuralVariantGenes(studyViewFilter);
+        return populateAlterationCounts(alterationCountByGenes, studyViewFilter, AlterationType.STRUCTURAL_VARIANT);
     }
 
     private < T extends AlterationCountByGene> List<T> populateAlterationCounts(@NonNull List<T> alterationCounts,
                                                                                 @NonNull StudyViewFilter studyViewFilter,
-                                                                                @NonNull CategorizedClinicalDataCountFilter categorizedClinicalDataCountFilter,
                                                                                 @NonNull AlterationType alterationType) {
         var updatedAlterationCounts = alterationCounts.stream().map(SerializationUtils::clone).toList();
         var profiledCountsMap = studyViewRepository.getTotalProfiledCounts(studyViewFilter,
-            categorizedClinicalDataCountFilter,
             alterationType.toString());
-        var profiledCountWithoutGenePanelData = studyViewRepository.getTotalProfiledCountsByAlterationType(studyViewFilter, categorizedClinicalDataCountFilter, alterationType.toString());
-        var matchingGenePanelIdsMap = studyViewRepository.getMatchingGenePanelIds(studyViewFilter,
-            categorizedClinicalDataCountFilter, alterationType.toString());
+        var profiledCountWithoutGenePanelData = studyViewRepository.getTotalProfiledCountsByAlterationType(studyViewFilter, alterationType.toString());
+        var matchingGenePanelIdsMap = studyViewRepository.getMatchingGenePanelIds(studyViewFilter, alterationType.toString());
 
         updatedAlterationCounts.parallelStream()
             .forEach(alterationCountByGene ->  {

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
@@ -118,22 +118,24 @@
     <sql id="numericalClinicalDataCountFilter">
         SELECT ${unique_id}
         FROM ${table_name}
-        WHERE attribute_name = '${clinicalDataFilter.attributeId}'
+        WHERE attribute_name = '${clinicalDataFilter.attributeId}' AND
+        type='${type}' AND
+        (attribute_value = '' OR match(attribute_value, '^[\d\.]+$'))
         <foreach item="dataFilterValue" collection="clinicalDataFilter.values" open=" AND ((" separator=") OR (" close="))">
             <trim prefix="" prefixOverrides="AND">
                 <if test="dataFilterValue.value eq 'NA'">
-                    AND attribute_value = -1000000
+                    AND attribute_value = ''
                 </if>
                 <choose>
                     <when test="dataFilterValue.start == dataFilterValue.end">
-                        AND abs(minus(attribute_value, ${dataFilterValue.start})) &lt; exp(-11)
+                        AND abs(minus(cast(attribute_value as float), ${dataFilterValue.start})) &lt; exp(-11)
                     </when>
                     <otherwise>
                         <if test="dataFilterValue.start != null">
-                            AND attribute_value &gt; ${dataFilterValue.start}
+                            AND cast(attribute_value as float) &gt; ${dataFilterValue.start}
                         </if>
                         <if test="dataFilterValue.end != null">
-                            AND attribute_value &lt;= ${dataFilterValue.end}
+                            AND cast(attribute_value as float) &lt;= ${dataFilterValue.end}
                         </if>
                     </otherwise>
                 </choose>

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
@@ -74,7 +74,7 @@
                 <foreach item="clinicalDataFilter" collection="categorizedClinicalDataCountFilter.getSampleNumericalClinicalDataFilters()" open="INTERSECT" separator="INTERSECT">
                     <include refid="numericalClinicalDataCountFilter">
                         <property name="unique_id" value="sample_unique_id"/>
-                        <property name="table_name" value="sample_clinical_attribute_numeric_mv"/>
+                        <property name="table_name" value="clinical_data_derived"/>
                         <property name="type" value="sample"/>
                     </include>
                 </foreach>
@@ -98,7 +98,7 @@
                 <foreach item="clinicalDataFilter" collection="categorizedClinicalDataCountFilter.getPatientNumericalClinicalDataFilters()" open="INTERSECT" separator="INTERSECT">
                     <include refid="numericalClinicalDataCountFilter">
                         <property name="unique_id" value="patient_unique_id"/>
-                        <property name="table_name" value="patient_clinical_attribute_numeric_mv"/>
+                        <property name="table_name" value="clinical_data_derived"/>
                         <property name="type" value="patient"/>
                     </include>
                 </foreach>

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -151,32 +151,6 @@
         GROUP BY genetic_profile.stable_id, genetic_profile.name, sample_derived.cancer_study_identifier;
     </select>
     
-    
-    <sql id="getCategoricalClinicalDataCountsQuery">
-        SELECT
-        attribute_name as attributeId,
-        CASE WHEN attribute_value = 'NULL' THEN 'NA' ELSE attribute_value END AS value,
-        Count(*) as count
-        FROM ${table_name_prefix}_clinical_attribute_categorical_view
-        <where>
-            patient_unique_id IN ( <include refid="getPatientIdsFromSampleIdFilters"/>
-            <if test="applyPatientIdFilters == true">
-                INTERSECT <include refid="patientUniqueIdsFromStudyViewFilter"/>
-            </if>
-            )
-            AND UPPER(attribute_value) NOT IN
-            <foreach item="filteredAttributeValue" collection="filteredAttributeValues" open="(" separator="," close=")">
-                #{filteredAttributeValue}
-            </foreach>
-            AND attribute_name IN
-            <foreach item="attributeId" collection="attributeIds" open="(" separator="," close=")">
-                #{attributeId}
-            </foreach>
-        </where>
-        GROUP BY attribute_name,
-        attribute_value
-    </sql>
-    
     <sql id="getCategoricalClinicalDataCountsQuerySample">
         SELECT
         attribute_name as attributeId,
@@ -234,20 +208,6 @@
         GROUP BY attribute_name,
         value
     </sql>
-    
-    
-    
-    <select id="getPatientClinicalDataCounts" resultType="org.cbioportal.model.ClinicalDataCount">
-        <include refid="getCategoricalClinicalDataCountsQuery">
-            <property name="table_name_prefix" value="patient"/>
-        </include>
-    </select>
-    
-    <select id="getSampleClinicalDataCounts" resultType="org.cbioportal.model.ClinicalDataCount">
-        <include refid="getCategoricalClinicalDataCountsQuery">
-            <property name="table_name_prefix" value="sample"/>
-        </include>
-    </select>
     
     <sql id="getSampleIdsFromPatientIds">
         SELECT sample_unique_id

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -228,11 +228,8 @@
     <select id="getClinicalAttributes" resultType="org.cbioportal.model.ClinicalAttribute">
         SELECT
             attr_id as attrId,
-            display_name as displayName,
-            description,
             datatype as dataType,
             patient_attribute as patientAttribute,
-            cancer_study_id as cancerStudyId,
             cs.cancer_study_identifier cancerStudyIdentifier
         FROM clinical_attribute_meta cam
         JOIN cancer_study cs on cs.cancer_study_id = cam.cancer_study_id

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -234,8 +234,8 @@
             patient_attribute as patientAttribute,
             cancer_study_id as cancerStudyId,
             cs.cancer_study_identifier cancerStudyIdentifier
-        FROM sling_db_2024_05_23_original.clinical_attribute_meta cam
-        JOIN sling_db_2024_05_23_original.cancer_study cs on cs.cancer_study_id = cam.cancer_study_id
+        FROM clinical_attribute_meta cam
+        JOIN cancer_study cs on cs.cancer_study_id = cam.cancer_study_id
     </select>
 
     <!-- Grab Total Profiled Counts -->

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -265,10 +265,17 @@
         </where>
     </sql>
     
-    <select id="getClinicalAttributeNames" resultType="String">
+    <select id="getClinicalAttributes" resultType="org.cbioportal.model.ClinicalAttribute">
         SELECT
-        DISTINCT(attribute_name)
-        FROM ${tableName};
+            attr_id as attrId,
+            display_name as displayName,
+            description,
+            datatype as dataType,
+            patient_attribute as patientAttribute,
+            cancer_study_id as cancerStudyId,
+            cs.cancer_study_identifier cancerStudyIdentifier
+        FROM sling_db_2024_05_23_original.clinical_attribute_meta cam
+        JOIN sling_db_2024_05_23_original.cancer_study cs on cs.cancer_study_id = cam.cancer_study_id
     </select>
 
     <!-- Grab Total Profiled Counts -->


### PR DESCRIPTION
- [ ] use `clinical_data_derived` table when filtering both numerical and categorical clinical data
- [ ] use `clinical_attribute_meta` table to group clinical attribute names
- [ ] remove redundant clinical data count methods and SQL