### PR TITLE
Fix a filtering issue with the violin plot patient data conversion

### DIFF
--- a/src/main/java/org/cbioportal/web/columnar/StudyViewColumnStoreController.java
+++ b/src/main/java/org/cbioportal/web/columnar/StudyViewColumnStoreController.java
@@ -362,11 +362,19 @@ public class StudyViewColumnStoreController {
         List<ClinicalData> patientClinicalDataList = filterNonEmptyClinicalData(
             studyViewColumnarService.getPatientClinicalData(interceptedStudyViewFilter, attributeIds)
         );
-
-        List<ClinicalData> combinedClinicalDataList = Stream.concat(
-            sampleClinicalDataList.stream(),
-            convertPatientClinicalDataToSampleClinicalData(patientClinicalDataList, filteredSamples).stream()
-        ).toList();
+        
+        List<ClinicalData> combinedClinicalDataList;
+        if (patientClinicalDataList.isEmpty()) {
+            combinedClinicalDataList = sampleClinicalDataList;
+        } else {
+            // fetch samples again without the numerical clinical data filter
+            List<Sample> samplesWithoutNumericalFilter = studyViewColumnarService.getFilteredSamples(interceptedStudyViewFilter); 
+            
+            combinedClinicalDataList = Stream.concat(
+                sampleClinicalDataList.stream(),
+                convertPatientClinicalDataToSampleClinicalData(patientClinicalDataList, samplesWithoutNumericalFilter).stream()
+            ).toList();
+        }
         
         // Only mutation count can use log scale
         boolean useLogScale = logScale && numericalAttributeId.equals("MUTATION_COUNT");

--- a/src/main/java/org/cbioportal/web/columnar/util/ClinicalDataViolinPlotUtil.java
+++ b/src/main/java/org/cbioportal/web/columnar/util/ClinicalDataViolinPlotUtil.java
@@ -18,11 +18,11 @@ public class ClinicalDataViolinPlotUtil {
     
     public static List<ClinicalData> convertPatientClinicalDataToSampleClinicalData(
         List<ClinicalData> patientClinicalDataList,
-        List<Sample> filteredSamples
+        List<Sample> samplesWithoutNumericalFilter
     ) {
         List<ClinicalData> sampleClinicalDataList = new ArrayList<>();
 
-        Map<String, Map<String, List<Sample>>> patientToSamples = filteredSamples
+        Map<String, Map<String, List<Sample>>> patientToSamples = samplesWithoutNumericalFilter
             .stream()
             .collect(Collectors.groupingBy(
                 s -> s.getCancerStudyIdentifier() + "_" + s.getPatientStableId(),


### PR DESCRIPTION
Use samples filtered without numerical clinical data filter when converting patient clinical data to sample clinical data