### PR TITLE
Demo rfc80 poc mutation data count specific gene parameter

### DIFF
--- a/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
+++ b/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
@@ -27,7 +27,9 @@ public interface StudyViewRepository {
     
     List<ClinicalData> getPatientClinicalData(StudyViewFilterContext studyViewFilterContext, List<String> attributeIds);
     
-    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, String specificHugoGeneSymbol);
+    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext);
+    
+    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, List<String> hugoGeneSymbols);
     
     List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilterContext studyViewFilterContext);
     List<CopyNumberCountByGene> getCnaGenes(StudyViewFilterContext studyViewFilterContext);
@@ -42,11 +44,15 @@ public interface StudyViewRepository {
 
     List<CaseListDataCount> getCaseListDataCountsPerStudy(StudyViewFilterContext studyViewFilterContext);
 
-    Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType, String specificHugoGeneSymbol);
+    Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType);
+
+    Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType, List<String> hugoGeneSymbols);
     
     int getFilteredSamplesCount(StudyViewFilterContext studyViewFilterContext);
     
-    Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType, String specificHugoGeneSymbol);
+    Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType);
+    
+    Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType, List<String> hugoGeneSymbols);
     
     int getTotalProfiledCountsByAlterationType(StudyViewFilterContext studyViewFilterContext, String alterationType);
     
@@ -65,6 +71,4 @@ public interface StudyViewRepository {
     List<GenomicDataCountItem> getCNACounts(StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters);
     
     List<GenomicDataCountItem> getMutationCountsByType(StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters);
-
-    AlterationCountByGene getMutatedGene(StudyViewFilterContext studyViewFilterContext, String specificHugoGeneSymbol);
 }

--- a/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
+++ b/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
@@ -27,7 +27,7 @@ public interface StudyViewRepository {
     
     List<ClinicalData> getPatientClinicalData(StudyViewFilterContext studyViewFilterContext, List<String> attributeIds);
     
-    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext);
+    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, String specificHugoGeneSymbol);
     
     List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilterContext studyViewFilterContext);
     List<CopyNumberCountByGene> getCnaGenes(StudyViewFilterContext studyViewFilterContext);
@@ -42,11 +42,11 @@ public interface StudyViewRepository {
 
     List<CaseListDataCount> getCaseListDataCountsPerStudy(StudyViewFilterContext studyViewFilterContext);
 
-    Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType);
+    Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType, String specificHugoGeneSymbol);
     
     int getFilteredSamplesCount(StudyViewFilterContext studyViewFilterContext);
     
-    Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType);
+    Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType, String specificHugoGeneSymbol);
     
     int getTotalProfiledCountsByAlterationType(StudyViewFilterContext studyViewFilterContext, String alterationType);
     
@@ -65,4 +65,6 @@ public interface StudyViewRepository {
     List<GenomicDataCountItem> getCNACounts(StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters);
     
     List<GenomicDataCountItem> getMutationCountsByType(StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters);
+
+    AlterationCountByGene getMutatedGene(StudyViewFilterContext studyViewFilterContext, String specificHugoGeneSymbol);
 }

--- a/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
+++ b/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
@@ -27,9 +27,7 @@ public interface StudyViewRepository {
     
     List<ClinicalData> getPatientClinicalData(StudyViewFilterContext studyViewFilterContext, List<String> attributeIds);
     
-    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext);
-    
-    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, List<String> hugoGeneSymbols);
+    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, String... hugoGeneSymbols);
     
     List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilterContext studyViewFilterContext);
     List<CopyNumberCountByGene> getCnaGenes(StudyViewFilterContext studyViewFilterContext);
@@ -44,15 +42,11 @@ public interface StudyViewRepository {
 
     List<CaseListDataCount> getCaseListDataCountsPerStudy(StudyViewFilterContext studyViewFilterContext);
 
-    Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType);
-
-    Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType, List<String> hugoGeneSymbols);
+    Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType, String... hugoGeneSymbols);
     
     int getFilteredSamplesCount(StudyViewFilterContext studyViewFilterContext);
     
-    Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType);
-    
-    Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType, List<String> hugoGeneSymbols);
+    Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType, String... hugoGeneSymbols);
     
     int getTotalProfiledCountsByAlterationType(StudyViewFilterContext studyViewFilterContext, String alterationType);
     

--- a/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
+++ b/src/main/java/org/cbioportal/persistence/StudyViewRepository.java
@@ -63,8 +63,6 @@ public interface StudyViewRepository {
     int getTotalSampleTreatmentCount(StudyViewFilterContext studyViewFilterContext);
 
     List<GenomicDataCountItem> getCNACounts(StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters);
-
-    Map<String, Integer> getMutationCounts(StudyViewFilterContext studyViewFilterContext, GenomicDataFilter genomicDataFilter);
     
     List<GenomicDataCountItem> getMutationCountsByType(StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters);
 }

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.java
@@ -26,7 +26,7 @@ public interface StudyViewMapper {
 
     List<GenomicDataCount> getMolecularProfileSampleCounts(@Param("studyViewFilterHelper") StudyViewFilterHelper studyViewFilterHelper);
     
-    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterHelper studyViewFilterHelper, AlterationFilterHelper alterationFilterHelper, List<String> hugoGeneSymbols);
+    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterHelper studyViewFilterHelper, AlterationFilterHelper alterationFilterHelper, String... hugoGeneSymbols);
     
     List<CopyNumberCountByGene> getCnaGenes(StudyViewFilterHelper studyViewFilterHelper, AlterationFilterHelper alterationFilterHelper);
 
@@ -42,11 +42,11 @@ public interface StudyViewMapper {
     
     List<ClinicalData> getPatientClinicalDataFromStudyViewFilter(StudyViewFilterHelper studyViewFilterHelper, List<String> attributeIds);
     
-    List<AlterationCountByGene> getTotalProfiledCounts(StudyViewFilterHelper studyViewFilterHelper, String alterationType, List<String> hugoGeneSymbols);
+    List<AlterationCountByGene> getTotalProfiledCounts(StudyViewFilterHelper studyViewFilterHelper, String alterationType, String... hugoGeneSymbols);
     
     int getFilteredSamplesCount(@Param("studyViewFilterHelper") StudyViewFilterHelper studyViewFilterHelper);
     
-    List<GenePanelToGene> getMatchingGenePanelIds(StudyViewFilterHelper studyViewFilterHelper, String alterationType, List<String> hugoGeneSymbols);
+    List<GenePanelToGene> getMatchingGenePanelIds(StudyViewFilterHelper studyViewFilterHelper, String alterationType, String... hugoGeneSymbols);
     
     int getTotalProfiledCountByAlterationType(StudyViewFilterHelper studyViewFilterHelper, String alterationType);
     
@@ -62,6 +62,4 @@ public interface StudyViewMapper {
     List<GenomicDataCountItem> getCNACounts(StudyViewFilterHelper studyViewFilterHelper, List<GenomicDataFilter> genomicDataFilters);
 
     List<GenomicDataCountItem> getMutationCountsByType(StudyViewFilterHelper studyViewFilterHelper, List<GenomicDataFilter> genomicDataFilters);
-
-    AlterationCountByGene getMutatedGene(StudyViewFilterHelper studyViewFilterHelper, AlterationFilterHelper alterationFilterHelper, String specificHugoGeneSymbol);
 }

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.java
@@ -26,7 +26,7 @@ public interface StudyViewMapper {
 
     List<GenomicDataCount> getMolecularProfileSampleCounts(@Param("studyViewFilterHelper") StudyViewFilterHelper studyViewFilterHelper);
     
-    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterHelper studyViewFilterHelper, AlterationFilterHelper alterationFilterHelper);
+    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterHelper studyViewFilterHelper, AlterationFilterHelper alterationFilterHelper, String specificHugoGeneSymbol);
     
     List<CopyNumberCountByGene> getCnaGenes(StudyViewFilterHelper studyViewFilterHelper, AlterationFilterHelper alterationFilterHelper);
 
@@ -42,11 +42,11 @@ public interface StudyViewMapper {
     
     List<ClinicalData> getPatientClinicalDataFromStudyViewFilter(StudyViewFilterHelper studyViewFilterHelper, List<String> attributeIds);
     
-    List<AlterationCountByGene> getTotalProfiledCounts(StudyViewFilterHelper studyViewFilterHelper, String alterationType);
+    List<AlterationCountByGene> getTotalProfiledCounts(StudyViewFilterHelper studyViewFilterHelper, String alterationType, String specificHugoGeneSymbol);
     
     int getFilteredSamplesCount(@Param("studyViewFilterHelper") StudyViewFilterHelper studyViewFilterHelper);
     
-    List<GenePanelToGene> getMatchingGenePanelIds(StudyViewFilterHelper studyViewFilterHelper, String alterationType);
+    List<GenePanelToGene> getMatchingGenePanelIds(StudyViewFilterHelper studyViewFilterHelper, String alterationType, String specificHugoGeneSymbol);
     
     int getTotalProfiledCountByAlterationType(StudyViewFilterHelper studyViewFilterHelper, String alterationType);
     
@@ -62,4 +62,6 @@ public interface StudyViewMapper {
     List<GenomicDataCountItem> getCNACounts(StudyViewFilterHelper studyViewFilterHelper, List<GenomicDataFilter> genomicDataFilters);
 
     List<GenomicDataCountItem> getMutationCountsByType(StudyViewFilterHelper studyViewFilterHelper, List<GenomicDataFilter> genomicDataFilters);
+
+    AlterationCountByGene getMutatedGene(StudyViewFilterHelper studyViewFilterHelper, AlterationFilterHelper alterationFilterHelper, String specificHugoGeneSymbol);
 }

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.java
@@ -19,7 +19,6 @@ import org.cbioportal.persistence.helper.StudyViewFilterHelper;
 import org.cbioportal.web.parameter.GenomicDataFilter;
 
 import java.util.List;
-import java.util.Map;
 
 
 public interface StudyViewMapper {
@@ -61,8 +60,6 @@ public interface StudyViewMapper {
     int getTotalSampleTreatmentCounts(@Param("studyViewFilterHelper") StudyViewFilterHelper studyViewFilterHelper);
 
     List<GenomicDataCountItem> getCNACounts(StudyViewFilterHelper studyViewFilterHelper, List<GenomicDataFilter> genomicDataFilters);
-
-    Map<String, Integer> getMutationCounts(StudyViewFilterHelper studyViewFilterHelper, GenomicDataFilter genomicDataFilter);
 
     List<GenomicDataCountItem> getMutationCountsByType(StudyViewFilterHelper studyViewFilterHelper, List<GenomicDataFilter> genomicDataFilters);
 }

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.java
@@ -26,7 +26,7 @@ public interface StudyViewMapper {
 
     List<GenomicDataCount> getMolecularProfileSampleCounts(@Param("studyViewFilterHelper") StudyViewFilterHelper studyViewFilterHelper);
     
-    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterHelper studyViewFilterHelper, AlterationFilterHelper alterationFilterHelper, String specificHugoGeneSymbol);
+    List<AlterationCountByGene> getMutatedGenes(StudyViewFilterHelper studyViewFilterHelper, AlterationFilterHelper alterationFilterHelper, List<String> hugoGeneSymbols);
     
     List<CopyNumberCountByGene> getCnaGenes(StudyViewFilterHelper studyViewFilterHelper, AlterationFilterHelper alterationFilterHelper);
 
@@ -42,11 +42,11 @@ public interface StudyViewMapper {
     
     List<ClinicalData> getPatientClinicalDataFromStudyViewFilter(StudyViewFilterHelper studyViewFilterHelper, List<String> attributeIds);
     
-    List<AlterationCountByGene> getTotalProfiledCounts(StudyViewFilterHelper studyViewFilterHelper, String alterationType, String specificHugoGeneSymbol);
+    List<AlterationCountByGene> getTotalProfiledCounts(StudyViewFilterHelper studyViewFilterHelper, String alterationType, List<String> hugoGeneSymbols);
     
     int getFilteredSamplesCount(@Param("studyViewFilterHelper") StudyViewFilterHelper studyViewFilterHelper);
     
-    List<GenePanelToGene> getMatchingGenePanelIds(StudyViewFilterHelper studyViewFilterHelper, String alterationType, String specificHugoGeneSymbol);
+    List<GenePanelToGene> getMatchingGenePanelIds(StudyViewFilterHelper studyViewFilterHelper, String alterationType, List<String> hugoGeneSymbols);
     
     int getTotalProfiledCountByAlterationType(StudyViewFilterHelper studyViewFilterHelper, String alterationType);
     

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
@@ -218,11 +218,6 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
 
         return mapper.getCNACounts(createStudyViewFilterHelper(studyViewFilterContext), genomicDataFilters);
     }
-
-    public Map<String, Integer> getMutationCounts(StudyViewFilterContext studyViewFilterContext, GenomicDataFilter genomicDataFilter) {
-
-        return mapper.getMutationCounts(createStudyViewFilterHelper(studyViewFilterContext), genomicDataFilter);
-    }
     
     public List<GenomicDataCountItem> getMutationCountsByType(StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters) {
 

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
@@ -50,9 +50,15 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     }
     
     @Override
-    public List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, String specificHugoGeneSymbol) {
+    public List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext) {
         return mapper.getMutatedGenes(createStudyViewFilterHelper(studyViewFilterContext),
-            AlterationFilterHelper.build(studyViewFilterContext.studyViewFilter().getAlterationFilter()), specificHugoGeneSymbol);
+            AlterationFilterHelper.build(studyViewFilterContext.studyViewFilter().getAlterationFilter()), null);
+    }
+
+    @Override
+    public List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, List<String> hugoGeneSymbols) {
+        return mapper.getMutatedGenes(createStudyViewFilterHelper(studyViewFilterContext),
+            AlterationFilterHelper.build(studyViewFilterContext.studyViewFilter().getAlterationFilter()), hugoGeneSymbols);
     }
 
     @Override
@@ -142,10 +148,18 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     public List<ClinicalData> getPatientClinicalData(StudyViewFilterContext studyViewFilterContext, List<String> attributeIds) {
         return mapper.getPatientClinicalDataFromStudyViewFilter(createStudyViewFilterHelper(studyViewFilterContext), attributeIds);
     }
+
+    @Override
+    public Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType) {
+        return mapper.getTotalProfiledCounts(createStudyViewFilterHelper(studyViewFilterContext), alterationType, null)
+            .stream()
+            .collect(Collectors.groupingBy(AlterationCountByGene::getHugoGeneSymbol,
+                Collectors.mapping(AlterationCountByGene::getNumberOfProfiledCases, Collectors.summingInt(Integer::intValue))));
+    }
     
     @Override
-    public Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType, String specificHugoGeneSymbol) {
-        return mapper.getTotalProfiledCounts(createStudyViewFilterHelper(studyViewFilterContext), alterationType, specificHugoGeneSymbol)
+    public Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType, List<String> hugoGeneSymbols) {
+        return mapper.getTotalProfiledCounts(createStudyViewFilterHelper(studyViewFilterContext), alterationType, hugoGeneSymbols)
             .stream()
             .collect(Collectors.groupingBy(AlterationCountByGene::getHugoGeneSymbol,
                 Collectors.mapping(AlterationCountByGene::getNumberOfProfiledCases, Collectors.summingInt(Integer::intValue))));
@@ -157,8 +171,16 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     }
 
     @Override
-    public Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType, String specificHugoGeneSymbol) {
-        return mapper.getMatchingGenePanelIds(createStudyViewFilterHelper(studyViewFilterContext), alterationType, specificHugoGeneSymbol)
+    public Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType) {
+        return mapper.getMatchingGenePanelIds(createStudyViewFilterHelper(studyViewFilterContext), alterationType, null)
+            .stream()
+            .collect(Collectors.groupingBy(GenePanelToGene::getHugoGeneSymbol,
+                Collectors.mapping(GenePanelToGene::getGenePanelId, Collectors.toSet())));
+    }
+
+    @Override
+    public Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType, List<String> hugoGeneSymbols) {
+        return mapper.getMatchingGenePanelIds(createStudyViewFilterHelper(studyViewFilterContext), alterationType, hugoGeneSymbols)
             .stream()
             .collect(Collectors.groupingBy(GenePanelToGene::getHugoGeneSymbol,
                 Collectors.mapping(GenePanelToGene::getGenePanelId, Collectors.toSet())));
@@ -222,12 +244,6 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     public List<GenomicDataCountItem> getMutationCountsByType(StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters) {
 
         return mapper.getMutationCountsByType(createStudyViewFilterHelper(studyViewFilterContext), genomicDataFilters);
-    }
-
-    @Override
-    public AlterationCountByGene getMutatedGene(StudyViewFilterContext studyViewFilterContext, String specificHugoGeneSymbol) {
-        return mapper.getMutatedGene(createStudyViewFilterHelper(studyViewFilterContext),
-            AlterationFilterHelper.build(studyViewFilterContext.studyViewFilter().getAlterationFilter()), specificHugoGeneSymbol);
     }
 
 }

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
@@ -48,15 +48,9 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     public List<Sample> getFilteredSamples(StudyViewFilterContext studyViewFilterContext) {
         return mapper.getFilteredSamples(createStudyViewFilterHelper(studyViewFilterContext));
     }
-    
-    @Override
-    public List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext) {
-        return mapper.getMutatedGenes(createStudyViewFilterHelper(studyViewFilterContext),
-            AlterationFilterHelper.build(studyViewFilterContext.studyViewFilter().getAlterationFilter()), null);
-    }
 
     @Override
-    public List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, List<String> hugoGeneSymbols) {
+    public List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, String... hugoGeneSymbols) {
         return mapper.getMutatedGenes(createStudyViewFilterHelper(studyViewFilterContext),
             AlterationFilterHelper.build(studyViewFilterContext.studyViewFilter().getAlterationFilter()), hugoGeneSymbols);
     }
@@ -148,17 +142,9 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     public List<ClinicalData> getPatientClinicalData(StudyViewFilterContext studyViewFilterContext, List<String> attributeIds) {
         return mapper.getPatientClinicalDataFromStudyViewFilter(createStudyViewFilterHelper(studyViewFilterContext), attributeIds);
     }
-
-    @Override
-    public Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType) {
-        return mapper.getTotalProfiledCounts(createStudyViewFilterHelper(studyViewFilterContext), alterationType, null)
-            .stream()
-            .collect(Collectors.groupingBy(AlterationCountByGene::getHugoGeneSymbol,
-                Collectors.mapping(AlterationCountByGene::getNumberOfProfiledCases, Collectors.summingInt(Integer::intValue))));
-    }
     
     @Override
-    public Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType, List<String> hugoGeneSymbols) {
+    public Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType, String... hugoGeneSymbols) {
         return mapper.getTotalProfiledCounts(createStudyViewFilterHelper(studyViewFilterContext), alterationType, hugoGeneSymbols)
             .stream()
             .collect(Collectors.groupingBy(AlterationCountByGene::getHugoGeneSymbol,
@@ -171,15 +157,7 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     }
 
     @Override
-    public Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType) {
-        return mapper.getMatchingGenePanelIds(createStudyViewFilterHelper(studyViewFilterContext), alterationType, null)
-            .stream()
-            .collect(Collectors.groupingBy(GenePanelToGene::getHugoGeneSymbol,
-                Collectors.mapping(GenePanelToGene::getGenePanelId, Collectors.toSet())));
-    }
-
-    @Override
-    public Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType, List<String> hugoGeneSymbols) {
+    public Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType, String... hugoGeneSymbols) {
         return mapper.getMatchingGenePanelIds(createStudyViewFilterHelper(studyViewFilterContext), alterationType, hugoGeneSymbols)
             .stream()
             .collect(Collectors.groupingBy(GenePanelToGene::getHugoGeneSymbol,

--- a/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMyBatisRepository.java
@@ -50,9 +50,9 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     }
     
     @Override
-    public List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext) {
+    public List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, String specificHugoGeneSymbol) {
         return mapper.getMutatedGenes(createStudyViewFilterHelper(studyViewFilterContext),
-            AlterationFilterHelper.build(studyViewFilterContext.studyViewFilter().getAlterationFilter()));
+            AlterationFilterHelper.build(studyViewFilterContext.studyViewFilter().getAlterationFilter()), specificHugoGeneSymbol);
     }
 
     @Override
@@ -144,8 +144,8 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     }
     
     @Override
-    public Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType) {
-        return mapper.getTotalProfiledCounts(createStudyViewFilterHelper(studyViewFilterContext), alterationType)
+    public Map<String, Integer> getTotalProfiledCounts(StudyViewFilterContext studyViewFilterContext, String alterationType, String specificHugoGeneSymbol) {
+        return mapper.getTotalProfiledCounts(createStudyViewFilterHelper(studyViewFilterContext), alterationType, specificHugoGeneSymbol)
             .stream()
             .collect(Collectors.groupingBy(AlterationCountByGene::getHugoGeneSymbol,
                 Collectors.mapping(AlterationCountByGene::getNumberOfProfiledCases, Collectors.summingInt(Integer::intValue))));
@@ -157,8 +157,8 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     }
 
     @Override
-    public Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType) {
-        return mapper.getMatchingGenePanelIds(createStudyViewFilterHelper(studyViewFilterContext), alterationType)
+    public Map<String, Set<String>> getMatchingGenePanelIds(StudyViewFilterContext studyViewFilterContext, String alterationType, String specificHugoGeneSymbol) {
+        return mapper.getMatchingGenePanelIds(createStudyViewFilterHelper(studyViewFilterContext), alterationType, specificHugoGeneSymbol)
             .stream()
             .collect(Collectors.groupingBy(GenePanelToGene::getHugoGeneSymbol,
                 Collectors.mapping(GenePanelToGene::getGenePanelId, Collectors.toSet())));
@@ -222,6 +222,12 @@ public class StudyViewMyBatisRepository implements StudyViewRepository {
     public List<GenomicDataCountItem> getMutationCountsByType(StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters) {
 
         return mapper.getMutationCountsByType(createStudyViewFilterHelper(studyViewFilterContext), genomicDataFilters);
+    }
+
+    @Override
+    public AlterationCountByGene getMutatedGene(StudyViewFilterContext studyViewFilterContext, String specificHugoGeneSymbol) {
+        return mapper.getMutatedGene(createStudyViewFilterHelper(studyViewFilterContext),
+            AlterationFilterHelper.build(studyViewFilterContext.studyViewFilter().getAlterationFilter()), specificHugoGeneSymbol);
     }
 
 }

--- a/src/main/java/org/cbioportal/service/AlterationCountService.java
+++ b/src/main/java/org/cbioportal/service/AlterationCountService.java
@@ -84,4 +84,5 @@ public interface AlterationCountService {
     
     List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilterContext studyViewFilterContext);
     
+    AlterationCountByGene getMutatedGene(StudyViewFilterContext studyViewFilterContext, String specificHugoGeneSymbol);
 }

--- a/src/main/java/org/cbioportal/service/AlterationCountService.java
+++ b/src/main/java/org/cbioportal/service/AlterationCountService.java
@@ -83,7 +83,7 @@ public interface AlterationCountService {
     
     List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext);
 
-    Map<String, AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, List<String> hugoGeneSymbols); 
+    Map<String, AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, String[] hugoGeneSymbols); 
     
     List<CopyNumberCountByGene> getCnaGenes(StudyViewFilterContext studyViewFilterContext);
     

--- a/src/main/java/org/cbioportal/service/AlterationCountService.java
+++ b/src/main/java/org/cbioportal/service/AlterationCountService.java
@@ -1,14 +1,16 @@
 package org.cbioportal.service;
 
 import org.apache.commons.math3.util.Pair;
-import org.cbioportal.model.*;
+import org.cbioportal.model.AlterationCountByGene;
+import org.cbioportal.model.AlterationCountByStructuralVariant;
+import org.cbioportal.model.AlterationFilter;
+import org.cbioportal.model.CopyNumberCountByGene;
+import org.cbioportal.model.MolecularProfileCaseIdentifier;
+import org.cbioportal.model.StudyViewFilterContext;
 import org.cbioportal.model.util.Select;
-import org.cbioportal.web.parameter.CategorizedClinicalDataCountFilter;
-import org.cbioportal.web.parameter.CustomSampleIdentifier;
-import org.cbioportal.web.parameter.SampleIdentifier;
-import org.cbioportal.web.parameter.StudyViewFilter;
 
 import java.util.List;
+import java.util.Map;
 
 public interface AlterationCountService {
 
@@ -80,9 +82,10 @@ public interface AlterationCountService {
                                                                     AlterationFilter alterationFilter);
     
     List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext);
+
+    Map<String, AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, List<String> hugoGeneSymbols); 
+    
     List<CopyNumberCountByGene> getCnaGenes(StudyViewFilterContext studyViewFilterContext);
     
     List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilterContext studyViewFilterContext);
-    
-    AlterationCountByGene getMutatedGene(StudyViewFilterContext studyViewFilterContext, String specificHugoGeneSymbol);
 }

--- a/src/main/java/org/cbioportal/service/impl/AlterationCountServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/impl/AlterationCountServiceImpl.java
@@ -255,26 +255,26 @@ public class AlterationCountServiceImpl implements AlterationCountService {
     @Override
     public List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext) {
         var alterationCountByGenes = studyViewRepository.getMutatedGenes(studyViewFilterContext);
-        return populateAlterationCounts(alterationCountByGenes, studyViewFilterContext, AlterationType.MUTATION_EXTENDED, null);
+        return populateAlterationCounts(alterationCountByGenes, studyViewFilterContext, AlterationType.MUTATION_EXTENDED);
     }
     
     public List<CopyNumberCountByGene> getCnaGenes(StudyViewFilterContext studyViewFilterContext) {
         var copyNumberCountByGenes = studyViewRepository.getCnaGenes(studyViewFilterContext);
-        return populateAlterationCounts(copyNumberCountByGenes, studyViewFilterContext, AlterationType.COPY_NUMBER_ALTERATION, null);
+        return populateAlterationCounts(copyNumberCountByGenes, studyViewFilterContext, AlterationType.COPY_NUMBER_ALTERATION);
     }
 
     @Override
     public List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilterContext studyViewFilterContext) {
         var alterationCountByGenes = studyViewRepository.getStructuralVariantGenes(studyViewFilterContext);
-        return populateAlterationCounts(alterationCountByGenes, studyViewFilterContext, AlterationType.STRUCTURAL_VARIANT, null);
+        return populateAlterationCounts(alterationCountByGenes, studyViewFilterContext, AlterationType.STRUCTURAL_VARIANT);
     }
 
     private < T extends AlterationCountByGene> List<T> populateAlterationCounts(@NonNull List<T> alterationCounts,
                                                                                 @NonNull StudyViewFilterContext studyViewFilterContext,
-                                                                                @NonNull AlterationType alterationType, List<String> hugoGeneSymbols) {
+                                                                                @NonNull AlterationType alterationType, String... hugoGeneSymbols) {
         final int profiledCountWithoutGenePanelData = studyViewRepository.getTotalProfiledCountsByAlterationType(studyViewFilterContext, alterationType.toString());
-        var profiledCountsMap = hugoGeneSymbols == null ? studyViewRepository.getTotalProfiledCounts(studyViewFilterContext, alterationType.toString()) : studyViewRepository.getTotalProfiledCounts(studyViewFilterContext, alterationType.toString(), hugoGeneSymbols);
-        final var matchingGenePanelIdsMap = hugoGeneSymbols == null ? studyViewRepository.getMatchingGenePanelIds(studyViewFilterContext, alterationType.toString()) : studyViewRepository.getMatchingGenePanelIds(studyViewFilterContext, alterationType.toString(), hugoGeneSymbols);
+        var profiledCountsMap = studyViewRepository.getTotalProfiledCounts(studyViewFilterContext, alterationType.toString(), hugoGeneSymbols);
+        final var matchingGenePanelIdsMap = studyViewRepository.getMatchingGenePanelIds(studyViewFilterContext, alterationType.toString(), hugoGeneSymbols);
         final int sampleProfileCountWithoutGenePanelData = studyViewRepository.getSampleProfileCountWithoutPanelData(studyViewFilterContext, alterationType.toString());
 
         alterationCounts.parallelStream()
@@ -295,7 +295,7 @@ public class AlterationCountServiceImpl implements AlterationCountService {
     }
 
     @Override
-    public Map<String, AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, List<String> hugoGeneSymbols) {
+    public Map<String, AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext, String[] hugoGeneSymbols) {
         List<AlterationCountByGene> alterationCounts = studyViewRepository.getMutatedGenes(studyViewFilterContext, hugoGeneSymbols);
         List<AlterationCountByGene> alterationCountByGenes = populateAlterationCounts(alterationCounts, studyViewFilterContext, AlterationType.MUTATION_EXTENDED, hugoGeneSymbols);
         return alterationCountByGenes.stream()

--- a/src/main/java/org/cbioportal/service/impl/AlterationCountServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/impl/AlterationCountServiceImpl.java
@@ -254,27 +254,27 @@ public class AlterationCountServiceImpl implements AlterationCountService {
 
     @Override
     public List<AlterationCountByGene> getMutatedGenes(StudyViewFilterContext studyViewFilterContext) {
-        var alterationCountByGenes = studyViewRepository.getMutatedGenes(studyViewFilterContext);
-        return populateAlterationCounts(alterationCountByGenes, studyViewFilterContext, AlterationType.MUTATION_EXTENDED);
+        var alterationCountByGenes = studyViewRepository.getMutatedGenes(studyViewFilterContext, null);
+        return populateAlterationCounts(alterationCountByGenes, studyViewFilterContext, AlterationType.MUTATION_EXTENDED, null);
     }
     
     public List<CopyNumberCountByGene> getCnaGenes(StudyViewFilterContext studyViewFilterContext) {
         var copyNumberCountByGenes = studyViewRepository.getCnaGenes(studyViewFilterContext);
-        return populateAlterationCounts(copyNumberCountByGenes, studyViewFilterContext, AlterationType.COPY_NUMBER_ALTERATION);
+        return populateAlterationCounts(copyNumberCountByGenes, studyViewFilterContext, AlterationType.COPY_NUMBER_ALTERATION, null);
     }
 
     @Override
     public List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilterContext studyViewFilterContext) {
         var alterationCountByGenes = studyViewRepository.getStructuralVariantGenes(studyViewFilterContext);
-        return populateAlterationCounts(alterationCountByGenes, studyViewFilterContext, AlterationType.STRUCTURAL_VARIANT);
+        return populateAlterationCounts(alterationCountByGenes, studyViewFilterContext, AlterationType.STRUCTURAL_VARIANT, null);
     }
 
     private < T extends AlterationCountByGene> List<T> populateAlterationCounts(@NonNull List<T> alterationCounts,
                                                                                 @NonNull StudyViewFilterContext studyViewFilterContext,
-                                                                                @NonNull AlterationType alterationType) {
+                                                                                @NonNull AlterationType alterationType, String specificHugoGeneSymbol) {
         final int profiledCountWithoutGenePanelData = studyViewRepository.getTotalProfiledCountsByAlterationType(studyViewFilterContext, alterationType.toString());
-        var profiledCountsMap = studyViewRepository.getTotalProfiledCounts(studyViewFilterContext, alterationType.toString());
-        final var matchingGenePanelIdsMap = studyViewRepository.getMatchingGenePanelIds(studyViewFilterContext, alterationType.toString());
+        var profiledCountsMap = studyViewRepository.getTotalProfiledCounts(studyViewFilterContext, alterationType.toString(), specificHugoGeneSymbol);
+        final var matchingGenePanelIdsMap = studyViewRepository.getMatchingGenePanelIds(studyViewFilterContext, alterationType.toString(), specificHugoGeneSymbol);
         final int sampleProfileCountWithoutGenePanelData = studyViewRepository.getSampleProfileCountWithoutPanelData(studyViewFilterContext, alterationType.toString());
 
         alterationCounts.parallelStream()
@@ -294,6 +294,11 @@ public class AlterationCountServiceImpl implements AlterationCountService {
         return alterationCounts;
     }
 
+    @Override
+    public AlterationCountByGene getMutatedGene(StudyViewFilterContext studyViewFilterContext, String specificHugoGeneSymbol) {
+        List<AlterationCountByGene> alterationCountByGenes = studyViewRepository.getMutatedGenes(studyViewFilterContext, specificHugoGeneSymbol);
+        return populateAlterationCounts(alterationCountByGenes, studyViewFilterContext, AlterationType.MUTATION_EXTENDED, specificHugoGeneSymbol).getFirst();
+    }
     
     private boolean hasGenePanelData(@NonNull Set<String> matchingGenePanelIds) {
         return matchingGenePanelIds.contains(WHOLE_EXOME_SEQUENCING) 

--- a/src/main/java/org/cbioportal/service/impl/StudyViewColumnarServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/impl/StudyViewColumnarServiceImpl.java
@@ -134,12 +134,8 @@ public class StudyViewColumnarServiceImpl implements StudyViewColumnarService {
     public List<GenomicDataCountItem> getMutationCountsByGeneSpecific(StudyViewFilter studyViewFilter, List<GenomicDataFilter> genomicDataFilters) {
         List<GenomicDataCountItem> genomicDataCountItemList = new ArrayList<>();
         int totalCount = studyViewRepository.getFilteredSamplesCount(createContext(studyViewFilter));
-        List<AlterationCountByGene> alterationCountByGenes = alterationCountService.getMutatedGenes(createContext(studyViewFilter));
         for (GenomicDataFilter genomicDataFilter : genomicDataFilters) {
-            AlterationCountByGene filteredAlterationCount = alterationCountByGenes.stream()
-                .filter(g -> g.getHugoGeneSymbol().equals(genomicDataFilter.getHugoGeneSymbol()))
-                .findFirst()
-                .orElse(new AlterationCountByGene());
+            AlterationCountByGene filteredAlterationCount = alterationCountService.getMutatedGene(createContext(studyViewFilter), genomicDataFilter.getHugoGeneSymbol());
             int mutatedCount = filteredAlterationCount.getNumberOfAlteredCases();
             int profiledCount = filteredAlterationCount.getNumberOfProfiledCases();
             List<GenomicDataCount> genomicDataCountList = new ArrayList<>();

--- a/src/main/java/org/cbioportal/service/impl/StudyViewColumnarServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/impl/StudyViewColumnarServiceImpl.java
@@ -134,8 +134,12 @@ public class StudyViewColumnarServiceImpl implements StudyViewColumnarService {
     public List<GenomicDataCountItem> getMutationCountsByGeneSpecific(StudyViewFilter studyViewFilter, List<GenomicDataFilter> genomicDataFilters) {
         List<GenomicDataCountItem> genomicDataCountItemList = new ArrayList<>();
         int totalCount = studyViewRepository.getFilteredSamplesCount(createContext(studyViewFilter));
+        List<String> hugoGeneSymbols = genomicDataFilters.stream()
+            .map(GenomicDataFilter::getHugoGeneSymbol)
+            .toList();
+        Map<String, AlterationCountByGene> alterationCountByGenes = alterationCountService.getMutatedGenes(createContext(studyViewFilter), hugoGeneSymbols);
         for (GenomicDataFilter genomicDataFilter : genomicDataFilters) {
-            AlterationCountByGene filteredAlterationCount = alterationCountService.getMutatedGene(createContext(studyViewFilter), genomicDataFilter.getHugoGeneSymbol());
+            AlterationCountByGene filteredAlterationCount = alterationCountByGenes.getOrDefault(genomicDataFilter.getHugoGeneSymbol(), new AlterationCountByGene());
             int mutatedCount = filteredAlterationCount.getNumberOfAlteredCases();
             int profiledCount = filteredAlterationCount.getNumberOfProfiledCases();
             List<GenomicDataCount> genomicDataCountList = new ArrayList<>();

--- a/src/main/java/org/cbioportal/service/impl/StudyViewColumnarServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/impl/StudyViewColumnarServiceImpl.java
@@ -134,9 +134,9 @@ public class StudyViewColumnarServiceImpl implements StudyViewColumnarService {
     public List<GenomicDataCountItem> getMutationCountsByGeneSpecific(StudyViewFilter studyViewFilter, List<GenomicDataFilter> genomicDataFilters) {
         List<GenomicDataCountItem> genomicDataCountItemList = new ArrayList<>();
         int totalCount = studyViewRepository.getFilteredSamplesCount(createContext(studyViewFilter));
-        List<String> hugoGeneSymbols = genomicDataFilters.stream()
+        String[] hugoGeneSymbols = genomicDataFilters.stream()
             .map(GenomicDataFilter::getHugoGeneSymbol)
-            .toList();
+            .toArray(String[]::new);
         Map<String, AlterationCountByGene> alterationCountByGenes = alterationCountService.getMutatedGenes(createContext(studyViewFilter), hugoGeneSymbols);
         for (GenomicDataFilter genomicDataFilter : genomicDataFilters) {
             AlterationCountByGene filteredAlterationCount = alterationCountByGenes.getOrDefault(genomicDataFilter.getHugoGeneSymbol(), new AlterationCountByGene());

--- a/src/main/java/org/cbioportal/web/parameter/GenomicDataFilter.java
+++ b/src/main/java/org/cbioportal/web/parameter/GenomicDataFilter.java
@@ -6,6 +6,13 @@ public class GenomicDataFilter extends DataFilter implements Serializable {
     private String hugoGeneSymbol;
     private String profileType;
 
+    public GenomicDataFilter() {}
+    
+    public GenomicDataFilter(String hugoGeneSymbol, String profileType) {
+        this.hugoGeneSymbol = hugoGeneSymbol;
+        this.profileType = profileType;
+    }
+    
     public String getHugoGeneSymbol() {
         return hugoGeneSymbol;
     }

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -30,6 +30,9 @@
         FROM genomic_event_derived
         <where>
             variant_type = 'mutation' AND
+            <if test="specificHugoGeneSymbol != null">
+                hugo_gene_symbol = #{specificHugoGeneSymbol} AND
+            </if>
             <include refid="applyStudyViewFilter">
                 <property name="filter_type" value="'SAMPLE_ID_ONLY'"/>
             </include>
@@ -334,6 +337,9 @@
             INNER JOIN gene_panel_to_gene_derived gptg on stgp.gene_panel_id = gptg.gene_panel_id
         <where>
             stgp.alteration_type = '${alterationType}'
+            <if test="specificHugoGeneSymbol != null">
+                AND gptg.gene = #{specificHugoGeneSymbol}
+            </if>
             AND stgp.gene_panel_id != 'WES'
             AND
             <include refid="applyStudyViewFilter">
@@ -393,6 +399,9 @@
                     </include>
                 </where>
             )
+            <if test="specificHugoGeneSymbol != null">
+                AND gene = #{specificHugoGeneSymbol}
+            </if>
         </where>
         GROUP BY gene, gene_panel_id;
     </select>

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -30,8 +30,12 @@
         FROM genomic_event_derived
         <where>
             variant_type = 'mutation' AND
-            <if test="specificHugoGeneSymbol != null">
-                hugo_gene_symbol = #{specificHugoGeneSymbol} AND
+            <if test="hugoGeneSymbols != null">
+                hugo_gene_symbol IN
+                <foreach item="hugoGeneSymbol" collection="hugoGeneSymbols" open="(" separator="," close=")">
+                    #{hugoGeneSymbol}
+                </foreach>
+                AND
             </if>
             <include refid="applyStudyViewFilter">
                 <property name="filter_type" value="'SAMPLE_ID_ONLY'"/>
@@ -337,8 +341,11 @@
             INNER JOIN gene_panel_to_gene_derived gptg on stgp.gene_panel_id = gptg.gene_panel_id
         <where>
             stgp.alteration_type = '${alterationType}'
-            <if test="specificHugoGeneSymbol != null">
-                AND gptg.gene = #{specificHugoGeneSymbol}
+            <if test="hugoGeneSymbols != null">
+                AND gptg.gene IN
+                <foreach item="hugoGeneSymbol" collection="hugoGeneSymbols" open="(" separator="," close=")">
+                    #{hugoGeneSymbol}
+                </foreach>
             </if>
             AND stgp.gene_panel_id != 'WES'
             AND
@@ -399,8 +406,11 @@
                     </include>
                 </where>
             )
-            <if test="specificHugoGeneSymbol != null">
-                AND gene = #{specificHugoGeneSymbol}
+            <if test="hugoGeneSymbols != null">
+                AND gene IN
+                <foreach item="hugoGeneSymbol" collection="hugoGeneSymbols" open="(" separator="," close=")">
+                    #{hugoGeneSymbol}
+                </foreach>
             </if>
         </where>
         GROUP BY gene, gene_panel_id;

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -30,7 +30,7 @@
         FROM genomic_event_derived
         <where>
             variant_type = 'mutation' AND
-            <if test="hugoGeneSymbols != null">
+            <if test="hugoGeneSymbols != null and hugoGeneSymbols.length > 0">
                 hugo_gene_symbol IN
                 <foreach item="hugoGeneSymbol" collection="hugoGeneSymbols" open="(" separator="," close=")">
                     #{hugoGeneSymbol}
@@ -341,7 +341,7 @@
             INNER JOIN gene_panel_to_gene_derived gptg on stgp.gene_panel_id = gptg.gene_panel_id
         <where>
             stgp.alteration_type = '${alterationType}'
-            <if test="hugoGeneSymbols != null">
+            <if test="hugoGeneSymbols != null and hugoGeneSymbols.length > 0">
                 AND gptg.gene IN
                 <foreach item="hugoGeneSymbol" collection="hugoGeneSymbols" open="(" separator="," close=")">
                     #{hugoGeneSymbol}
@@ -406,7 +406,7 @@
                     </include>
                 </where>
             )
-            <if test="hugoGeneSymbols != null">
+            <if test="hugoGeneSymbols != null and hugoGeneSymbols.length > 0">
                 AND gene IN
                 <foreach item="hugoGeneSymbol" collection="hugoGeneSymbols" open="(" separator="," close=")">
                     #{hugoGeneSymbol}

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -268,28 +268,6 @@
         FROM cna_sum
     </select>
 
-    <!-- for /mutation-data-counts/fetch (returns GenomicDataCountItem objects) mutation counts pie chart part -->
-    <select id="getMutationCounts">
-        WITH profiled_count as (
-            SELECT count(distinct sgp.sample_unique_id)
-            FROM sample_to_gene_panel_derived sgp
-                JOIN gene_panel_to_gene_derived gpg ON sgp.gene_panel_id = gpg.gene_panel_id
-            WHERE sample_unique_id IN (<include refid="sampleUniqueIdsFromStudyViewFilter"/>)
-                AND gpg.gene = #{genomicDataFilter.hugoGeneSymbol}
-        ),
-        mutated_count as (
-            SELECT count(distinct sample_unique_id)
-            FROM genomic_event_derived
-            WHERE sample_unique_id IN (<include refid="sampleUniqueIdsFromStudyViewFilter"/>)
-                AND hugo_gene_symbol = #{genomicDataFilter.hugoGeneSymbol}
-                AND variant_type = 'mutation'
-        )
-        SELECT
-            cast((SELECT * FROM mutated_count) as INTEGER) as mutatedCount,
-            cast(((SELECT * FROM profiled_count) - (SELECT * FROM mutated_count)) as INTEGER) as notMutatedCount,
-            cast(((SELECT * FROM (<include refid="getTotalSampleCount"/>)) - (SELECT * FROM profiled_count)) as INTEGER) as notProfiledCount
-    </select>
-
     <!-- for /mutation-data-counts/fetch - (returns GenomicDataCountItem objects) mutation type counts table part-->
     <select id="getMutationCountsByType" resultMap="GenomicDataCountItemResultMap">
         SELECT

--- a/src/test/java/org/cbioportal/persistence/mybatisclickhouse/GenomicDataFilterTest.java
+++ b/src/test/java/org/cbioportal/persistence/mybatisclickhouse/GenomicDataFilterTest.java
@@ -1,0 +1,111 @@
+package org.cbioportal.persistence.mybatisclickhouse;
+
+import org.cbioportal.model.GenomicDataCount;
+import org.cbioportal.model.GenomicDataCountItem;
+import org.cbioportal.persistence.helper.StudyViewFilterHelper;
+import org.cbioportal.persistence.mybatisclickhouse.config.MyBatisConfig;
+import org.cbioportal.web.parameter.GenomicDataFilter;
+import org.cbioportal.web.parameter.StudyViewFilter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@Import(MyBatisConfig.class)
+@DataJpaTest
+@DirtiesContext
+@AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
+@ContextConfiguration(initializers = AbstractTestcontainers.Initializer.class)
+public class GenomicDataFilterTest extends AbstractTestcontainers {
+
+    private static final String STUDY_TCGA_PUB = "study_tcga_pub";
+    private static final String STUDY_ACC_TCGA = "acc_tcga";
+
+    @Autowired
+    private StudyViewMapper studyViewMapper;
+
+    @Test
+    public void getCNACounts() {
+        StudyViewFilter studyViewFilter = new StudyViewFilter();
+        studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
+
+        GenomicDataFilter genomicDataFilterCNA = new GenomicDataFilter("AKT1", "cna");
+        List<GenomicDataCountItem> actualCountsCNA = studyViewMapper.getCNACounts(StudyViewFilterHelper.build(studyViewFilter, null, null), List.of(genomicDataFilterCNA));
+        List<GenomicDataCountItem> expectedCountsCNA = List.of(
+            new GenomicDataCountItem("AKT1", "cna", List.of(
+                new GenomicDataCount("Homozygously deleted", "-2", 2),
+                new GenomicDataCount("Heterozygously deleted", "-1", 2),
+                new GenomicDataCount("Diploid", "0", 2),
+                new GenomicDataCount("Gained", "1", 2),
+                new GenomicDataCount("Amplified", "2", 2),
+                new GenomicDataCount("NA", "NA", 5)
+            )));
+        assertThat(actualCountsCNA)
+            .usingRecursiveComparison()
+            .ignoringCollectionOrder()
+            .isEqualTo(expectedCountsCNA);
+
+        GenomicDataFilter genomicDataFilterGISTIC = new GenomicDataFilter("AKT1", "gistic");
+        List<GenomicDataCountItem> actualCountsGISTIC = studyViewMapper.getCNACounts(StudyViewFilterHelper.build(studyViewFilter, null, null), List.of(genomicDataFilterGISTIC));
+        List<GenomicDataCountItem> expectedCountsGISTIC = List.of(
+            new GenomicDataCountItem("AKT1", "gistic", List.of(
+                new GenomicDataCount("Homozygously deleted", "-2", 2),
+                new GenomicDataCount("Heterozygously deleted", "-1", 3),
+                new GenomicDataCount("Diploid", "0", 3),
+                new GenomicDataCount("Gained", "1", 3),
+                new GenomicDataCount("Amplified", "2", 3),
+                new GenomicDataCount("NA", "NA", 1)
+            )));
+        assertThat(actualCountsGISTIC)
+            .usingRecursiveComparison()
+            .ignoringCollectionOrder()
+            .isEqualTo(expectedCountsGISTIC);
+    }
+    
+    @Test
+    public void getMutationCounts() {
+        StudyViewFilter studyViewFilter = new StudyViewFilter();
+        studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
+        
+        GenomicDataFilter genomicDataFilterMutation = new GenomicDataFilter("AKT1", "cna");
+        Map<String, Integer> actualMutationCounts = studyViewMapper.getMutationCounts(StudyViewFilterHelper.build(studyViewFilter, null, null), genomicDataFilterMutation);
+        Map<String, Integer> expectedMutationCounts = new HashMap<>();
+        expectedMutationCounts.put("mutatedCount", 2);
+        expectedMutationCounts.put("notMutatedCount", 2);
+        expectedMutationCounts.put("notProfiledCount", 11);
+        assertThat(actualMutationCounts)
+            .usingRecursiveComparison()
+            .ignoringCollectionOrder()
+            .isEqualTo(expectedMutationCounts);
+    }
+    
+    @Test
+    public void getMutationCountsByType() {
+        StudyViewFilter studyViewFilter = new StudyViewFilter();
+        studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
+
+        GenomicDataFilter genomicDataFilterMutation = new GenomicDataFilter("AKT1", "mutation");
+        List<GenomicDataCountItem> actualMutationCountsByType = studyViewMapper.getMutationCountsByType(StudyViewFilterHelper.build(studyViewFilter, null, null), List.of(genomicDataFilterMutation));
+        List<GenomicDataCountItem> expectedMutationCountsByType = List.of(
+            new GenomicDataCountItem("AKT1", "mutations", List.of(
+                new GenomicDataCount("nonsense mutation", "nonsense_mutation", 1, 1),
+                new GenomicDataCount("missense mutation", "missense_mutation", 1, 1)
+            )));
+        assertThat(actualMutationCountsByType)
+            .usingRecursiveComparison()
+            .ignoringCollectionOrder()
+            .isEqualTo(expectedMutationCountsByType);
+    }
+}

--- a/src/test/java/org/cbioportal/persistence/mybatisclickhouse/GenomicDataFilterTest.java
+++ b/src/test/java/org/cbioportal/persistence/mybatisclickhouse/GenomicDataFilterTest.java
@@ -16,9 +16,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,23 +70,6 @@ public class GenomicDataFilterTest extends AbstractTestcontainers {
             .usingRecursiveComparison()
             .ignoringCollectionOrder()
             .isEqualTo(expectedCountsGISTIC);
-    }
-    
-    @Test
-    public void getMutationCounts() {
-        StudyViewFilter studyViewFilter = new StudyViewFilter();
-        studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
-        
-        GenomicDataFilter genomicDataFilterMutation = new GenomicDataFilter("AKT1", "cna");
-        Map<String, Integer> actualMutationCounts = studyViewMapper.getMutationCounts(StudyViewFilterHelper.build(studyViewFilter, null, null), genomicDataFilterMutation);
-        Map<String, Integer> expectedMutationCounts = new HashMap<>();
-        expectedMutationCounts.put("mutatedCount", 2);
-        expectedMutationCounts.put("notMutatedCount", 2);
-        expectedMutationCounts.put("notProfiledCount", 11);
-        assertThat(actualMutationCounts)
-            .usingRecursiveComparison()
-            .ignoringCollectionOrder()
-            .isEqualTo(expectedMutationCounts);
     }
     
     @Test

--- a/src/test/java/org/cbioportal/persistence/mybatisclickhouse/GenomicDataFilterTest.java
+++ b/src/test/java/org/cbioportal/persistence/mybatisclickhouse/GenomicDataFilterTest.java
@@ -40,7 +40,7 @@ public class GenomicDataFilterTest extends AbstractTestcontainers {
         studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
 
         GenomicDataFilter genomicDataFilterCNA = new GenomicDataFilter("AKT1", "cna");
-        List<GenomicDataCountItem> actualCountsCNA = studyViewMapper.getCNACounts(StudyViewFilterHelper.build(studyViewFilter, null, null), List.of(genomicDataFilterCNA));
+        List<GenomicDataCountItem> actualCountsCNA = studyViewMapper.getCNACounts(StudyViewFilterHelper.build(studyViewFilter, null), List.of(genomicDataFilterCNA));
         List<GenomicDataCountItem> expectedCountsCNA = List.of(
             new GenomicDataCountItem("AKT1", "cna", List.of(
                 new GenomicDataCount("Homozygously deleted", "-2", 2),
@@ -56,7 +56,7 @@ public class GenomicDataFilterTest extends AbstractTestcontainers {
             .isEqualTo(expectedCountsCNA);
 
         GenomicDataFilter genomicDataFilterGISTIC = new GenomicDataFilter("AKT1", "gistic");
-        List<GenomicDataCountItem> actualCountsGISTIC = studyViewMapper.getCNACounts(StudyViewFilterHelper.build(studyViewFilter, null, null), List.of(genomicDataFilterGISTIC));
+        List<GenomicDataCountItem> actualCountsGISTIC = studyViewMapper.getCNACounts(StudyViewFilterHelper.build(studyViewFilter, null), List.of(genomicDataFilterGISTIC));
         List<GenomicDataCountItem> expectedCountsGISTIC = List.of(
             new GenomicDataCountItem("AKT1", "gistic", List.of(
                 new GenomicDataCount("Homozygously deleted", "-2", 2),
@@ -78,7 +78,7 @@ public class GenomicDataFilterTest extends AbstractTestcontainers {
         studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
 
         GenomicDataFilter genomicDataFilterMutation = new GenomicDataFilter("AKT1", "mutation");
-        List<GenomicDataCountItem> actualMutationCountsByType = studyViewMapper.getMutationCountsByType(StudyViewFilterHelper.build(studyViewFilter, null, null), List.of(genomicDataFilterMutation));
+        List<GenomicDataCountItem> actualMutationCountsByType = studyViewMapper.getMutationCountsByType(StudyViewFilterHelper.build(studyViewFilter, null), List.of(genomicDataFilterMutation));
         List<GenomicDataCountItem> expectedMutationCountsByType = List.of(
             new GenomicDataCountItem("AKT1", "mutations", List.of(
                 new GenomicDataCount("nonsense mutation", "nonsense_mutation", 1, 1),

--- a/src/test/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapperTest.java
+++ b/src/test/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapperTest.java
@@ -65,7 +65,7 @@ public class StudyViewMapperTest extends AbstractTestcontainers {
             AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()));
         assertEquals(3, alterationCountByGenes.size());
 
-        var testBrca1AlterationCount = alterationCountByGenes.stream().filter(a -> Objects.equals(a.getHugoGeneSymbol(), "brca1")).findFirst();
+        var testBrca1AlterationCount = alterationCountByGenes.stream().filter(a -> Objects.equals(a.getHugoGeneSymbol(), "BRCA1")).findFirst();
         assert (testBrca1AlterationCount.isPresent());
         assertEquals(Integer.valueOf(5), testBrca1AlterationCount.get().getTotalCount());
     }
@@ -118,7 +118,7 @@ public class StudyViewMapperTest extends AbstractTestcontainers {
 
         assertEquals(3, totalProfiledCountsMap.size());
 
-        var akt2TotalProfiledCounts = totalProfiledCountsMap.stream().filter(c -> c.getHugoGeneSymbol().equals("akt2")).findFirst();
+        var akt2TotalProfiledCounts = totalProfiledCountsMap.stream().filter(c -> c.getHugoGeneSymbol().equals("AKT2")).findFirst();
         assertTrue(akt2TotalProfiledCounts.isPresent());
         assertEquals(4, akt2TotalProfiledCounts.get().getNumberOfProfiledCases().intValue());
     }

--- a/src/test/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapperTest.java
+++ b/src/test/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapperTest.java
@@ -62,7 +62,7 @@ public class StudyViewMapperTest extends AbstractTestcontainers {
         StudyViewFilter studyViewFilter = new StudyViewFilter();
         studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
         var alterationCountByGenes = studyViewMapper.getMutatedGenes(StudyViewFilterHelper.build(studyViewFilter, null),
-            AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()));
+            AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()), null);
         assertEquals(3, alterationCountByGenes.size());
 
         var testBrca1AlterationCount = alterationCountByGenes.stream().filter(a -> Objects.equals(a.getHugoGeneSymbol(), "BRCA1")).findFirst();
@@ -83,7 +83,7 @@ public class StudyViewMapperTest extends AbstractTestcontainers {
         alterationFilter.setMutationEventTypes(mutationEventTypeFilterMap);
 
         var alterationCountByGenes = studyViewMapper.getMutatedGenes(StudyViewFilterHelper.build(studyViewFilter, null),
-            AlterationFilterHelper.build(alterationFilter));
+            AlterationFilterHelper.build(alterationFilter), null);
         assertEquals(2, alterationCountByGenes.size());
 
         AlterationFilter onlyMutationStatusFilter = new AlterationFilter();
@@ -93,7 +93,7 @@ public class StudyViewMapperTest extends AbstractTestcontainers {
         onlyMutationStatusFilter.setIncludeUnknownStatus(true);
 
         var alterationCountByGenes1 = studyViewMapper.getMutatedGenes(StudyViewFilterHelper.build(studyViewFilter, null),
-            AlterationFilterHelper.build(onlyMutationStatusFilter));
+            AlterationFilterHelper.build(onlyMutationStatusFilter), null);
         assertEquals(1, alterationCountByGenes1.size());
 
         AlterationFilter mutationTypeAndStatusFilter = new AlterationFilter();
@@ -104,7 +104,7 @@ public class StudyViewMapperTest extends AbstractTestcontainers {
         mutationTypeAndStatusFilter.setIncludeUnknownStatus(true);
 
         var alterationCountByGenes2 = studyViewMapper.getMutatedGenes(StudyViewFilterHelper.build(studyViewFilter, null),
-            AlterationFilterHelper.build(onlyMutationStatusFilter));
+            AlterationFilterHelper.build(onlyMutationStatusFilter), null);
         assertEquals(1, alterationCountByGenes2.size());
     }
 
@@ -114,7 +114,7 @@ public class StudyViewMapperTest extends AbstractTestcontainers {
         studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
 
         var totalProfiledCountsMap = studyViewMapper.getTotalProfiledCounts(StudyViewFilterHelper.build(studyViewFilter, null),
-            "MUTATION_EXTENDED");
+            "MUTATION_EXTENDED", null);
 
         assertEquals(3, totalProfiledCountsMap.size());
 

--- a/src/test/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapperTest.java
+++ b/src/test/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapperTest.java
@@ -62,7 +62,7 @@ public class StudyViewMapperTest extends AbstractTestcontainers {
         StudyViewFilter studyViewFilter = new StudyViewFilter();
         studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
         var alterationCountByGenes = studyViewMapper.getMutatedGenes(StudyViewFilterHelper.build(studyViewFilter, null),
-            AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()), null);
+            AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()));
         assertEquals(3, alterationCountByGenes.size());
 
         var testBrca1AlterationCount = alterationCountByGenes.stream().filter(a -> Objects.equals(a.getHugoGeneSymbol(), "BRCA1")).findFirst();
@@ -83,7 +83,7 @@ public class StudyViewMapperTest extends AbstractTestcontainers {
         alterationFilter.setMutationEventTypes(mutationEventTypeFilterMap);
 
         var alterationCountByGenes = studyViewMapper.getMutatedGenes(StudyViewFilterHelper.build(studyViewFilter, null),
-            AlterationFilterHelper.build(alterationFilter), null);
+            AlterationFilterHelper.build(alterationFilter));
         assertEquals(2, alterationCountByGenes.size());
 
         AlterationFilter onlyMutationStatusFilter = new AlterationFilter();
@@ -93,7 +93,7 @@ public class StudyViewMapperTest extends AbstractTestcontainers {
         onlyMutationStatusFilter.setIncludeUnknownStatus(true);
 
         var alterationCountByGenes1 = studyViewMapper.getMutatedGenes(StudyViewFilterHelper.build(studyViewFilter, null),
-            AlterationFilterHelper.build(onlyMutationStatusFilter), null);
+            AlterationFilterHelper.build(onlyMutationStatusFilter));
         assertEquals(1, alterationCountByGenes1.size());
 
         AlterationFilter mutationTypeAndStatusFilter = new AlterationFilter();
@@ -104,7 +104,7 @@ public class StudyViewMapperTest extends AbstractTestcontainers {
         mutationTypeAndStatusFilter.setIncludeUnknownStatus(true);
 
         var alterationCountByGenes2 = studyViewMapper.getMutatedGenes(StudyViewFilterHelper.build(studyViewFilter, null),
-            AlterationFilterHelper.build(onlyMutationStatusFilter), null);
+            AlterationFilterHelper.build(onlyMutationStatusFilter));
         assertEquals(1, alterationCountByGenes2.size());
     }
 
@@ -114,7 +114,7 @@ public class StudyViewMapperTest extends AbstractTestcontainers {
         studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
 
         var totalProfiledCountsMap = studyViewMapper.getTotalProfiledCounts(StudyViewFilterHelper.build(studyViewFilter, null),
-            "MUTATION_EXTENDED", null);
+            "MUTATION_EXTENDED");
 
         assertEquals(3, totalProfiledCountsMap.size());
 

--- a/src/test/resources/clickhouse_data.sql
+++ b/src/test/resources/clickhouse_data.sql
@@ -34,32 +34,33 @@ insert into genetic_entity (id,entity_type,stable_id) values (20,'generic_assay'
 insert into genetic_entity (id,entity_type,stable_id) values (28,'generic_assay','mean_1');
 insert into genetic_entity (id,entity_type,stable_id) values (29,'generic_assay','mean_2');
 
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(207,'akt1',1,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(208,'akt2',2,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(10000,'akt3',3,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(369,'araf',4,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(472,'atm',5,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(673,'braf',6,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(672,'brca1',7,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(675,'brca2',8,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(3265,'hras',9,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(3845,'kras',10,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(4893,'nras',11,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(79501,'or4f5',12,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(148398,'samd11',13,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(26155,'noc2l',14,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(2064,'erbb2',15,'protein-coding');
-insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(2886,'grb7',16,'protein-coding');
-insert into cosmic_mutation (cosmic_mutation_id,protein_change,entrez_gene_id,count,keyword) values(3677745,'d45a',79501,1,'or4f5 d45 missense');
-insert into cosmic_mutation (cosmic_mutation_id,protein_change,entrez_gene_id,count,keyword) values(426644,'g145c',79501,1,'or4f5 g145 missense');
-insert into cosmic_mutation (cosmic_mutation_id,protein_change,entrez_gene_id,count,keyword) values(460103,'p23p',148398,1,'samd11 p23 silent');
-insert into cosmic_mutation (cosmic_mutation_id,protein_change,entrez_gene_id,count,keyword) values(4010395,'s146s',26155,1,'noc2l s146 silent');
-insert into cosmic_mutation (cosmic_mutation_id,protein_change,entrez_gene_id,count,keyword) values(1290240,'m1t',26155,1,'noc2l truncating');
-insert into cosmic_mutation (cosmic_mutation_id,protein_change,entrez_gene_id,count,keyword) values(4010425,'q197*',26155,1,'noc2l truncating');
+-- hugo_gene_symbol should be UPPERCASE
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(207,'AKT1',1,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(208,'AKT2',2,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(10000,'AKT3',3,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(369,'ARAF',4,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(472,'ATM',5,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(673,'BRAF',6,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(672,'BRCA1',7,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(675,'BRCA2',8,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(3265,'HRAS',9,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(3845,'KRAS',10,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(4893,'NRAS',11,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(79501,'OR4F5',12,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(148398,'SAMD11',13,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(26155,'NOC2L',14,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(2064,'ERBB2',15,'protein-coding');
+insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(2886,'GRB7',16,'protein-coding');
+insert into cosmic_mutation (cosmic_mutation_id,protein_change,entrez_gene_id,count,keyword) values(3677745,'d45a',79501,1,'OR4F5 d45 missense');
+insert into cosmic_mutation (cosmic_mutation_id,protein_change,entrez_gene_id,count,keyword) values(426644,'g145c',79501,1,'OR4F5 g145 missense');
+insert into cosmic_mutation (cosmic_mutation_id,protein_change,entrez_gene_id,count,keyword) values(460103,'p23p',148398,1,'SAMD11 p23 silent');
+insert into cosmic_mutation (cosmic_mutation_id,protein_change,entrez_gene_id,count,keyword) values(4010395,'s146s',26155,1,'NOC2L s146 silent');
+insert into cosmic_mutation (cosmic_mutation_id,protein_change,entrez_gene_id,count,keyword) values(1290240,'m1t',26155,1,'NOC2L truncating');
+insert into cosmic_mutation (cosmic_mutation_id,protein_change,entrez_gene_id,count,keyword) values(4010425,'q197*',26155,1,'NOC2L truncating');
 
 insert into gene_alias (entrez_gene_id,gene_alias) values (207,'akt alias');
 insert into gene_alias (entrez_gene_id,gene_alias) values (207,'akt alias2');
-insert into gene_alias (entrez_gene_id,gene_alias) values (675,'brca1 alias');
+insert into gene_alias (entrez_gene_id,gene_alias) values (675,'BRCA1 alias');
 
 insert into reference_genome_gene (entrez_gene_id,cytoband,start,end,chr,reference_genome_id) values(207,'14q32.33',105235686,105262088,14,1);
 insert into reference_genome_gene (entrez_gene_id,cytoband,start,end,chr,reference_genome_id) values(207,'14q32.33',104769349,104795751,14,2);
@@ -78,12 +79,14 @@ insert into genetic_profile (genetic_profile_id,stable_id,cancer_study_id,geneti
 insert into genetic_profile (genetic_profile_id,stable_id,cancer_study_id,genetic_alteration_type,datatype,name,description,show_profile_in_analysis_tab) values (9,'study_tcga_pub_gsva_scores',1,'geneset_score','gsva-score','gsva scores','gsva scores for oncogenic signature gene sets from msigdb calculated with gsva version 1.22.4, r version 3.3.2.',1);
 insert into genetic_profile (genetic_profile_id,stable_id,cancer_study_id,genetic_alteration_type,datatype,name,description,show_profile_in_analysis_tab,generic_assay_type) values (11,'study_tcga_pub_treatment_ic50',1,'generic_assay','ic50','treatment ic50 values','treatment response ic50 values',1,'treatment_response');
 insert into genetic_profile (genetic_profile_id,stable_id,cancer_study_id,genetic_alteration_type,datatype,name,description,show_profile_in_analysis_tab,generic_assay_type) values (12,'study_tcga_pub_mutational_signature',1,'generic_assay','limit-value','mutational_signature values','mutational_signature values',1,'mutational_signature');
+insert into genetic_profile (genetic_profile_id,stable_id,cancer_study_id,genetic_alteration_type,datatype,name,description,show_profile_in_analysis_tab) values (14,'study_tcga_pub_cna',1,'COPY_NUMBER_ALTERATION','discrete','Copy-number alterations','Copy number alterations (amplifications and deletions) from targeted sequencing.',1);
 
 insert into genetic_profile_samples (genetic_profile_id,ordered_sample_list) values (2,'1,2,3,4,5,6,7,8,9,10,11,12,13,14,');
 insert into genetic_profile_samples (genetic_profile_id,ordered_sample_list) values (3,'2,3,6,8,9,10,12,13,');
 insert into genetic_profile_samples (genetic_profile_id,ordered_sample_list) values (4,'1,2,3,4,5,6,7,8,9,10,11,12,13,14,');
 insert into genetic_profile_samples (genetic_profile_id,ordered_sample_list) values (5,'2,');
 insert into genetic_profile_samples (genetic_profile_id,ordered_sample_list) values (11,'1,2,3,4,5,6,7,8,9,10,11,12,13,14,');
+insert into genetic_profile_samples (genetic_profile_id,ordered_sample_list) values (14,'1,2,3,4,5,6,7,8,9,10,11,12,');
 
 insert into patient (internal_id,stable_id,cancer_study_id) values (1,'tcga-a1-a0sb',1);
 insert into patient (internal_id,stable_id,cancer_study_id) values (2,'tcga-a1-a0sd',1);
@@ -173,12 +176,12 @@ insert into sample (internal_id,stable_id,sample_type,patient_id) values (322,'G
 insert into sample (internal_id,stable_id,sample_type,patient_id) values (323,'GENIE-TEST-323-01','primary solid tumor',323);
 
 
-insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (2038,672,'17',41244748,41244748,'g','a','q934*','nonsense_mutation','37','+','snp','rs80357223','unknown','nm_007294','c.(2800-2802)cag>tag','p38398',934,934,1,'brca1 truncating');
-insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (22604,672,'17',41258504,41258504,'a','c','c61g','missense_mutation','37','+','snp','rs28897672','bycluster','nm_007294','c.(181-183)tgt>ggt','p38398',61,61,1,'brca1 c61 missense');
-insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (2039,672,'17',41276033,41276033,'c','t','c27_splice','splice_site','37','+','snp','rs80358010','bycluster','nm_007294','c.e2+1','na',-1,-1,1,'brca1 truncating');
-insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (2040,207,'17',41244748,41244748,'g','a','q934*','nonsense_mutation','37','+','snp','rs80357223','unknown','nm_007294','c.(2800-2802)cag>tag','p38398',934,934,1,'brca1 truncating');
-insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (2041,207,'17',41258504,41258504,'a','c','c61g','missense_mutation','37','+','snp','rs28897672','bycluster','nm_007294','c.(181-183)tgt>ggt','p38398',61,61,1,'brca1 c61 missense');
-insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (2042,208,'17',41276033,41276033,'c','t','c27_splice','splice_site','37','+','snp','rs80358010','bycluster','nm_007294','c.e2+1','na',-1,-1,1,'brca1 truncating');
+insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (2038,672,'17',41244748,41244748,'g','a','q934*','nonsense_mutation','37','+','snp','rs80357223','unknown','nm_007294','c.(2800-2802)cag>tag','p38398',934,934,1,'BRCA1 truncating');
+insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (22604,672,'17',41258504,41258504,'a','c','c61g','missense_mutation','37','+','snp','rs28897672','bycluster','nm_007294','c.(181-183)tgt>ggt','p38398',61,61,1,'BRCA1 c61 missense');
+insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (2039,672,'17',41276033,41276033,'c','t','c27_splice','splice_site','37','+','snp','rs80358010','bycluster','nm_007294','c.e2+1','na',-1,-1,1,'BRCA1 truncating');
+insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (2040,207,'17',41244748,41244748,'g','a','q934*','nonsense_mutation','37','+','snp','rs80357223','unknown','nm_007294','c.(2800-2802)cag>tag','p38398',934,934,1,'BRCA1 truncating');
+insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (2041,207,'17',41258504,41258504,'a','c','c61g','missense_mutation','37','+','snp','rs28897672','bycluster','nm_007294','c.(181-183)tgt>ggt','p38398',61,61,1,'BRCA1 c61 missense');
+insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (2042,208,'17',41276033,41276033,'c','t','c27_splice','splice_site','37','+','snp','rs80358010','bycluster','nm_007294','c.e2+1','na',-1,-1,1,'BRCA1 truncating');
 
 insert into alteration_driver_annotation (alteration_event_id,genetic_profile_id,sample_id, driver_filter, driver_filter_annotation, driver_tiers_filter, driver_tiers_filter_annotation) values (2038,6,6, 'putative_driver', 'pathogenic', 'tier 1', 'highly actionable');
 insert into alteration_driver_annotation (alteration_event_id,genetic_profile_id,sample_id, driver_filter, driver_filter_annotation, driver_tiers_filter, driver_tiers_filter_annotation) values (22604,6,6, 'putative_passenger', 'pathogenic', 'tier 2', 'potentially actionable');
@@ -506,9 +509,9 @@ insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values
 insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(2078,'erg',27,'protein-coding');
 
 insert into structural_variant (genetic_profile_id,sample_id,site1_entrez_gene_id,site1_ensembl_transcript_id,site1_chromosome,site1_region,site1_region_number,site1_contig,site1_position,site1_description,site2_entrez_gene_id,site2_ensembl_transcript_id,site2_chromosome,site2_region,site2_region_number,site2_contig,site2_position,site2_description,ncbi_build,dna_support,rna_support,tumor_read_count,tumor_variant_count,annotation,event_info,comments,sv_status)
-values(7,1,57670,'enst00000242365','7','exon',-1,'q13.4',138536968,'kiaa1549-braf.k16b10.cosf509_1',673,'enst00000288602','7','exon',-1,'p13.1',140482957,'kiaa1549-braf.k16b10.cosf509_2','grch37','no','yes',100000,90000,'kiaa1549-braf.k16b10.cosf509','fusion','gain-of-function','SOMATIC');
+values(7,1,57670,'enst00000242365','7','exon',-1,'q13.4',138536968,'kiaa1549-BRAF.k16b10.cosf509_1',673,'enst00000288602','7','exon',-1,'p13.1',140482957,'kiaa1549-BRAF.k16b10.cosf509_2','grch37','no','yes',100000,90000,'kiaa1549-BRAF.k16b10.cosf509','fusion','gain-of-function','SOMATIC');
 insert into structural_variant (genetic_profile_id,sample_id,site1_entrez_gene_id,site1_ensembl_transcript_id,site1_chromosome,site1_region,site1_region_number,site1_contig,site1_position,site1_description,site2_entrez_gene_id,site2_ensembl_transcript_id,site2_chromosome,site2_region,site2_region_number,site2_contig,site2_position,site2_description,ncbi_build,dna_support,rna_support,tumor_read_count,tumor_variant_count,annotation,event_info,comments,sv_status)
-values(7,2,57670,'enst00000242365','7','exon',-1,'q13.4',138536968,'kiaa1549-braf.k16b10.cosf509_1',673,'enst00000288602','7','exon',-1,'p13.1',140482957,'kiaa1549-braf.k16b10.cosf509_2','grch37','no','yes',100000,90000,'kiaa1549-braf.k16b10.cosf509','fusion','gain-of-function','GERMLINE');
+values(7,2,57670,'enst00000242365','7','exon',-1,'q13.4',138536968,'kiaa1549-BRAF.k16b10.cosf509_1',673,'enst00000288602','7','exon',-1,'p13.1',140482957,'kiaa1549-BRAF.k16b10.cosf509_2','grch37','no','yes',100000,90000,'kiaa1549-BRAF.k16b10.cosf509','fusion','gain-of-function','GERMLINE');
 insert into structural_variant (genetic_profile_id,sample_id,site1_entrez_gene_id,site1_ensembl_transcript_id,site1_chromosome,site1_region,site1_region_number,site1_contig,site1_position,site1_description,site2_entrez_gene_id,site2_ensembl_transcript_id,site2_chromosome,site2_region,site2_region_number,site2_contig,site2_position,site2_description,ncbi_build,dna_support,rna_support,tumor_read_count,tumor_variant_count,annotation,event_info,comments,sv_status)
 values(7,1,8031,'enst00000344348','10','exon',-1,'q13.4',51582939,'ncoa4-ret.n7r12_1',5979,'enst00000340058','10','exon',-1,'p13.1',43612031,'ncoa4-ret.n7r12_2','grch37','no','yes',100001,80000,'ncoa4-ret.n7r1','fusion','gain-of-function','SOMATIC');
 insert into structural_variant (genetic_profile_id,sample_id,site1_entrez_gene_id,site1_ensembl_transcript_id,site1_chromosome,site1_region,site1_region_number,site1_contig,site1_position,site1_description,site2_entrez_gene_id,site2_ensembl_transcript_id,site2_chromosome,site2_region,site2_region_number,site2_contig,site2_position,site2_description,ncbi_build,dna_support,rna_support,tumor_read_count,tumor_variant_count,annotation,event_info,comments,sv_status)
@@ -518,9 +521,9 @@ values(7,2,27436,'enst00000318522','2','exon',-1,'q13.4',42492091,'eml4-alk.e6ba
 insert into structural_variant (genetic_profile_id,sample_id,site1_entrez_gene_id,site1_ensembl_transcript_id,site1_chromosome,site1_region,site1_region_number,site1_contig,site1_position,site1_description,site2_entrez_gene_id,site2_ensembl_transcript_id,site2_chromosome,site2_region,site2_region_number,site2_contig,site2_position,site2_description,ncbi_build,dna_support,rna_support,tumor_read_count,tumor_variant_count,annotation,event_info,comments,sv_status)
 values(7,1,7113,'enst00000332149','21','exon',-1,'q13.4',42880007,'tmprss2-erg.t1e2.cosf23.1_1',2078,'enst00000442448','21','exon',-1,'p13.1',39956869,'tmprss2-erg.t1e2.cosf23.1_2','grch37','no','yes',100003,60000,'tmprss2-erg.t1e2.cosf23.1','fusion','gain-of-function','SOMATIC');
 insert into structural_variant (genetic_profile_id,sample_id,site1_entrez_gene_id,site1_ensembl_transcript_id,site1_chromosome,site1_region,site1_region_number,site1_contig,site1_position,site1_description,site2_entrez_gene_id,site2_ensembl_transcript_id,site2_chromosome,site2_region,site2_region_number,site2_contig,site2_position,site2_description,ncbi_build,dna_support,rna_support,tumor_read_count,tumor_variant_count,annotation,event_info,comments,sv_status)
-values(7,2,57670,'enst00000242365','7','exon',-1,'q13.4',138536968,'kiaa1549-braf.k16b10.cosf509_1',673,'enst00000288602','7','exon',-1,'p13.1',140482957,'kiaa1549-braf.k16b10.cosf509_2','grch37','no','yes',100000,90000,'kiaa1549-braf.k16b10.cosf509','fusion','gain-of-function','SOMATIC');
+values(7,2,57670,'enst00000242365','7','exon',-1,'q13.4',138536968,'kiaa1549-BRAF.k16b10.cosf509_1',673,'enst00000288602','7','exon',-1,'p13.1',140482957,'kiaa1549-BRAF.k16b10.cosf509_2','grch37','no','yes',100000,90000,'kiaa1549-BRAF.k16b10.cosf509','fusion','gain-of-function','SOMATIC');
 insert into structural_variant (genetic_profile_id,sample_id,site1_entrez_gene_id,site1_ensembl_transcript_id,site1_chromosome,site1_region,site1_region_number,site1_contig,site1_position,site1_description,site2_entrez_gene_id,site2_ensembl_transcript_id,site2_chromosome,site2_region,site2_region_number,site2_contig,site2_position,site2_description,ncbi_build,dna_support,rna_support,tumor_read_count,tumor_variant_count,annotation,event_info,comments,sv_status)
-values(13,15,57670,'enst00000242365','7','exon',-1,'q13.4',138536968,'kiaa1549-braf.k16b10.cosf509_1',673,'enst00000288602','7','exon',-1,'p13.1',140482957,'kiaa1549-braf.k16b10.cosf509_2','grch37','no','yes',100000,90000,'kiaa1549-braf.k16b10.cosf509','fusion','gain-of-function','SOMATIC');
+values(13,15,57670,'enst00000242365','7','exon',-1,'q13.4',138536968,'kiaa1549-BRAF.k16b10.cosf509_1',673,'enst00000288602','7','exon',-1,'p13.1',140482957,'kiaa1549-BRAF.k16b10.cosf509_2','grch37','no','yes',100000,90000,'kiaa1549-BRAF.k16b10.cosf509','fusion','gain-of-function','SOMATIC');
 insert into structural_variant (genetic_profile_id,sample_id,site1_entrez_gene_id,site1_ensembl_transcript_id,site1_chromosome,site1_region,site1_region_number,site1_contig,site1_position,site1_description,site2_entrez_gene_id,site2_ensembl_transcript_id,site2_chromosome,site2_region,site2_region_number,site2_contig,site2_position,site2_description,ncbi_build,dna_support,rna_support,tumor_read_count,tumor_variant_count,annotation,event_info,comments,sv_status)
 values(13,15,8031,'enst00000344348','10','exon',-1,'q13.4',51582939,'ncoa4-ret.n7r12_1',5979,'enst00000340058','10','exon',-1,'p13.1',43612031,'ncoa4-ret.n7r12_2','grch37','no','yes',100001,80000,'ncoa4-ret.n7r1-2','fusion','gain-of-function','SOMATIC');
 insert into structural_variant (genetic_profile_id,sample_id,site1_entrez_gene_id,site1_ensembl_transcript_id,site1_chromosome,site1_region,site1_region_number,site1_contig,site1_position,site1_description,site2_entrez_gene_id,site2_ensembl_transcript_id,site2_chromosome,site2_region,site2_region_number,site2_contig,site2_position,site2_description,ncbi_build,dna_support,rna_support,tumor_read_count,tumor_variant_count,annotation,event_info,comments,sv_status)
@@ -539,8 +542,9 @@ values (5,7,2, 'putative_driver', 'pathogenic', 'class 3', 'highly actionable');
 insert into mut_sig (cancer_study_id,entrez_gene_id,rank,numbasescovered,nummutations,p_value,q_value) values (1,207,1,998421,17,0.00000315,0.00233);
 insert into mut_sig (cancer_study_id,entrez_gene_id,rank,numbasescovered,nummutations,p_value,q_value) values (1,208,2,3200341,351,0.000000012,0.00000000000212);
 
-insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (2,1,'-0.4674,-0.6270,-1.2266,-1.2479,-1.2262,0.6962,-0.3338,-0.1264,0.7559,-1.1267,-0.5893,-1.1546,-1.0027,-1.3157,');
-insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (2,2,'1.4146,-0.0662,-0.8585,-1.6576,-0.3552,-0.8306,0.8102,0.1146,0.3498,0.0349,0.4927,-0.8665,-0.4754,-0.7221,');
+-- gistic values (genetic_profile_id = 2) should only be {-2, -1, 0, 1, 2}
+insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (2,1,'-1,2,0,1,-2,2,-1,0,1,-2,2,0,1,-1,');
+insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (4,2,'1.4146,-0.0662,-0.8585,-1.6576,-0.3552,-0.8306,0.8102,0.1146,0.3498,0.0349,0.4927,-0.8665,-0.4754,-0.7221,');
 insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (3,2,'-0.8097,0.7360,-1.0225,-0.8922,0.7247,0.3537,1.2702,-0.1419,');
 
 insert into cna_event (cna_event_id,entrez_gene_id,alteration) values (1,207,-2);
@@ -605,11 +609,11 @@ insert into geneset_hierarchy_leaf (node_id,geneset_id) values (4,1);
 insert into geneset_hierarchy_leaf (node_id,geneset_id) values (4,2);
 insert into geneset_hierarchy_leaf (node_id,geneset_id) values (5,2);
 
-insert into mutation_count_by_keyword (genetic_profile_id,keyword,entrez_gene_id,keyword_count,gene_count) values (6, 'akt1 truncating', 207, 54, 64);
+insert into mutation_count_by_keyword (genetic_profile_id,keyword,entrez_gene_id,keyword_count,gene_count) values (6, 'AKT1 truncating', 207, 54, 64);
 insert into mutation_count_by_keyword (genetic_profile_id,keyword,entrez_gene_id,keyword_count,gene_count) values (6, null, 207, 21, 22);
-insert into mutation_count_by_keyword (genetic_profile_id,keyword,entrez_gene_id,keyword_count,gene_count) values (6, 'araf g1513 missense', 369, 1, 2);
-insert into mutation_count_by_keyword (genetic_profile_id,keyword,entrez_gene_id,keyword_count,gene_count) values (6, 'araf g1514 missense', 369, 4, 7);
-insert into mutation_count_by_keyword (genetic_profile_id,keyword,entrez_gene_id,keyword_count,gene_count) values (8, 'noc2l truncating', 26155, 1, 3);
+insert into mutation_count_by_keyword (genetic_profile_id,keyword,entrez_gene_id,keyword_count,gene_count) values (6, 'ARAF g1513 missense', 369, 1, 2);
+insert into mutation_count_by_keyword (genetic_profile_id,keyword,entrez_gene_id,keyword_count,gene_count) values (6, 'ARAF g1514 missense', 369, 4, 7);
+insert into mutation_count_by_keyword (genetic_profile_id,keyword,entrez_gene_id,keyword_count,gene_count) values (8, 'NOC2L truncating', 26155, 1, 3);
 
 
 -- treatment test data
@@ -634,3 +638,4 @@ insert into generic_entity_properties (id,genetic_entity_id,name,value) values (
 
 insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (12,28,'-0.0670,-0.6270,-1.2266,-1.2079,-1.2262,0.6962,-0.3338,-0.1260,0.7559,-1.1267,-0.5893,-1.1506,-1.0027,-1.3157,');
 insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (12,29,'1.0106,-0.0662,-0.8585,-1.6576,-0.3552,-0.8306,0.8102,0.1106,0.3098,0.0309,0.0927,-0.8665,-0.0750,-0.7221,');
+insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (14,1,'1,-1,NA,2,0,-2,1,NA,-1,0,2,-2,');


### PR DESCRIPTION
Fix cBioPortal/rfc80-team#38 and cBioPortal/rfc80-team#43

Describe changes proposed in this pull request:
- Add basic unit tests
- Overload mutatedGenes and populateAlterationCounts related methods to provide a way to query limited list of genes, thus fasten the speed of endpoint 'mutation-data-count'