### PR TITLE
Upgrade circleci config version and improve api/security tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ commands:
               echo "Build failed!"
               exit 1
             fi
-            docker save -o $DOCKER_TAG-web-shenandoah.tar $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
 
 jobs:
     build_backend:
@@ -294,11 +293,8 @@ jobs:
         image: ubuntu-2204:2024.08.1
       resource_class: medium
       working_directory: /tmp/repos
-      parameters:
-        push:
-          description: Push image to Docker Hub
-          type: boolean
-          default: false
+      environment:
+        DOCKER_REPO: cbioportal/cbioportal-dev
       steps:
         - attach_workspace:
             at: /tmp/repos
@@ -306,6 +302,15 @@ jobs:
             path: /tmp/repos/cbioportal
         - build_push_image:
             push: "false"
+        - run:
+            name: Save cbioportal image as tar
+            command: |
+              export $DOCKER_TAG=$CIRCLE_SHA1
+              docker save -o $DOCKER_TAG-web-shenandoah.tar $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
+        - persist_to_workspace:
+            root: /tmp/repos
+            paths:
+                - $DOCKER_TAG-web-shenandoah.tar
 
     push_image:
       machine:
@@ -336,7 +341,8 @@ jobs:
         - run:
             name: Load cbioportal image
             command: |
-              docker load -i $DOCKER_REPO:$CIRCLE_SHA1-web-shenandoah.tar
+              export $DOCKER_TAG=$CIRCLE_SHA1
+              docker load -i $DOCKER_REPO:$DOCKER_TAG-web-shenandoah.tar
         - run:
             name: Instantiate a cbioportal instance
             environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,6 +292,19 @@ jobs:
             paths:
               - cbioportal-frontend
 
+    checkout_pr:
+      machine:
+        image: ubuntu-2204:2024.08.1
+      resource_class: medium
+      working_directory: /tmp/repos
+      steps:
+        - checkout:
+            path: /tmp/repos/cbioportal
+        - persist_to_workspace:
+            root: /tmp/repos
+            paths:
+              - cbioportal
+
     build_image:
       machine:
         image: ubuntu-2204:2024.08.1
@@ -302,8 +315,6 @@ jobs:
       steps:
         - attach_workspace:
             at: /tmp/repos
-        - checkout:
-            path: /tmp/repos/cbioportal
         - build_push_image:
             push: "false"
         - run:
@@ -324,8 +335,6 @@ jobs:
       steps:
         - attach_workspace:
             at: /tmp/repos
-        - checkout:
-            path: /tmp/repos/cbioportal
         - build_push_image:
             push: "true"
 
@@ -340,8 +349,6 @@ jobs:
       steps:
         - attach_workspace:
             at: /tmp/repos
-        - checkout:
-            path: /tmp/repos/cbioportal
         - run:
             name: Load cbioportal image
             command: |
@@ -455,16 +462,19 @@ workflows:
                     - install_yarn
     tests:
       jobs:
+        - checkout_pr
         - pull_cbioportal_test_codebase
         - pull_cbioportal_frontend_codebase
         - build_image:
             requires:
+              - checkout_pr
               - pull_cbioportal_test_codebase
               - pull_cbioportal_frontend_codebase
         - push_image:
             context:
               - api-tests
             requires:
+              - checkout_pr
               - pull_cbioportal_test_codebase
               - pull_cbioportal_frontend_codebase
         - run_api_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ defaults: &defaults
     docker:
         - image: circleci/node:15.2.1-browsers
 
-version: 2
+version: 2.1
 commands:
   build_push_image:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,6 +306,7 @@ jobs:
             name: Save cbioportal image as tar
             command: |
               export DOCKER_TAG=$CIRCLE_SHA1
+              echo "test" > test.txt
               #docker save -o cbioportal-web-shenandoah.tar $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
         - run:
             name: Debug step
@@ -314,7 +315,7 @@ jobs:
         - persist_to_workspace:
             root: /tmp/repos
             paths:
-              - cbioportal
+              - test.txt
 
     push_image:
       machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,6 @@ jobs:
               OUTPUT_FORMAT='{severity: .cvss.severity, source_id: .source_id, vulnerable_range: .vulnerable_range, fixed_by: .fixed_by, url: .url, description: .description}'
               SORT='sort_by(.severity | if . == "CRITICAL" then 0 elif . == "HIGH" then 1 elif . == "MEDIUM" then 2 elif . == "LOW" then 3 else 4 end)'
               docker pull $BASE_IMAGE
-              docker pull $PR_IMAGE
               docker-scout cves $BASE_IMAGE --format sbom | jq -r "[.vulnerabilities[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > base_report.sbom
               docker-scout cves $PR_IMAGE --format sbom | jq -r "[.vulnerabilities[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > pr_report.sbom
               DIFF=$(jq -s 'map(map(.source_id)) | .[0] - .[1]' pr_report.sbom base_report.sbom)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ jobs:
             name: Log in to Docker
             command: |
               export DOCKER_TAG=$CIRCLE_SHA1-web-shenandoah
-              echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin;
+              echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - run:
             name: Push cBioPortal image to Docker Hub
             environment:
@@ -364,8 +364,6 @@ jobs:
               yarn --ignore-engines
               yarn run apitests
 
-        - store_artifacts:
-            path: /tmp/repos/cbioportal-test/web-metadata.json
         - store_artifacts:
             path: /tmp/repos/docker-compose-logs.txt
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
               echo "Build failed!"
               exit 1
             fi
-            docker save -o $DOCKER_TAG-web-shenandoah.tar
+            docker save -o $DOCKER_TAG-web-shenandoah.tar $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
 
 jobs:
     build_backend:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,7 @@ jobs:
             name: Save cbioportal image as tar
             command: |
               export DOCKER_TAG=$CIRCLE_SHA1
-              echo "test" > $CIRCLE_SHA1.txt
+              echo "test2" > $CIRCLE_SHA1.txt
               #docker save -o cbioportal-web-shenandoah.tar $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
         - run:
             name: Debug step

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -475,19 +475,18 @@ workflows:
             requires:
               - checkout_pr
               - pull_cbioportal_test_codebase
-              - pull_cbioportal_frontend_codebase
         - push_image:
             context:
               - api-tests
             requires:
               - checkout_pr
               - pull_cbioportal_test_codebase
-              - pull_cbioportal_frontend_codebase
         - run_api_tests:
             context:
               - api-tests
             requires:
               - build_image
+              - pull_cbioportal_frontend_codebase
         - run_security_tests:
             context:
               - docker-scout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,6 @@ jobs:
               fi
 
 workflows:
-    version: 2
     end_to_end_tests:
         jobs:
             - build_backend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ jobs:
             paths:
               - cbioportal-frontend
 
-    build_push_image:
+    build_image:
       machine:
         image: ubuntu-2204:2024.08.1
       resource_class: medium
@@ -281,7 +281,7 @@ jobs:
                 exit 0
               fi
               cd cbioportal-test
-              ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=true --skip_web_and_data=true
+              ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=false --skip_web_and_data=true
               EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
               if [ $EXISTS -eq 0 ]; then
                 echo "Build succeeded!"
@@ -289,6 +289,24 @@ jobs:
                 echo "Build failed!"
                 exit 1
               fi
+
+    push_image:
+      machine:
+        image: ubuntu-2204:2024.08.1
+      resource_class: medium
+      steps:
+        - run:
+            name: Log in to Docker
+            command: |
+              export DOCKER_TAG=$CIRCLE_SHA1-web-shenandoah
+              echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin;
+        - run:
+            name: Push cBioPortal image to Docker Hub
+            environment:
+              DOCKER_REPO: cbioportal/cbioportal-dev
+            command: |
+              export DOCKER_TAG=$CIRCLE_SHA1-web-shenandoah
+              docker image push cbioportal/cbioportal-dev:$DOCKER_TAG
 
     run_api_tests:
       machine:
@@ -417,28 +435,24 @@ workflows:
                     - build_backend
                     - pull_frontend_codebase
                     - install_yarn
-    api_tests:
+    tests:
       jobs:
         - pull_cbioportal_test_codebase
         - pull_cbioportal_frontend_codebase
-        - wait_for_approval:
-            type: approval
+        - build_image:
             requires:
               - pull_cbioportal_test_codebase
               - pull_cbioportal_frontend_codebase
-        - build_push_image:
-            context:
-              - api-tests
-            requires:
-              - wait_for_approval
         - run_api_tests:
             context:
               - api-tests
             requires:
-              - build_push_image
-
-    security_tests:
-      jobs:
+              - build_image
         - run_security_tests:
             context:
               - docker-scout
+            requires:
+              - build_image
+        - push_image:
+            context:
+              - api-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,7 @@ jobs:
             name: Save cbioportal image as tar
             command: |
               export DOCKER_TAG=$CIRCLE_SHA1
-              echo "test" > test.txt
+              echo "test" > $CIRCLE_SHA1.txt
               #docker save -o cbioportal-web-shenandoah.tar $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
         - run:
             name: Debug step
@@ -315,7 +315,7 @@ jobs:
         - persist_to_workspace:
             root: /tmp/repos
             paths:
-              - test.txt
+              - $CIRCLE_SHA1.txt
 
     push_image:
       machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,6 +410,8 @@ jobs:
       environment:
         BASE_REPO: cbioportal/cbioportal
         DEV_REPO: cbioportal/cbioportal-dev
+        OUTPUT_FORMAT: '{severity: .cvss.severity, source_id: .source_id, vulnerable_range: .vulnerable_range, fixed_by: .fixed_by, url: .url, description: .description}'
+        SORT: 'sort_by(.severity | if . == "CRITICAL" then 0 elif . == "HIGH" then 1 elif . == "MEDIUM" then 2 elif . == "LOW" then 3 else 4 end)'
       steps:
         - attach_workspace:
               at: /tmp/repos
@@ -427,16 +429,20 @@ jobs:
               export DOCKER_TAG=$CIRCLE_SHA1
               docker load -i $DOCKER_TAG-web-shenandoah.tar
         - run:
-            name: Run Docker Scout vulnerability test
+            name: Run Docker Scout on master
             command: |
-              BASE_IMAGE=$BASE_REPO:master-web-shenandoah
-              PR_IMAGE=$DEV_REPO:$CIRCLE_SHA1-web-shenandoah
-              OUTPUT_FORMAT='{severity: .cvss.severity, source_id: .source_id, vulnerable_range: .vulnerable_range, fixed_by: .fixed_by, url: .url, description: .description}'
-              SORT='sort_by(.severity | if . == "CRITICAL" then 0 elif . == "HIGH" then 1 elif . == "MEDIUM" then 2 elif . == "LOW" then 3 else 4 end)'
-              docker pull $BASE_IMAGE
-              docker-scout cves $BASE_IMAGE --format sbom | jq -r "[.vulnerabilities[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > base_report.sbom
-              docker-scout cves $PR_IMAGE --format sbom | jq -r "[.vulnerabilities[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > pr_report.sbom
-              DIFF=$(jq -s 'map(map(.source_id)) | .[0] - .[1]' pr_report.sbom base_report.sbom)
+              IMAGE=$BASE_REPO:master-web-shenandoah
+              docker pull $IMAGE
+              docker-scout cves $IMAGE --format sbom | jq -r "[.vulnerabilities[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > master_report.sbom
+        - run:
+            name: Run Docker Scout on PR
+            command: |
+              IMAGE=$DEV_REPO:$CIRCLE_SHA1-web-shenandoah
+              docker-scout cves $IMAGE --format sbom | jq -r "[.vulnerabilities[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > pr_report.sbom
+        - run:
+            name: Analyze and report results
+            command: |
+              DIFF=$(jq -s 'map(map(.source_id)) | .[0] - .[1]' pr_report.sbom master_report.sbom)
               COUNT=$(echo $DIFF | jq 'length')
               if [ "$COUNT" -gt 0 ]; then
                 printf "New vulnerabilities found: $COUNT\n"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ commands:
               echo "Build failed!"
               exit 1
             fi
+            docker save -o $DOCKER_TAG-web-shenandoah.tar
 
 jobs:
     build_backend:
@@ -325,15 +326,20 @@ jobs:
         docker_layer_caching: true
       resource_class: large
       working_directory: /tmp/repos
+      environment:
+        DOCKER_REPO: cbioportal/cbioportal-dev
       steps:
         - attach_workspace:
             at: /tmp/repos
         - checkout:
             path: /tmp/repos/cbioportal
         - run:
+            name: Load cbioportal image
+            command: |
+              docker load -i $DOCKER_REPO:$CIRCLE_SHA1-web-shenandoah.tar
+        - run:
             name: Instantiate a cbioportal instance
             environment:
-              DOCKER_REPO: cbioportal/cbioportal-dev
               APP_CLICKHOUSE_MODE: "true"
             command: |
               cd cbioportal-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,22 +300,17 @@ jobs:
             at: /tmp/repos
         - checkout:
             path: /tmp/repos/cbioportal
-        #- build_push_image:
-        #    push: "false"
+        - build_push_image:
+            push: "false"
         - run:
             name: Save cbioportal image as tar
             command: |
               export DOCKER_TAG=$CIRCLE_SHA1
-              echo "test2" > $CIRCLE_SHA1.txt
-              #docker save -o cbioportal-web-shenandoah.tar $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
-        - run:
-            name: Debug step
-            command: |
-              ls
+              docker save -o $DOCKER_TAG-web-shenandoah.tar $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
         - persist_to_workspace:
             root: /tmp/repos
             paths:
-              - $CIRCLE_SHA1.txt
+              - "*.tar"
 
     push_image:
       machine:
@@ -347,7 +342,7 @@ jobs:
             name: Load cbioportal image
             command: |
               export DOCKER_TAG=$CIRCLE_SHA1
-              docker load -i $DOCKER_REPO:$DOCKER_TAG-web-shenandoah.tar
+              docker load -i $DOCKER_TAG-web-shenandoah.tar
         - run:
             name: Instantiate a cbioportal instance
             environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,10 @@ jobs:
       machine:
         image: ubuntu-2204:2024.08.1
       resource_class: medium
+      working_directory: /tmp/repos
       steps:
+        - attach_workspace:
+            at: /tmp/repos
         - build_push_image:
             push: "true"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,10 +395,13 @@ jobs:
         image: ubuntu-2204:2024.08.1
         docker_layer_caching: true
       resource_class: medium
+      working_directory: /tmp/repos
       environment:
         BASE_REPO: cbioportal/cbioportal
         DEV_REPO: cbioportal/cbioportal-dev
       steps:
+        - attach_workspace:
+              at: /tmp/repos
         - run:
             name: Install Docker Scout
             command: |
@@ -406,20 +409,12 @@ jobs:
         - run:
             name: Log in to Docker
             command: |
-              echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin;
+              echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - run:
-            name: Wait for cbioportal docker images
+            name: Load cbioportal image
             command: |
-              URL="https://hub.docker.com/v2/repositories/$DEV_REPO/tags/$CIRCLE_SHA1-web-shenandoah"
-              while true; do
-                TAG_FOUND=$(curl -s $URL | jq -r .name)
-                if [ $TAG_FOUND = "$CIRCLE_SHA1-web-shenandoah" ]; then
-                  echo "Image found!"
-                  exit 0
-                fi
-                echo "Image not found yet. Waiting for API Tests to finish building. Retrying in 30 seconds..."
-                sleep 30
-              done
+              export DOCKER_TAG=$CIRCLE_SHA1
+              docker load -i $DOCKER_TAG-web-shenandoah.tar
         - run:
             name: Run Docker Scout vulnerability test
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,6 +307,10 @@ jobs:
             command: |
               export DOCKER_TAG=$CIRCLE_SHA1
               docker save -o $DOCKER_TAG-web-shenandoah.tar $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
+        - run:
+            name: Debug step
+            command: |
+              ls
         - persist_to_workspace:
             root: /tmp/repos
             paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,7 @@ jobs:
         - persist_to_workspace:
             root: /tmp/repos
             paths:
-                - $CIRCLE_SHA1-web-shenandoah.tar
+              - $CIRCLE_SHA1-web-shenandoah.tar
 
     push_image:
       machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,10 @@ commands:
             fi
             cd cbioportal-test
             ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=<<parameters.push>> --skip_web_and_data=true
-            if [ "<<parameters.push>> = "false" ]; then
-              EXISTS=$(docker inspect --type=image $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
+            if [ "<<parameters.push>>" = "false" ]; then
+              EXISTS=$(docker inspect --type=image $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?);
             else
-              EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
+              EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?);
             fi
             if [ $EXISTS -eq 0 ]; then
               echo "Build succeeded!"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,10 @@ commands:
             fi
             cd cbioportal-test
             ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=<<parameters.push>> --skip_web_and_data=true
-            EXISTS=$(docker inspect --type=image $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
+            if [ "<<parameters.push>> = "false" ]; then
+              EXISTS=$(docker inspect --type=image $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
+            else;
+              EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
             if [ $EXISTS -eq 0 ]; then
               echo "Build succeeded!"
             else
@@ -457,6 +460,12 @@ workflows:
             requires:
               - pull_cbioportal_test_codebase
               - pull_cbioportal_frontend_codebase
+        - push_image:
+            context:
+              - api-tests
+            requires:
+              - pull_cbioportal_test_codebase
+              - pull_cbioportal_frontend_codebase
         - run_api_tests:
             context:
               - api-tests
@@ -465,10 +474,5 @@ workflows:
         - run_security_tests:
             context:
               - docker-scout
-            requires:
-              - build_image
-        - push_image:
-            context:
-              - api-tests
             requires:
               - build_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ jobs:
         - run:
             name: Save cbioportal image as tar
             command: |
-              export $DOCKER_TAG=$CIRCLE_SHA1
+              export DOCKER_TAG=$CIRCLE_SHA1
               docker save -o $DOCKER_TAG-web-shenandoah.tar $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
         - persist_to_workspace:
             root: /tmp/repos
@@ -341,7 +341,7 @@ jobs:
         - run:
             name: Load cbioportal image
             command: |
-              export $DOCKER_TAG=$CIRCLE_SHA1
+              export DOCKER_TAG=$CIRCLE_SHA1
               docker load -i $DOCKER_REPO:$DOCKER_TAG-web-shenandoah.tar
         - run:
             name: Instantiate a cbioportal instance

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,9 @@ commands:
             ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=<<parameters.push>> --skip_web_and_data=true
             if [ "<<parameters.push>> = "false" ]; then
               EXISTS=$(docker inspect --type=image $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
-            else;
+            else
               EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
+            fi
             if [ $EXISTS -eq 0 ]; then
               echo "Build succeeded!"
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,13 +300,13 @@ jobs:
             at: /tmp/repos
         - checkout:
             path: /tmp/repos/cbioportal
-        - build_push_image:
-            push: "false"
+        #- build_push_image:
+        #    push: "false"
         - run:
             name: Save cbioportal image as tar
             command: |
               export DOCKER_TAG=$CIRCLE_SHA1
-              docker save -o $DOCKER_TAG-web-shenandoah.tar $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
+              #docker save -o cbioportal-web-shenandoah.tar $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
         - run:
             name: Debug step
             command: |
@@ -314,7 +314,7 @@ jobs:
         - persist_to_workspace:
             root: /tmp/repos
             paths:
-              - $CIRCLE_SHA1-web-shenandoah.tar
+              - cbioportal
 
     push_image:
       machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -456,3 +456,5 @@ workflows:
         - push_image:
             context:
               - api-tests
+            requires:
+              - build_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,6 +314,8 @@ jobs:
       steps:
         - attach_workspace:
             at: /tmp/repos
+        - checkout:
+            path: /tmp/repos/cbioportal
         - build_push_image:
             push: "true"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,36 @@ defaults: &defaults
         - image: circleci/node:15.2.1-browsers
 
 version: 2
+commands:
+  build_push_image:
+    parameters:
+      push:
+        description: Push image to DockerHub
+        type: string
+        default: "false"
+    steps:
+      - run:
+          name: Build cBioPortal docker image
+          environment:
+            DOCKER_REPO: cbioportal/cbioportal-dev
+          command: |
+            export DOCKER_TAG=$CIRCLE_SHA1
+            URL="https://hub.docker.com/v2/repositories/cbioportal/cbioportal-dev/tags/$DOCKER_TAG-web-shenandoah"
+            TAG_FOUND=$(curl -s $URL | jq -r .name)
+            if [ $TAG_FOUND = "$DOCKER_TAG-web-shenandoah" ]; then
+              echo "Image already exists. Skipping build step!"
+              exit 0
+            fi
+            cd cbioportal-test
+            ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=<<parameters.push>> --skip_web_and_data=true
+            EXISTS=$(docker inspect --type=image $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
+            if [ $EXISTS -eq 0 ]; then
+              echo "Build succeeded!"
+            else
+              echo "Build failed!"
+              exit 1
+            fi
+
 jobs:
     build_backend:
         docker:
@@ -263,50 +293,26 @@ jobs:
         image: ubuntu-2204:2024.08.1
       resource_class: medium
       working_directory: /tmp/repos
+      parameters:
+        push:
+          description: Push image to Docker Hub
+          type: boolean
+          default: false
       steps:
         - attach_workspace:
             at: /tmp/repos
         - checkout:
             path: /tmp/repos/cbioportal
-        - run:
-            name: Build cBioPortal docker image
-            environment:
-              DOCKER_REPO: cbioportal/cbioportal-dev
-            command: |
-              export DOCKER_TAG=$CIRCLE_SHA1
-              URL="https://hub.docker.com/v2/repositories/cbioportal/cbioportal-dev/tags/$DOCKER_TAG-web-shenandoah"
-              TAG_FOUND=$(curl -s $URL | jq -r .name)
-              if [ $TAG_FOUND = "$DOCKER_TAG-web-shenandoah" ]; then
-                echo "Image already exists. Skipping build step!"
-                exit 0
-              fi
-              cd cbioportal-test
-              ./scripts/build-push-image.sh --src=/tmp/repos/cbioportal --push=false --skip_web_and_data=true
-              EXISTS=$(docker manifest inspect $DOCKER_REPO:$DOCKER_TAG-web-shenandoah > /dev/null; echo $?)
-              if [ $EXISTS -eq 0 ]; then
-                echo "Build succeeded!"
-              else
-                echo "Build failed!"
-                exit 1
-              fi
+        - build_push_image:
+            push: "false"
 
     push_image:
       machine:
         image: ubuntu-2204:2024.08.1
       resource_class: medium
       steps:
-        - run:
-            name: Log in to Docker
-            command: |
-              export DOCKER_TAG=$CIRCLE_SHA1-web-shenandoah
-              echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - run:
-            name: Push cBioPortal image to Docker Hub
-            environment:
-              DOCKER_REPO: cbioportal/cbioportal-dev
-            command: |
-              export DOCKER_TAG=$CIRCLE_SHA1-web-shenandoah
-              docker image push cbioportal/cbioportal-dev:$DOCKER_TAG
+        - build_push_image:
+            push: "true"
 
     run_api_tests:
       machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,7 @@ jobs:
         - persist_to_workspace:
             root: /tmp/repos
             paths:
-                - $DOCKER_TAG-web-shenandoah.tar
+                - $CIRCLE_SHA1-web-shenandoah.tar
 
     push_image:
       machine:


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Combine security tests and api tests into a single workflow.
- Optimize image builds, reducing test time by 50%.
- Eliminate manual approval needed for docker authentication.

> Docker Scout can be modified to use [native comparison functionality](https://docs.docker.com/reference/cli/docker/scout/compare/) once it is not in experimental stage anymore.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
## (Before) Old Tests Dependency Graph
![Screenshot 2025-01-07 at 2 47 35 PM](https://github.com/user-attachments/assets/e35bf310-71e8-4a4c-8e44-21a758bb623c)
## (After) New Tests Dependency Graph
![Screenshot 2025-01-07 at 3 10 22 PM](https://github.com/user-attachments/assets/f4cd87cb-b70b-40f8-b25f-c9d522378852)


# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
