### PR TITLE
Fix missing sample treatment counts

### DIFF
--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
@@ -200,12 +200,12 @@
                     ced.patient_unique_id AS patient_unique_id,
                     min(ced.start_date) AS time_taken,
                     ced.cancer_study_identifier AS cancer_study_identifier
-                    FROM clinical_event_derived ced
-                    <where>
-                        key = 'SAMPLE_ID'
-                        AND (event_type LIKE 'Sample Acquisition' OR event_type LIKE 'SPECIMEN')
-                    </where>
-                    GROUP BY patient_unique_id, ced.value, cancer_study_identifier
+                FROM clinical_event_derived ced
+                <where>
+                    key = 'SAMPLE_ID'
+                    AND (event_type ILIKE 'Sample Acquisition' OR event_type ILIKE 'SPECIMEN')
+                </where>
+                GROUP BY patient_unique_id, ced.value, cancer_study_identifier
             ) ced
             INNER JOIN (
             <!-- Nested sub query to grab all treatments group by patients-->

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -569,7 +569,7 @@
         FROM clinical_event_derived ced
         <where>
             AND key = 'SAMPLE_ID'
-            AND (event_type LIKE 'Sample Acquisition' OR event_type LIKE 'SPECIMEN')
+            AND (event_type ILIKE 'Sample Acquisition' OR event_type ILIKE 'SPECIMEN')
             AND
             concat(ced.cancer_study_identifier, '_', ced.value) IN ( <include refid="sampleUniqueIdsFromStudyViewFilter"/>)
             AND
@@ -608,7 +608,7 @@
             FROM clinical_event_derived ced
             <where>
                 key = 'SAMPLE_ID'
-                AND (event_type LIKE 'Sample Acquisition' OR event_type LIKE 'SPECIMEN')
+                AND (event_type ILIKE 'Sample Acquisition' OR event_type ILIKE 'SPECIMEN')
             </where>
             GROUP BY patient_unique_id, ced.value, cancer_study_identifier
         ),


### PR DESCRIPTION
Use case-insensitive `ILIKE` instead of case-sensitive `LIKE` when looking for `sample acquisition` and `specimen`

Fix #11129 
Fix #11134 