### PR TITLE
Add instructions for accessing frontend on localhost with a self-signed certificate

### DIFF
--- a/docs/development/Frontend-Setup-Guideline.md
+++ b/docs/development/Frontend-Setup-Guideline.md
@@ -1,0 +1,49 @@
+# Accessing Frontend on localhost with a Self-Signed Certificate
+
+When running the frontend locally with a self-signed SSL certificate, most browsers will block access to `https://localhost` due to security policies. To bypass this and open localhost with a self-signed certificate, follow these steps to start your browser in insecure mode.
+
+## Chrome (Insecure Mode)
+
+1. Open a terminal or command prompt.
+
+2. Start Chrome with the following command, which disables certificate checking and web security for the session:
+
+**For macOS or Linux:**
+   
+    google-chrome --ignore-certificate-errors --disable-web-security --user-data-dir=/tmp/temp-chrome-profile 
+
+    
+**For Windows:**
+
+    C:\ProgramFiles\Google\Chrome\Application\chrome.exe" --ignore-certificate-errors --disable-web-security --user-data-dir=C:\tmp\temp-chrome-profile 
+
+
+This command opens Chrome in a temporary profile with relaxed security settings, allowing access to https://localhost without SSL warnings.
+
+After testing, close the browser. Do not use this browser session for regular browsing as it is less secure.
+
+
+## Firefox (Disable Certificate Checking)
+ 1. Open Firefox and navigate to about:config in the address bar.
+
+ 2. Modify the following settings:
+
+    1. security.ssl.enable_ocsp_stapling → false
+
+    2. security.cert_pinning.enforcement_level → 0
+
+    3. network.stricttransportsecurity.preloadlist → false
+
+    After applying these changes, you can access https://localhost with a self-signed certificate.
+
+
+## Security Note
+Starting a browser in insecure mode or disabling certificate checks can expose you to risks. These methods should be used strictly for local development and testing purposes. Close the browser after testing and reopen it in normal mode for daily browsing.
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Fix #10947
 # changes
1) Added documentation to guide users on how to access the frontend on localhost with a self-signed certificate.
2) Included instructions for running Chrome in insecure mode on both macOS/Linux and Windows.
3) Added steps for disabling certificate checking in Firefox.
4) Provided a security note cautioning users to only use insecure browser modes for development purposes.
# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
