### PR TITLE
Add configuration for google tag manager embed

### DIFF
--- a/docs/deployment/customization/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/deployment/customization/Customizing-your-instance-of-cBioPortal.md
@@ -284,6 +284,12 @@ If the download_group is present in user groups then download options are shown 
             <td>disabled</td>
             <td>string</td>
         </tr>
+        <tr>
+            <td>google_tag_manager_id</td>
+            <td>enables google tag manager on your site</td>
+            <td>disabled</td>
+            <td>string</td>
+        </tr>
    </tbody>
 </table>
 

--- a/src/main/java/org/cbioportal/legacy/service/FrontendPropertiesServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/FrontendPropertiesServiceImpl.java
@@ -49,6 +49,7 @@ public class FrontendPropertiesServiceImpl implements FrontendPropertiesService 
     genomenexus_url_grch38("genomenexus.url.grch38", null),
     genomenexus_isoform_override_source("genomenexus.isoform_override_source", null),
     google_analytics_profile_id("google_analytics_profile_id", null),
+    google_tag_manager_id("google_tag_manager_id", null),
     analytics_report_url("analytics_report_url", null),
     oncoprint_hide_vus_default("oncoprint.hide_vus.default", null),
     mycancergenome_show("mycancergenome.show", null),

--- a/src/main/java/org/cbioportal/legacy/web/IndexPageController.java
+++ b/src/main/java/org/cbioportal/legacy/web/IndexPageController.java
@@ -118,6 +118,9 @@ public class IndexPageController {
     model.addAttribute(
         "appVersion", frontendPropertiesService.getFrontendProperty(FrontendProperty.app_version));
     model.addAttribute("postData", postData.isEmpty() ? "undefined" : postData);
+    model.addAttribute(
+        "googleTagManagerId",
+        frontendPropertiesService.getFrontendProperty(FrontendProperty.google_tag_manager_id));
 
     return "index";
   }

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -236,7 +236,9 @@ pathway_commons.url=http://www.pathwaycommons.org/pc2
 bitly.access.token=
 
 # google analytics
-google_analytics_profile_id=
+# Note: use one or the other of these properties, not both
+# google_analytics_profile_id=
+# google_tag_manager_id=
 
 # genomespace linking
 genomespace=true

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html class="cbioportal-frontend" lang="en">
 <head>
+
+    <script th:if="${googleTagManagerId != null}" th:inline="javascript">
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer',/*[[${googleTagManagerId}]]*/);
+    </script>
+
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
  
     <link rel="icon" href="/images/cbioportal_icon.png"/>
@@ -70,6 +79,12 @@
 </head>
 
 <body>
+
+    <noscript th:if="${googleTagManagerId != null}">
+        <iframe th:src="'https://www.googletagmanager.com/ns.html?id=' + ${googleTagManagerId}"
+                height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+
     <script>
         loadReactApp(window.frontendConfig);
     </script>


### PR DESCRIPTION
Add a new frontend config property called google_tag_manager_id and, if it not null, insert the gtm embed code in the index.html template