### PR TITLE
Add posibility to create and drop published virtual studies with custom IDs

### DIFF
--- a/src/main/java/org/cbioportal/legacy/service/util/SessionServiceRequestHandler.java
+++ b/src/main/java/org/cbioportal/legacy/service/util/SessionServiceRequestHandler.java
@@ -1,6 +1,6 @@
 package org.cbioportal.legacy.service.util;
 
-import static org.cbioportal.legacy.utils.removeme.Session.*;
+import static org.cbioportal.legacy.utils.removeme.Session.SessionType;
 
 import com.mongodb.BasicDBObject;
 import java.io.Serializable;
@@ -180,6 +180,32 @@ public class SessionServiceRequestHandler {
   }
 
   /**
+   * Creates a virtual study with custom id
+   *
+   * @param virtualStudyData - definition of virtual study
+   * @return virtual study object with id and the virtualStudyData
+   */
+  public VirtualStudy createVirtualStudy(String id, VirtualStudyData virtualStudyData) {
+
+    String url =
+        UriComponentsBuilder.fromUriString(sessionServiceURL)
+            .pathSegment("virtual_study")
+            .pathSegment(id)
+            .build()
+            .toUriString();
+
+    ResponseEntity<VirtualStudy> responseEntity =
+        new RestTemplate()
+            .exchange(
+                url,
+                HttpMethod.POST,
+                new HttpEntity<>(virtualStudyData, getHttpHeaders()),
+                new ParameterizedTypeReference<>() {});
+
+    return responseEntity.getBody();
+  }
+
+  /**
    * Soft delete of the virtual study by de-associating all assigned users.
    *
    * @param id - id of virtual study to soft delete
@@ -206,6 +232,23 @@ public class SessionServiceRequestHandler {
             .toUriString();
 
     new RestTemplate().put(url, new HttpEntity<>(virtualStudy.getData(), getHttpHeaders()));
+  }
+
+  /**
+   * Drop virtual study
+   *
+   * @param virtualStudyId - id of virtual study to drop
+   */
+  public void dropVirtualStudy(String virtualStudyId) {
+
+    String url =
+        UriComponentsBuilder.fromUriString(sessionServiceURL)
+            .pathSegment("virtual_study")
+            .pathSegment(virtualStudyId)
+            .build()
+            .toUriString();
+
+    new RestTemplate().delete(url, new HttpEntity<>(getHttpHeaders()));
   }
 
   private List<PageSettings> getPageSettingsForUser(

--- a/src/main/java/org/cbioportal/legacy/web/PublicVirtualStudiesController.java
+++ b/src/main/java/org/cbioportal/legacy/web/PublicVirtualStudiesController.java
@@ -7,8 +7,10 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import org.cbioportal.legacy.service.CancerTypeService;
+import org.cbioportal.legacy.service.StudyService;
 import org.cbioportal.legacy.service.exception.AccessForbiddenException;
 import org.cbioportal.legacy.service.exception.CancerTypeNotFoundException;
+import org.cbioportal.legacy.service.exception.StudyNotFoundException;
 import org.cbioportal.legacy.service.util.SessionServiceRequestHandler;
 import org.cbioportal.legacy.web.parameter.VirtualStudy;
 import org.cbioportal.legacy.web.parameter.VirtualStudyData;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -39,14 +42,17 @@ public class PublicVirtualStudiesController {
   private final SessionServiceRequestHandler sessionServiceRequestHandler;
 
   private final CancerTypeService cancerTypeService;
+  private final StudyService studyService;
 
   public PublicVirtualStudiesController(
       @Value("${session.endpoint.publisher-api-key:}") String requiredPublisherApiKey,
       SessionServiceRequestHandler sessionServiceRequestHandler,
-      CancerTypeService cancerTypeService) {
+      CancerTypeService cancerTypeService,
+      StudyService studyService) {
     this.requiredPublisherApiKey = requiredPublisherApiKey;
     this.sessionServiceRequestHandler = sessionServiceRequestHandler;
     this.cancerTypeService = cancerTypeService;
+    this.studyService = studyService;
   }
 
   @GetMapping
@@ -69,9 +75,10 @@ public class PublicVirtualStudiesController {
       @PathVariable String id,
       @RequestHeader(value = "X-PUBLISHER-API-KEY") String providedPublisherApiKey,
       @RequestParam(required = false) String typeOfCancerId,
-      @RequestParam(required = false) String pmid) {
+      @RequestParam(required = false) String pmid,
+      @RequestBody(required = false) VirtualStudyData virtualStudyData) {
     ensureProvidedPublisherApiKeyCorrect(providedPublisherApiKey);
-    publishVirtualStudy(id, typeOfCancerId, pmid);
+    publishVirtualStudy(id, typeOfCancerId, pmid, virtualStudyData);
     return ResponseEntity.ok().build();
   }
 
@@ -79,9 +86,14 @@ public class PublicVirtualStudiesController {
   @ApiResponse(responseCode = "200", description = "OK")
   public ResponseEntity<Void> unPublishVirtualStudy(
       @PathVariable String id,
+      @RequestParam(defaultValue = "true") boolean softDelete,
       @RequestHeader(value = "X-PUBLISHER-API-KEY") String providedPublisherApiKey) {
     ensureProvidedPublisherApiKeyCorrect(providedPublisherApiKey);
-    unPublishVirtualStudy(id);
+    if (softDelete) {
+      unPublishVirtualStudy(id);
+    } else {
+      dropPublicVirtualStudy(id);
+    }
     return ResponseEntity.ok().build();
   }
 
@@ -92,13 +104,32 @@ public class PublicVirtualStudiesController {
    * @param typeOfCancerId - if specified (not null) update type of cancer of published virtual
    *     study
    * @param pmid - if specified (not null) update PubMed ID of published virtual study
+   * @param virtualStudyData - if specified (not null) create new virtual study with this data,
+   *     otherwise updates virtual study with the given id
    */
-  private void publishVirtualStudy(String id, String typeOfCancerId, String pmid) {
-    VirtualStudy virtualStudyDataToPublish = sessionServiceRequestHandler.getVirtualStudyById(id);
-    VirtualStudyData virtualStudyData = virtualStudyDataToPublish.getData();
-    updateStudyMetadataFieldsIfSpecified(virtualStudyData, typeOfCancerId, pmid);
-    virtualStudyData.setUsers(Set.of(ALL_USERS));
-    sessionServiceRequestHandler.updateVirtualStudy(virtualStudyDataToPublish);
+  private void publishVirtualStudy(
+      String id, String typeOfCancerId, String pmid, VirtualStudyData virtualStudyData) {
+    if (virtualStudyData == null) {
+      VirtualStudy virtualStudyDataToPublish = sessionServiceRequestHandler.getVirtualStudyById(id);
+      virtualStudyData = virtualStudyDataToPublish.getData();
+      updateStudyMetadataFieldsIfSpecified(virtualStudyData, typeOfCancerId, pmid);
+      virtualStudyData.setUsers(Set.of(ALL_USERS));
+      sessionServiceRequestHandler.updateVirtualStudy(virtualStudyDataToPublish);
+    } else {
+      updateStudyMetadataFieldsIfSpecified(virtualStudyData, typeOfCancerId, pmid);
+      virtualStudyData.setUsers(Set.of(ALL_USERS));
+      try {
+        studyService.getStudy(id);
+        throw new IllegalStateException(
+            "The study with id="
+                + id
+                + " already exists. Please use a different id for the virtual study.");
+      } catch (StudyNotFoundException e) {
+        LOG.debug(
+            "The study with id={} does not exist, proceeding to create a new virtual study.", id);
+      }
+      sessionServiceRequestHandler.createVirtualStudy(id, virtualStudyData);
+    }
   }
 
   /**
@@ -113,13 +144,28 @@ public class PublicVirtualStudiesController {
           "The virtual study with id=" + id + " has not been found in the public list.");
     }
     VirtualStudyData virtualStudyData = virtualStudyToUnPublish.getData();
+    checkIfVSWasPublished(id, virtualStudyData);
+    virtualStudyData.setUsers(Set.of(virtualStudyData.getOwner()));
+    sessionServiceRequestHandler.updateVirtualStudy(virtualStudyToUnPublish);
+  }
+
+  /**
+   * Drops public virtual study, removing it from the public list
+   *
+   * @param id - id of public virtual study to drop
+   */
+  private void dropPublicVirtualStudy(String id) {
+    VirtualStudy virtualStudyToUnPublish = sessionServiceRequestHandler.getVirtualStudyById(id);
+    checkIfVSWasPublished(id, virtualStudyToUnPublish.getData());
+    sessionServiceRequestHandler.dropVirtualStudy(virtualStudyToUnPublish.getId());
+  }
+
+  private static void checkIfVSWasPublished(String id, VirtualStudyData virtualStudyData) {
     Set<String> users = virtualStudyData.getUsers();
     if (users == null || users.isEmpty() || !users.contains(ALL_USERS)) {
       throw new NoSuchElementException(
           "The virtual study with id=" + id + " has not been found in the public list.");
     }
-    virtualStudyData.setUsers(Set.of(virtualStudyData.getOwner()));
-    sessionServiceRequestHandler.updateVirtualStudy(virtualStudyToUnPublish);
   }
 
   private void ensureProvidedPublisherApiKeyCorrect(String providedPublisherApiKey) {


### PR DESCRIPTION
To support RFC96 Virtual Study Authorisation Model we need static human readable ids to assign permissions to them

Fix # (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- a
- b

# Checks
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
