### PR TITLE
Support clickhouse mode for circleci api tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,10 +299,11 @@ jobs:
             name: Instantiate a cbioportal instance
             environment:
               DOCKER_REPO: cbioportal/cbioportal-dev
+              CLICKHOUSE_MODE: true
             command: |
               cd cbioportal-test
               export DOCKER_IMAGE_CBIOPORTAL=$DOCKER_REPO:$CIRCLE_SHA1-web-shenandoah
-              nohup ./scripts/docker-compose.sh --docker_args='-e CLICKHOUSE_MODE=true' >> /tmp/repos/docker-compose-logs.txt 2>&1 &
+              nohup ./scripts/docker-compose.sh >> /tmp/repos/docker-compose-logs.txt 2>&1 &
         - run:
             name: Wait for cbioportal to be live at localhost
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,7 @@ jobs:
             command: |
               cd cbioportal-test
               export DOCKER_IMAGE_CBIOPORTAL=$DOCKER_REPO:$CIRCLE_SHA1-web-shenandoah
-              nohup ./scripts/docker-compose.sh >> /tmp/repos/docker-compose-logs.txt 2>&1 &
+              nohup ./scripts/docker-compose.sh --docker_args='-e CLICKHOUSE_MODE=true' >> /tmp/repos/docker-compose-logs.txt 2>&1 &
         - run:
             name: Wait for cbioportal to be live at localhost
             command: |


### PR DESCRIPTION
Describe changes proposed in this pull request:
- cBioportal instances in circle ci environment now support setting clickhouse mode to true/false

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
