### PR TITLE
Switch off spring security on public VS endpoints

### DIFF
--- a/src/main/java/org/cbioportal/security/config/ApiSecurityConfig.java
+++ b/src/main/java/org/cbioportal/security/config/ApiSecurityConfig.java
@@ -39,6 +39,7 @@ public class ApiSecurityConfig {
                     "/api/swagger-resources/**",
                     "/api/swagger-ui.html",
                     "/api/health",
+                    "/api/public_virtual_studies/**",
                     "/api/cache/**").permitAll()
                 .anyRequest().authenticated()
             )


### PR DESCRIPTION
We are making this change to simplify publishing and unpublishing by using only our custom authorization token, without spring security tokens. The same way the `/api/cache` call does.
https://github.com/cBioPortal/cbioportal/blob/5c4aab003028c55f610cdf9c8a1863550b52203c/docs/Create-And-Publish-Virtual-Study.md?plain=1#L26-L34

cBioPortal does not have an admin role atm. Having the token makes you an admin.