### PR TITLE
Restore sample check endpoint for CIS

### DIFF
--- a/src/main/java/org/cbioportal/legacy/web/MskEntityTranslationController.java
+++ b/src/main/java/org/cbioportal/legacy/web/MskEntityTranslationController.java
@@ -117,7 +117,7 @@ public class MskEntityTranslationController {
   }
 
   @RequestMapping(
-      value = {"/api-legacy/cis/{sampleID}", "/api-legacy/darwin/{sampleID}"},
+      value = {"/api-legacy/cis/{sampleID}"},
       method = RequestMethod.GET)
   public ModelAndView redirectIMPACT(@PathVariable String sampleID, ModelMap model) {
     return new ModelAndView(getRedirectURL(sampleID), model);

--- a/src/main/java/org/cbioportal/legacy/web/MskEntityTranslationController.java
+++ b/src/main/java/org/cbioportal/legacy/web/MskEntityTranslationController.java
@@ -116,6 +116,13 @@ public class MskEntityTranslationController {
     return new ModelAndView(getRedirectURL(decryptedId), model);
   }
 
+  @RequestMapping(
+      value = {"/api-legacy/cis/{sampleID}", "/api-legacy/darwin/{sampleID}"},
+      method = RequestMethod.GET)
+  public ModelAndView redirectIMPACT(@PathVariable String sampleID, ModelMap model) {
+    return new ModelAndView(getRedirectURL(sampleID), model);
+  }
+
   @RequestMapping(value = "/api-legacy/crdb/{sampleID}", method = RequestMethod.GET)
   public ModelAndView redirectCRDB(@PathVariable String sampleID, ModelMap model) {
     return new ModelAndView(getRedirectURL(sampleID), model);


### PR DESCRIPTION
This endpoint `/api-legacy/cis/{sampleID}` was inadvertantly deleted during darwin removal.  It is used by CIS system.