### PR TITLE
Add samples to the treatments endpoint

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewController.java
@@ -60,6 +60,7 @@ import org.cbioportal.legacy.web.parameter.Projection;
 import org.cbioportal.legacy.web.parameter.SampleIdentifier;
 import org.cbioportal.legacy.web.parameter.StudyViewFilter;
 import org.cbioportal.legacy.web.util.DensityPlotParameters;
+import org.cbioportal.shared.enums.ProjectionType;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -574,11 +575,15 @@ public class ColumnarStoreStudyViewController {
       @Parameter(required = false)
           @RequestParam(name = "tier", required = false, defaultValue = "Agent")
           ClinicalEventKeyCode tier,
+      @Parameter(description = "Level of detail of the response")
+          @RequestParam(defaultValue = "SUMMARY")
+          ProjectionType projection,
       @Parameter(required = true, description = "Study view filter")
           @Valid
           @RequestBody(required = false)
           StudyViewFilter studyViewFilter) {
-    return ResponseEntity.ok(studyViewService.getSampleTreatmentReport(studyViewFilter));
+    return ResponseEntity.ok(
+        studyViewService.getSampleTreatmentReport(studyViewFilter, projection));
   }
 
   @Hidden // should unhide when we remove legacy controller

--- a/src/main/java/org/cbioportal/domain/studyview/StudyViewService.java
+++ b/src/main/java/org/cbioportal/domain/studyview/StudyViewService.java
@@ -40,6 +40,7 @@ import org.cbioportal.legacy.web.parameter.GenericAssayDataFilter;
 import org.cbioportal.legacy.web.parameter.GenomicDataBinFilter;
 import org.cbioportal.legacy.web.parameter.GenomicDataFilter;
 import org.cbioportal.legacy.web.parameter.StudyViewFilter;
+import org.cbioportal.shared.enums.ProjectionType;
 import org.cbioportal.shared.util.ClinicalDataCountItemUtil;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
@@ -169,10 +170,11 @@ public class StudyViewService {
       cacheResolver = "staticRepositoryCacheOneResolver",
       condition =
           "@cacheEnabledConfig.getEnabledClickhouse() && @studyViewFilterUtil.isUnfilteredQuery(#studyViewFilter)")
-  public SampleTreatmentReport getSampleTreatmentReport(StudyViewFilter studyViewFilter) {
+  public SampleTreatmentReport getSampleTreatmentReport(
+      StudyViewFilter studyViewFilter, ProjectionType projection) {
     return treatmentCountReportUseCases
         .getSampleTreatmentReportUseCase()
-        .execute(buildStudyViewFilterContext(studyViewFilter));
+        .execute(buildStudyViewFilterContext(studyViewFilter), projection);
   }
 
   @Cacheable(

--- a/src/main/java/org/cbioportal/domain/treatment/repository/TreatmentRepository.java
+++ b/src/main/java/org/cbioportal/domain/treatment/repository/TreatmentRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.cbioportal.domain.studyview.StudyViewFilterContext;
 import org.cbioportal.legacy.model.PatientTreatment;
 import org.cbioportal.legacy.model.SampleTreatment;
+import org.cbioportal.shared.enums.ProjectionType;
 
 /**
  * Repository interface for performing operations related to patient and sample treatments. This
@@ -37,7 +38,8 @@ public interface TreatmentRepository {
    * @param studyViewFilterContext the context containing the filter criteria for the study view
    * @return a list of {@link SampleTreatment} representing the treatments for samples
    */
-  List<SampleTreatment> getSampleTreatments(StudyViewFilterContext studyViewFilterContext);
+  List<SampleTreatment> getSampleTreatments(
+      StudyViewFilterContext studyViewFilterContext, ProjectionType projection);
 
   /**
    * Retrieves the total count of sample treatments based on the provided study view filter context.

--- a/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/treatment/ClickhouseTreatmentMapper.java
+++ b/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/treatment/ClickhouseTreatmentMapper.java
@@ -37,7 +37,8 @@ public interface ClickhouseTreatmentMapper {
    * @return a list of sample treatment counts
    */
   List<SampleTreatment> getSampleTreatmentCounts(
-      @Param("studyViewFilterContext") StudyViewFilterContext studyViewFilterContext);
+      @Param("studyViewFilterContext") StudyViewFilterContext studyViewFilterContext,
+      @Param("projection") String projection);
 
   /**
    * Retrieves the total sample treatment counts based on the study view filter context.

--- a/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/treatment/ClickhouseTreatmentRepository.java
+++ b/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/treatment/ClickhouseTreatmentRepository.java
@@ -5,6 +5,7 @@ import org.cbioportal.domain.studyview.StudyViewFilterContext;
 import org.cbioportal.domain.treatment.repository.TreatmentRepository;
 import org.cbioportal.legacy.model.PatientTreatment;
 import org.cbioportal.legacy.model.SampleTreatment;
+import org.cbioportal.shared.enums.ProjectionType;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
@@ -29,8 +30,9 @@ public class ClickhouseTreatmentRepository implements TreatmentRepository {
   }
 
   @Override
-  public List<SampleTreatment> getSampleTreatments(StudyViewFilterContext studyViewFilterContext) {
-    return mapper.getSampleTreatmentCounts(studyViewFilterContext);
+  public List<SampleTreatment> getSampleTreatments(
+      StudyViewFilterContext studyViewFilterContext, ProjectionType projection) {
+    return mapper.getSampleTreatmentCounts(studyViewFilterContext, projection.name());
   }
 
   @Override

--- a/src/main/java/org/cbioportal/legacy/model/SampleTreatment.java
+++ b/src/main/java/org/cbioportal/legacy/model/SampleTreatment.java
@@ -1,3 +1,10 @@
 package org.cbioportal.legacy.model;
 
-public record SampleTreatment(String treatment, int preSampleCount, int postSampleCount) {}
+import java.util.List;
+
+public record SampleTreatment(
+    String treatment,
+    int preSampleCount,
+    int postSampleCount,
+    List<ClinicalEventSample> preSamples,
+    List<ClinicalEventSample> postSamples) {}

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/typehandler/ClinicalEventSampleTypeHandler.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/typehandler/ClinicalEventSampleTypeHandler.java
@@ -1,0 +1,64 @@
+package org.cbioportal.legacy.persistence.mybatis.typehandler;
+
+import java.sql.Array;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.cbioportal.legacy.model.ClinicalEventSample;
+
+public class ClinicalEventSampleTypeHandler extends BaseTypeHandler<List<ClinicalEventSample>> {
+  @Override
+  public void setNonNullParameter(
+      PreparedStatement ps, int i, List<ClinicalEventSample> parameter, JdbcType jdbcType)
+      throws SQLException {
+    ps.setString(i, Arrays.toString(parameter.toArray()).replace("[", "").replace("]", ""));
+  }
+
+  @Override
+  public List<ClinicalEventSample> getNullableResult(ResultSet rs, String columnName)
+      throws SQLException {
+    Array sqlArray = rs.getArray(columnName);
+    return convertClickhouseArrayToSamples(sqlArray);
+  }
+
+  @Override
+  public List<ClinicalEventSample> getNullableResult(ResultSet rs, int columnIndex)
+      throws SQLException {
+    Array sqlArray = rs.getArray(columnIndex);
+    return convertClickhouseArrayToSamples(sqlArray);
+  }
+
+  @Override
+  public List<ClinicalEventSample> getNullableResult(CallableStatement cs, int columnIndex)
+      throws SQLException {
+    Array sqlArray = cs.getArray(columnIndex);
+    return convertClickhouseArrayToSamples(sqlArray);
+  }
+
+  private List<ClinicalEventSample> convertClickhouseArrayToSamples(Array sqlArray)
+      throws SQLException {
+    return Arrays.stream((Object[]) sqlArray.getArray())
+        .map(
+            obj -> {
+              List<Object> fields = (List<Object>) obj;
+              String sampleId = (String) fields.get(0);
+              String uniqPatientId = (String) fields.get(1);
+              Integer timeTaken = (Integer) fields.get(2);
+              String studyId = (String) fields.get(3);
+              String patientId = uniqPatientId.replaceFirst(studyId + "_", "");
+
+              ClinicalEventSample sample = new ClinicalEventSample();
+              sample.setSampleId(sampleId);
+              sample.setPatientId(patientId);
+              sample.setTimeTaken(timeTaken);
+              sample.setStudyId(studyId);
+              return sample;
+            })
+        .toList();
+  }
+}

--- a/src/main/resources/mappers/clickhouse/treatment/ClickhouseTreatmentMapper.xml
+++ b/src/main/resources/mappers/clickhouse/treatment/ClickhouseTreatmentMapper.xml
@@ -66,49 +66,74 @@
             )
         </where>
     </select>
-
+    
     <resultMap id="SampleTreatmentCount" type="org.cbioportal.legacy.model.SampleTreatment">
         <constructor>
             <arg column="treatment" javaType="String"/>
             <arg column="preSampleCount" javaType="_int"/>
             <arg column="postSampleCount" javaType="_int"/>
+            <arg column="preSamples" javaType="java.util.List" typeHandler="org.cbioportal.legacy.persistence.mybatis.typehandler.ClinicalEventSampleTypeHandler" />
+            <arg column="postSamples" javaType="java.util.List" typeHandler="org.cbioportal.legacy.persistence.mybatis.typehandler.ClinicalEventSampleTypeHandler" />
         </constructor>
     </resultMap>
-    <!-- Count (Pre/Post) Sample Acquisition Events for every Treatment per Patient -->
-    <select id="getSampleTreatmentCounts" resultMap="SampleTreatmentCount">
-        <!-- Nested sub query to grab minimum sample acquisition event  and also filter out duplicates -->
-        WITH sample_acquisition_events AS (
+    
+    <sql id="sampleAcquisitionEvents">
         SELECT
-        ced.value AS sample_id,
-        ced.patient_unique_id,
-        min(ced.start_date) AS time_taken,
-        ced.cancer_study_identifier AS cancer_study_identifier
+            ced.value AS sample_id,
+            ced.patient_unique_id,
+            min(ced.start_date) AS time_taken,
+            ced.cancer_study_identifier AS cancer_study_identifier
         FROM clinical_event_derived ced
         <where>
             key = 'SAMPLE_ID'
             AND (event_type ILIKE 'Sample Acquisition' OR event_type ILIKE 'SPECIMEN')
         </where>
         GROUP BY patient_unique_id, ced.value, cancer_study_identifier
-        ),
-        <!-- Nested sub query to grab minimum treatment event. When there are multiple treatments that are of the same
-        type we only care about the first treatment.
-         -->
-        treatments AS (
+    </sql>
+    
+    <sql id="treatments">
         SELECT
-        patient_unique_id,
-        value AS treatment,
-        argMin(start_date, start_date) AS treatment_time_taken
+            patient_unique_id,
+            value AS treatment,
+            argMin(start_date, start_date) AS treatment_time_taken
         FROM clinical_event_derived
         <where>
             lower(event_type) = 'treatment'
             AND key = 'AGENT'
         </where>
         GROUP BY patient_unique_id, value
-        )
+    </sql>
+    
+    <!-- Count (Pre/Post) Sample Acquisition Events for every Treatment per Patient -->
+    <select id="getSampleTreatmentCounts" resultMap="SampleTreatmentCount">
+        <!-- Nested sub query to grab minimum sample acquisition event  and also filter out duplicates -->
+        WITH sample_acquisition_events AS (<include refid="sampleAcquisitionEvents" />),
+        <!-- Nested sub query to grab minimum treatment event. When there are multiple treatments that are of the same
+        type we only care about the first treatment.
+         -->
+        treatments AS (<include refid="treatments" />)
         SELECT
-        countIf(ced.sample_id,ced.time_taken &lt;= treatments.treatment_time_taken) AS preSampleCount,
-        countIf(ced.sample_id, ced.time_taken &gt; treatments.treatment_time_taken) AS postSampleCount,
-        treatments.treatment AS treatment
+            countIf(ced.sample_id, ced.time_taken &lt;= treatments.treatment_time_taken) AS preSampleCount,
+            countIf(ced.sample_id, ced.time_taken &gt; treatments.treatment_time_taken) AS postSampleCount,
+            treatments.treatment AS treatment
+            <choose>
+                <when test="projection == 'DETAILED'">
+                    ,
+                    groupArrayIf(
+                        (ced.sample_id, ced.patient_unique_id, ced.time_taken, ced.cancer_study_identifier),
+                        ced.time_taken &lt;= treatments.treatment_time_taken
+                    ) AS preSamples,
+                    groupArrayIf(
+                        (ced.sample_id, ced.patient_unique_id, ced.time_taken, ced.cancer_study_identifier),
+                        ced.time_taken &gt; treatments.treatment_time_taken
+                    ) AS postSamples
+                </when>
+                <otherwise>
+                    ,
+                    array() AS preSamples,
+                    array() AS postSamples
+                </otherwise>
+            </choose>
         FROM sample_acquisition_events ced
         INNER JOIN treatments ON treatments.patient_unique_id = ced.patient_unique_id
         <where>

--- a/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/treatment/ClickhouseTreatmentMapperTest.java
+++ b/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/treatment/ClickhouseTreatmentMapperTest.java
@@ -14,6 +14,7 @@ import org.cbioportal.legacy.web.parameter.filter.OredPatientTreatmentFilters;
 import org.cbioportal.legacy.web.parameter.filter.OredSampleTreatmentFilters;
 import org.cbioportal.legacy.web.parameter.filter.PatientTreatmentFilter;
 import org.cbioportal.legacy.web.parameter.filter.SampleTreatmentFilter;
+import org.cbioportal.shared.enums.ProjectionType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,13 +91,40 @@ public class ClickhouseTreatmentMapperTest {
 
     var sampleTreatmentCounts =
         mapper.getSampleTreatmentCounts(
-            StudyViewFilterFactory.make(
-                studyViewFilter, null, studyViewFilter.getStudyIds(), null));
+            StudyViewFilterFactory.make(studyViewFilter, null, studyViewFilter.getStudyIds(), null),
+            ProjectionType.SUMMARY.name());
+
+    var sampleTreatmentCountsWithSampleLists =
+        mapper.getSampleTreatmentCounts(
+            StudyViewFilterFactory.make(studyViewFilter, null, studyViewFilter.getStudyIds(), null),
+            ProjectionType.DETAILED.name());
 
     assertEquals(1, totalSampleTreatmentCount);
     assertEquals("madeupanib", sampleTreatmentCounts.getFirst().treatment());
     assertEquals(1, sampleTreatmentCounts.getFirst().postSampleCount());
     assertEquals(0, sampleTreatmentCounts.getFirst().preSampleCount());
+    assertEquals(1, sampleTreatmentCountsWithSampleLists.getFirst().postSampleCount());
+    assertEquals(0, sampleTreatmentCountsWithSampleLists.getFirst().preSampleCount());
+    assertEquals(1, sampleTreatmentCountsWithSampleLists.getFirst().postSamples().size());
+    assertEquals(0, sampleTreatmentCountsWithSampleLists.getFirst().preSamples().size());
+
+    assertEquals(
+        "tcga-a1-a0sd-01",
+        sampleTreatmentCountsWithSampleLists.getFirst().postSamples().getFirst().getSampleId());
+    assertEquals(
+        "tcga-a1-a0sd",
+        sampleTreatmentCountsWithSampleLists.getFirst().postSamples().getFirst().getPatientId());
+    assertEquals(
+        "study_tcga_pub",
+        sampleTreatmentCountsWithSampleLists.getFirst().postSamples().getFirst().getStudyId());
+    assertEquals(
+        233,
+        sampleTreatmentCountsWithSampleLists
+            .getFirst()
+            .postSamples()
+            .getFirst()
+            .getTimeTaken()
+            .intValue());
 
     SampleTreatmentFilter filter = new SampleTreatmentFilter();
     filter.setTreatment("madeupanib");
@@ -116,10 +144,16 @@ public class ClickhouseTreatmentMapperTest {
 
     sampleTreatmentCounts =
         mapper.getSampleTreatmentCounts(
-            StudyViewFilterFactory.make(
-                studyViewFilter, null, studyViewFilter.getStudyIds(), null));
+            StudyViewFilterFactory.make(studyViewFilter, null, studyViewFilter.getStudyIds(), null),
+            ProjectionType.SUMMARY.name());
+
+    sampleTreatmentCountsWithSampleLists =
+        mapper.getSampleTreatmentCounts(
+            StudyViewFilterFactory.make(studyViewFilter, null, studyViewFilter.getStudyIds(), null),
+            ProjectionType.DETAILED.name());
 
     assertEquals(0, totalSampleTreatmentCount);
     assertEquals(0, sampleTreatmentCounts.size());
+    assertEquals(0, sampleTreatmentCountsWithSampleLists.size());
   }
 }


### PR DESCRIPTION
Fix #11618

`/treatments/sample-counts/fetch` endpoint now returns list of samples when `DETAILED` projection is enabled.

`/treatments/patient-counts/fetch` endpoint is still missing samples, but the comparison feature seems working fine.