### PR TITLE
Check for non-numerical values in numerical data count filter

### DIFF
--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
@@ -288,11 +288,8 @@
                     such as "UNKNOWN", "NOT COLLECTED", "NOT RELEASED", etc.
                 -->
                 <if test="dataFilterValue.value != null">
-                    AND (
-                    <include refid="normalizeAttributeValue">
-                        <property name="attribute_value" value="${attribute_value}"/>
-                    </include>
-                    ) ILIKE #{dataFilterValue.value}
+                    AND 
+                    ${attribute_value} ILIKE #{dataFilterValue.value}
                 </if>
                 <!--
                     Special case: Numerical range values such as <18, >=90, etc.
@@ -481,11 +478,7 @@
                         </include> = 'NA'
                     </when>
                     <otherwise>
-                        (
-                        <include refid="normalizeAttributeValue">
-                            <property name="attribute_value" value="attribute_value"/>
-                        </include>
-                        ) ILIKE #{dataFilterValue.value}
+                        attribute_value ILIKE #{dataFilterValue.value}
                     </otherwise>
                 </choose> 
             </foreach> 
@@ -612,11 +605,7 @@
                         </include> = 'NA'
                     </when>
                     <otherwise>
-                        (
-                        <include refid="normalizeAttributeValue">
-                            <property name="attribute_value" value="value"/>
-                        </include>
-                        ) ILIKE #{dataFilterValue.value}
+                        value ILIKE #{dataFilterValue.value}
                     </otherwise>
                 </choose>
             </foreach>

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
@@ -374,6 +374,13 @@
                         <property name="attribute_value" value="attribute_value"/>
                     </include>
                 </if>
+                <if test="dataFilterValue.value != null">
+                    AND (
+                    <include refid="normalizeAttributeValue">
+                        <property name="attribute_value" value="attribute_value"/>
+                    </include>
+                    ) ILIKE #{dataFilterValue.value}
+                </if>
                 <if test="dataFilterValue.start != null and dataFilterValue.end == null">
                     AND match(attribute_value, '^>?=?[-+]?[0-9]*[.,]?[0-9]+$')
                 </if>

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
@@ -272,6 +272,77 @@
         </foreach>
     </sql>
 
+    <sql id="applyNumericalDataFilter">
+        <foreach item="dataFilterValue" collection="${data_filter_collection}" open="((" separator=") OR (" close="))">
+            <trim prefix="" prefixOverrides="AND">
+                <!-- Special case: NA -->
+                <if test="dataFilterValue.value eq 'NA'">
+                    AND
+                    <include refid="isAttributeValueNA">
+                        <property name="attribute_value" value="${attribute_value}"/>
+                    </include>
+                </if>
+                <!--
+                    Special case: Non-numerical value within numerical filter collection.
+                    Even if the data type is numerical we can still have non-numerical values
+                    such as "UNKNOWN", "NOT COLLECTED", "NOT RELEASED", etc.
+                -->
+                <if test="dataFilterValue.value != null">
+                    AND (
+                    <include refid="normalizeAttributeValue">
+                        <property name="attribute_value" value="${attribute_value}"/>
+                    </include>
+                    ) ILIKE #{dataFilterValue.value}
+                </if>
+                <!--
+                    Special case: Numerical range values such as <18, >=90, etc.
+                    We need to make sure to treat these values as numerical for filtering purposes.
+                -->
+                <if test="dataFilterValue.start != null and dataFilterValue.end == null">
+                    AND match(${attribute_value}, '^>?=?[-+]?[0-9]*[.,]?[0-9]+$')
+                </if>
+                <if test="dataFilterValue.start == null and dataFilterValue.end != null">
+                    AND match(${attribute_value}, '^&lt;?=?[-+]?[0-9]*[.,]?[0-9]+$')
+                </if>
+                <if test="dataFilterValue.start != null and dataFilterValue.end != null">
+                    AND match(${attribute_value}, '^[-+]?[0-9]*[.,]?[0-9]+$')
+                </if>
+                <!--
+                    Actual filtering of values that fall within the range of (start, end].
+                    Note that start value is exclusive, but end value is inclusive.
+                -->
+                <if test="dataFilterValue.start != null or dataFilterValue.end != null">
+                    <choose>
+                        <when test="dataFilterValue.start == dataFilterValue.end">
+                            AND abs(
+                                minus(
+                                <include refid="castStringValueToFloat">
+                                    <property name="attribute_value" value="${attribute_value}"/>
+                                </include>,
+                                cast(#{dataFilterValue.start} as float)
+                                )
+                            ) &lt; exp(-11)
+                        </when>
+                        <otherwise>
+                            <if test="dataFilterValue.start != null">
+                                AND
+                                <include refid="castStringValueToFloat">
+                                    <property name="attribute_value" value="${attribute_value}"/>
+                                </include> &gt; cast(#{dataFilterValue.start} as float)
+                            </if>
+                            <if test="dataFilterValue.end != null">
+                                AND
+                                <include refid="castStringValueToFloat">
+                                    <property name="attribute_value" value="${attribute_value}"/>
+                                </include> &lt;= cast(#{dataFilterValue.end} as float)
+                            </if>
+                        </otherwise>
+                    </choose>
+                </if>
+            </trim>
+        </foreach>
+    </sql>
+    
     <sql id="applyClinicalDataCountFilter">
         <foreach item="clinicalDataFilter"
             collection="studyViewFilterHelper.studyViewFilter.clinicalDataFilters"
@@ -288,11 +359,11 @@
                         </include> 
                     </when>
                     <otherwise>
-                            <include refid="numericalClinicalDataCountFilter">
-                                <property name="unique_id" value="sample_unique_id"/>
-                                <property name="table_name" value="clinical_data_derived"/>
-                                <property name="type" value="sample"/>
-                            </include>
+                        <include refid="numericalClinicalDataCountFilter">
+                            <property name="unique_id" value="sample_unique_id"/>
+                            <property name="table_name" value="clinical_data_derived"/>
+                            <property name="type" value="sample"/>
+                        </include>
                     </otherwise>
                 </choose>
 
@@ -362,64 +433,15 @@
 
         <!-- if non-NA is selected, prepare non-NA samples -->
         <if test="userSelectsNumericalValue">
-        SELECT ${unique_id}
-        FROM ${table_name}
-        WHERE attribute_name = #{clinicalDataFilter.attributeId} AND
-        type='${type}'
-        <foreach item="dataFilterValue" collection="clinicalDataFilter.values" open=" AND ((" separator=") OR (" close="))">
-            <trim prefix="" prefixOverrides="AND">
-                <if test="dataFilterValue.value eq 'NA'">
-                    AND
-                    <include refid="isAttributeValueNA">
-                        <property name="attribute_value" value="attribute_value"/>
-                    </include>
-                </if>
-                <if test="dataFilterValue.value != null">
-                    AND (
-                    <include refid="normalizeAttributeValue">
-                        <property name="attribute_value" value="attribute_value"/>
-                    </include>
-                    ) ILIKE #{dataFilterValue.value}
-                </if>
-                <if test="dataFilterValue.start != null and dataFilterValue.end == null">
-                    AND match(attribute_value, '^>?=?[-+]?[0-9]*[.,]?[0-9]+$')
-                </if>
-                <if test="dataFilterValue.start == null and dataFilterValue.end != null">
-                    AND match(attribute_value, '^&lt;?=?[-+]?[0-9]*[.,]?[0-9]+$')
-                </if>
-                <if test="dataFilterValue.start != null and dataFilterValue.end != null">
-                    AND match(attribute_value, '^[-+]?[0-9]*[.,]?[0-9]+$')
-                </if>
-                <if test="dataFilterValue.start != null or dataFilterValue.end != null">
-                    <choose>
-                        <when test="dataFilterValue.start == dataFilterValue.end">
-                            AND abs(
-                                minus(
-                                    <include refid="castStringValueToFloat">
-                                        <property name="attribute_value" value="attribute_value"/>
-                                    </include>,
-                                    cast(#{dataFilterValue.start} as float)
-                                )
-                            ) &lt; exp(-11)
-                        </when>
-                        <otherwise>
-                            <if test="dataFilterValue.start != null">
-                                AND
-                                <include refid="castStringValueToFloat">
-                                    <property name="attribute_value" value="attribute_value"/>
-                                </include> &gt; cast(#{dataFilterValue.start} as float)
-                            </if>
-                            <if test="dataFilterValue.end != null">
-                                AND
-                                <include refid="castStringValueToFloat">
-                                    <property name="attribute_value" value="attribute_value"/>
-                                </include> &lt;= cast(#{dataFilterValue.end} as float)
-                            </if>
-                        </otherwise>
-                    </choose>
-                </if>
-            </trim>
-        </foreach>
+            SELECT ${unique_id}
+            FROM ${table_name}
+            WHERE attribute_name = #{clinicalDataFilter.attributeId} AND
+            type='${type}'
+            AND
+            <include refid="applyNumericalDataFilter">
+                <property name="attribute_value" value="attribute_value"/>
+                <property name="data_filter_collection" value="clinicalDataFilter.values"/>
+            </include>
         </if>
         )
     </sql>
@@ -501,47 +523,10 @@
             SELECT DISTINCT sample_unique_id
             FROM (<include refid="selectAllNumericalGeneticAlterations"/>) AS genomic_numerical_query
             WHERE
-            <foreach item="dataFilterValue" collection="genomicDataFilter.values" open="((" separator=") OR (" close="))">
-                <trim prefix="" prefixOverrides="AND">
-                    <if test="dataFilterValue.start != null and dataFilterValue.end == null">
-                        AND match(alteration_value, '^>?=?[-+]?[0-9]*[.,]?[0-9]+$')
-                    </if>
-                    <if test="dataFilterValue.start == null and dataFilterValue.end != null">
-                        AND match(alteration_value, '^&lt;?=?[-+]?[0-9]*[.,]?[0-9]+$')
-                    </if>
-                    <if test="dataFilterValue.start != null and dataFilterValue.end != null">
-                        AND match(alteration_value, '^[-+]?[0-9]*[.,]?[0-9]+$')
-                    </if>
-                    <if test="dataFilterValue.start != null or dataFilterValue.end != null">
-                        <choose>
-                            <when test="dataFilterValue.start == dataFilterValue.end">
-                                AND abs(
-                                minus(
-                                <include refid="castStringValueToFloat">
-                                    <property name="attribute_value" value="alteration_value"/>
-                                </include>,
-                                cast(#{dataFilterValue.start} as float)
-                                )
-                                ) &lt; exp(-11)
-                            </when>
-                            <otherwise>
-                                <if test="dataFilterValue.start != null">
-                                    AND
-                                    <include refid="castStringValueToFloat">
-                                        <property name="attribute_value" value="alteration_value"/>
-                                    </include> &gt; cast(#{dataFilterValue.start} as float)
-                                </if>
-                                <if test="dataFilterValue.end != null">
-                                    AND
-                                    <include refid="castStringValueToFloat">
-                                        <property name="attribute_value" value="alteration_value"/>
-                                    </include> &lt;= cast(#{dataFilterValue.end} as float)
-                                </if>
-                            </otherwise>
-                        </choose>
-                    </if>
-                </trim>
-            </foreach>
+            <include refid="applyNumericalDataFilter">
+                <property name="attribute_value" value="alteration_value"/>
+                <property name="data_filter_collection" value="genomicDataFilter.values"/>
+            </include>
         </if>
     </sql>
     
@@ -603,53 +588,11 @@
             <include refid="normalizeAttributeValue">
                 <property name="attribute_value" value="value"/>
             </include> != 'NA'
-            <foreach item="dataFilterValue" collection="genericAssayDataFilter.values" open=" AND ((" separator=") OR (" close="))">
-                <trim prefix="" prefixOverrides="AND">
-                    <if test="dataFilterValue.value eq 'NA'">
-                        AND
-                        <include refid="isAttributeValueNA">
-                            <property name="attribute_value" value="value"/>
-                        </include>
-                    </if>
-                    <if test="dataFilterValue.start != null and dataFilterValue.end == null">
-                        AND match(value, '^>?=?[-+]?[0-9]*[.,]?[0-9]+$')
-                    </if>
-                    <if test="dataFilterValue.start == null and dataFilterValue.end != null">
-                        AND match(value, '^&lt;?=?[-+]?[0-9]*[.,]?[0-9]+$')
-                    </if>
-                    <if test="dataFilterValue.start != null and dataFilterValue.end != null">
-                        AND match(value, '^[-+]?[0-9]*[.,]?[0-9]+$')
-                    </if>
-                    <if test="dataFilterValue.start != null or dataFilterValue.end != null">
-                        <choose>
-                            <when test="dataFilterValue.start == dataFilterValue.end">
-                                AND abs(
-                                minus(
-                                <include refid="castStringValueToFloat">
-                                    <property name="attribute_value" value="value"/>
-                                </include>,
-                                cast(#{dataFilterValue.start} as float)
-                                )
-                                ) &lt; exp(-11)
-                            </when>
-                            <otherwise>
-                                <if test="dataFilterValue.start != null">
-                                    AND
-                                    <include refid="castStringValueToFloat">
-                                        <property name="attribute_value" value="value"/>
-                                    </include> &gt; cast(#{dataFilterValue.start} as float)
-                                </if>
-                                <if test="dataFilterValue.end != null">
-                                    AND
-                                    <include refid="castStringValueToFloat">
-                                        <property name="attribute_value" value="value"/>
-                                    </include> &lt;= cast(#{dataFilterValue.end} as float)
-                                </if>
-                            </otherwise>
-                        </choose>
-                    </if>
-                </trim>
-            </foreach>
+            AND
+            <include refid="applyNumericalDataFilter">
+                <property name="attribute_value" value="value"/>
+                <property name="data_filter_collection" value="genericAssayDataFilter.values"/>
+            </include>
         </if>
     </sql>
     

--- a/src/test/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapperClinicalDataCountTest.java
+++ b/src/test/java/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapperClinicalDataCountTest.java
@@ -59,8 +59,8 @@ public class StudyViewMapperClinicalDataCountTest extends AbstractTestcontainers
         assertEquals(2, findClinicaDataCount(mutationsCounts, "4"));
         assertEquals(4, findClinicaDataCount(mutationsCounts, "2"));
         assertEquals(2, findClinicaDataCount(mutationsCounts, "1"));
-        // 1 empty string + 1 'NAN' + 11 samples with no data
-        assertEquals(13, findClinicaDataCount(mutationsCounts, "NA"));
+        // 1 empty string + 1 'NAN' + 12 samples with no data
+        assertEquals(14, findClinicaDataCount(mutationsCounts, "NA"));
     }
     
     @Test
@@ -87,8 +87,8 @@ public class StudyViewMapperClinicalDataCountTest extends AbstractTestcontainers
         assertEquals(1, findClinicaDataCount(categoricalClinicalDataCounts, "MDA"));
         assertEquals(1, findClinicaDataCount(categoricalClinicalDataCounts, "OHSU"));
         assertEquals(1, findClinicaDataCount(categoricalClinicalDataCounts, "UCSF"));
-        // 1 empty string + 1 'NA' + 11 samples with no data
-        assertEquals(13, findClinicaDataCount(categoricalClinicalDataCounts, "NA"));
+        // 1 empty string + 1 'NA' + 12 samples with no data
+        assertEquals(14, findClinicaDataCount(categoricalClinicalDataCounts, "NA"));
     }
 
     @Test
@@ -114,8 +114,8 @@ public class StudyViewMapperClinicalDataCountTest extends AbstractTestcontainers
         assertEquals(1, findClinicaDataCount(categoricalClinicalDataCounts, "NOT RELEASED"));
         assertEquals(1, findClinicaDataCount(categoricalClinicalDataCounts, "NOT COLLECTED"));
         assertEquals(1, findClinicaDataCount(categoricalClinicalDataCounts, "UNKNOWN"));
-        // 1 empty string + 1 'N/A' + 11 samples with no data
-        assertEquals(13, findClinicaDataCount(categoricalClinicalDataCounts, "NA"));
+        // 1 empty string + 1 'N/A' + 12 samples with no data
+        assertEquals(14, findClinicaDataCount(categoricalClinicalDataCounts, "NA"));
     }
 
     @Test
@@ -181,7 +181,7 @@ public class StudyViewMapperClinicalDataCountTest extends AbstractTestcontainers
     }
     
     private void assertAgeCounts(List<ClinicalDataCount> ageCounts) {
-        assertEquals(14, ageCounts.size());
+        assertEquals(15, ageCounts.size());
         
         assertEquals(3, findClinicaDataCount(ageCounts, "<18"));
         assertEquals(1, findClinicaDataCount(ageCounts, "18"));
@@ -197,6 +197,7 @@ public class StudyViewMapperClinicalDataCountTest extends AbstractTestcontainers
         assertEquals(2, findClinicaDataCount(ageCounts, "82"));
         assertEquals(1, findClinicaDataCount(ageCounts, "89"));
         assertEquals(2, findClinicaDataCount(ageCounts, ">89"));
+        assertEquals(1, findClinicaDataCount(ageCounts, "UNKNOWN"));
     }
     
     @Test

--- a/src/test/resources/clickhouse_data.sql
+++ b/src/test/resources/clickhouse_data.sql
@@ -133,6 +133,7 @@ insert into patient (internal_id,stable_id,cancer_study_id) values (320,'GENIE-T
 insert into patient (internal_id,stable_id,cancer_study_id) values (321,'GENIE-TEST-321',3);
 insert into patient (internal_id,stable_id,cancer_study_id) values (322,'GENIE-TEST-322',3);
 insert into patient (internal_id,stable_id,cancer_study_id) values (323,'GENIE-TEST-323',3);
+insert into patient (internal_id,stable_id,cancer_study_id) values (324,'GENIE-TEST-324',3);
 
 insert into genetic_profile_samples (genetic_profile_id,ordered_sample_list) values(10,'1,2,3,4,5,6,7,8,9,10,11,');
 
@@ -178,6 +179,7 @@ insert into sample (internal_id,stable_id,sample_type,patient_id) values (320,'G
 insert into sample (internal_id,stable_id,sample_type,patient_id) values (321,'GENIE-TEST-321-01','primary solid tumor',321);
 insert into sample (internal_id,stable_id,sample_type,patient_id) values (322,'GENIE-TEST-322-01','primary solid tumor',322);
 insert into sample (internal_id,stable_id,sample_type,patient_id) values (323,'GENIE-TEST-323-01','primary solid tumor',323);
+insert into sample (internal_id,stable_id,sample_type,patient_id) values (324,'GENIE-TEST-324-01','primary solid tumor',324);
 
 
 insert into mutation_event (mutation_event_id,entrez_gene_id,chr,start_position,end_position,reference_allele,tumor_seq_allele,protein_change,mutation_type,ncbi_build,strand,variant_type,db_snp_rs,db_snp_val_status,refseq_mrna_id,codon_change,uniprot_accession,protein_pos_start,protein_pos_end,canonical_transcript,keyword) values (2038,672,'17',41244748,41244748,'g','a','q934*','nonsense_mutation','37','+','snp','rs80357223','unknown','nm_007294','c.(2800-2802)cag>tag','p38398',934,934,1,'BRCA1 truncating');
@@ -457,6 +459,7 @@ insert into clinical_patient (internal_id,attr_id,attr_value) values (319,'age',
 insert into clinical_patient (internal_id,attr_id,attr_value) values (320,'age','N/A');
 insert into clinical_patient (internal_id,attr_id,attr_value) values (321,'age','');
 insert into clinical_patient (internal_id,attr_id,attr_value) values (322,'age','NAN');
+insert into clinical_patient (internal_id,attr_id,attr_value) values (324,'age','UNKNOWN');
 
 insert into clinical_sample (internal_id,attr_id,attr_value) values (1,'other_sample_id','5c631ce8-f96a-4c35-a459-556fc4ab21e1');
 insert into clinical_sample (internal_id,attr_id,attr_value) values (1,'days_to_collection','276');


### PR DESCRIPTION
Fix #11204

~~This only fixes numericalClinicalDataCountFilter.~~

Now applied the same fix to `numericalGenomicDataFilter` and `numericalGenericAssayDataFilter` as well by unifying the filter logic under one SQL.

TODO: add unit tests with variety of clinical, genomic, and generic assay data filter combinations