### PR TITLE
feat : Added backend SPA forwarding support for result view comparison and pathways subtabs new routes

### DIFF
--- a/src/main/java/org/cbioportal/application/WebAppConfig.java
+++ b/src/main/java/org/cbioportal/application/WebAppConfig.java
@@ -44,6 +44,8 @@ public class WebAppConfig implements WebMvcConfigurer {
 		List<String> endpoints = List.of(
 			"/results/*",
 			"/results**",
+			"/results/comparison/*",
+			"/results/pathways/*",
 			"/patient/*",
 			"/patient**",
 			"/study/*",


### PR DESCRIPTION
Fix [#9762](https://github.com/cBioPortal/cbioportal/issues/9762)

Describe changes proposed in this pull request:
- This PR updates the backend configuration to explicitly forward comparison and pathways subtabs paths to the SPA entry point. This is required to support the new path-based routing for comparison and pathways subtabs.
- This is required for this enhancement [Use of path URL for comparison and pathways subtab](https://github.com/cBioPortal/cbioportal-frontend/pull/5162)

# Checks
- [✔ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml
