### PR TITLE
Require manual approval from admins for circleci api tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,15 +371,22 @@ workflows:
       jobs:
         - pull_cbioportal_test_codebase
         - pull_cbioportal_frontend_codebase
+        - hold:
+            type: approval
+            requires:
+              - pull_cbioportal_test_codebase
+              - pull_cbioportal_frontend_codebase
         - build_push_image:
             context:
               - api-tests
             requires:
+              - hold
               - pull_cbioportal_test_codebase
         - run_api_tests:
             context:
               - api-tests
             requires:
+              - hold
               - pull_cbioportal_test_codebase
               - pull_cbioportal_frontend_codebase
               - build_push_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,7 +371,7 @@ workflows:
       jobs:
         - pull_cbioportal_test_codebase
         - pull_cbioportal_frontend_codebase
-        - hold:
+        - wait_for_approval:
             type: approval
             requires:
               - pull_cbioportal_test_codebase
@@ -380,13 +380,13 @@ workflows:
             context:
               - api-tests
             requires:
-              - hold
+              - wait_for_approval
               - pull_cbioportal_test_codebase
         - run_api_tests:
             context:
               - api-tests
             requires:
-              - hold
+              - wait_for_approval
               - pull_cbioportal_test_codebase
               - pull_cbioportal_frontend_codebase
               - build_push_image


### PR DESCRIPTION
Fix # (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- Circleci api tests now require approval from cbioportal organization members before they can run.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
