### PR TITLE
fix: Extract correct values for user email and use configuration property for user displayed name

### DIFF
--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -136,7 +136,7 @@ skin.study_view.link_text=To build your own case set, try out our enhanced Study
 ## setting controlling whether Download tabs and download/copy-to-clipboard controls should be shown
 # skin.hide_download_controls=false
 
-## setting controlling which name should be used to display the authenticated user (email, or username)
+## setting controlling which name should be used to display the authenticated user (email, name or username)
 # skin.user_display_name=email
 
 ## enable and set this property to specify a study group to be used to identify public studies for which no specific authorization entries are needed in the `authorities` table


### PR DESCRIPTION
Extract user email from authentication token, use configuration property to define displayed user name.

Fix # When using oauth2 or optional_oauth2 random UUID is displayed instead of user email or full name.

Describe changes proposed in this pull request:
- for oauth2 authentication extract email from Principal class
- use configuration property _skin.user_display_name_ to define what value should be show for user name, this property was already defined but never used

# Checks
- [X] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [X] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR

![cbioportal-before](https://github.com/user-attachments/assets/4ffc3818-0bb9-4ec4-aefe-7550e58c510a)

to

![cbioportal-after](https://github.com/user-attachments/assets/bb1fbd10-2a53-4ae6-a9e4-f1c46b7417e0)

