### PR TITLE
Improve circleci api tests by removing redundant image builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,31 +269,20 @@ jobs:
         - checkout:
             path: /tmp/repos/cbioportal
         - run:
-            name: Check if image already exists in DockerHub
-            environment:
-              DOCKER_REPO: cbioportal/cbioportal-dev
-            command: |
-              URL='https://hub.docker.com/v2/repositories/cbioportal/cbioportal-dev/tags/$CIRCLE_SHA1-web-shenandoah'
-              TAG_FOUND=$(curl -s $URL | jq -r .name)
-              if [ $TAG_FOUND = "$CIRCLE_SHA1-web-shenandoah" ]; then
-                echo "Image already exists. Skipping build step!"
-                echo 'export SKIP_BUILD=1' >> $BASH_ENV
-              else
-                echo "Continue with the image build step!"
-              echo 'export SKIP_BUILD=0' >> $BASH_ENV
-              fi
-        - run:
             name: Build cBioPortal docker image
             environment:
               DOCKER_REPO: cbioportal/cbioportal-dev
             command: |
-              if [ "$SKIP_BUILD" -eq 1 ]; then
+              export DOCKER_TAG=$CIRCLE_SHA1-web-shenandoah
+              URL='https://hub.docker.com/v2/repositories/cbioportal/cbioportal-dev/tags/$DOCKER_TAG'
+              TAG_FOUND=$(curl -s $URL | jq -r .name)
+              if [ $TAG_FOUND = $DOCKER_TAG ]; then
+                echo "Image already exists. Skipping build step!"
                 exit 0
               fi
               cd cbioportal-test
-              export DOCKER_TAG=$CIRCLE_SHA1
               ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=true --skip_web_and_data=true
-              EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
+              EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG > /dev/null; echo $?)
               if [ $EXISTS -eq 0 ]; then
                 echo "Build succeeded!"
               else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,16 +273,16 @@ jobs:
             environment:
               DOCKER_REPO: cbioportal/cbioportal-dev
             command: |
-              export DOCKER_TAG=$CIRCLE_SHA1-web-shenandoah
-              URL='https://hub.docker.com/v2/repositories/cbioportal/cbioportal-dev/tags/$DOCKER_TAG'
+              export DOCKER_TAG=$CIRCLE_SHA1
+              URL='https://hub.docker.com/v2/repositories/cbioportal/cbioportal-dev/tags/$DOCKER_TAG-web-shenandoah'
               TAG_FOUND=$(curl -s $URL | jq -r .name)
-              if [ $TAG_FOUND = $DOCKER_TAG ]; then
+              if [ $TAG_FOUND = "$DOCKER_TAG-web-shenandoah" ]; then
                 echo "Image already exists. Skipping build step!"
                 exit 0
               fi
               cd cbioportal-test
               ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=true --skip_web_and_data=true
-              EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG > /dev/null; echo $?)
+              EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
               if [ $EXISTS -eq 0 ]; then
                 echo "Build succeeded!"
               else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,10 +269,27 @@ jobs:
         - checkout:
             path: /tmp/repos/cbioportal
         - run:
+            name: Check if image already exists in DockerHub
+            environment:
+              DOCKER_REPO: cbioportal/cbioportal-dev
+            command: |
+              URL='https://hub.docker.com/v2/repositories/cbioportal/cbioportal-dev/tags/$CIRCLE_SHA1-web-shenandoah'
+              TAG_FOUND=$(curl -s $URL | jq -r .name)
+              if [ $TAG_FOUND = "$CIRCLE_SHA1-web-shenandoah" ]; then
+                echo "Image already exists. Skipping build step!"
+                echo 'export SKIP_BUILD=1' >> $BASH_ENV
+              else
+                echo "Continue with the image build step!"
+              echo 'export SKIP_BUILD=0' >> $BASH_ENV
+              fi
+        - run:
             name: Build cBioPortal docker image
             environment:
               DOCKER_REPO: cbioportal/cbioportal-dev
             command: |
+              if [ "$SKIP_BUILD" -eq 1 ]; then
+                exit 0
+              fi
               cd cbioportal-test
               export DOCKER_TAG=$CIRCLE_SHA1
               ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=true --skip_web_and_data=true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
               DOCKER_REPO: cbioportal/cbioportal-dev
             command: |
               export DOCKER_TAG=$CIRCLE_SHA1
-              URL='https://hub.docker.com/v2/repositories/cbioportal/cbioportal-dev/tags/$DOCKER_TAG-web-shenandoah'
+              URL="https://hub.docker.com/v2/repositories/cbioportal/cbioportal-dev/tags/$DOCKER_TAG-web-shenandoah"
               TAG_FOUND=$(curl -s $URL | jq -r .name)
               if [ $TAG_FOUND = "$DOCKER_TAG-web-shenandoah" ]; then
                 echo "Image already exists. Skipping build step!"


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Api Tests on circleci skip build step if image already exists

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
