### PR TITLE
Change COMMENTS column in SV table to longtext instead of varchar(255)

### DIFF
--- a/src/main/resources/db-scripts/cgds.sql
+++ b/src/main/resources/db-scripts/cgds.sql
@@ -399,7 +399,7 @@ CREATE TABLE `structural_variant` (
   `EVENT_INFO` varchar(255),
   `CLASS` varchar(25),
   `LENGTH` int(11),
-  `COMMENTS` varchar(255),
+  `COMMENTS` longtext,
   `SV_STATUS` varchar(25) NOT NULL DEFAULT 'SOMATIC' COMMENT 'GERMLINE or SOMATIC.',
   `ANNOTATION_JSON` JSON,
   PRIMARY KEY (`INTERNAL_ID`),

--- a/src/main/resources/db-scripts/migration.sql
+++ b/src/main/resources/db-scripts/migration.sql
@@ -1028,3 +1028,7 @@ CREATE INDEX idx_clinical_event_key ON clinical_event_data (`KEY`);
 CREATE INDEX idx_clinical_event_value ON clinical_event_data (`VALUE`);
 CREATE INDEX idx_sample_stable_id ON sample (`STABLE_ID`);
 UPDATE `info` SET `DB_SCHEMA_VERSION`="2.13.1";
+
+-- changes for issue 10806
+ALTER TABLE structural_variant MODIFY COLUMN COMMENTS longtext;
+UPDATE `info` SET `DB_SCHEMA_VERSION`="2.13.1";


### PR DESCRIPTION
Resolves https://github.com/cBioPortal/cbioportal/issues/10806


- This PR implements the requested enhancements.
- 
The type of comments column in sv table has been changed to longtext from varchar(255).
- Db scripts were updated with relavant changes. 
- Ran all tests to ensure that nothing in the Java part was accidentally broken by running: mvn integration-test
- Please let me know if any modifications are needed. Thanks!