### PR TITLE
Custom sample filtering performance and security improvement

### DIFF
--- a/src/main/java/org/cbioportal/persistence/helper/StudyViewFilterHelper.java
+++ b/src/main/java/org/cbioportal/persistence/helper/StudyViewFilterHelper.java
@@ -55,6 +55,7 @@ public final class StudyViewFilterHelper {
     private final StudyViewFilter studyViewFilter;
     private final CategorizedGenericAssayDataCountFilter categorizedGenericAssayDataCountFilter;
     private final List<CustomSampleIdentifier> customDataSamples;
+    private final String[] filteredSampleIdentifiers;
     private final List<String> involvedCancerStudies;
 
     private StudyViewFilterHelper(@NonNull StudyViewFilter studyViewFilter, 
@@ -65,6 +66,13 @@ public final class StudyViewFilterHelper {
         this.categorizedGenericAssayDataCountFilter = extractGenericAssayDataCountFilters(studyViewFilter, genericAssayProfilesMap);
         this.customDataSamples = customDataSamples;
         this.involvedCancerStudies = involvedCancerStudies;
+        if (studyViewFilter != null && studyViewFilter.getSampleIdentifiers() != null) {
+            this.filteredSampleIdentifiers = studyViewFilter.getSampleIdentifiers().stream()
+                .map(sampleIdentifier -> sampleIdentifier.getStudyId() + "_" + sampleIdentifier.getSampleId())
+                .toArray(String[]::new);
+        } else {
+            this.filteredSampleIdentifiers = new String[0];
+        }
     }
 
     public StudyViewFilter studyViewFilter() {
@@ -77,6 +85,10 @@ public final class StudyViewFilterHelper {
     
     public List<CustomSampleIdentifier> customDataSamples() {
         return this.customDataSamples;
+    }
+    
+    public String[] filteredSampleIdentifiers() {
+        return this.filteredSampleIdentifiers;
     }
     
     public List<String> involvedCancerStudies() {

--- a/src/main/java/org/cbioportal/persistence/helper/StudyViewFilterHelper.java
+++ b/src/main/java/org/cbioportal/persistence/helper/StudyViewFilterHelper.java
@@ -55,7 +55,6 @@ public final class StudyViewFilterHelper {
     private final StudyViewFilter studyViewFilter;
     private final CategorizedGenericAssayDataCountFilter categorizedGenericAssayDataCountFilter;
     private final List<CustomSampleIdentifier> customDataSamples;
-    private final String[] filteredSampleIdentifiers;
     private final List<String> involvedCancerStudies;
 
     private StudyViewFilterHelper(@NonNull StudyViewFilter studyViewFilter, 
@@ -66,13 +65,6 @@ public final class StudyViewFilterHelper {
         this.categorizedGenericAssayDataCountFilter = extractGenericAssayDataCountFilters(studyViewFilter, genericAssayProfilesMap);
         this.customDataSamples = customDataSamples;
         this.involvedCancerStudies = involvedCancerStudies;
-        if (studyViewFilter != null && studyViewFilter.getSampleIdentifiers() != null) {
-            this.filteredSampleIdentifiers = studyViewFilter.getSampleIdentifiers().stream()
-                .map(sampleIdentifier -> sampleIdentifier.getStudyId() + "_" + sampleIdentifier.getSampleId())
-                .toArray(String[]::new);
-        } else {
-            this.filteredSampleIdentifiers = new String[0];
-        }
     }
 
     public StudyViewFilter studyViewFilter() {
@@ -88,7 +80,13 @@ public final class StudyViewFilterHelper {
     }
     
     public String[] filteredSampleIdentifiers() {
-        return this.filteredSampleIdentifiers;
+        if (studyViewFilter != null && studyViewFilter.getSampleIdentifiers() != null) {
+            return studyViewFilter.getSampleIdentifiers().stream()
+                .map(sampleIdentifier -> sampleIdentifier.getStudyId() + "_" + sampleIdentifier.getSampleId())
+                .toArray(String[]::new);
+        } else {
+            return new String[0];
+        }
     }
     
     public List<String> involvedCancerStudies() {

--- a/src/main/java/org/cbioportal/web/parameter/CustomSampleIdentifier.java
+++ b/src/main/java/org/cbioportal/web/parameter/CustomSampleIdentifier.java
@@ -6,6 +6,8 @@ public class CustomSampleIdentifier extends SampleIdentifier implements Serializ
     
     private boolean isFilteredOut = false;
     private String value;
+    
+    private String uniqueSampleId;
 
     public boolean getIsFilteredOut() {
         return isFilteredOut;
@@ -21,5 +23,15 @@ public class CustomSampleIdentifier extends SampleIdentifier implements Serializ
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    // Generating unique SampleId by concatenating studyId and sampleId
+    public String getUniqueSampleId() {
+        // Assuming studyId and sampleId are available in SampleIdentifier
+        // Concatenate with "_" in between if both values are not null
+        if (getStudyId() != null && getSampleId() != null) {
+            return getStudyId() + "_" + getSampleId();
+        }
+        return null;  // or return a default value if either studyId or sampleId is null
     }
 }

--- a/src/main/java/org/cbioportal/web/parameter/CustomSampleIdentifier.java
+++ b/src/main/java/org/cbioportal/web/parameter/CustomSampleIdentifier.java
@@ -6,7 +6,6 @@ public class CustomSampleIdentifier extends SampleIdentifier implements Serializ
     
     private boolean isFilteredOut = false;
     private String value;
-    
     private String uniqueSampleId;
 
     public boolean getIsFilteredOut() {
@@ -32,6 +31,6 @@ public class CustomSampleIdentifier extends SampleIdentifier implements Serializ
         if (getStudyId() != null && getSampleId() != null) {
             return getStudyId() + "_" + getSampleId();
         }
-        return null;  // or return a default value if either studyId or sampleId is null
+        return null;  // or return null if either studyId or sampleId is null
     }
 }

--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewFilterMapper.xml
@@ -61,14 +61,14 @@
 
             </if>
 
-            <if test="studyViewFilterHelper.studyViewFilter.sampleIdentifiers != null and !studyViewFilterHelper.studyViewFilter.sampleIdentifiers.isEmpty()">
-                INTERSECT
+            <if test="studyViewFilterHelper.filteredSampleIdentifiers != null and studyViewFilterHelper.filteredSampleIdentifiers.length > 0">
+            INTERSECT
                 SELECT sample_unique_id
                 FROM sample_derived
                 WHERE sample_unique_id IN
-                <foreach item="sampleIdentifier" collection="studyViewFilterHelper.studyViewFilter.sampleIdentifiers" open="(" separator="," close=")">
-                    '${sampleIdentifier.studyId}_${sampleIdentifier.sampleId}'
-                </foreach>
+                (
+                    #{studyViewFilterHelper.filteredSampleIdentifiers, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
+                )
             </if>
             <if test="studyViewFilterHelper.studyViewFilter.customDataFilters != null and !studyViewFilterHelper.studyViewFilter.customDataFilters.isEmpty() and studyViewFilterHelper.customDataSamples != null">
                 INTERSECT
@@ -86,8 +86,8 @@
                             sample_unique_id IN (
                                 '',
                                 <foreach item="sampleIdentifier" collection="studyViewFilterHelper.customDataSamples" separator=",">
-                                    <if test="!sampleIdentifier.getIsFilteredOut()">
-                                        '${sampleIdentifier.studyId}_${sampleIdentifier.sampleId}'
+                                    <if test="!sampleIdentifier.getIsFilteredOut() and sampleIdentifier.getUniqueSampleId() != null">
+                                        #{sampleIdentifier.uniqueSampleId}
                                     </if>
                                 </foreach>
                             )
@@ -97,8 +97,11 @@
                                 <if test="customDataFilterValue.value eq 'NA'">
                                     OR
                                     sample_unique_id NOT IN (
+                                        '',
                                         <foreach item="sampleIdentifier" collection="studyViewFilterHelper.customDataSamples" separator=",">
-                                            '${sampleIdentifier.studyId}_${sampleIdentifier.sampleId}'
+                                            <if test="sampleIdentifier.getUniqueSampleId() != null">
+                                                #{sampleIdentifier.uniqueSampleId}
+                                            </if>
                                         </foreach>
                                     )
                                 </if>


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/11195

- `concat` has poor performance during my test, we should try to not use `concat` in a large `foreach` clause
- clickhouse support native `array` in the query, and it has better performance, try replace large foreach with `array`

**In this pull request:**
- Change back from string to prepared statement for security reason
- Use native `array` to improve performance