### PR TITLE
Improve circleci tests with reusable docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
             export DOCKER_TAG=$CIRCLE_SHA1
             URL="https://hub.docker.com/v2/repositories/cbioportal/cbioportal-dev/tags/$DOCKER_TAG-web-shenandoah"
             TAG_FOUND=$(curl -s $URL | jq -r .name)
-            if [ $TAG_FOUND = "$DOCKER_TAG-web-shenandoah" ]; then
+            if [ $TAG_FOUND = "$DOCKER_TAG-web-shenandoah" ] && [ "<<parameters.push>>" = "true" ]; then
               echo "Image already exists. Skipping build step!"
               exit 0
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,9 @@ commands:
             export DOCKER_TAG=$CIRCLE_SHA1
             URL="https://hub.docker.com/v2/repositories/cbioportal/cbioportal-dev/tags/$DOCKER_TAG-web-shenandoah"
             TAG_FOUND=$(curl -s $URL | jq -r .name)
-            if [ $TAG_FOUND = "$DOCKER_TAG-web-shenandoah" ] && [ "<<parameters.push>>" = "true" ]; then
-              echo "Image already exists. Skipping build step!"
+            if [ $TAG_FOUND = "$DOCKER_TAG-web-shenandoah" ]; then
+              echo "Image already exists. Pulling remote image and skipping build step!"
+              docker pull $DOCKER_REPO:$DOCKER_TAG-web-shenandoah
               exit 0
             fi
             cd cbioportal-test


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Circleci reuses images on workflow re-runs.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
