### PR TITLE
Remove unused noauthsessionservice property

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This should open the ports. Now we are ready to run the cBioPortal web app local
 ```
 
 java -Xms2g -Xmx4g \
-     -Dauthenticate=noauthsessionservice \
+     -Dauthenticate=false \
      -Dsession.service.url=http://localhost:5000/api/sessions/my_portal/ \
      -Dsession.service.origin='*' \
      -Dspring.datasource.username=cbio_user \

--- a/docs/development/session-service-working.md
+++ b/docs/development/session-service-working.md
@@ -13,8 +13,6 @@
 Here are the properties that needs to be set
 
 ```
-WARNING: do not use session service with -Dauthenticate=false
- either use authentication or change to -Dauthenticate=noauthsessionservice
 session.service.url=
 #if basic authentication is enabled on session service one should set:
 session.service.user=

--- a/src/main/java/org/cbioportal/security/config/ApiSecurityConfig.java
+++ b/src/main/java/org/cbioportal/security/config/ApiSecurityConfig.java
@@ -23,7 +23,7 @@ import org.springframework.security.web.context.SecurityContextHolderFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
-@ConditionalOnProperty(name = "authenticate", havingValue = {"false", "noauthsessionservice", "optional_oauth2"}, isNot = true)
+@ConditionalOnProperty(name = "authenticate", havingValue = {"false", "optional_oauth2"}, isNot = true)
 public class ApiSecurityConfig {
 
     // Add security filter chains that handle calls to the API endpoints.


### PR DESCRIPTION
Fix #10799

Describe changes proposed in this pull request:
- Update README.md to use `-Dauthenticate=false`
- Remove `noauthsessionservice` from ApiSecurityConfig.java

**Note:**
The `noauthsessionservice` is still reference in `session-service-working.md` file https://github.com/cBioPortal/cbioportal/blob/master/docs/development/session-service-working.md#21-configuring-session-service. What would be the alternative property for `noauthsessionservice`?

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml
