### PR TITLE
Make the "fetchGenericAssayData()" method more robust against possible NPEs

### DIFF
--- a/src/main/java/org/cbioportal/legacy/service/impl/GenericAssayServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/GenericAssayServiceImpl.java
@@ -176,7 +176,7 @@ public class GenericAssayServiceImpl implements GenericAssayService {
                     throw new IllegalArgumentException("InternalSampleIdsMap for MolecularProfileId " + molecularProfileId + " is null.");
                 }
                 if (sample.getInternalId() == null) {
-                    throw new IllegalArgumentException("InternalId for Sample " + sample.getStableId() + " is null.");
+                    throw new IllegalArgumentException("InternalId for Sample " + sample.getInternalId() + " is null.");
                 }
                 Integer indexOfSampleId = internalSampleIdsMap.get(molecularProfileId).get(sample.getInternalId());
                 if (indexOfSampleId != null && molecularAlterationsMap.containsKey(molecularProfileId)) {


### PR DESCRIPTION
Make the "fetchGenericAssayData()" method more robust against possible NullPointerExceptions

Fix #10877

Describe changes proposed in this pull request:
- Added NullPointer checks
- In case of NPE an IllegalArgumentException will be thrown

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

