### PR TITLE
Extract groups from OAuth JWT token 

### DIFF
--- a/src/main/java/org/cbioportal/application/security/util/ClaimRoleExtractorUtil.java
+++ b/src/main/java/org/cbioportal/application/security/util/ClaimRoleExtractorUtil.java
@@ -2,6 +2,7 @@ package org.cbioportal.application.security.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -19,6 +20,7 @@ public class ClaimRoleExtractorUtil {
         try {
             // Convert the map to a JSON string
             ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.registerModule(new JavaTimeModule());
             String jsonString = objectMapper.writeValueAsString(claims);
 
             JsonNode rolesCursor = new ObjectMapper().readTree(jsonString);
@@ -50,6 +52,9 @@ public class ClaimRoleExtractorUtil {
                     throw new BadCredentialsException("Cannot Find user Roles in JWT Access Token ");
                 }
                 
+            }
+            if (rolesCursor.isTextual()) {
+                rolesCursor = new ObjectMapper().readTree(rolesCursor.asText());
             }
             return StreamSupport.stream(rolesCursor.spliterator(), false)
                 .map(JsonNode::asText)

--- a/src/test/java/org/cbioportal/application/security/util/ClaimRoleExtractorUtilTest.java
+++ b/src/test/java/org/cbioportal/application/security/util/ClaimRoleExtractorUtilTest.java
@@ -1,0 +1,90 @@
+package org.cbioportal.application.security.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(MockitoJUnitRunner.class)
+class ClaimRoleExtractorUtilTest {
+
+    @Test
+    void shouldExtractRolesFromSerializedClaims() {
+        String claims = """
+            {
+                "roles": ["role1", "role2"]
+            }
+            """;
+        String jwtRolesPath = "roles";
+        var result = ClaimRoleExtractorUtil.extractClientRoles(claims, jwtRolesPath);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.contains("role1"));
+        assertTrue(result.contains("role2"));
+    }
+
+    @Test
+    void shouldExtractRolesFromJsonNodeClaims() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String roleString = """
+                ["role1","role2","role3"]
+            """;
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("roles", roleString);
+        String jwtRolesPath = "roles";
+
+        var result = ClaimRoleExtractorUtil.extractClientRoles(root, jwtRolesPath);
+
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        assertTrue(result.contains("role1"));
+        assertTrue(result.contains("role2"));
+        assertTrue(result.contains("role3"));
+    }
+
+    @Test
+    void shouldExtractRolesFromString() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String groupString = """
+                ["GROUP_A","GROUP_B","GROUP_C"]
+            """;
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("groups", groupString);
+        String jwtRolesPath = "groups";
+
+        var result = ClaimRoleExtractorUtil.extractClientRoles(root, jwtRolesPath);
+
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        assertTrue(result.contains("GROUP_A"));
+        assertTrue(result.contains("GROUP_B"));
+        assertTrue(result.contains("GROUP_C"));
+    }
+
+    @Test
+    void shouldExtractRolesFormIdToken() {
+        
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("aud", "my-app-client-id");
+        claims.put("exp", Instant.now());
+        claims.put("iat", Instant.now());
+        claims.put("groups", List.of("GROUP_X", "GROUP_Y"));
+
+        String jwtRolesPath = "groups";
+        var result = ClaimRoleExtractorUtil.extractClientRoles(claims, jwtRolesPath);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.contains("GROUP_X"));
+        assertTrue(result.contains("GROUP_Y"));
+    }
+
+}


### PR DESCRIPTION
Extract array of groups from string

Fix #11429 

Describe changes proposed in this pull request:
- Register Java Time Module in Object Mapper to prevent exception on serializing JWT claims ( ID token contains few dates )
- for group properties if string instead of array is found deserialize this string to extract array from it

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

