### PR TITLE
Integrate Docker Scout as part of security tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,6 +351,40 @@ jobs:
         - store_artifacts:
             path: /tmp/repos/docker-compose-logs.txt
 
+    run_security_tests:
+      machine:
+        image: ubuntu-2204:2024.08.1
+        docker_layer_caching: true
+      resource_class: medium
+      environment:
+        BASE_REPO: cbioportal/cbioportal
+        DEV_REPO: cbioportal/cbioportal-dev
+      steps:
+        - run:
+            name: Log in to Docker
+            command: |
+              echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin;
+        - run:
+            name: Run Docker Scout vulnerability test
+            command: |
+              BASE_IMAGE=$BASE_REPO:master-web-shenandoah
+              PR_IMAGE=$DEV_REPO:$CIRCLE_SHA1-web-shenandoah
+              OUTPUT_FORMAT='{severity: .cvss.severity, source_id: .source_id, vulnerable_range: .vulnerable_range, fixed_by: .fixed_by, url: .url, description: .description}'
+              SORT='sort_by(.severity | if . == "CRITICAL" then 0 elif . == "HIGH" then 1 elif . == "MEDIUM" then 2 elif . == "LOW" then 3 else 4 end)'
+              docker pull $BASE_IMAGE
+              docker pull $PR_IMAGE
+              docker scout cves $BASE_IMAGE --format sbom | jq -r "[.vulnerabilities.[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > base_report.sbom
+              docker scout cves $PR_IMAGE --format sbom | jq -r "[.vulnerabilities.[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > pr_report.sbom
+              DIFF=$(jq -s 'map(map(.source_id)) | .[0] - .[1]' pr_report.sbom base_report.sbom)
+              COUNT=$(echo $DIFF | jq 'length')
+              if [ "$COUNT" -gt 0 ]; then
+                printf "New vulnerabilities found: $COUNT\n"
+                jq '.[] | select(.source_id as $a | '"$DIFF"' | index($a))' pr_report.sbom
+                exit 1
+              else
+                echo "No new vulnerabilities found!"
+                exit 0
+              fi
 
 workflows:
     version: 2
@@ -383,5 +417,13 @@ workflows:
         - run_api_tests:
             context:
               - api-tests
+            requires:
+              - build_push_image
+
+    security_tests:
+      jobs:
+        - run_security_tests:
+            context:
+              - docker-scout
             requires:
               - build_push_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ jobs:
                   echo "Image found!"
                   exit 0
                 fi
-                echo "Image not built yet. Retrying in 30 seconds..."
+                echo "Image not found yet. Waiting for API Tests to finish building. Retrying in 30 seconds..."
                 sleep 30
               done
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,6 +361,10 @@ jobs:
         DEV_REPO: cbioportal/cbioportal-dev
       steps:
         - run:
+            name: Install Docker Scout
+            command: |
+              curl -sSfL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s -- -b /home/circleci/bin
+        - run:
             name: Log in to Docker
             command: |
               echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin;
@@ -386,8 +390,8 @@ jobs:
               SORT='sort_by(.severity | if . == "CRITICAL" then 0 elif . == "HIGH" then 1 elif . == "MEDIUM" then 2 elif . == "LOW" then 3 else 4 end)'
               docker pull $BASE_IMAGE
               docker pull $PR_IMAGE
-              docker scout cves $BASE_IMAGE --format sbom | jq -r "[.vulnerabilities.[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > base_report.sbom
-              docker scout cves $PR_IMAGE --format sbom | jq -r "[.vulnerabilities.[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > pr_report.sbom
+              docker-scout cves $BASE_IMAGE --format sbom | jq -r "[.vulnerabilities[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > base_report.sbom
+              docker-scout cves $PR_IMAGE --format sbom | jq -r "[.vulnerabilities[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > pr_report.sbom
               DIFF=$(jq -s 'map(map(.source_id)) | .[0] - .[1]' pr_report.sbom base_report.sbom)
               COUNT=$(echo $DIFF | jq 'length')
               if [ "$COUNT" -gt 0 ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,6 +365,19 @@ jobs:
             command: |
               echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin;
         - run:
+            name: Wait for cbioportal docker images
+            command: |
+              URL="https://hub.docker.com/v2/repositories/$DEV_REPO/tags/$CIRCLE_SHA1-web-shenandoah"
+              while true; do
+                TAG_FOUND=$(curl -s $URL | jq -r .name)
+                if [ $TAG_FOUND = "$CIRCLE_SHA1-web-shenandoah" ]; then
+                  echo "Image found!"
+                  exit 0
+                fi
+                echo "Image not built yet. Retrying in 30 seconds..."
+                sleep 30
+              done
+        - run:
             name: Run Docker Scout vulnerability test
             command: |
               BASE_IMAGE=$BASE_REPO:master-web-shenandoah
@@ -425,5 +438,3 @@ workflows:
         - run_security_tests:
             context:
               - docker-scout
-            requires:
-              - build_push_image


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Security Tests have been added as part of circleci. These tests use Docker Scout to check any new vulnerabilities were introduced by the PR.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
