### PR TITLE
:lock: Update Default Filter Chain Ordering for Spring Security

### DIFF
--- a/src/main/java/org/cbioportal/security/config/ApiSecurityConfig.java
+++ b/src/main/java/org/cbioportal/security/config/ApiSecurityConfig.java
@@ -8,6 +8,8 @@ import org.cbioportal.utils.config.annotation.ConditionalOnProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -30,6 +32,7 @@ public class ApiSecurityConfig {
     // see: "Creating and Customizing Filter Chains" @ https://spring.io/guides/topicals/spring-security-architecture
 
     @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     public SecurityFilterChain securityFilterChain(HttpSecurity http, @Nullable DataAccessTokenService tokenService) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
             // This filter chain only grabs requests to the '/api' path.

--- a/src/main/java/org/cbioportal/security/config/OAuth2SecurityConfig.java
+++ b/src/main/java/org/cbioportal/security/config/OAuth2SecurityConfig.java
@@ -48,6 +48,7 @@ public class OAuth2SecurityConfig {
     private static final String LOGIN_URL = "/login";
 
     @Bean
+    @Order(1)
     public SecurityFilterChain filterChain(HttpSecurity http, ClientRegistrationRepository clientRegistrationRepository) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
             .cors(Customizer.withDefaults())


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/11156. Accessing via API token wasn't working because of a race condition. This forces an order. See related issue: https://github.com/spring-projects/spring-security/issues/15220 