### PR TITLE
remove unneeded references to old tables

### DIFF
--- a/src/main/resources/db-scripts/cgds.sql
+++ b/src/main/resources/db-scripts/cgds.sql
@@ -45,8 +45,6 @@
 DROP TABLE IF EXISTS `info`;
 DROP TABLE IF EXISTS `clinical_event_data`;
 DROP TABLE IF EXISTS `clinical_event`;
-DROP TABLE IF EXISTS `pdb_uniprot_residue_mapping`;
-DROP TABLE IF EXISTS `pdb_uniprot_alignment`;
 DROP TABLE IF EXISTS `cosmic_mutation`;
 DROP TABLE IF EXISTS `copy_number_seg_file`;
 DROP TABLE IF EXISTS `copy_number_seg`;

--- a/src/main/resources/db-scripts/migration.sql
+++ b/src/main/resources/db-scripts/migration.sql
@@ -294,7 +294,6 @@ INSERT INTO mutation_count_by_keyword
     GROUP BY g2.`GENETIC_PROFILE_ID` , mutation_event.`KEYWORD` , m2.`ENTREZ_GENE_ID`;
 UPDATE info SET DB_SCHEMA_VERSION="2.2.0";
 
-
 ##version: 2.3.0
 -- ========================== new geneset related tables =============================================
 
@@ -419,9 +418,9 @@ CREATE TABLE `reference_genome_gene` (
 
 INSERT INTO reference_genome_gene (ENTREZ_GENE_ID, CYTOBAND, EXONIC_LENGTH, CHR, REFERENCE_GENOME_ID)
 (SELECT
-	ENTREZ_GENE_ID,
-	CYTOBAND,
-	LENGTH,
+  ENTREZ_GENE_ID,
+  CYTOBAND,
+  LENGTH,
   SUBSTRING_INDEX(
     SUBSTRING_INDEX(
       SUBSTRING_INDEX(
@@ -429,7 +428,7 @@ INSERT INTO reference_genome_gene (ENTREZ_GENE_ID, CYTOBAND, EXONIC_LENGTH, CHR,
       'q', 1),
     'cen', 1),
   ' ', 1),
-	1
+  1
 FROM `gene`);
 
 UPDATE info SET DB_SCHEMA_VERSION="2.4.1";
@@ -854,16 +853,16 @@ UPDATE `info` SET `DB_SCHEMA_VERSION`="2.12.4";
 ##version: 2.12.5
 -- survival data migration
 -- create temporary table to store survival attributes
-CREATE TEMPORARY TABLE IF NOT EXISTS survival_attributes AS 
-  (SELECT DISTINCT Concat(Substr(ATTR_ID, 1, Char_length(ATTR_ID) - 7), 
-                   "_STATUS") AS ATTR_ID 
-   FROM   clinical_attribute_meta 
-   WHERE  ATTR_ID LIKE "%_STATUS" 
-          AND Substr(ATTR_ID, 1, Char_length(ATTR_ID) - 7)IN (SELECT DISTINCT 
-              Substr(ATTR_ID, 1, Char_length(ATTR_ID) - 7) AS 
-              SurvivalDataStatusPrefix 
-              FROM   clinical_attribute_meta 
-              WHERE  ATTR_ID LIKE "%_MONTHS")); 
+CREATE TEMPORARY TABLE IF NOT EXISTS survival_attributes AS
+  (SELECT DISTINCT Concat(Substr(ATTR_ID, 1, Char_length(ATTR_ID) - 7),
+                   "_STATUS") AS ATTR_ID
+   FROM   clinical_attribute_meta
+   WHERE  ATTR_ID LIKE "%_STATUS"
+          AND Substr(ATTR_ID, 1, Char_length(ATTR_ID) - 7)IN (SELECT DISTINCT
+              Substr(ATTR_ID, 1, Char_length(ATTR_ID) - 7) AS
+              SurvivalDataStatusPrefix
+              FROM   clinical_attribute_meta
+              WHERE  ATTR_ID LIKE "%_MONTHS"));
 
 -- mapping to 0/1
 UPDATE clinical_patient SET ATTR_VALUE = CONCAT("1:",ATTR_VALUE) WHERE ATTR_ID in (SELECT ATTR_ID FROM survival_attributes) AND ATTR_VALUE in ('DECEASED','Recurred/Progressed','Recurred','Progressed','Yes','yes','1','PROGRESSION','Event','DEAD OF MELANOMA','DEAD WITH TUMOR','Metastatic Relapse','Localized Relapse');
@@ -932,7 +931,7 @@ UPDATE `info` SET `DB_SCHEMA_VERSION`="2.12.7";
 
 ##version: 2.12.8
 CREATE INDEX idx_mutation_type ON mutation_event (`MUTATION_TYPE`);
-CREATE INDEX idx_cna_type ON cna_event (`ALTERATION`);                                                        
+CREATE INDEX idx_cna_type ON cna_event (`ALTERATION`);
 CREATE INDEX idx_driver_filter ON alteration_driver_annotation (`DRIVER_FILTER`);
 CREATE INDEX idx_driver_tiers_filter ON alteration_driver_annotation (`DRIVER_TIERS_FILTER`);
 UPDATE `info` SET `DB_SCHEMA_VERSION`="2.12.8";
@@ -978,8 +977,6 @@ UPDATE `info` SET `DB_SCHEMA_VERSION`="2.12.12";
 ALTER TABLE `sample` MODIFY COLUMN `STABLE_ID` VARCHAR(63) NOT NULL;
 UPDATE `info` SET `DB_SCHEMA_VERSION`="2.12.13";
 
-
-
 ##version: 2.12.14
 ALTER TABLE `structural_variant` MODIFY COLUMN `SITE1_ENTREZ_GENE_ID` int(11);
 ALTER TABLE `structural_variant` ADD COLUMN `SITE1_REGION` varchar(25) AFTER `SITE1_CHROMOSOME`;
@@ -1020,7 +1017,6 @@ ALTER TABLE `mutation_event` CHANGE COLUMN `ONCOTATOR_UNIPROT_ACCESSION` `UNIPRO
 ALTER TABLE `mutation_event` CHANGE COLUMN `ONCOTATOR_PROTEIN_POS_START` `PROTEIN_POS_START` int(11);
 ALTER TABLE `mutation_event` CHANGE COLUMN `ONCOTATOR_PROTEIN_POS_END` `PROTEIN_POS_END` int(11);
 UPDATE `info` SET `DB_SCHEMA_VERSION`="2.13.0";
-
 
 ##version: 2.13.1
 ALTER TABLE `clinical_event_data` MODIFY COLUMN `VALUE` varchar(3000) NOT NULL;

--- a/src/test/resources/cgds-h2.sql
+++ b/src/test/resources/cgds-h2.sql
@@ -45,8 +45,6 @@
 DROP TABLE IF EXISTS `info`;
 DROP TABLE IF EXISTS `clinical_event_data`;
 DROP TABLE IF EXISTS `clinical_event`;
-DROP TABLE IF EXISTS `pdb_uniprot_residue_mapping`;
-DROP TABLE IF EXISTS `pdb_uniprot_alignment`;
 DROP TABLE IF EXISTS `cosmic_mutation`;
 DROP TABLE IF EXISTS `copy_number_seg_file`;
 DROP TABLE IF EXISTS `copy_number_seg`;


### PR DESCRIPTION
Describe changes proposed in this pull request:
- tables pdb_uniprot_alignment and pdb_uniprot_residue_mapping were removed at db version 2.12.12 there is no need to refer to them in cgds.sql or cgds-h2.sql
- whitespace standardization in migration.sql

These changes should have no semantic effect. When installing a new database schema there is no need to purge tables which should not be present and are not created.

# Checks
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
