### PR TITLE
Update News images for RFC87

### DIFF
--- a/docs/News.md
+++ b/docs/News.md
@@ -2,7 +2,9 @@
 
 *   **New feature** (_Windows users only_): The Group Comparison results can now be visualized in 3D with AVM, an interactive 3D visualization software tool with data shaping functions and integrated pathways. Read more on [AVM for cBioPortal](https://bit.ly/avm-cbioportal). 
     * **Note for private instances**: To enable this feature in private cBioPortal instances, please see [this instruction](https://docs.cbioportal.org/deployment/customization/application.properties-reference#add-custom-buttons-to-data-tables).
-![image](https://github.com/user-attachments/assets/4070d986-f337-433d-83e8-659cf1531238)
+  ![image](https://github.com/user-attachments/assets/4150368b-c38c-41f8-a1da-af8c3d79ebf1)
+  ![image](https://github.com/user-attachments/assets/bba1221d-e07a-460a-ac6e-774d737cdc30)
+
 
 
 ## July 29, 2024


### PR DESCRIPTION
Two updates to the existing news item:
- added image of visualization
- cropping data table image so easier to see location of button (especially in narrow panel)

Explanation: The original image was too subtle indicating where the new button was in the data table, and there was no display of the visualization. 

Note: The total real estate occupied by the images is actually the same, since the original image was cropped to be half the size.

# Screenshots

Original:
![News2-Old](https://github.com/user-attachments/assets/e8d4d619-b6e8-4f29-8573-f2fb5c905b0b)

New:
![News2-New](https://github.com/user-attachments/assets/5a096a2e-0003-45fb-810e-c49bf5cd70f5)

# Notify reviewers
@jjgao 