### PR TITLE
fix frontendproperties readFile() to work with classpath and update download_custom_buttons_json reference

### DIFF
--- a/docs/deployment/customization/application.properties-Reference.md
+++ b/docs/deployment/customization/application.properties-Reference.md
@@ -800,9 +800,9 @@ enable_study_tags=true|false
 ```
 
 # Add Custom Buttons to data tables
-Custom Buttons can be defined which will conditionally appear in all group comparison data tables (with CopyDownloadControls) to launch a custom URL. This can be used, for example, to launch a software application (that is installed on the user's system) with the data. This configuration can also customize new elements on the Visualize page. It points to a JSON file on the classpath. (See [download_custom_buttons reference](download_custom_buttons-Reference.md)).
+Custom Buttons can be defined which will conditionally appear in all group comparison data tables (with CopyDownloadControls) to launch a custom URL. This can be used, for example, to launch a software application (that is installed on the user's system) with the data. This configuration can also customize new elements on the Visualize page. It points to a JSON file. (See [download_custom_buttons reference](download_custom_buttons-Reference.md)). 
 
 
 ```
-download_custom_buttons_json=classpath:/custom_buttons/download_custom_button_avm.json
+download_custom_buttons_json=classpath:cbioportal-webapp/custom_buttons/download_custom_button_avm.json
 ```

--- a/docs/deployment/customization/application.properties-Reference.md
+++ b/docs/deployment/customization/application.properties-Reference.md
@@ -804,5 +804,5 @@ Custom Buttons can be defined which will conditionally appear in all group compa
 
 
 ```
-download_custom_buttons_json=classpath:cbioportal-webapp/custom_buttons/download_custom_button_avm.json
+download_custom_buttons_json=classpath:custom_buttons/download_custom_button_avm.json
 ```

--- a/docs/deployment/customization/download_custom_buttons-Reference.md
+++ b/docs/deployment/customization/download_custom_buttons-Reference.md
@@ -4,8 +4,7 @@ Custom Buttons can be defined which will conditionally appear in all group compa
 
 ## Configuration File
 
-The Custom Buttons are defined in a JSON file in the classpath. Set `download_custom_buttons_json` to refer to the file in the 
-`application.properties` (See [application.properties reference](application.properties-Reference.md#add-custom-buttons-to-data-tables)).
+The Custom Buttons are defined in a JSON file on the classpath. Set `download_custom_buttons_json` to refer to the file (see [application.properties reference](application.properties-Reference.md#add-custom-buttons-to-data-tables)).
 
 ## JSON format
 
@@ -68,5 +67,3 @@ To modify software to leverage this:
 - Modify your software to read data from clipboard.
 - Modify your software or installer to register a URL protocol to launch.
 - Modify your software or installer to install a custom font.
-
-

--- a/src/main/java/org/cbioportal/service/FrontendPropertiesServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/FrontendPropertiesServiceImpl.java
@@ -320,26 +320,24 @@ public class FrontendPropertiesServiceImpl implements FrontendPropertiesService 
 
             // try absolute or relative to working directory
             File file = new File(filePath);
-            log.info("Trying absolute file:" + filePath);
-            if (file.exists()) 
-            {
+            if (file.exists()) {
                 inputStream = new FileInputStream(file);
-            }
-            // try relative to PORTAL_HOME
-            else if (home != null)
-            {
+            } else if (home != null) {
+                // try relative to PORTAL_HOME
                 file = new File(Paths.get(home, filePath).toString());
                 if (file.exists()) {
                     inputStream = new FileInputStream(file);
                 }
-            }     
+            } 
 
-            // try resource (e.g. app.jar)
-            if (inputStream == null)
-            {
+            if (inputStream != null) {
+                log.info("Reading frontend config file: {}", file.getAbsolutePath());
+            } else {
+                // try resource (e.g. app.jar)
                 inputStream = this.getClass().getClassLoader().getResourceAsStream(filePath);
-
-                if (inputStream == null) {
+                if (inputStream != null) {
+                    log.info("Reading frontend config resource: {}", filePath);
+                } else {
                     throw new Exception("File not found in system or classpath: " + filePath);
                 }
             }

--- a/src/main/java/org/cbioportal/service/FrontendPropertiesServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/FrontendPropertiesServiceImpl.java
@@ -6,8 +6,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ResourceUtils;
 
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -291,18 +296,31 @@ public class FrontendPropertiesServiceImpl implements FrontendPropertiesService 
             );
     }
 
-    private String readFile(String fileName) {
-        if (fileName != null && !fileName.isEmpty()) {
-            try (BufferedReader br = Files.newBufferedReader(Paths.get(fileName))) {
-                return br.lines().map(String::trim).collect(Collectors.joining(""));
-            } catch (Exception e) {
-                log.error("Error reading frontend config file: {}", e.getMessage());
-                return null;
-            }
+    /**
+     * Read the file and return the content as a single-line string. This works for:
+     * 1) loose files given absolute path
+     * 2) loose files relative to PORTAL_HOME
+     * 3) "classpath:..."" (relative to PORTAL_HOME)
+     * @propertiesFileName: the file path 
+     * REF: see getFileContents() in a couple of other locations
+     */
+    private String readFile(String propertiesFileName) {
+        if (propertiesFileName == null || propertiesFileName.isEmpty()) {
+            return null;
         }
-        return null;
+
+        try {
+            File file = ResourceUtils.getFile(propertiesFileName);
+            InputStream inputStream = new FileInputStream(file);
+            BufferedReader br = new BufferedReader(new InputStreamReader(inputStream));
+            return br.lines().map(String::trim).collect(Collectors.joining(""));            
+        } catch (Exception e) {
+            log.error("Error reading frontend config file: {}", e.getMessage());
+            return null;
+        }
     }
-    
+
+   
     public String getFrontendUrl(String propertyValue) {
         String frontendUrlRuntime = env.getProperty("frontend.url.runtime", "");
         if (frontendUrlRuntime.length() > 0) {

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -427,7 +427,7 @@ spring.devtools.restart.enabled=false
 #enable_study_tags=true|false
 
 ## Custom Buttons
-# download_custom_buttons_json=classpath:cbioportal-webapp/custom_buttons/download_custom_button_avm.json
+# download_custom_buttons_json=classpath:custom_buttons/download_custom_button_avm.json
 
 # EOL - Do not delete the following lines
 

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -427,7 +427,7 @@ spring.devtools.restart.enabled=false
 #enable_study_tags=true|false
 
 ## Custom Buttons
-# download_custom_buttons_json=classpath:/custom_buttons/download_custom_button_avm.json
+# download_custom_buttons_json=classpath:cbioportal-webapp/custom_buttons/download_custom_button_avm.json
 
 # EOL - Do not delete the following lines
 


### PR DESCRIPTION
This fixes the readFile() method which is used by frontendproperties (application.properties) to read the contents of a file in, to work with the "classpath:" syntax.  This PR also updates the reference config for download_custom_buttons_json to the classpath syntax so it works.

Properties affected:
- frontendConfigOverride
- query_sets_of_genes
- skin.patient_view.custom_sample_type_colors_json
- oncoprint.clinical_tracks.config_json

# Explanation
The existing documentation for these properties mentioned that "classpath:" syntax could be used.  E.g. from the application.properties.EXAMPLE, I don't believe this would work:

```
DOES NOT WORK
oncoprint.clinical_tracks.config_json=classpath:/oncoprint-default-tracks.json
```

However, the readFile() method didn't support that syntax.  It would only work with the file system. Furthermore, production instances (at least the public cBioPortal) build the server to a single "app.jar" file (using the "web" docker config).  If the above file exists in the "web-and-data" loose configuration via the repo, but no longer exists as a loose file in the "web" configuration, then you have configuration that works in dev but fails in production.
```
WORKS IN DEV BUT NOT PRODUCTION
download_custom_buttons_json=/cbioportal-webapp/custom_buttons/download_custom_button_avm.json
```

That means that these properties only worked if they had an absolute path reference to a file, and the file is manually placed on the file system of the server (and not packed into the app.jar). E.g.
```
WORKS IF THE FILE IS MANUALLY PLACED ON THE SERVER:
download_custom_buttons_json=/somefolder/download_custom_button_avm.json
```


# Checks
[DONE] I have tested the docker "web-and-data" container with loose files. All 3 of these variants work successfully in that scenario:

```
WORKS NOW:
download_custom_buttons_json=/cbioportal-webapp/custom_buttons/download_custom_button_avm.json
download_custom_buttons_json=custom_buttons/download_custom_button_avm.json
download_custom_buttons_json=classpath:custom_buttons/download_custom_button_avm.json
```

[TODO] This needs to be tested in the "web" container with just the app.jar.  The "classpath" syntax should work, since this pattern is used in other places, but I have been unable to test this image to confirm. I get an error 
```
Error: Could not find or load main class org.cbioportal.PortalApplication
Caused by: java.lang.ClassNotFoundException: org.cbioportal.PortalApplication: 
```

[TODO] This needs to be regressed to make sure that existing instances that use these properties and are referencing loose files this way still work in the "web" container with just app.jar. For example, if there is an instance that uses something like this:

```
VERIFY STILL WORKS:
oncoprint.clinical_tracks.config_json=/somefolder/oncoprint-default-tracks.json
```

This should work based on the above tests with the "web-and-data" container, but to be safe, it should be tested with the "web" container.

# Reviewers
@alisman 
 