### PR TITLE
Fix web and date image build

### DIFF
--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -38,8 +38,7 @@ RUN apt-get update; apt-get install -y --no-install-recommends \
         python3-dev \
         python3-pip \
         unzip \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip3 install wheel
+    && rm -rf /var/lib/apt/lists/*
 
 # copy over core files and data-related scripts
 RUN mkdir -p /cbioportal


### PR DESCRIPTION
`python3-wheel` is now installed by default, no need to install separately

```
# apt-get install python3-wheel
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
python3-wheel is already the newest version (0.42.0-2).
```