### PR TITLE
Set custom http header with elapsed time on all api endpoints

### DIFF
--- a/src/main/java/org/cbioportal/WebAppConfig.java
+++ b/src/main/java/org/cbioportal/WebAppConfig.java
@@ -2,6 +2,7 @@ package org.cbioportal;
 
 import java.util.List;
 
+import org.cbioportal.web.ExecuterTimeInterceptor;
 import org.cbioportal.web.util.InvolvedCancerStudyExtractorInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -12,6 +13,7 @@ import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.handler.WebRequestHandlerInterceptorAdapter;
 
 // TODO Consider creating separate DispatcherServlets as in the original web.xml
 // See: https://stackoverflow.com/a/30686733/11651683
@@ -74,6 +76,9 @@ public class WebAppConfig implements WebMvcConfigurer {
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(involvedCancerStudyExtractorInterceptor());
+        registry.addInterceptor(new WebRequestHandlerInterceptorAdapter(
+            new ExecuterTimeInterceptor()
+        )).addPathPatterns("/**");
 	}
 
 	@Override

--- a/src/main/java/org/cbioportal/web/ExecuterTimeInterceptor.java
+++ b/src/main/java/org/cbioportal/web/ExecuterTimeInterceptor.java
@@ -1,0 +1,27 @@
+package org.cbioportal.web;
+
+import org.springframework.ui.ModelMap;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.context.request.WebRequestInterceptor;
+
+public class ExecuterTimeInterceptor implements WebRequestInterceptor {
+    
+    @Override
+    public void postHandle(WebRequest webRequest, ModelMap modelMap) {
+        //unimplemented
+    }
+
+    @Override
+    public void afterCompletion(WebRequest webRequest, Exception e) {
+        //unimplemented
+    }
+
+    @Override
+    public void preHandle(WebRequest webRequest) {
+        
+            long startTime = System.currentTimeMillis();
+            webRequest.setAttribute("startTime", startTime, 0);
+        
+    }
+    
+}

--- a/src/main/java/org/cbioportal/web/GeneralControllerAdvice.java
+++ b/src/main/java/org/cbioportal/web/GeneralControllerAdvice.java
@@ -1,0 +1,28 @@
+package org.cbioportal.web;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@ControllerAdvice
+public class GeneralControllerAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType, Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
+        ServletServerHttpRequest servletServerRequest = (ServletServerHttpRequest) request;
+        long startTime = (long) servletServerRequest.getServletRequest().getAttribute("startTime");
+        long timeElapsed = System.currentTimeMillis() - startTime;
+        response.getHeaders().add("Elapsed-Time", String.valueOf(timeElapsed));
+        return body;
+    }
+}


### PR DESCRIPTION
Add http-header response with elapsed time processing request.  This allows frontend to report the actual performance without the complication of stalled requests due to browser request concurrency limits.