### PR TITLE
Improved logging for security tests on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,11 +435,15 @@ jobs:
               IMAGE=$BASE_REPO:master-web-shenandoah
               docker pull $IMAGE
               docker-scout cves $IMAGE --format sbom | jq -r "[.vulnerabilities[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > master_report.sbom
+              echo "Docker Scout Report for Master"
+              cat master_report.sbom | jq
         - run:
             name: Run Docker Scout on PR
             command: |
               IMAGE=$DEV_REPO:$CIRCLE_SHA1-web-shenandoah
               docker-scout cves $IMAGE --format sbom | jq -r "[.vulnerabilities[].vulnerabilities[] | $OUTPUT_FORMAT] | $SORT" > pr_report.sbom
+              echo "Docker Scout Report for PR"
+              cat pr_report.sbom | jq
         - run:
             name: Analyze and report results
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,8 +455,13 @@ jobs:
                 exit 1
               else
                 echo "No new vulnerabilities found!"
+                echo "Individual reports for master and pr have been saved under the Artifacts tab."
                 exit 0
               fi
+        - store_artifacts:
+            path: /tmp/repos/master_report.sbom
+        - store_artifacts:
+            path: /tmp/repos/pr_report.sbom
 
 workflows:
     end_to_end_tests:


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Security tests on circleci now show the docker scout report in logs and the report is also saved as an artifact.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
