### PR TITLE
Fix broken violin plot tests

### DIFF
--- a/src/main/java/org/cbioportal/service/impl/ViolinPlotServiceImpl.java
+++ b/src/main/java/org/cbioportal/service/impl/ViolinPlotServiceImpl.java
@@ -39,11 +39,9 @@ public class ViolinPlotServiceImpl implements ViolinPlotService {
         result.setRows(new ArrayList<>());
         
         // collect filtered samples into a set for quick lookup
-        Set<String> samplesForSampleCountsIds = 
+        Set<Integer> samplesForSampleCountsIds =
             samplesForSampleCounts.stream()
-                .map(s -> s.getInternalId() == null ? 
-                    s.getCancerStudyIdentifier() + "_" + s.getStableId():  s.getInternalId().toString()
-                )
+                .map(Sample::getInternalId)
                 .collect(Collectors.toSet());
         
         // clinicalDataMap is a map sampleId->studyId->data
@@ -216,14 +214,12 @@ public class ViolinPlotServiceImpl implements ViolinPlotService {
     
     @SafeVarargs
     private static int countFilteredSamples(
-        Set<String> filteredSampleIds,
+        Set<Integer> filteredSampleIds,
         List<ClinicalData>... dataLists
     ) {
         return (int) Arrays.stream(dataLists)
             .flatMap(Collection::stream)
-            .map(c -> c.getInternalId() == null ? 
-                c.getStudyId() + "_" + c.getSampleId() : c.getInternalId().toString()
-            )
+            .map(ClinicalData::getInternalId)
             .filter(filteredSampleIds::contains)
             .count();
     }

--- a/src/main/resources/db-scripts/clickhouse/clickhouse.sql
+++ b/src/main/resources/db-scripts/clickhouse/clickhouse.sql
@@ -212,6 +212,7 @@ WHERE
 
 CREATE TABLE IF NOT EXISTS clinical_data_derived
 (
+    internal_id Int,
     sample_unique_id String,
     patient_unique_id String,
     attribute_name LowCardinality(String),
@@ -224,7 +225,8 @@ CREATE TABLE IF NOT EXISTS clinical_data_derived
 
 -- Insert sample attribute data
 INSERT INTO TABLE clinical_data_derived
-SELECT sm.sample_unique_id        AS sample_unique_id,
+SELECT sm.internal_id             AS internal_id,
+       sm.sample_unique_id        AS sample_unique_id,
        sm.patient_unique_id       AS patient_unique_id,
        cam.attr_id                AS attribute_name,
        ifNull(csamp.attr_value, '')          AS attribute_value,
@@ -241,10 +243,11 @@ WHERE cam.patient_attribute = 0;
 
 -- INSERT patient attribute data
 INSERT INTO TABLE clinical_data_derived
-SELECT ''                                                   AS sample_unique_id,
+SELECT p.internal_id                                        AS internal_id,
+       ''                                                   AS sample_unique_id,
        concat(cs.cancer_study_identifier, '_', p.stable_id) AS patient_unique_id,
        cam.attr_id                                          AS attribute_name,
-       ifNull(clinpat.attr_value, '')                                   AS attribute_value,
+       ifNull(clinpat.attr_value, '')                       AS attribute_value,
        cs.cancer_study_identifier                           AS cancer_study_identifier,
        'patient'                                            AS type
 FROM patient AS p

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -6,6 +6,7 @@
     <!-- for /filtered-sample/fetch (returns Sample objects) -->
     <select id="getFilteredSamples" resultType="org.cbioportal.model.Sample">
         SELECT
+            internal_id as internalId,
             patient_stable_id as patientStableId,
             sample_stable_id as stableId,
             cancer_study_identifier as cancerStudyIdentifier,
@@ -91,6 +92,7 @@
 
     <select id="getSampleClinicalDataFromStudyViewFilter" resultType="org.cbioportal.model.ClinicalData">
         SELECT
+            internal_id as internalId,
             replaceOne(sample_unique_id, concat(cancer_study_identifier, '_'), '') as sampleId,
             replaceOne(patient_unique_id, concat(cancer_study_identifier, '_'), '') as patientId,
             attribute_name as attrId,
@@ -113,6 +115,7 @@
 
     <select id="getPatientClinicalDataFromStudyViewFilter" resultType="org.cbioportal.model.ClinicalData">
         SELECT
+            internal_id as internalId,
             replaceOne(patient_unique_id, concat(cancer_study_identifier, '_'), '') as patientId,
             attribute_name as attrId,
             attribute_value as attrValue,


### PR DESCRIPTION
Test were broken because of a recent change.

https://github.com/cBioPortal/cbioportal/pull/11122/files#diff-56914186e87a454b648d8de091437680e98016b6eb40ad243063cf9794149799R44-R46

This PR reverts that change and adds internal id to the `Sample` and `ClinicalData` SQL queries instead.