### PR TITLE
Add missing study view filters for clinical data binning

### DIFF
--- a/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
+++ b/src/main/java/org/cbioportal/web/util/StudyViewFilterUtil.java
@@ -246,9 +246,16 @@ public class StudyViewFilterUtil {
         return (
             filter != null &&
                 filter.getClinicalDataFilters() == null &&
+                filter.getClinicalEventFilters() == null &&
+                filter.getMutationDataFilters() == null &&
+                filter.getStructuralVariantFilters() == null &&
                 filter.getGeneFilters() == null &&
                 filter.getSampleTreatmentFilters() == null &&
                 filter.getPatientTreatmentFilters() == null &&
+                filter.getPatientTreatmentGroupFilters() == null &&
+                filter.getSampleTreatmentGroupFilters() == null &&
+                filter.getPatientTreatmentTargetFilters() == null &&
+                filter.getSampleTreatmentTargetFilters() == null &&
                 filter.getGenomicProfiles() == null &&
                 filter.getGenomicDataFilters() == null &&
                 filter.getGenericAssayDataFilters() == null &&


### PR DESCRIPTION
This is to fix a legacy issue where certain study view filters could be ignored when applying filters for clinical data binning 