### PR TITLE
Fix freqency error in Legacy

### DIFF
--- a/src/main/java/org/cbioportal/legacy/persistence/GenePanelRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/GenePanelRepository.java
@@ -43,4 +43,6 @@ public interface GenePanelRepository {
 
     @Cacheable(cacheResolver = "generalRepositoryCacheResolver", condition = "@cacheEnabledConfig.getEnabled()")
     List<GenePanelToGene> getGenesOfPanels(List<String> genePanelIds);
+
+    Set<Integer> findGeneIdsPresentInGenePanelList(Set<Integer> geneIdsToCheck);
 }

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/GenePanelMapper.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/GenePanelMapper.java
@@ -31,4 +31,11 @@ public interface GenePanelMapper {
     List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers);
 
     List<GenePanelToGene> getGenesOfPanels(List<String> genePanelIds);
+
+    /**
+     * Finds Entrez Gene IDs from the input collection that exist in the gene_panel_list table.
+     * @param geneIdsToCheck Collection of Entrez Gene IDs to check.
+     * @return A Set (or List) of Entrez Gene IDs found in gene_panel_list.
+     */
+    Set<Integer> findGeneIdsPresentInGenePanelList(Set<Integer> geneIdsToCheck);
 }

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/GenePanelMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/GenePanelMyBatisRepository.java
@@ -77,4 +77,9 @@ public class GenePanelMyBatisRepository implements GenePanelRepository {
     public List<GenePanelToGene> getGenesOfPanels(List<String> genePanelIds) {
         return genePanelMapper.getGenesOfPanels(genePanelIds);
     }
+
+    @Override
+    public Set<Integer> findGeneIdsPresentInGenePanelList(Set<Integer> geneIdsToCheck) {
+        return genePanelMapper.findGeneIdsPresentInGenePanelList(geneIdsToCheck);
+    }
 }

--- a/src/main/java/org/cbioportal/legacy/service/AlterationCountService.java
+++ b/src/main/java/org/cbioportal/legacy/service/AlterationCountService.java
@@ -16,13 +16,15 @@ public interface AlterationCountService {
                                                                           Select<Integer> entrezGeneIds,
                                                                           boolean includeFrequency,
                                                                           boolean includeMissingAlterationsFromGenePanel,
-                                                                          AlterationFilter alterationFilter);
+                                                                          AlterationFilter alterationFilter,
+                                                                          boolean includeOffPanelAlterations);
 
     Pair<List<AlterationCountByGene>, Long> getPatientAlterationGeneCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                                            Select<Integer> entrezGeneIds,
                                                                            boolean includeFrequency,
                                                                            boolean includeMissingAlterationsFromGenePanel,
-                                                                           AlterationFilter alterationFilter);
+                                                                           AlterationFilter alterationFilter,
+                                                                           boolean includeOffPanelAlterations);
 
     Pair<List<AlterationCountByGene>, Long> getSampleMutationGeneCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                                         Select<Integer> entrezGeneIds,

--- a/src/main/java/org/cbioportal/legacy/service/GenePanelService.java
+++ b/src/main/java/org/cbioportal/legacy/service/GenePanelService.java
@@ -36,4 +36,17 @@ public interface GenePanelService {
     List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers);
 
 	List<GenePanel> fetchGenePanels(List<String> genePanelIds, String projection);
+
+    /**
+     * Finds Entrez Gene IDs from the input collection that are present
+     * in the gene_panel_list table (i.e., associated with at least one gene panel).
+     * This method is intended to be used by other services to determine which genes
+     * out of a given set have panel associations.
+     *
+     * @param geneIdsToCheck Collection of Entrez Gene IDs to check.
+     * @return A Set of Entrez Gene IDs from the input collection that were found
+     * associated with at least one gene panel in the database.
+     * Returns an empty set if the input is null/empty or no matches are found.
+     */
+    Set<Integer> findGeneIdsAssociatedWithAnyPanel(Set<Integer> geneIdsToCheck);
 }

--- a/src/main/java/org/cbioportal/legacy/service/impl/AlterationCountServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/AlterationCountServiceImpl.java
@@ -6,15 +6,16 @@ import org.cbioportal.legacy.model.AlterationCountByGene;
 import org.cbioportal.legacy.model.AlterationCountByStructuralVariant;
 import org.cbioportal.legacy.model.AlterationFilter;
 import org.cbioportal.legacy.model.CopyNumberCountByGene;
+import org.cbioportal.legacy.model.GenePanel;
+import org.cbioportal.legacy.model.GenePanelData;
+import org.cbioportal.legacy.model.GenePanelToGene;
 import org.cbioportal.legacy.model.MolecularProfile;
 import org.cbioportal.legacy.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.legacy.model.util.Select;
 import org.cbioportal.legacy.persistence.AlterationRepository;
 import org.cbioportal.legacy.persistence.MolecularProfileRepository;
-import org.cbioportal.legacy.persistence.StudyViewRepository;
 import org.cbioportal.legacy.service.AlterationCountService;
-import org.cbioportal.legacy.service.SignificantCopyNumberRegionService;
-import org.cbioportal.legacy.service.SignificantlyMutatedGeneService;
+import org.cbioportal.legacy.service.GenePanelService;
 import org.cbioportal.legacy.service.util.AlterationCountServiceUtil;
 import org.cbioportal.legacy.service.util.AlterationEnrichmentUtil;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicReference;
@@ -40,19 +42,22 @@ public class AlterationCountServiceImpl implements AlterationCountService {
     private final AlterationEnrichmentUtil<CopyNumberCountByGene> alterationEnrichmentUtilCna;
     private final AlterationEnrichmentUtil<AlterationCountByStructuralVariant> alterationEnrichmentUtilStructVar;
     private final MolecularProfileRepository molecularProfileRepository;
-
+    private final GenePanelService genePanelService;
     
     @Autowired
     public AlterationCountServiceImpl(AlterationRepository alterationRepository, AlterationEnrichmentUtil<AlterationCountByGene> alterationEnrichmentUtil,
                                       AlterationEnrichmentUtil<CopyNumberCountByGene> alterationEnrichmentUtilCna,
                                       AlterationEnrichmentUtil<AlterationCountByStructuralVariant> alterationEnrichmentUtilStructVar,
-                                      MolecularProfileRepository molecularProfileRepository) {
+                                      MolecularProfileRepository molecularProfileRepository,
+                                      GenePanelService genePanelService) {
         this.alterationRepository = alterationRepository;
         this.alterationEnrichmentUtil = alterationEnrichmentUtil;
         this.alterationEnrichmentUtilCna = alterationEnrichmentUtilCna;
         this.alterationEnrichmentUtilStructVar = alterationEnrichmentUtilStructVar;
         this.molecularProfileRepository = molecularProfileRepository;
+        this.genePanelService = genePanelService;
     }
+    
     @Override
     public Pair<List<AlterationCountByGene>, Long> getSampleAlterationGeneCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                                                  Select<Integer> entrezGeneIds,
@@ -170,35 +175,6 @@ public class AlterationCountServiceImpl implements AlterationCountService {
         );
     }
 
-// -- Should be reinstated when the legacy CNA count endpoint retires            
-//    @Override
-//    public List<AlterationCountByGene> getSampleCnaCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
-//                                                          Select<Integer> entrezGeneIds,
-//                                                          boolean includeFrequency,
-//                                                          boolean includeMissingAlterationsFromGenePanel,
-//                                                          AlterationEventTypeFilter alterationFilter) {
-//        return getSampleAlterationCounts(molecularProfileCaseIdentifiers,
-//            entrezGeneIds,
-//            includeFrequency,
-//            includeMissingAlterationsFromGenePanel,
-//            new ArrayList<>(),
-//            alterationFilter);
-//    }
-//
-//    @Override
-//    public List<AlterationCountByGene> getPatientCnaCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
-//                                                           List<Integer> entrezGeneIds,
-//                                                           boolean includeFrequency,
-//                                                           boolean includeMissingAlterationsFromGenePanel,
-//                                                           AlterationEventTypeFilter alterationFilter) {
-//        return getPatientAlterationCounts(molecularProfileCaseIdentifiers,
-//            entrezGeneIds,
-//            includeFrequency,
-//            includeMissingAlterationsFromGenePanel,
-//            new ArrayList<>(),
-//            alterationFilter);
-//    }
-
     @Override
     public Pair<List<CopyNumberCountByGene>, Long> getSampleCnaGeneCounts(List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
                                                                           Select<Integer> entrezGeneIds,
@@ -273,16 +249,66 @@ public class AlterationCountServiceImpl implements AlterationCountService {
                     .groupingBy(identifier -> molecularProfileIdStudyIdMap.get(identifier.getMolecularProfileId())))
                 .values()
                 .forEach(studyMolecularProfileCaseIdentifiers -> {
+                    // 1. Fetch raw alteration data for this study group
                     List<S> studyAlterationCountByGenes = dataFetcher.apply(studyMolecularProfileCaseIdentifiers);
+
+                    // -------- START: Gene Panel Filtering Logic --------
+                    // 2. Fetch GenePanelData using the service
+                    List<GenePanelData> genePanelDataList = genePanelService.fetchGenePanelDataInMultipleMolecularProfiles(studyMolecularProfileCaseIdentifiers);
+
+                    // 3. Extract unique panel IDs used in this group
+                    Set<String> studyPanelIds = genePanelDataList.stream()
+                        .map(GenePanelData::getGenePanelId)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet());
+
+                    // 4. Only filter if panels are actually associated
+                    if (!studyPanelIds.isEmpty()) {
+                        // 5. Fetch the GenePanel objects for these IDs, requesting detailed info (includes gene list)
+                        List<GenePanel> detailedGenePanels = genePanelService.fetchGenePanels(new ArrayList<>(studyPanelIds), "DETAILED");
+
+                        // 6. Aggregate all unique Entrez Gene IDs from the genes lists within these panels
+                        Set<Integer> panelGeneIds = detailedGenePanels.stream() // Stream<GenePanel>
+                            .map(GenePanel::getGenes)     // Stream<List<GenePanelToGene>>
+                            .filter(Objects::nonNull)     // Filter out panels with null gene lists (safety check)
+                            .flatMap(List::stream)     // Stream<GenePanelToGene> (flatten list of lists)
+                            .map(GenePanelToGene::getEntrezGeneId) // Stream<Integer>
+                            .collect(Collectors.toSet());         // Set<Integer>
+
+                        // 7. Filter the alteration list based on the collected panel gene IDs
+                        final Set<Integer> finalPanelGeneIds = panelGeneIds;
+                        studyAlterationCountByGenes = studyAlterationCountByGenes.stream()
+                            .filter(alterationCount -> {
+                                Integer entrezGeneId = getEntrezGeneIdIfApplicable(alterationCount); // Use helper
+                                if (entrezGeneId == null) {
+                                    return true; // Keep non-gene-specific alterations
+                                }
+                                return finalPanelGeneIds.contains(entrezGeneId); // Keep if gene is on panel
+                            })
+                            .toList();
+                    }
+                    // -------- END: Gene Panel Filtering Logic --------
+                    
+                    // 8. Proceed with frequency calculation using the *filtered* list
                     if (includeFrequency) {
                         Long studyProfiledCasesCount = includeFrequencyFunction.apply(studyMolecularProfileCaseIdentifiers, studyAlterationCountByGenes);
                         profiledCasesCount.updateAndGet(v -> v + studyProfiledCasesCount);
                     }
+
+                    // 9. Merge the *filtered* results into the total map
                     AlterationCountServiceUtil.setupAlterationGeneCountsMap(studyAlterationCountByGenes, totalResult);
                 });
             alterationCountByGenes = new ArrayList<>(totalResult.values());
         }
         return new Pair<>(alterationCountByGenes, profiledCasesCount.get());
+    }
+    
+    private Integer getEntrezGeneIdIfApplicable(AlterationCountBase alterationCount) {
+        if (alterationCount instanceof AlterationCountByGene alterationCountByGene) {
+            return alterationCountByGene.getEntrezGeneId();
+        } else {
+            return null;
+        }
     }
 
 }

--- a/src/main/java/org/cbioportal/legacy/service/impl/AlterationCountServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/AlterationCountServiceImpl.java
@@ -146,7 +146,7 @@ public class AlterationCountServiceImpl implements AlterationCountService {
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
             alterationFilter,
-            true
+            true // Set this to false will not work because SV involves 2 genes
         );
     }
 
@@ -161,7 +161,7 @@ public class AlterationCountServiceImpl implements AlterationCountService {
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
             alterationFilter,
-            true
+            true // Set this to false will not work because SV involves 2 genes
         );
     }
 
@@ -182,7 +182,7 @@ public class AlterationCountServiceImpl implements AlterationCountService {
             includeFrequency,
             dataFetcher,
             includeFrequencyFunction,
-            true
+            true // Set this to false will not work because SV involves 2 genes
         );
     }
 
@@ -313,6 +313,7 @@ public class AlterationCountServiceImpl implements AlterationCountService {
 
         // First pass: separate alterations we can decide on immediately vs. those needing checks
         for (S alteration : studyAlterationCountByGenes) {
+            // For SV it returns null. When we have new ways to separate SV 2 genes we can start filter on them
             Integer geneId = alteration instanceof AlterationCountByGene alterationCountByGene ? alterationCountByGene.getEntrezGeneId() : null;
 
             if (geneId == null || genesOnAssociatedPanels.contains(geneId)) {

--- a/src/main/java/org/cbioportal/legacy/service/impl/AlterationEnrichmentServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/AlterationEnrichmentServiceImpl.java
@@ -55,7 +55,8 @@ public class AlterationEnrichmentServiceImpl implements AlterationEnrichmentServ
                                 Select.all(),
                                 true,
                                 true,
-                                alterationFilter);
+                                alterationFilter,
+                                true);
                     } else {
                         return alterationCountService
                             .getPatientAlterationGeneCounts(
@@ -63,7 +64,8 @@ public class AlterationEnrichmentServiceImpl implements AlterationEnrichmentServ
                                 Select.all(),
                                 true,
                                 true,
-                                alterationFilter);
+                                alterationFilter,
+                                true);
                     }
                 }));
     }

--- a/src/main/java/org/cbioportal/legacy/service/impl/GenePanelServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/GenePanelServiceImpl.java
@@ -216,4 +216,22 @@ public class GenePanelServiceImpl implements GenePanelService {
         return genePanelData;
     }
 
+    /**
+     * Finds Entrez Gene IDs from the input collection that are present
+     * in the gene_panel_list table (i.e., associated with at least one gene panel).
+     * This directly calls the repository method. The caller is responsible for
+     * calculating the difference if orphan genes are needed.
+     *
+     * @param geneIdsToCheck Collection of Entrez Gene IDs to check.
+     * @return A Set of Entrez Gene IDs found associated with at least one gene panel.
+     * Returns an empty set if the input is null/empty or no matches are found.
+     */
+    @Override
+    public Set<Integer> findGeneIdsAssociatedWithAnyPanel(Set<Integer> geneIdsToCheck) {
+        if (geneIdsToCheck == null || geneIdsToCheck.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        return genePanelRepository.findGeneIdsPresentInGenePanelList(geneIdsToCheck);
+    }
 }

--- a/src/main/java/org/cbioportal/legacy/service/util/ProfiledCasesCounter.java
+++ b/src/main/java/org/cbioportal/legacy/service/util/ProfiledCasesCounter.java
@@ -210,7 +210,7 @@ public class ProfiledCasesCounter<T extends AlterationCountBase> {
             String gene1HugoSymbol = ((AlterationCountByStructuralVariant) alterationCount).getGene1HugoGeneSymbol();
             Integer gene2EntrezId = ((AlterationCountByStructuralVariant) alterationCount).getGene2EntrezGeneId();
             String gene2HugoSymbol = ((AlterationCountByStructuralVariant) alterationCount).getGene2HugoGeneSymbol();
-            List<GenePanel> panels = entrezIdToGenePanel.getOrDefault(new Pair<>(gene1EntrezId, gene2HugoSymbol), new ArrayList<>());
+            List<GenePanel> panels = entrezIdToGenePanel.getOrDefault(new Pair<>(gene1EntrezId, gene1HugoSymbol), new ArrayList<>());
             panels.addAll(entrezIdToGenePanel.getOrDefault(new Pair<>(gene2EntrezId, gene2HugoSymbol), new ArrayList<>()));
             return panels.stream().distinct().collect(Collectors.toList());
         }

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/GenePanelMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/GenePanelMapper.xml
@@ -186,4 +186,17 @@
             </choose>
         </where>
     </select>
+
+    <select id="findGeneIdsPresentInGenePanelList" resultType="java.lang.Integer">
+        SELECT DISTINCT gene_id
+        FROM gene_panel_list
+        <where>
+            <if test="collection != null and !collection.isEmpty()">
+                gene_id IN
+                <foreach item="id" collection="collection" open="(" separator="," close=")">
+                    #{id}
+                </foreach>
+            </if>
+        </where>
+    </select>
 </mapper>

--- a/src/test/java/org/cbioportal/legacy/service/impl/AlterationCountServiceImplTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/impl/AlterationCountServiceImplTest.java
@@ -128,7 +128,8 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
             entrezGeneIds,
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
-            alterationFilter);
+            alterationFilter,
+            true);
         
         verify(alterationEnrichmentUtil, times(1)).includeFrequencyForSamples(anyList(), anyList(), anyBoolean());
 
@@ -148,7 +149,8 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
             entrezGeneIds,
             includeFrequency,
             includeMissingAlterationsFromGenePanel,
-            alterationFilter);
+            alterationFilter,
+            true);
 
         verify(alterationEnrichmentUtil, times(1)).includeFrequencyForPatients(anyList(), anyList(), anyBoolean());
     }

--- a/src/test/java/org/cbioportal/legacy/service/impl/AlterationCountServiceImplTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/impl/AlterationCountServiceImplTest.java
@@ -12,6 +12,7 @@ import org.cbioportal.legacy.model.MutationEventType;
 import org.cbioportal.legacy.model.util.Select;
 import org.cbioportal.legacy.persistence.AlterationRepository;
 import org.cbioportal.legacy.persistence.MolecularProfileRepository;
+import org.cbioportal.legacy.service.GenePanelService;
 import org.cbioportal.legacy.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.legacy.service.util.AlterationEnrichmentUtil;
 import org.cbioportal.legacy.service.util.MolecularProfileUtil;
@@ -54,6 +55,8 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
     private MolecularProfileUtil molecularProfileUtil;
     @Mock
     private MolecularProfileRepository molecularProfileRepository;
+    @Mock
+    private GenePanelService genePanelService;
 
     List<MolecularProfileCaseIdentifier> caseIdentifiers = Arrays.asList(new MolecularProfileCaseIdentifier("A", MOLECULAR_PROFILE_ID));
     Select<MutationEventType> mutationEventTypes = Select.byValues(Arrays.asList(MutationEventType.missense_mutation));
@@ -82,7 +85,7 @@ public class AlterationCountServiceImplTest extends BaseServiceImplTest {
         MockitoAnnotations.openMocks(this);
 
         alterationCountService = new AlterationCountServiceImpl(alterationRepository, alterationEnrichmentUtil,
-            alterationEnrichmentUtilCna, alterationEnrichmentUtilStructVar, molecularProfileRepository);
+            alterationEnrichmentUtilCna, alterationEnrichmentUtilStructVar, molecularProfileRepository, genePanelService);
         
         MolecularProfile molecularProfile = new MolecularProfile();
         molecularProfile.setStableId(MOLECULAR_PROFILE_ID);

--- a/src/test/java/org/cbioportal/legacy/service/impl/AlterationEnrichmentServiceImplTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/impl/AlterationEnrichmentServiceImplTest.java
@@ -72,7 +72,7 @@ public class AlterationEnrichmentServiceImplTest extends BaseServiceImplTest {
         for (String molecularProfileId : groupMolecularProfileCaseSets.keySet()) {
             Mockito.when(alterationCountService.getSampleAlterationGeneCounts(
                 groupMolecularProfileCaseSets.get(molecularProfileId),
-                Select.all(), true, true, alterationFilter)
+                Select.all(), true, true, alterationFilter, true)
             ).thenReturn(alterationSampleCountByGeneList);
         }
 


### PR DESCRIPTION
Fix #10967 
### Fix freqency error in Legacy: Filter alteration counts by gene panel coverage per study

* For mutations and CNAs, if an altered gene is on a gene panel that doesn't come with its study, it's "off-panel" and hence filtered out.
* SVs are not affected because of their 2 gene-partners nature. The ClickHouse implementation has a workaround by breaking that partnership apart into individual genes and then they can be (and are) filered.