### PR TITLE
Improve numerical clinical data filter

### DIFF
--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
@@ -283,18 +283,39 @@
                         <property name="attribute_value" value="attribute_value"/>
                     </include>
                 </if>
-                <if test="dataFilterValue.start != null || dataFilterValue.end != null">
-                    AND match(attribute_value, '^[\d\.]+$')
+                <if test="dataFilterValue.start != null and dataFilterValue.end == null">
+                    AND match(attribute_value, '^>?=?[-+]?[0-9]*[.,]?[0-9]+$')
+                </if>
+                <if test="dataFilterValue.start == null and dataFilterValue.end != null">
+                    AND match(attribute_value, '^&lt;?=?[-+]?[0-9]*[.,]?[0-9]+$')
+                </if>
+                <if test="dataFilterValue.start != null and dataFilterValue.end != null">
+                    AND match(attribute_value, '^[-+]?[0-9]*[.,]?[0-9]+$')
+                </if>
+                <if test="dataFilterValue.start != null or dataFilterValue.end != null">   
                     <choose>
                         <when test="dataFilterValue.start == dataFilterValue.end">
-                            AND abs(minus(cast(attribute_value as float), ${dataFilterValue.start})) &lt; exp(-11)
+                            AND abs(
+                                minus(
+                                    <include refid="castStringValueToFloat">
+                                        <property name="attribute_value" value="attribute_value"/>
+                                    </include>,
+                                    ${dataFilterValue.start}
+                                )
+                            ) &lt; exp(-11)
                         </when>
                         <otherwise>
                             <if test="dataFilterValue.start != null">
-                                AND cast(attribute_value as float) &gt; ${dataFilterValue.start}
+                                AND
+                                <include refid="castStringValueToFloat">
+                                    <property name="attribute_value" value="attribute_value"/>
+                                </include> &gt; ${dataFilterValue.start}
                             </if>
                             <if test="dataFilterValue.end != null">
-                                AND cast(attribute_value as float) &lt;= ${dataFilterValue.end}
+                                AND
+                                <include refid="castStringValueToFloat">
+                                    <property name="attribute_value" value="attribute_value"/>
+                                </include> &lt;= ${dataFilterValue.end}
                             </if>
                         </otherwise>
                     </choose>

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -618,6 +618,29 @@
         </where>
     </sql>
     
+    <!--
+        Convert string values to a single numerical value for filtering purposes only.
+        Not designed as a general purpose decimal number parser.
+        
+        Examples conversions:
+        '6' to 6
+        '>=6' to 6
+        '<=6' to 6
+        '>6' to 6.00..1...
+        '<6' to 5.99..9...
+    -->
+    <sql id="castStringValueToFloat">
+        multiIf(
+            (startsWith(${attribute_value}, '&lt;=') OR startsWith(${attribute_value}, '>=')),
+            cast(substr(${attribute_value}, 3) as float),
+            startsWith(${attribute_value}, '&lt;'),
+            cast(substr(${attribute_value}, 2) as float) - exp(-10),
+            startsWith(${attribute_value}, '>'),
+            cast(substr(${attribute_value}, 2) as float) + exp(-10),
+            cast(${attribute_value} as float)
+        )
+    </sql>
+    
     <!-- This is to match actual NA values ('NA', 'NAN', and 'N/A') in addition to the empty string -->
     <sql id="isAttributeValueNA">
         ${attribute_value}=''


### PR DESCRIPTION
Fix cBioPortal/rfc80-team#32
Fixes https://github.com/cBioPortal/rfc80-team/issues/44


Handle numerical clinical data values such as `<18`, `>90`, `<=3`, `>=9` when range filtering.

This PR also improves the numerical value matching. Previously only positive integers could be matched, with this PR negative values as well as decimal numbers are also matched.