### PR TITLE
Fix for issue #11609: group comparison should be case-insensitive

### DIFF
--- a/src/main/java/org/cbioportal/application/security/CancerStudyPermissionEvaluator.java
+++ b/src/main/java/org/cbioportal/application/security/CancerStudyPermissionEvaluator.java
@@ -368,7 +368,7 @@ public class CancerStudyPermissionEvaluator implements PermissionEvaluator {
         Arrays.stream(cancerStudy.getGroups().split(";"))
             .filter(g -> !g.isEmpty())
             .collect(Collectors.toSet());
-    if (!Collections.disjoint(groups, grantedAuthorities)) {
+    if (!caseInsensitiveDisjoint(groups, grantedAuthorities)) {
       if (log.isDebugEnabled()) {
         log.debug("hasAccessToCancerStudy(), user has access by groups return true");
       }
@@ -391,6 +391,12 @@ public class CancerStudyPermissionEvaluator implements PermissionEvaluator {
       }
     }
     return toReturn;
+  }
+
+  private static boolean caseInsensitiveDisjoint(Collection<String> c1, Collection<String> c2) {
+    Set<String> upperC1 = c1.stream().map(String::toUpperCase).collect(Collectors.toSet());
+    Set<String> upperC2 = c2.stream().map(String::toUpperCase).collect(Collectors.toSet());
+    return Collections.disjoint(upperC1, upperC2);
   }
 
   private boolean hasAccessToCancerStudy(


### PR DESCRIPTION
Closes #11609

This request fixes the following issue:
if we have `set authorities=true ` in app properties
and if we have a `group` value in `cancer_study `table `sample_group` 
and if we have authority 'sample_group'  (or 'cbioportal:sample_group', depending on the filtering option) in `authorities `table for a user.

Then the access to that cancer study is not granted to the use even though the authroity matches the cancer study group.

This happens because authorities are convereted to upper case while cancer group names are not.

To fix this the pull request changes `Collections.disjoint` (which is case-sensitive) to a case-insensitive utility method `caseInsensitiveDisjoint`.

