### PR TITLE
Fix the broken link on the ER Diagram page in docs

### DIFF
--- a/docs/development/cBioPortal-ER-Diagram.md
+++ b/docs/development/cBioPortal-ER-Diagram.md
@@ -1,4 +1,6 @@
 # cBioPortal ER Diagram
 [cBioPortal ER Diagram - PDF Version](https://github.com/cBioPortal/cbioportal/blob/master/src/main/resources/db-scripts/cbioportal-er-diagram.pdf)
 
-![cBioPortal ER Diagram](https://github.com/cBioPortal/cbioportal/blob/master/src/main/resources/db-scripts/cbioportal-er-diagram.png)
+[cBioPortal ER Diagram - PNG File](https://github.com/cBioPortal/cbioportal/blob/master/src/main/resources/db-scripts/cbioportal-er-diagram.png)
+
+<img src="https://github.com/cBioPortal/cbioportal/raw/master/src/main/resources/db-scripts/cbioportal-er-diagram.png" alt="cBioPortal ER Diagram" style="max-width: 100%; height: auto;">


### PR DESCRIPTION
Fix #10760 

Describe changes proposed in this pull request:

Updated the ER diagram link in the documentation to reflect the correct location after the v6 migration.
Verified that the broken link is replaced with the correct URL.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
Before :
<img width="1090" alt="Screenshot 2024-12-31 at 3 36 50 PM" src="https://github.com/user-attachments/assets/9f2923a9-15e9-4e4d-a095-c6cbb660aab4" />

After:
<img width="1132" alt="Screenshot 2024-12-31 at 3 37 14 PM" src="https://github.com/user-attachments/assets/40c8568e-5464-4963-b5ca-c2d7bd05086a" />


# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
