### PR TITLE
Add On-Panel Alteration Count

### DIFF
--- a/src/main/java/org/cbioportal/domain/alteration/usecase/GetAlterationCountByGeneUseCase.java
+++ b/src/main/java/org/cbioportal/domain/alteration/usecase/GetAlterationCountByGeneUseCase.java
@@ -76,7 +76,7 @@ public class GetAlterationCountByGeneUseCase extends AbstractAlterationCountByGe
 
   /**
    * Combines alteration counts by Hugo gene symbols. If multiple entries exist for the same gene
-   * symbol, their number of altered cases, off-panel cases, and total counts are summed up. Returns
+   * symbol, their number of altered cases, on-panel cases, and total counts are summed up. Returns
    * a list of unique AlterationCountByGene objects where each gene symbol is represented only once.
    *
    * <p>This appears in the Data where Genes have similar Hugo Gene Symbols but different Entrez Ids
@@ -93,14 +93,14 @@ public class GetAlterationCountByGeneUseCase extends AbstractAlterationCountByGe
         AlterationCountByGene toUpdate =
             alterationCountByGeneMap.get(alterationCount.getHugoGeneSymbol());
 
-        // Combine on-panel counts
+        // Combine total altered cases (on-panel + off-panel)
         toUpdate.setNumberOfAlteredCases(
             toUpdate.getNumberOfAlteredCases() + alterationCount.getNumberOfAlteredCases());
 
-        // Combine off-panel counts
-        toUpdate.setNumberOfAlteredCasesOffPanel(
-            toUpdate.getNumberOfAlteredCasesOffPanel()
-                + alterationCount.getNumberOfAlteredCasesOffPanel());
+        // Combine on-panel counts
+        toUpdate.setNumberOfAlteredCasesOnPanel(
+            toUpdate.getNumberOfAlteredCasesOnPanel()
+                + alterationCount.getNumberOfAlteredCasesOnPanel());
 
         // Combine total counts
         toUpdate.setTotalCount(toUpdate.getTotalCount() + alterationCount.getTotalCount());

--- a/src/main/java/org/cbioportal/domain/alteration/usecase/GetAlterationCountByGeneUseCase.java
+++ b/src/main/java/org/cbioportal/domain/alteration/usecase/GetAlterationCountByGeneUseCase.java
@@ -76,8 +76,8 @@ public class GetAlterationCountByGeneUseCase extends AbstractAlterationCountByGe
 
   /**
    * Combines alteration counts by Hugo gene symbols. If multiple entries exist for the same gene
-   * symbol, their number of altered cases and total counts are summed up. Returns a list of unique
-   * AlterationCountByGene objects where each gene symbol is represented only once.
+   * symbol, their number of altered cases, off-panel cases, and total counts are summed up. Returns
+   * a list of unique AlterationCountByGene objects where each gene symbol is represented only once.
    *
    * <p>This appears in the Data where Genes have similar Hugo Gene Symbols but different Entrez Ids
    *
@@ -92,8 +92,17 @@ public class GetAlterationCountByGeneUseCase extends AbstractAlterationCountByGe
       if (alterationCountByGeneMap.containsKey(alterationCount.getHugoGeneSymbol())) {
         AlterationCountByGene toUpdate =
             alterationCountByGeneMap.get(alterationCount.getHugoGeneSymbol());
+
+        // Combine on-panel counts
         toUpdate.setNumberOfAlteredCases(
             toUpdate.getNumberOfAlteredCases() + alterationCount.getNumberOfAlteredCases());
+
+        // Combine off-panel counts
+        toUpdate.setNumberOfAlteredCasesOffPanel(
+            toUpdate.getNumberOfAlteredCasesOffPanel()
+                + alterationCount.getNumberOfAlteredCasesOffPanel());
+
+        // Combine total counts
         toUpdate.setTotalCount(toUpdate.getTotalCount() + alterationCount.getTotalCount());
       } else {
         alterationCountByGeneMap.put(alterationCount.getHugoGeneSymbol(), alterationCount);

--- a/src/main/java/org/cbioportal/legacy/model/AlterationCountBase.java
+++ b/src/main/java/org/cbioportal/legacy/model/AlterationCountBase.java
@@ -6,6 +6,7 @@ import java.util.Set;
 public abstract class AlterationCountBase implements Serializable {
 
   private Integer numberOfAlteredCases;
+  private Integer numberOfAlteredCasesOffPanel;
   private Integer totalCount;
   private Integer numberOfProfiledCases;
   private Set<String> matchingGenePanelIds;
@@ -16,6 +17,14 @@ public abstract class AlterationCountBase implements Serializable {
 
   public void setNumberOfAlteredCases(Integer numberOfAlteredCases) {
     this.numberOfAlteredCases = numberOfAlteredCases;
+  }
+
+  public Integer getNumberOfAlteredCasesOffPanel() {
+    return numberOfAlteredCasesOffPanel;
+  }
+
+  public void setNumberOfAlteredCasesOffPanel(Integer numberOfAlteredCasesOffPanel) {
+    this.numberOfAlteredCasesOffPanel = numberOfAlteredCasesOffPanel;
   }
 
   public Integer getTotalCount() {

--- a/src/main/java/org/cbioportal/legacy/model/AlterationCountBase.java
+++ b/src/main/java/org/cbioportal/legacy/model/AlterationCountBase.java
@@ -6,7 +6,7 @@ import java.util.Set;
 public abstract class AlterationCountBase implements Serializable {
 
   private Integer numberOfAlteredCases;
-  private Integer numberOfAlteredCasesOffPanel;
+  private Integer numberOfAlteredCasesOnPanel;
   private Integer totalCount;
   private Integer numberOfProfiledCases;
   private Set<String> matchingGenePanelIds;
@@ -19,12 +19,12 @@ public abstract class AlterationCountBase implements Serializable {
     this.numberOfAlteredCases = numberOfAlteredCases;
   }
 
-  public Integer getNumberOfAlteredCasesOffPanel() {
-    return numberOfAlteredCasesOffPanel;
+  public Integer getNumberOfAlteredCasesOnPanel() {
+    return numberOfAlteredCasesOnPanel;
   }
 
-  public void setNumberOfAlteredCasesOffPanel(Integer numberOfAlteredCasesOffPanel) {
-    this.numberOfAlteredCasesOffPanel = numberOfAlteredCasesOffPanel;
+  public void setNumberOfAlteredCasesOnPanel(Integer numberOfAlteredCasesOnPanel) {
+    this.numberOfAlteredCasesOnPanel = numberOfAlteredCasesOnPanel;
   }
 
   public Integer getTotalCount() {

--- a/src/main/java/org/cbioportal/legacy/model/AlterationCountByGene.java
+++ b/src/main/java/org/cbioportal/legacy/model/AlterationCountByGene.java
@@ -7,7 +7,6 @@ public class AlterationCountByGene extends AlterationCountBase {
 
   private Integer entrezGeneId;
   private String hugoGeneSymbol;
-  private Integer numberOfAlteredCases;
   private BigDecimal qValue;
 
   public Integer getEntrezGeneId() {
@@ -24,14 +23,6 @@ public class AlterationCountByGene extends AlterationCountBase {
 
   public void setHugoGeneSymbol(String hugoGeneSymbol) {
     this.hugoGeneSymbol = hugoGeneSymbol;
-  }
-
-  public Integer getNumberOfAlteredCases() {
-    return numberOfAlteredCases;
-  }
-
-  public void setNumberOfAlteredCases(Integer numberOfAlteredCases) {
-    this.numberOfAlteredCases = numberOfAlteredCases;
   }
 
   @JsonProperty("qValue")

--- a/src/main/resources/mappers/clickhouse/alteration/ClickhouseAlterationMapper.xml
+++ b/src/main/resources/mappers/clickhouse/alteration/ClickhouseAlterationMapper.xml
@@ -11,13 +11,12 @@
         SELECT
         hugo_gene_symbol as hugoGeneSymbol,
         entrez_gene_id as entrezGeneId,
-        COUNT(DISTINCT sample_unique_id) as numberOfAlteredCases,
+        COUNT(DISTINCT CASE WHEN off_panel = 0 THEN sample_unique_id END) as numberOfAlteredCases,
+        COUNT(DISTINCT CASE WHEN off_panel = 1 THEN sample_unique_id END) as numberOfAlteredCasesOffPanel,
         COUNT(*) as totalCount
         FROM genomic_event_derived
         <where>
             variant_type = 'mutation' AND
-            <!-- Filter out samples altered on genes that are not profiled -->
-            off_panel = 0 AND
             <!-- Mutation Status UnCalled is only used in Patient View to see how many supporting reads a variant might have in a sample -->
             mutation_status != 'UNCALLED' AND
             <include
@@ -42,13 +41,12 @@
         entrez_gene_id as entrezGeneId,
         cna_alteration as alteration,
         cna_cytoband as cytoband,
-        COUNT(DISTINCT sample_unique_id) as numberOfAlteredCases,
+        COUNT(DISTINCT CASE WHEN off_panel = 0 THEN sample_unique_id END) as numberOfAlteredCases,
+        COUNT(DISTINCT CASE WHEN off_panel = 1 THEN sample_unique_id END) as numberOfAlteredCasesOffPanel,
         COUNT(*) as totalCount
         FROM genomic_event_derived
         <where>
             variant_type = 'cna' AND
-            <!-- Filter out samples altered on genes that are not profiled -->
-            off_panel = 0 AND
             <include
                 refid="org.cbioportal.infrastructure.repository.clickhouse.studyview.ClickhouseStudyViewFilterMapper.applyStudyViewFilterUsingSampleId"
             />
@@ -66,13 +64,12 @@
         SELECT
         hugo_gene_symbol as hugoGeneSymbol,
         entrez_gene_id as entrezGeneId,
-        COUNT(DISTINCT sample_unique_id) as numberOfAlteredCases,
+        COUNT(DISTINCT CASE WHEN off_panel = 0 THEN sample_unique_id END) as numberOfAlteredCases,
+        COUNT(DISTINCT CASE WHEN off_panel = 1 THEN sample_unique_id END) as numberOfAlteredCasesOffPanel,
         COUNT(*) as totalCount
         FROM genomic_event_derived
         <where>
             variant_type = 'structural_variant' AND
-            <!-- Filter out samples altered on genes that are not profiled -->
-            off_panel = 0 AND
             <include
                 refid="org.cbioportal.infrastructure.repository.clickhouse.studyview.ClickhouseStudyViewFilterMapper.applyStudyViewFilterUsingSampleId"
             />
@@ -207,6 +204,7 @@ totalProfiled Count per gene in java.
             pgb.hugoGeneSymbol AS hugoGeneSymbol,
             ifNull(tcg.entrezGeneId, 0) AS entrezGeneId,
             tcg.numberOfAlteredCases as numberOfAlteredCases,
+            tcg.numberOfAlteredCasesOffPanel as numberOfAlteredCasesOffPanel,
             pgb.profiled_count as numberOfProfiledCases
         FROM total_count_by_genes tcg
             RIGHT JOIN profiled_count_by_genes pgb ON tcg.hugoGeneSymbol = pgb.hugoGeneSymbol

--- a/src/main/resources/mappers/clickhouse/alteration/ClickhouseAlterationMapper.xml
+++ b/src/main/resources/mappers/clickhouse/alteration/ClickhouseAlterationMapper.xml
@@ -11,8 +11,8 @@
         SELECT
         hugo_gene_symbol as hugoGeneSymbol,
         entrez_gene_id as entrezGeneId,
-        COUNT(DISTINCT CASE WHEN off_panel = 0 THEN sample_unique_id END) as numberOfAlteredCases,
-        COUNT(DISTINCT CASE WHEN off_panel = 1 THEN sample_unique_id END) as numberOfAlteredCasesOffPanel,
+        COUNT(DISTINCT sample_unique_id) as numberOfAlteredCases,
+        COUNT(DISTINCT CASE WHEN off_panel = 0 THEN sample_unique_id END) as numberOfAlteredCasesOnPanel,
         COUNT(*) as totalCount
         FROM genomic_event_derived
         <where>
@@ -41,8 +41,8 @@
         entrez_gene_id as entrezGeneId,
         cna_alteration as alteration,
         cna_cytoband as cytoband,
-        COUNT(DISTINCT CASE WHEN off_panel = 0 THEN sample_unique_id END) as numberOfAlteredCases,
-        COUNT(DISTINCT CASE WHEN off_panel = 1 THEN sample_unique_id END) as numberOfAlteredCasesOffPanel,
+        COUNT(DISTINCT sample_unique_id) as numberOfAlteredCases,
+        COUNT(DISTINCT CASE WHEN off_panel = 0 THEN sample_unique_id END) as numberOfAlteredCasesOnPanel,
         COUNT(*) as totalCount
         FROM genomic_event_derived
         <where>
@@ -64,8 +64,8 @@
         SELECT
         hugo_gene_symbol as hugoGeneSymbol,
         entrez_gene_id as entrezGeneId,
-        COUNT(DISTINCT CASE WHEN off_panel = 0 THEN sample_unique_id END) as numberOfAlteredCases,
-        COUNT(DISTINCT CASE WHEN off_panel = 1 THEN sample_unique_id END) as numberOfAlteredCasesOffPanel,
+        COUNT(DISTINCT sample_unique_id) as numberOfAlteredCases,
+        COUNT(DISTINCT CASE WHEN off_panel = 0 THEN sample_unique_id END) as numberOfAlteredCasesOnPanel,
         COUNT(*) as totalCount
         FROM genomic_event_derived
         <where>
@@ -173,7 +173,8 @@ totalProfiled Count per gene in java.
         total_count_by_genes AS (
             SELECT ged.hugo_gene_symbol AS hugoGeneSymbol,
             ged.entrez_gene_id as entrezGeneId,
-            COUNT(DISTINCT ${unique_id}) as numberOfAlteredCases
+            COUNT(DISTINCT ${unique_id}) as numberOfAlteredCases,
+            COUNT(DISTINCT CASE WHEN off_panel = 0 THEN ${unique_id} END) as numberOfAlteredCasesOnPanel
             FROM genomic_event_derived ged
             <where>
                 ged.mutation_status != 'UNCALLED'
@@ -204,7 +205,7 @@ totalProfiled Count per gene in java.
             pgb.hugoGeneSymbol AS hugoGeneSymbol,
             ifNull(tcg.entrezGeneId, 0) AS entrezGeneId,
             tcg.numberOfAlteredCases as numberOfAlteredCases,
-            tcg.numberOfAlteredCasesOffPanel as numberOfAlteredCasesOffPanel,
+            tcg.numberOfAlteredCasesOnPanel as numberOfAlteredCasesOnPanel,
             pgb.profiled_count as numberOfProfiledCases
         FROM total_count_by_genes tcg
             RIGHT JOIN profiled_count_by_genes pgb ON tcg.hugoGeneSymbol = pgb.hugoGeneSymbol

--- a/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/alteration/ClickhouseAlterationMapperTest.java
+++ b/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/alteration/ClickhouseAlterationMapperTest.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import org.cbioportal.domain.studyview.StudyViewFilterFactory;
 import org.cbioportal.infrastructure.repository.clickhouse.AbstractTestcontainers;
 import org.cbioportal.infrastructure.repository.clickhouse.config.MyBatisConfig;
-import org.cbioportal.legacy.model.AlterationCountBase;
 import org.cbioportal.legacy.model.AlterationFilter;
 import org.cbioportal.legacy.model.CNA;
 import org.cbioportal.legacy.model.MutationEventType;
@@ -53,7 +52,7 @@ public class ClickhouseAlterationMapperTest {
             .filter(a -> Objects.equals(a.getHugoGeneSymbol(), "BRCA1"))
             .findFirst();
     assert (testBrca1AlterationCount.isPresent());
-    assertEquals(Integer.valueOf(3), testBrca1AlterationCount.get().getTotalCount());
+    assertEquals(Integer.valueOf(5), testBrca1AlterationCount.get().getTotalCount());
   }
 
   @Test
@@ -101,24 +100,6 @@ public class ClickhouseAlterationMapperTest {
   }
 
   @Test
-  public void testMutatedGenesOffPanelFiltering() {
-    StudyViewFilter studyViewFilter = new StudyViewFilter();
-    studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
-    var alterationCountByGenes =
-        mapper.getMutatedGenes(
-            StudyViewFilterFactory.make(studyViewFilter, null, studyViewFilter.getStudyIds(), null),
-            AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()));
-
-    var testBrca1AlterationCount =
-        alterationCountByGenes.stream()
-            .filter(a -> Objects.equals(a.getHugoGeneSymbol(), "BRCA1"))
-            .mapToInt(AlterationCountBase::getTotalCount)
-            .sum();
-    // 5 mutations for BRCA1 - 2 off panel = 3
-    assertEquals(3, testBrca1AlterationCount);
-  }
-
-  @Test
   public void getCnaGenes() {
     StudyViewFilter studyViewFilter = new StudyViewFilter();
     studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
@@ -126,7 +107,7 @@ public class ClickhouseAlterationMapperTest {
         mapper.getCnaGenes(
             StudyViewFilterFactory.make(studyViewFilter, null, studyViewFilter.getStudyIds(), null),
             AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()));
-    assertEquals(2, alterationCountByGenes.size());
+    assertEquals(3, alterationCountByGenes.size());
 
     // Test cna count for akt1
     var testAKT1AlterationCount =
@@ -153,7 +134,7 @@ public class ClickhouseAlterationMapperTest {
         mapper.getCnaGenes(
             StudyViewFilterFactory.make(studyViewFilter, null, studyViewFilter.getStudyIds(), null),
             AlterationFilterHelper.build(alterationFilter));
-    assertEquals(1, alterationCountByGenes.size());
+    assertEquals(2, alterationCountByGenes.size());
 
     // Test cna count for akt1 filtering for AMP
     var testAKT1AlterationCount =
@@ -162,24 +143,6 @@ public class ClickhouseAlterationMapperTest {
             .mapToInt(c -> c.getTotalCount().intValue())
             .sum();
     assertEquals(2, testAKT1AlterationCount);
-  }
-
-  @Test
-  public void testCnaGenesOffPanelFiltering() {
-    StudyViewFilter studyViewFilter = new StudyViewFilter();
-    studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB));
-    var alterationCountByGenes =
-        mapper.getCnaGenes(
-            StudyViewFilterFactory.make(studyViewFilter, null, studyViewFilter.getStudyIds(), null),
-            AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()));
-
-    var testAKT2AlterationCount =
-        alterationCountByGenes.stream()
-            .filter(a -> Objects.equals(a.getHugoGeneSymbol(), "AKT2"))
-            .mapToInt(AlterationCountBase::getTotalCount)
-            .sum();
-    // 1 cna for AKT2 - 1 off panel = 0
-    assertEquals(0, testAKT2AlterationCount);
   }
 
   @Test
@@ -207,25 +170,6 @@ public class ClickhouseAlterationMapperTest {
             .mapToInt(c -> c.getTotalCount().intValue())
             .sum();
     assertEquals(3, testncoa4AlterationCount);
-  }
-
-  @Test
-  public void testStructuralVariantGenesOffPanelFiltering() {
-    StudyViewFilter studyViewFilter = new StudyViewFilter();
-    studyViewFilter.setStudyIds(List.of(STUDY_TCGA_PUB, STUDY_ACC_TCGA));
-    var alterationCountByGenes =
-        mapper.getStructuralVariantGenes(
-            StudyViewFilterFactory.make(studyViewFilter, null, studyViewFilter.getStudyIds(), null),
-            AlterationFilterHelper.build(studyViewFilter.getAlterationFilter()));
-    assertEquals(8, alterationCountByGenes.size());
-
-    // 3 NCOA4 across 2 studies - 0 off panel = 3
-    var testNcoa4AlterationCount =
-        alterationCountByGenes.stream()
-            .filter(a -> Objects.equals(a.getHugoGeneSymbol(), "ncoa4"))
-            .mapToInt(AlterationCountBase::getTotalCount)
-            .sum();
-    assertEquals(3, testNcoa4AlterationCount);
   }
 
   @Test


### PR DESCRIPTION
Fix #11568 

# Add On-Panel Alteration Count

## Overview
Add `numberOfAlteredCasesOnPanel` field to gene alteration API responses. This change restores the natural semantics of existing fields while providing on-panel specific counts for reliable frequency calculations.

**Affected Components:**
- API endpoints: `/mutated-genes/fetch`, `/structural-variant-genes/fetch`, `/cna-genes/fetch`
- MyBatis mapper: `ClickhouseAlterationMapper.xml`
- Model class: `AlterationCountBase`
- Service layer: `GetAlterationCountByGeneUseCase`

## API Changes

**New Field Added:**
- `numberOfAlteredCasesOnPanel` (Integer): Count of samples with on-panel alterations only

**Existing Fields - Restored Natural Semantics:**
- `numberOfAlteredCases`: Total samples with alterations (as it should be)
- `totalCount`: Total alteration records (as it should be)

**Response Example:**
```json
{
  "hugoGeneSymbol": "TP53",
  "entrezGeneId": 7157,
  "numberOfAlteredCases": 57,
  "numberOfAlteredCasesOnPanel": 45,
  "numberOfProfiledCases": 150,
  "totalCount": 57
}
```

## Backend Changes

### SQL Query Modifications
**Single change across all queries:**
- **Removed**: `WHERE off_panel = 0` filter
- **Added**: `COUNT(DISTINCT CASE WHEN off_panel = 0 THEN sample_unique_id END) as numberOfAlteredCasesOnPanel`

**Result:**
- Queries now return all genes (including off-panel-only genes)
- Existing fields show true totals
- New field provides on-panel subset

### Model Class Update
**AlterationCountBase.java:**
```java
private Integer numberOfAlteredCasesOnPanel;

public Integer getNumberOfAlteredCasesOnPanel() {
    return numberOfAlteredCasesOnPanel;
}

public void setNumberOfAlteredCasesOnPanel(Integer numberOfAlteredCasesOnPanel) {
    this.numberOfAlteredCasesOnPanel = numberOfAlteredCasesOnPanel;
}
```

### Service Layer Update
**GetAlterationCountByGeneUseCase.java:**
- Updated aggregation logic to include on-panel counts when combining duplicate Hugo symbols
- Simple addition: `existingOnPanel + newOnPanel`

## Summary
This change simply removes an artificial filter and adds one field. The result is that the API now provides complete alteration data while maintaining the ability to focus on reliable on-panel alterations when needed.