### PR TITLE
Update swagger URLs in notebook docs

### DIFF
--- a/docs/web-API-and-Clients.md
+++ b/docs/web-API-and-Clients.md
@@ -56,7 +56,7 @@ Although we recommend [cBioPortalData](/#cbioportaldata-recommended) or [cbiopor
 
 ```
 library(rapiclient)
-client <- get_api(url = "https://www.cbioportal.org/api/v2/api-docs")
+client <- get_api(url = "https://www.cbioportal.org/api/v3/api-docs")
 ```
 
 #### CGDSR (deprecated)
@@ -74,7 +74,7 @@ Generate a client in Python using [bravado](https://github.com/Yelp/bravado) lik
 
 ```python
 from bravado.client import SwaggerClient
-cbioportal = SwaggerClient.from_url('https://www.cbioportal.org/api/v2/api-docs',
+cbioportal = SwaggerClient.from_url('https://www.cbioportal.org/api/v3/api-docs',
                                     config={"validate_requests":False,"validate_responses":False,"validate_swagger_spec": False})
 ```
 


### PR DESCRIPTION
Fix #11356 

Describe changes proposed in this pull request:
Updated outdated links in the Markdown file. The new URLs added are tested and screenshots attached.

# Checks
- [ ✓] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [ ✓] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
Before:
![Screenshot 2025-01-30 231806](https://github.com/user-attachments/assets/8a9abfc3-6c8f-42f4-843f-a22f0ec22969)

After:
![Screenshot 2025-01-30 231846](https://github.com/user-attachments/assets/a87ef3dd-0a07-4e62-bfcb-0af9442b6b85)


# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
