### PR TITLE
Added PR title checker

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,26 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR Title Prefix
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = context.payload.pull_request.title.trim();
+            const allowedPrefixes = ["feat:", "fix:", "test:", "chore:", "docs:"];
+            const prefixRegex = new RegExp(`^(${allowedPrefixes.join('|')})`, 'i');
+
+            if (!prefixRegex.test(title)) {
+              const errorMessage = `PR title does not start with one of the allowed prefixes: ${allowedPrefixes.join(', ')}`;
+              core.setFailed(errorMessage);
+            } else {
+              console.log('PR title check passed successfully.');
+            }


### PR DESCRIPTION
Created a new GitHub Action workflow (`pr-title-check.yml`) that verifies if pull request titles start with one of the specified prefixes: "feat:", "fix:", "test:", "chore:", "docs:". This ensures consistency and clarity in PR titles, helping to categorize changes effectively. 

Fix #10692 



# Checks
- [X] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [X] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.



