### PR TITLE
Fix mutation frequency in legacy

### DIFF
--- a/src/main/java/org/cbioportal/legacy/service/util/ProfiledCasesCounter.java
+++ b/src/main/java/org/cbioportal/legacy/service/util/ProfiledCasesCounter.java
@@ -1,14 +1,5 @@
 package org.cbioportal.legacy.service.util;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.commons.math3.util.Pair;
 import org.cbioportal.legacy.model.AlterationCountBase;
 import org.cbioportal.legacy.model.AlterationCountByGene;
@@ -19,6 +10,16 @@ import org.cbioportal.legacy.model.GenePanelToGene;
 import org.cbioportal.legacy.service.GenePanelService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Component
 public class ProfiledCasesCounter<T extends AlterationCountBase> {
@@ -234,7 +235,7 @@ public class ProfiledCasesCounter<T extends AlterationCountBase> {
           ((AlterationCountByStructuralVariant) alterationCount).getGene2HugoGeneSymbol();
       List<GenePanel> panels =
           entrezIdToGenePanel.getOrDefault(
-              new Pair<>(gene1EntrezId, gene2HugoSymbol), new ArrayList<>());
+              new Pair<>(gene1EntrezId, gene1HugoSymbol), new ArrayList<>());
       panels.addAll(
           entrezIdToGenePanel.getOrDefault(
               new Pair<>(gene2EntrezId, gene2HugoSymbol), new ArrayList<>()));

--- a/src/main/java/org/cbioportal/legacy/service/util/ProfiledCasesCounter.java
+++ b/src/main/java/org/cbioportal/legacy/service/util/ProfiledCasesCounter.java
@@ -1,5 +1,14 @@
 package org.cbioportal.legacy.service.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.commons.math3.util.Pair;
 import org.cbioportal.legacy.model.AlterationCountBase;
 import org.cbioportal.legacy.model.AlterationCountByGene;
@@ -10,16 +19,6 @@ import org.cbioportal.legacy.model.GenePanelToGene;
 import org.cbioportal.legacy.service.GenePanelService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Component
 public class ProfiledCasesCounter<T extends AlterationCountBase> {
@@ -219,20 +218,17 @@ public class ProfiledCasesCounter<T extends AlterationCountBase> {
 
   private List<GenePanel> getGenePanelsForAlterationCount(
       T alterationCount, Map<Pair<Integer, String>, List<GenePanel>> entrezIdToGenePanel) {
-    if (alterationCount instanceof AlterationCountByGene) {
-      Integer entrezId = ((AlterationCountByGene) alterationCount).getEntrezGeneId();
-      String hugoSymbol = ((AlterationCountByGene) alterationCount).getHugoGeneSymbol();
+    if (alterationCount instanceof AlterationCountByGene alterationCountByGene) {
+      Integer entrezId = alterationCountByGene.getEntrezGeneId();
+      String hugoSymbol = alterationCountByGene.getHugoGeneSymbol();
       return entrezIdToGenePanel.getOrDefault(new Pair<>(entrezId, hugoSymbol), new ArrayList<>());
     }
-    if (alterationCount instanceof AlterationCountByStructuralVariant) {
-      Integer gene1EntrezId =
-          ((AlterationCountByStructuralVariant) alterationCount).getGene1EntrezGeneId();
-      String gene1HugoSymbol =
-          ((AlterationCountByStructuralVariant) alterationCount).getGene1HugoGeneSymbol();
-      Integer gene2EntrezId =
-          ((AlterationCountByStructuralVariant) alterationCount).getGene2EntrezGeneId();
-      String gene2HugoSymbol =
-          ((AlterationCountByStructuralVariant) alterationCount).getGene2HugoGeneSymbol();
+    if (alterationCount
+        instanceof AlterationCountByStructuralVariant alterationCountByStructuralVariant) {
+      Integer gene1EntrezId = alterationCountByStructuralVariant.getGene1EntrezGeneId();
+      String gene1HugoSymbol = alterationCountByStructuralVariant.getGene1HugoGeneSymbol();
+      Integer gene2EntrezId = alterationCountByStructuralVariant.getGene2EntrezGeneId();
+      String gene2HugoSymbol = alterationCountByStructuralVariant.getGene2HugoGeneSymbol();
       List<GenePanel> panels =
           entrezIdToGenePanel.getOrDefault(
               new Pair<>(gene1EntrezId, gene1HugoSymbol), new ArrayList<>());


### PR DESCRIPTION
Fix #10967

## Fix: Correct Aggregation of Profiled Counts Across Multiple Studies

### Problem:

The `numberOfProfiledCases` (denominator for frequency calculations) was not correctly aggregated when combining gene alteration data across multiple studies. If a gene was altered in Study A but had zero alterations in Study B, Study B's samples often did not contribute to the total profiled count for that gene, leading to incorrect frequencies.

### Solution:

The `getAlterationGeneCounts` method has been refactored to calculate `numberOfProfiledCases` globally, ensuring all relevant samples contribute to the denominator for genes with alterations.

The new workflow is:
1.  Fetch all raw alteration counts (only for genes with >0 alterations) from all selected studies.
2.  Merge these raw counts, summing `TotalCount` and `NumberOfAlteredCases` for identical genes found across different studies.
3.  If frequency is requested, call the frequency calculation logic (`includeFrequencyFunction`, which wraps `profiledCasesCounter.calculate`) *once* on this globally merged list. This step computes and sets the `numberOfProfiledCases` for each gene using the context of all samples involved, with the `includeMissingAlterationsFromGenePanel` behavior effectively turned off (focusing only on the initially altered genes).

### Impact:

* Provides accurate `numberOfProfiledCases` and frequency calculations for genes when results are aggregated across multiple studies.
* The displayed results correctly focus on genes that have at least one alteration in the queried studies.

### Screenshots:
<img width="402" alt="image" src="https://github.com/user-attachments/assets/20b0a862-0ac0-45b1-87ca-1bef6071ec5c" />
<img width="688" alt="image" src="https://github.com/user-attachments/assets/f7c9014c-78a3-47da-9dec-937400b884da" />
