### PR TITLE
Cast all data filter start and end values to float

### DIFF
--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
@@ -513,7 +513,7 @@
                                 <include refid="castStringValueToFloat">
                                     <property name="attribute_value" value="alteration_value"/>
                                 </include>,
-                                #{dataFilterValue.start}
+                                cast(#{dataFilterValue.start} as float)
                                 )
                                 ) &lt; exp(-11)
                             </when>
@@ -522,13 +522,13 @@
                                     AND
                                     <include refid="castStringValueToFloat">
                                         <property name="attribute_value" value="alteration_value"/>
-                                    </include> &gt; #{dataFilterValue.start}
+                                    </include> &gt; cast(#{dataFilterValue.start} as float)
                                 </if>
                                 <if test="dataFilterValue.end != null">
                                     AND
                                     <include refid="castStringValueToFloat">
                                         <property name="attribute_value" value="alteration_value"/>
-                                    </include> &lt;= #{dataFilterValue.end}
+                                    </include> &lt;= cast(#{dataFilterValue.end} as float)
                                 </if>
                             </otherwise>
                         </choose>
@@ -621,7 +621,7 @@
                                 <include refid="castStringValueToFloat">
                                     <property name="attribute_value" value="value"/>
                                 </include>,
-                                #{dataFilterValue.start}
+                                cast(#{dataFilterValue.start} as float)
                                 )
                                 ) &lt; exp(-11)
                             </when>
@@ -630,13 +630,13 @@
                                     AND
                                     <include refid="castStringValueToFloat">
                                         <property name="attribute_value" value="value"/>
-                                    </include> &gt; #{dataFilterValue.start}
+                                    </include> &gt; cast(#{dataFilterValue.start} as float)
                                 </if>
                                 <if test="dataFilterValue.end != null">
                                     AND
                                     <include refid="castStringValueToFloat">
                                         <property name="attribute_value" value="value"/>
-                                    </include> &lt;= #{dataFilterValue.end}
+                                    </include> &lt;= cast(#{dataFilterValue.end} as float)
                                 </if>
                             </otherwise>
                         </choose>


### PR DESCRIPTION
Fix #11197

TODO: `na` bin is still missing in the clickhouse response.

![image](https://github.com/user-attachments/assets/2f9ef024-b066-4f59-a3f8-345c10403219)

