### PR TITLE
Use PR-specific image for circleci api tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ jobs:
             name: Build cBioPortal docker image
             command: |
               cd cbioportal-test
-              ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal
+              sh ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal
         - run:
             name: Instantiate a cbioportal instance
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,9 +287,9 @@ jobs:
               DOCKER_IMAGE_CBIOPORTAL: cbioportal-local
             command: |
               cd cbioportal-test
-              export DOCKER_IMAGE_CBIOPORTAL=$(jq -r '.["containerimage.digest"]' web-metadata.json)
+              export DOCKER_IMAGE_CBIOPORTAL=$(jq -r '.["containerimage.config.digest"]' web-metadata.json)
               docker image ls
-              docker tag $(jq -r '.["containerimage.digest"]' web-metadata.json) cbioportal-local
+              docker tag $(jq -r '.["containerimage.config.digest"]' web-metadata.json) cbioportal-local
               docker image ls
               echo $DOCKER_IMAGE_CBIOPORTAL
               nohup ./scripts/docker-compose.sh >> /tmp/repos/docker-compose-logs.txt 2>&1 &

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,9 +283,14 @@ jobs:
               fi
         - run:
             name: Instantiate a cbioportal instance
+            environment:
+              DOCKER_IMAGE_CBIOPORTAL: cbioportal-local
             command: |
               cd cbioportal-test
               export DOCKER_IMAGE_CBIOPORTAL=$(jq -r '.["containerimage.digest"]' web-metadata.json)
+              docker image ls
+              docker tag $(jq -r '.["containerimage.digest"]' web-metadata.json) cbioportal-local
+              docker image ls
               echo $DOCKER_IMAGE_CBIOPORTAL
               nohup ./scripts/docker-compose.sh >> /tmp/repos/docker-compose-logs.txt 2>&1 &
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,15 +283,9 @@ jobs:
               fi
         - run:
             name: Instantiate a cbioportal instance
-            environment:
-              DOCKER_IMAGE_CBIOPORTAL: cbioportal-local
             command: |
               cd cbioportal-test
               export DOCKER_IMAGE_CBIOPORTAL=$(jq -r '.["containerimage.config.digest"]' web-metadata.json)
-              docker image ls
-              docker tag $(jq -r '.["containerimage.config.digest"]' web-metadata.json) cbioportal-local
-              docker image ls
-              echo $DOCKER_IMAGE_CBIOPORTAL
               nohup ./scripts/docker-compose.sh >> /tmp/repos/docker-compose-logs.txt 2>&1 &
         - run:
             name: Wait for cbioportal to be live at localhost
@@ -312,7 +306,7 @@ jobs:
               cd cbioportal
               echo "Matching gitCommitId..."
               INSTANCE_COMMIT_ID=$(curl -s http://localhost:8080/api/info | jq -r '.["gitCommitId"]')
-              PR_COMMIT_ID=$(git rev-parse head)
+              PR_COMMIT_ID=$CIRCLE_SHA1
               if [ "$INSTANCE_COMMIT_ID" = "$PR_COMMIT_ID" ]; then
                 echo "gitCommitId successfully matched!"
                 echo "cBioPortal is ready:"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,8 @@ jobs:
       resource_class: medium
       working_directory: /tmp/repos
       steps:
+        - checkout:
+            path: /tmp/repos/cbioportal
         - run:
             name: Build cBioPortal docker image
             command: |
@@ -280,8 +282,6 @@ jobs:
       steps:
         - attach_workspace:
             at: /tmp/repos
-        - checkout:
-            path: /tmp/repos/cbioportal
         - run:
             name: Instantiate a cbioportal instance
             environment:
@@ -358,9 +358,11 @@ workflows:
       jobs:
         - pull_cbioportal_test_codebase
         - pull_cbioportal_frontend_codebase
+        - build_push_image
         - run_api_tests:
             context:
               - api-tests
             requires:
               - pull_cbioportal_test_codebase
               - pull_cbioportal_frontend_codebase
+              - build_push_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,8 +276,12 @@ jobs:
               cd cbioportal-test
               export DOCKER_TAG=$CIRCLE_SHA1
               ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=true
-              EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG > /dev/null; echo $?)
-              exit $EXISTS
+              EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
+              if [ $EXISTS -eq 0 ]; then
+                echo "Build succeeded!"
+              else
+                echo "Build failed!"
+                exit 1
 
     run_api_tests:
       machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,6 +258,19 @@ jobs:
             paths:
               - cbioportal-frontend
 
+    build_push_image:
+      machine:
+        image: ubuntu-2204:2024.08.1
+      resource_class: medium
+      working_directory: /tmp/repos
+      steps:
+        - run:
+            name: Build cBioPortal docker image
+            command: |
+              cd cbioportal-test
+              export DOCKER_TAG=$CIRCLE_SHA1
+              ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=true || exit 1
+
     run_api_tests:
       machine:
         image: ubuntu-2204:2024.08.1
@@ -270,22 +283,12 @@ jobs:
         - checkout:
             path: /tmp/repos/cbioportal
         - run:
-            name: Build cBioPortal docker image
-            command: |
-              cd cbioportal-test
-              sh ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal
-              if [ ! -f web-metadata.json ]; then
-                echo "Build failed!"
-                exit 1
-              else
-                echo "Build succeeded!"
-                cat web-metadata.json
-              fi
-        - run:
             name: Instantiate a cbioportal instance
+            environment:
+              DOCKER_REPO: cbioportal/cbioportal-dev
             command: |
               cd cbioportal-test
-              export DOCKER_IMAGE_CBIOPORTAL=$(jq -r '.["containerimage.config.digest"]' web-metadata.json)
+              export DOCKER_IMAGE_CBIOPORTAL=$DOCKER_REPO:$CIRCLE_SHA1
               nohup ./scripts/docker-compose.sh >> /tmp/repos/docker-compose-logs.txt 2>&1 &
         - run:
             name: Wait for cbioportal to be live at localhost

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,10 +283,6 @@ jobs:
                 echo "Build failed!"
                 exit 1
               fi
-        - persist_to_workspace:
-            root: /tmp/repos
-            paths:
-              - cbioportal
 
     run_api_tests:
       machine:
@@ -297,6 +293,8 @@ jobs:
       steps:
         - attach_workspace:
             at: /tmp/repos
+        - checkout:
+            path: /tmp/repos/cbioportal
         - run:
             name: Instantiate a cbioportal instance
             environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ jobs:
             command: |
               cd cbioportal-test
               export DOCKER_TAG=$CIRCLE_SHA1
-              ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=true || exit 1
+              ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=true
 
     run_api_tests:
       machine:
@@ -361,6 +361,8 @@ workflows:
         - pull_cbioportal_test_codebase
         - pull_cbioportal_frontend_codebase
         - build_push_image:
+            context:
+              - api-tests
             requires:
               - pull_cbioportal_test_codebase
         - run_api_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,7 @@ jobs:
 
         - store_artifacts:
             path: /tmp/repos/cbioportal-test/web-metadata.json
+        - store_artifacts:
             path: /tmp/repos/docker-compose-logs.txt
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,9 @@ workflows:
       jobs:
         - pull_cbioportal_test_codebase
         - pull_cbioportal_frontend_codebase
-        - build_push_image
+        - build_push_image:
+            requires:
+              - pull_cbioportal_test_codebase
         - run_api_tests:
             context:
               - api-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,6 +282,7 @@ jobs:
               else
                 echo "Build failed!"
                 exit 1
+              fi
 
     run_api_tests:
       machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,6 +261,7 @@ jobs:
     run_api_tests:
       machine:
         image: ubuntu-2204:2024.08.1
+        docker_layer_caching: true
       resource_class: large
       working_directory: /tmp/repos
       steps:
@@ -273,11 +274,19 @@ jobs:
             command: |
               cd cbioportal-test
               sh ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal
+              if [ ! -f web-metadata.json ]; then
+                echo "Build failed!"
+                exit 1
+              else
+                echo "Build succeeded!"
+                cat metadata.json
+              fi
         - run:
             name: Instantiate a cbioportal instance
             command: |
               cd cbioportal-test
               export DOCKER_IMAGE_CBIOPORTAL=$(jq -r '.["containerimage.digest"]' web-metadata.json)
+              echo $DOCKER_IMAGE_CBIOPORTAL
               nohup ./scripts/docker-compose.sh >> /tmp/repos/docker-compose-logs.txt 2>&1 &
         - run:
             name: Wait for cbioportal to be live at localhost
@@ -324,6 +333,7 @@ jobs:
               yarn run apitests
 
         - store_artifacts:
+            path: /tmp/repos/cbioportal-test/web-metadata.json
             path: /tmp/repos/docker-compose-logs.txt
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,8 @@ jobs:
       resource_class: medium
       working_directory: /tmp/repos
       steps:
+        - attach_workspace:
+            at: /tmp/repos
         - checkout:
             path: /tmp/repos/cbioportal
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,10 @@ jobs:
                 echo "Build failed!"
                 exit 1
               fi
+        - persist_to_workspace:
+            root: /tmp/repos
+            paths:
+              - cbioportal
 
     run_api_tests:
       machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,7 +279,7 @@ jobs:
                 exit 1
               else
                 echo "Build succeeded!"
-                cat metadata.json
+                cat web-metadata.json
               fi
         - run:
             name: Instantiate a cbioportal instance

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,10 +270,14 @@ jobs:
             path: /tmp/repos/cbioportal
         - run:
             name: Build cBioPortal docker image
+            environment:
+              DOCKER_REPO: cbioportal/cbioportal-dev
             command: |
               cd cbioportal-test
               export DOCKER_TAG=$CIRCLE_SHA1
               ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=true
+              EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG > /dev/null; echo $?)
+              exit $EXISTS
 
     run_api_tests:
       machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,11 +269,15 @@ jobs:
         - checkout:
             path: /tmp/repos/cbioportal
         - run:
-            name: Instantiate a cbioportal instance
-            environment:
-              DOCKER_IMAGE_CBIOPORTAL: cbioportal/cbioportal:demo-rfc80-poc-web-shenandoah
+            name: Build cBioPortal docker image
             command: |
               cd cbioportal-test
+              ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal
+        - run:
+            name: Instantiate a cbioportal instance
+            command: |
+              cd cbioportal-test
+              export DOCKER_IMAGE_CBIOPORTAL=$(jq -r '.["containerimage.digest"]' web-metadata.json)
               nohup ./scripts/docker-compose.sh >> /tmp/repos/docker-compose-logs.txt 2>&1 &
         - run:
             name: Wait for cbioportal to be live at localhost
@@ -288,6 +292,24 @@ jobs:
               done
               echo "Failed to connect to cbioportal at localhost:8080!"
               exit 1
+        - run:
+            name: Confirm cbioportal config matches PR
+            command: |
+              cd cbioportal
+              echo "Matching gitCommitId..."
+              INSTANCE_COMMIT_ID=$(curl -s http://localhost:8080/api/info | jq -r '.["gitCommitId"]')
+              PR_COMMIT_ID=$(git rev-parse head)
+              if [ "$INSTANCE_COMMIT_ID" = "$PR_COMMIT_ID" ]; then
+                echo "gitCommitId successfully matched!"
+                echo "cBioPortal is ready:"
+                curl -s http://localhost:8080/api/info
+                exit 0
+              else
+                echo "gitCommitIds do not match!"
+                echo "Instance Commit ID: $INSTANCE_COMMIT_ID"
+                echo "PR Commit ID: $PR_COMMIT_ID"
+                exit 1
+              fi
         - run:
             name: Run API Tests
             environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ jobs:
               DOCKER_REPO: cbioportal/cbioportal-dev
             command: |
               cd cbioportal-test
-              export DOCKER_IMAGE_CBIOPORTAL=$DOCKER_REPO:$CIRCLE_SHA1
+              export DOCKER_IMAGE_CBIOPORTAL=$DOCKER_REPO:$CIRCLE_SHA1-web-shenandoah
               nohup ./scripts/docker-compose.sh >> /tmp/repos/docker-compose-logs.txt 2>&1 &
         - run:
             name: Wait for cbioportal to be live at localhost


### PR DESCRIPTION
Fix # (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- Build PR-specific image which is then used in api tests
- Add logging logic to ensure circleci tests use the correct config for cbioportal instance

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
