### PR TITLE
Remove deprecated Jwt-related functionality, replace by a different library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,11 @@
             <version>${apache_httpclient.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>9.41.2</version>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
Fix #11062 

`org.springframework.security.jwt` is not usable since it does not handle valid tokens with `typ="at+jwt"`. Replaced with `nimbus-jose-jwt`. No new tests are needed since this just replaces one library with another: current test suite should be sufficient.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml