### PR TITLE
Deployment/Customization Docs: changed links to relative so they work both in github website and docs website

### DIFF
--- a/docs/deployment/customization/Caching.md
+++ b/docs/deployment/customization/Caching.md
@@ -11,7 +11,7 @@ if they have already been constructed. They would only be constructed for the in
 The portal is configured to use Ehcache or Redis for backend caching. Ehcache supports a hybrid (disk + heap),
 disk-only, and heap-only mode. Redis stores the cache in memory and periodically writes the updated data to disk. Cache
 configuration is specified inside `application.properties`(more
-information [here](/deployment/customization/application.properties-Reference.md#cache-settings)).
+information [here](application.properties-Reference.md#cache-settings)).
 
 ## Creating additional caches
 

--- a/docs/deployment/customization/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/deployment/customization/Customizing-your-instance-of-cBioPortal.md
@@ -7,7 +7,7 @@ customize the web page cosmetics, such as custom images,
 texts, which tabs are visible, etc.
 Nearly all the skins properties have defaults, which can be overwritten by
 changing the `application.properties` file located in `$PORTAL_HOME`--see
-[the deployment manual](/deployment/deploy-without-docker/Deploying.md). If your cBioPortal instance
+[the deployment manual](../deploy-without-docker/Deploying.md). If your cBioPortal instance
 does not yet contain a `application.properties` file, you can copy
 `src/main/resources/application.properties.EXAMPLE` and edit it.
 

--- a/docs/deployment/customization/application.properties-Reference.md
+++ b/docs/deployment/customization/application.properties-Reference.md
@@ -353,7 +353,7 @@ googleplus.consumer.secret=2jCfg4SPWdGfXF44WC588dK
 
 (note: these are just examples, you need to get your own) You will also need to go to "Google+ API" and click Enable button. In case of problems make sure to enable DEBUG logging for org.springframework.social and org.springframework.security.web.authentication.
 
-To activate password authentication follow the [Deployment with authentication steps](/deployment/deploy-without-docker/Deploying.md#required-login) and set `authenticate=googleplus`.
+To activate password authentication follow the [Deployment with authentication steps](../deploy-without-docker/Deploying.md#required-login) and set `authenticate=googleplus`.
 
 In addition, set this property in `application.properties`:
 
@@ -361,7 +361,7 @@ In addition, set this property in `application.properties`:
 app.name=cbioportal
 ```
 
-app.name should be set to the name of the portal instance referenced in the "AUTHORITY" column of the "AUTHORITIES" table. See the [User Authorization](/deployment/authorization-and-authentication/User-Authorization.md) for more information.
+app.name should be set to the name of the portal instance referenced in the "AUTHORITY" column of the "AUTHORITIES" table. See the [User Authorization](../authorization-and-authentication/User-Authorization.md) for more information.
 
 ## OncoKB integration
 
@@ -371,7 +371,7 @@ OncoKB integration can be turned on or off with the following property (default:
 show.oncokb=true|false
 ```
 
-A private token is required to access the OncoKB Data (for details see the section [OncoKB Data Access](/deployment/integration-with-other-webservices/OncoKB-Data-Access.md)):
+A private token is required to access the OncoKB Data (for details see the section [OncoKB Data Access](../integration-with-other-webservices/OncoKB-Data-Access.md)):
 
 ```
 oncokb.token=
@@ -562,7 +562,7 @@ cBioPortal is supported on the backend with Ehcache or Redis. These caches are c
 
 The cache type is set using `persistence.cache_type`. Valid values are `no-cache`, `redis` (redis), `ehache-heap` (ehcache heap-only), `ehache-disk` (ehcache disk-only), and `ehache-hybrid` (ehcache disk + heap). By default, `persistence.cache_type` is set to `no-cache` which disables the cache. When the cache is disabled, no responses will be stored in the cache.
 
-:warning: the 'redis' caching option will likely cause a conflict when installing the portal in a Tomcat installation which uses redisson for session management. If you plan to deploy cbioportal to such a system, avoid the 'redis' caching option for `persistence.cache_type` and be sure to build cbioportal.war with the maven option `-Dexclude-redisson` (see [Building with Maven](/deployment/deploy-without-docker/Build-from-Source.md#building-with-maven)).
+:warning: the 'redis' caching option will likely cause a conflict when installing the portal in a Tomcat installation which uses redisson for session management. If you plan to deploy cbioportal to such a system, avoid the 'redis' caching option for `persistence.cache_type` and be sure to build cbioportal.war with the maven option `-Dexclude-redisson` (see [Building with Maven](../deploy-without-docker/Build-from-Source.md#building-with-maven)).
 
 ```
 persistence.cache_type=[no-cache or ehache-heap or ehcache-disk or ehcache-hybrid or redis]
@@ -596,7 +596,7 @@ For general statistics about the cache such as memory usage (not currently imple
 
 **WARNING**: It must be noted that since cache statistics endpoint returns data on cache keys, the endpoint may expose otherwise hidden database query parameters such as sample identifiers, study names, etc. Generally, it is recommended that the endpoint only be turned on during cache-related development for testing. Deployers of a protected portal where users only have authorities to a subset of studies should carefully consider whether or not to turn on the cache statistics endpoint, as it does not filter the results.
 
-For more information on how caching is implemented in cBioPortal refer to the [Caching](/deployment/customization/Caching.md) documentation.
+For more information on how caching is implemented in cBioPortal refer to the [Caching](Caching.md) documentation.
 
 ### Redis
 
@@ -800,7 +800,7 @@ enable_study_tags=true|false
 ```
 
 # Add Custom Buttons to data tables
-Custom Buttons can be defined which will conditionally appear in all group comparison data tables (with CopyDownloadControls) to launch a custom URL. This can be used, for example, to launch a software application (that is installed on the user's system) with the data. This configuration can also customize new elements on the Visualize page. It points to a JSON file on the classpath. (See [download_custom_buttons reference](/deployment/customization/download_custom_buttons-Reference.md)).
+Custom Buttons can be defined which will conditionally appear in all group comparison data tables (with CopyDownloadControls) to launch a custom URL. This can be used, for example, to launch a software application (that is installed on the user's system) with the data. This configuration can also customize new elements on the Visualize page. It points to a JSON file on the classpath. (See [download_custom_buttons reference](download_custom_buttons-Reference.md)).
 
 
 ```

--- a/docs/deployment/customization/download_custom_buttons-Reference.md
+++ b/docs/deployment/customization/download_custom_buttons-Reference.md
@@ -5,7 +5,7 @@ Custom Buttons can be defined which will conditionally appear in all group compa
 ## Configuration File
 
 The Custom Buttons are defined in a JSON file in the classpath. Set `download_custom_buttons_json` to refer to the file in the 
-`application.properties` (See [application.properties reference](/deployment/customization/application.properties-Reference.md#add-custom-buttons-to-data-tables)).
+`application.properties` (See [application.properties reference](application.properties-Reference.md#add-custom-buttons-to-data-tables)).
 
 ## JSON format
 

--- a/docs/deployment/customization/portal.properties--Reference.md
+++ b/docs/deployment/customization/portal.properties--Reference.md
@@ -1,1 +1,1 @@
-This file has been depreciated and information about customizing cBioPortal can be found in [application.properties documentation](/deployment/customization/application.properties-Reference.md).
+This file has been depreciated and information about customizing cBioPortal can be found in [application.properties documentation](application.properties-Reference.md).

--- a/docs/deployment/customization/portal.properties--Reference.md
+++ b/docs/deployment/customization/portal.properties--Reference.md
@@ -1,1 +1,1 @@
-This file has been depreciated and information about customizing cBioPortal can be found in [application.properties documentation](application.properties-Reference.md).
+This file has been deprecated and information about customizing cBioPortal can be found in [application.properties documentation](application.properties-Reference.md).


### PR DESCRIPTION
This is a partial fix to issue #10937, where cross-links using absolute paths give 404 errors in the github repo browser. It updates the cross-links in the /docs/deployment/customization/  documents.

# Checks
- Verified these updates in the github repo browser
- NOTE: cannot verify in documentation website, but it should work since I believe there are already a couple of cases where relative links are used.