### PR TITLE
Fix broken links in cBioPortal-ER-Diagram.md

### DIFF
--- a/docs/development/cBioPortal-ER-Diagram.md
+++ b/docs/development/cBioPortal-ER-Diagram.md
@@ -1,4 +1,4 @@
 # cBioPortal ER Diagram
-[cBioPortal ER Diagram - PDF Version](https://github.com/cBioPortal/cbioportal/blob/master/db-scripts/src/main/resources/cbioportal-er-diagram.pdf)
+[cBioPortal ER Diagram - PDF Version](https://github.com/cBioPortal/cbioportal/blob/master/src/main/resources/db-scripts/cbioportal-er-diagram.pdf)
 
-![cBioPortal ER Diagram](https://raw.githubusercontent.com/cBioPortal/cbioportal/master/db-scripts/src/main/resources/cbioportal-er-diagram.png)
+![cBioPortal ER Diagram](https://github.com/cBioPortal/cbioportal/blob/master/src/main/resources/db-scripts/cbioportal-er-diagram.png)


### PR DESCRIPTION
Fixed cBioPortal ER Diagram links that were broken in documentation.
