### PR TITLE
Fix molecular-profile-sample-counts

### DIFF
--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -156,10 +156,10 @@
             JOIN sample_profile sp ON sd.internal_id = sp.sample_id
             JOIN genetic_profile gp ON sp.genetic_profile_id = gp.genetic_profile_id
         WHERE
-            <include refid="applyStudyViewFilter">
-                <property name="filter_type" value="'SAMPLE_ID_ONLY'"/>
-            </include>
+            sgp.sample_unique_id IN (<include refid="sampleUniqueIdsFromStudyViewFilter"/>)
             AND sgp.alteration_type = 'MUTATION_EXTENDED'
+            AND gp.genetic_alteration_type = 'MUTATION_EXTENDED'
+        GROUP BY gp.stable_id, gp.name, sgp.cancer_study_identifier
     </select>
 
     <!-- for /sample-lists-counts/fetch (returns CaseListDataCount) -->

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -137,14 +137,29 @@
             genetic_profile.name AS label,
             count(sample_profile.genetic_profile_id) AS count
         FROM sample_profile
-            LEFT JOIN sample_derived ON sample_profile.sample_id=sample_derived.internal_id
-            LEFT JOIN genetic_profile on sample_profile.genetic_profile_id = genetic_profile.genetic_profile_id
-         <where>
-                <include refid="applyStudyViewFilter">
-                    <property name="filter_type" value="'SAMPLE_ID_ONLY'"/>
-                </include>
+            JOIN sample_derived ON sample_profile.sample_id=sample_derived.internal_id
+            JOIN genetic_profile on sample_profile.genetic_profile_id = genetic_profile.genetic_profile_id
+        <where>
+            genetic_profile.genetic_alteration_type != 'MUTATION_EXTENDED' AND
+            <include refid="applyStudyViewFilter">
+                <property name="filter_type" value="'SAMPLE_ID_ONLY'"/>
+            </include>
         </where>
         GROUP BY genetic_profile.stable_id, genetic_profile.name, sample_derived.cancer_study_identifier
+        UNION ALL
+        SELECT
+            replaceOne(gp.stable_id, concat(sgp.cancer_study_identifier,'_'), '') AS value,
+            gp.name AS label,
+            count(distinct sgp.sample_unique_id) AS count
+        FROM sample_to_gene_panel_derived sgp
+            JOIN sample_derived sd ON sgp.sample_unique_id = sd.sample_unique_id
+            JOIN sample_profile sp ON sd.internal_id = sp.sample_id
+            JOIN genetic_profile gp ON sp.genetic_profile_id = gp.genetic_profile_id
+        WHERE
+            <include refid="applyStudyViewFilter">
+                <property name="filter_type" value="'SAMPLE_ID_ONLY'"/>
+            </include>
+            AND sgp.alteration_type = 'MUTATION_EXTENDED'
     </select>
 
     <!-- for /sample-lists-counts/fetch (returns CaseListDataCount) -->


### PR DESCRIPTION
Fix #11016 and #11046

Describe changes proposed in this pull request:
- Used another way to count profiled mutations inside `molecular-profile-sample-counts` endpoint SQL
- Changed LEFT JOINs to JOINs. Not sure if this will break anything.