### PR TITLE
update github dependency graph with docker builds

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -56,6 +56,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha
 
+      - name: Update Github Dependency Graph
+        uses: anchore/sbom-action@v0
+        with:
+          image: cbioportal/cbioportal:${{ steps.meta.output.tags }}
+          dependency-snapshot: 'true'
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
   build_and_publish_web:
       if: github.repository == 'cBioPortal/cbioportal'
       runs-on: ubuntu-latest
@@ -103,3 +110,9 @@ jobs:
             cache-from: type=gha
             cache-to: type=gha
 
+        - name: Update Github Dependency Graph
+          uses: anchore/sbom-action@v0
+          with:
+            image: cbioportal/cbioportal:${{ steps.meta.output.tags }}
+            dependency-snapshot: 'true'
+            github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -56,13 +56,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha
 
-      - name: Update Github Dependency Graph
-        uses: anchore/sbom-action@v0
-        with:
-          image: cbioportal/cbioportal:${{ steps.meta.output.tags }}
-          dependency-snapshot: 'true'
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-
   build_and_publish_web:
       if: github.repository == 'cBioPortal/cbioportal'
       runs-on: ubuntu-latest
@@ -109,6 +102,25 @@ jobs:
             file: docker/web/Dockerfile
             cache-from: type=gha
             cache-to: type=gha
+
+  update_dependency_graph:
+      needs: build_and_publish_web
+      if: github.repository == 'cBioPortal/cbioportal' && github.ref == 'refs/heads/master'
+      runs-on: ubuntu-latest
+      steps:
+        - name: Extract metadata
+          id: meta
+          uses: docker/metadata-action@v4
+          with:
+            images: |
+              cbioportal/cbioportal
+            # Do not generate latest tag
+            flavor: |
+              latest=false
+              suffix=-web-shenandoah
+            tags: |
+              type=ref,event=branch
+              type=semver,pattern={{version}}
 
         - name: Update Github Dependency Graph
           uses: anchore/sbom-action@v0


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Github dependency graph now gets updated automatically on every successful docker build

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
