### PR TITLE
Update the names for oncoprint tracks and custom sample color

### DIFF
--- a/src/main/java/org/cbioportal/legacy/service/FrontendPropertiesServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/FrontendPropertiesServiceImpl.java
@@ -243,8 +243,8 @@ public class FrontendPropertiesServiceImpl implements FrontendPropertiesService 
             // First, add properties that require pre-processing.
             case "frontendConfigOverride":
             case "query_sets_of_genes":
-            case "skin.patient_view.custom_sample_type_colors_json":
-            case "oncoprint.clinical_tracks.config_json":
+            case "skin_patient_view_custom_sample_type_colors_json":
+            case "oncoprint_clinical_tracks_config_json":
             case "download_custom_buttons_json":
                 return readFile(propertyValue);
             case "oncoprintOncoKbHotspotsDefault":


### PR DESCRIPTION
There is a bug that prevents the user to customize the oncoprint clinical tracks and custom sample color. User can upload a json file as stated in the documentation but this is broken. For reference, the documentation mentions that oncoprint clinical tracks can be set by:
`oncoprint.clinical_tracks.config_json=classpath:/oncoprint-default-tracks.json`

**The current bug:**
 oncoprint_clinical_tracks_config_json is set by:
 `oncoprint_clinical_tracks_config_json("oncoprint.clinical_tracks.config_json", null)`
and the custom sample colors by:
`skin_patient_view_custom_sample_type_colors_json("skin.patient_view.custom_sample_type_colors_json", null)`

In the function `getPropertyValue` the variable names do not match:
```
case "frontendConfigOverride":
            case "query_sets_of_genes":
            case "skin.patient_view.custom_sample_type_colors_json":
            case "oncoprint.clinical_tracks.config_json":
            case "download_custom_buttons_json":
                return readFile(propertyValue);`
```
and it will return the propertyValue:
```
default:
      return propertyValue;
```

