### PR TITLE
Re-apply caching to all study view service methods

### DIFF
--- a/src/main/java/org/cbioportal/service/impl/ClinicalDataDensityPlotServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/impl/ClinicalDataDensityPlotServiceImpl.java
@@ -9,6 +9,7 @@ import org.cbioportal.model.DensityPlotData;
 import org.cbioportal.service.ClinicalDataDensityPlotService;
 import org.cbioportal.web.columnar.StudyViewColumnStoreController;
 import org.cbioportal.web.util.DensityPlotParameters;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -18,8 +19,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+
 @Service
 public class ClinicalDataDensityPlotServiceImpl implements ClinicalDataDensityPlotService {
+
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public DensityPlotData getDensityPlotData(List<ClinicalData> sampleClinicalData, DensityPlotParameters densityPlotParameters) {
         DensityPlotData result = new DensityPlotData();

--- a/src/main/java/org/cbioportal/service/impl/StudyViewColumnarServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/impl/StudyViewColumnarServiceImpl.java
@@ -52,43 +52,75 @@ public class StudyViewColumnarServiceImpl implements StudyViewColumnarService {
         this.customDataFilterUtil = customDataFilterUtil;
     }
 
-    @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
+    // should  condition = "@cacheEnabledConfig.getEnabled() && #singleStudyUnfiltered" 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<Sample> getFilteredSamples(StudyViewFilter studyViewFilter) {
         
         return studyViewRepository.getFilteredSamples(createContext(studyViewFilter));
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<AlterationCountByGene> getMutatedGenes(StudyViewFilter studyViewFilter) throws StudyNotFoundException {
         return alterationCountService.getMutatedGenes(createContext(studyViewFilter));
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<GenomicDataCount> getMolecularProfileSampleCounts(StudyViewFilter studyViewFilter) {
         return studyViewRepository.getMolecularProfileSampleCounts(createContext(studyViewFilter));
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<ClinicalEventTypeCount> getClinicalEventTypeCounts(StudyViewFilter studyViewFilter) {
         return studyViewRepository.getClinicalEventTypeCounts(createContext(studyViewFilter));
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public PatientTreatmentReport getPatientTreatmentReport(StudyViewFilter studyViewFilter) {
         return treatmentCountReportService.getPatientTreatmentReport(createContext(studyViewFilter));
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public SampleTreatmentReport getSampleTreatmentReport(StudyViewFilter studyViewFilter) {
         return treatmentCountReportService.getSampleTreatmentReport(createContext(studyViewFilter));
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<ClinicalDataCountItem> getGenomicDataBinCounts(StudyViewFilter studyViewFilter, List<GenomicDataBinFilter> genomicDataBinFilters) {
         return generateDataCountItemsFromDataCounts(studyViewRepository.getGenomicDataBinCounts(createContext(studyViewFilter), genomicDataBinFilters));
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<ClinicalDataCountItem> getGenericAssayDataBinCounts(StudyViewFilter studyViewFilter, List<GenericAssayDataBinFilter> genericAssayDataBinFilters) {
         return generateDataCountItemsFromDataCounts(studyViewRepository.getGenericAssayDataBinCounts(createContext(studyViewFilter), genericAssayDataBinFilters));
@@ -98,16 +130,28 @@ public class StudyViewColumnarServiceImpl implements StudyViewColumnarService {
         return alterationCountService.getCnaGenes(createContext(studyViewFilter));
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<AlterationCountByGene> getStructuralVariantGenes(StudyViewFilter studyViewFilter) throws StudyNotFoundException {
         return alterationCountService.getStructuralVariantGenes(createContext(studyViewFilter));
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public Map<String, ClinicalDataType> getClinicalAttributeDatatypeMap() {
         return studyViewRepository.getClinicalAttributeDatatypeMap();
     }
-    
+
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<ClinicalDataCountItem> getClinicalDataCounts(StudyViewFilter studyViewFilter, List<String> filteredAttributes) {
         StudyViewFilterContext studyViewFilterContext = createContext(studyViewFilter);
@@ -123,6 +167,10 @@ public class StudyViewColumnarServiceImpl implements StudyViewColumnarService {
         );
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<CaseListDataCount> getCaseListDataCounts(StudyViewFilter studyViewFilter) {
         // the study view merges case lists by type across studies
@@ -130,27 +178,47 @@ public class StudyViewColumnarServiceImpl implements StudyViewColumnarService {
         var caseListDataCountsPerStudy = studyViewRepository.getCaseListDataCountsPerStudy(createContext(studyViewFilter));
         return mergeCaseListCounts(caseListDataCountsPerStudy);
     }
-    
+
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<ClinicalData> getPatientClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds) {
         return studyViewRepository.getPatientClinicalData(createContext(studyViewFilter), attributeIds);
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<ClinicalData> getSampleClinicalData(StudyViewFilter studyViewFilter, List<String> attributeIds) {
         return studyViewRepository.getSampleClinicalData(createContext(studyViewFilter), attributeIds);
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<GenomicDataCountItem> getCNACountsByGeneSpecific(StudyViewFilter studyViewFilter, List<GenomicDataFilter> genomicDataFilters) {
         return studyViewRepository.getCNACounts(createContext(studyViewFilter), genomicDataFilters);
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<GenericAssayDataCountItem> getGenericAssayDataCounts(StudyViewFilter studyViewFilter, List<GenericAssayDataFilter> genericAssayDataFilters) {
         return studyViewRepository.getGenericAssayDataCounts(createContext(studyViewFilter), genericAssayDataFilters);
     }
-
+    
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<GenomicDataCountItem> getMutationCountsByGeneSpecific(StudyViewFilter studyViewFilter, List<GenomicDataFilter> genomicDataFilters) {
         List<GenomicDataCountItem> genomicDataCountItemList = new ArrayList<>();
@@ -168,10 +236,15 @@ public class StudyViewColumnarServiceImpl implements StudyViewColumnarService {
         return genomicDataCountItemList;
     }
 
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     @Override
     public List<GenomicDataCountItem> getMutationTypeCountsByGeneSpecific(StudyViewFilter studyViewFilter, List<GenomicDataFilter> genomicDataFilters) {
         return studyViewRepository.getMutationCountsByType(createContext(studyViewFilter), genomicDataFilters);
     }
+    
     
     private StudyViewFilterContext createContext(StudyViewFilter studyViewFilter) {
         List<CustomSampleIdentifier> customSampleIdentifiers = customDataFilterUtil.extractCustomDataSamples(studyViewFilter);

--- a/src/main/java/org/cbioportal/service/impl/ViolinPlotServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/impl/ViolinPlotServiceImpl.java
@@ -5,6 +5,7 @@ import org.apache.commons.math3.analysis.function.Gaussian;
 import org.apache.commons.math3.stat.descriptive.rank.Percentile;
 import org.cbioportal.model.*;
 import org.cbioportal.service.ViolinPlotService;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -16,7 +17,11 @@ public class ViolinPlotServiceImpl implements ViolinPlotService {
     // If a row has less than this many points, do not compute a
     //  violin, because it doesn't make sense.
     static final int SHOW_ONLY_POINTS_THRESHOLD = 7;
-    
+
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     public ClinicalViolinPlotData getClinicalViolinPlotData(
         List<ClinicalData> sampleClinicalDataForViolinPlot,
         List<Sample> samplesForSampleCounts,

--- a/src/main/java/org/cbioportal/web/columnar/ClinicalDataBinner.java
+++ b/src/main/java/org/cbioportal/web/columnar/ClinicalDataBinner.java
@@ -14,6 +14,7 @@ import org.cbioportal.web.parameter.DataBinMethod;
 import org.cbioportal.web.parameter.StudyViewFilter;
 import org.cbioportal.web.util.DataBinner;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -41,7 +42,11 @@ public class ClinicalDataBinner {
             .flatMap(Collection::stream)
             .toList();
     }
-    
+
+    @Cacheable(
+        cacheResolver = "staticRepositoryCacheOneResolver",
+        condition = "@cacheEnabledConfig.getEnabled()"
+    )
     public List<ClinicalDataBin> fetchClinicalDataBinCounts(
         DataBinMethod dataBinMethod,
         ClinicalDataBinCountFilter dataBinCountFilter,


### PR DESCRIPTION
We want to renable caching for the new clickhouse endpoints.  This will make for very zippy initial load.   Ultimately we want to only cache UNFILTERED requests so as not to put EVERYthing in cache.  We need to work on the condition to detect that.