### PR TITLE
Fix integration test load local file

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cd ./data && ./init.sh && rm -rf ./studies/* && cd ../config && \
           cat $PORTAL_SOURCE_DIR/src/main/resources/application.properties | \
-              sed 's|spring.datasource.url=.*|spring.datasource.url=jdbc:mysql://cbioportal-database:3306/cbioportal?useSSL=false&allowLoadLocalInfile=true|' | \
+              sed 's|spring.datasource.url=.*|spring.datasource.url=jdbc:mysql://cbioportal-database:3306/cbioportal?useSSL=false\&allowLoadLocalInfile=true|' | \
               sed 's|spring.datasource.username=.*|spring.datasource.username=cbio_user|' | \
               sed 's|spring.datasource.password=.*|spring.datasource.password=somepassword|' \
               > application.properties

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cd ./data && ./init.sh && rm -rf ./studies/* && cd ../config && \
           cat $PORTAL_SOURCE_DIR/src/main/resources/application.properties | \
-              sed 's|spring.datasource.url=.*|spring.datasource.url=jdbc:mysql://cbioportal-database:3306/cbioportal?useSSL=false|' | \
+              sed 's|spring.datasource.url=.*|spring.datasource.url=jdbc:mysql://cbioportal-database:3306/cbioportal?useSSL=false&AllowLoadLocalInfile=true|' | \
               sed 's|spring.datasource.username=.*|spring.datasource.username=cbio_user|' | \
               sed 's|spring.datasource.password=.*|spring.datasource.password=somepassword|' \
               > application.properties

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cd ./data && ./init.sh && rm -rf ./studies/* && cd ../config && \
           cat $PORTAL_SOURCE_DIR/src/main/resources/application.properties | \
-              sed 's|spring.datasource.url=.*|spring.datasource.url=jdbc:mysql://cbioportal-database:3306/cbioportal?useSSL=false&AllowLoadLocalInfile=true|' | \
+              sed 's|spring.datasource.url=.*|spring.datasource.url=jdbc:mysql://cbioportal-database:3306/cbioportal?useSSL=false&allowLoadLocalInfile=true|' | \
               sed 's|spring.datasource.username=.*|spring.datasource.username=cbio_user|' | \
               sed 's|spring.datasource.password=.*|spring.datasource.password=somepassword|' \
               > application.properties


### PR DESCRIPTION
Seeing this error in the integration tests:

https://github.com/cBioPortal/cbioportal/actions/runs/11519388647/job/32068264624#step:15:671

> java.lang.RuntimeException: org.mskcc.cbio.portal.dao.DaoException: Loading local data is disabled; this must be enabled on both the client and server sides

TODO: Enable loading of local files on the server side (maybe with `my.cnf` file in the cbioportal-docker-compose repo? See [docs](https://forums.docker.com/t/my-cnf-files-located-incorrectly-with-mysql-5-7-docker-image/129035))
