### PR TITLE
Generic Assay categorical patient level filtering - legacy

### DIFF
--- a/src/main/java/org/cbioportal/legacy/model/GenericAssayData.java
+++ b/src/main/java/org/cbioportal/legacy/model/GenericAssayData.java
@@ -7,6 +7,8 @@ public class GenericAssayData extends MolecularData implements Serializable {
 
     @NotNull
     private String genericAssayStableId;
+    
+    private boolean patientLevel;
 
     /**
      * @return the genericAssayStableId
@@ -26,4 +28,12 @@ public class GenericAssayData extends MolecularData implements Serializable {
 	public String getStableId() {
 		return genericAssayStableId;
 	}
+
+    public void setPatientLevel(boolean patientLevel) {
+        this.patientLevel = patientLevel;
+    }
+    
+    public boolean getPatientLevel() {
+        return patientLevel;
+    }
 }

--- a/src/main/java/org/cbioportal/legacy/service/impl/GenericAssayServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/GenericAssayServiceImpl.java
@@ -169,6 +169,9 @@ public class GenericAssayServiceImpl implements GenericAssayService {
                         molecularData.setStudyId(sample.getCancerStudyIdentifier());
                         molecularData.setGenericAssayStableId(molecularAlteration.getGenericAssayStableId());
                         molecularData.setValue(molecularAlteration.getSplitValues()[indexOfSampleId]);
+                        if (molecularProfile.getPatientLevel() != null) {
+                            molecularData.setPatientLevel(molecularProfile.getPatientLevel());
+                        }
                         result.add(molecularData);
                     }
                 }


### PR DESCRIPTION
Fix #11347 
Describe changes proposed in this pull request:
- Added support for patient-level data counting in GenericAssayDataCounts
- For patient-level data:
  - Calculate total count using unique patient IDs
  - Only use first sample from each patient for value counts

- Sample-level counting logic remains unchanged
- Code refactored to determine counting mode based on patientLevel flag