### PR TITLE
Add special case for null start end values for numerical study view filters

### DIFF
--- a/src/main/java/org/cbioportal/domain/studyview/StudyViewFilterContext.java
+++ b/src/main/java/org/cbioportal/domain/studyview/StudyViewFilterContext.java
@@ -55,8 +55,7 @@ public record StudyViewFilterContext(
     var firstValue = clinicalDataFilter.getValues().getFirst();
     var lastValue = clinicalDataFilter.getValues().getLast();
     // there is a case where a categorical filter will have a set of null filter values first
-    // check if the first set of filter values is null, and if so, use the last set of filter values
-    // instead
+    // check if the first set of filter values is null. if so, use the last set of filter values
     var filterValue =
         firstValue.getStart() == null
                 && firstValue.getEnd() == null

--- a/src/main/java/org/cbioportal/domain/studyview/StudyViewFilterContext.java
+++ b/src/main/java/org/cbioportal/domain/studyview/StudyViewFilterContext.java
@@ -54,6 +54,9 @@ public record StudyViewFilterContext(
   public boolean isCategoricalClinicalDataFilter(ClinicalDataFilter clinicalDataFilter) {
     var firstValue = clinicalDataFilter.getValues().getFirst();
     var lastValue = clinicalDataFilter.getValues().getLast();
+    // there is a case where a categorical filter will have a set of null filter values first
+    // check if the first set of filter values is null, and if so, use the last set of filter values
+    // instead
     var filterValue =
         firstValue.getStart() == null
                 && firstValue.getEnd() == null

--- a/src/main/java/org/cbioportal/domain/studyview/StudyViewFilterContext.java
+++ b/src/main/java/org/cbioportal/domain/studyview/StudyViewFilterContext.java
@@ -52,7 +52,14 @@ public record StudyViewFilterContext(
   }
 
   public boolean isCategoricalClinicalDataFilter(ClinicalDataFilter clinicalDataFilter) {
-    var filterValue = clinicalDataFilter.getValues().getFirst();
+    var firstValue = clinicalDataFilter.getValues().getFirst();
+    var lastValue = clinicalDataFilter.getValues().getLast();
+    var filterValue =
+        firstValue.getStart() == null
+                && firstValue.getEnd() == null
+                && firstValue.getValue() == null
+            ? lastValue
+            : firstValue;
     return filterValue.getValue() != null;
   }
 }

--- a/src/main/resources/mappers/clickhouse/studyview/ClickhouseStudyViewFilterMapper.xml
+++ b/src/main/resources/mappers/clickhouse/studyview/ClickhouseStudyViewFilterMapper.xml
@@ -281,6 +281,12 @@
                     ${attribute_value} ILIKE #{dataFilterValue.value}
                 </if>
                 <!--
+                    Special case: In case null start and end values go through, don't apply a filter.
+                -->
+                <if test="dataFilterValue.start == null and dataFilterValue.end == null">
+                    AND 1=1
+                </if>
+                <!--
                     Special case: Numerical range values such as <18, >=90, etc.
                     We need to make sure to treat these values as numerical for filtering purposes.
                 -->

--- a/src/main/resources/mappers/clickhouse/studyview/ClickhouseStudyViewFilterMapper.xml
+++ b/src/main/resources/mappers/clickhouse/studyview/ClickhouseStudyViewFilterMapper.xml
@@ -281,7 +281,7 @@
                     ${attribute_value} ILIKE #{dataFilterValue.value}
                 </if>
                 <!--
-                    Special case: In case null start and end values go through, don't apply a filter.
+                    Special case: In case null start, end, and value values go through, don't apply filter.
                 -->
                 <if test="dataFilterValue.start == null and dataFilterValue.end == null">
                     AND 1=1

--- a/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/sample/ClickhouseSampleMapperTest.java
+++ b/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/sample/ClickhouseSampleMapperTest.java
@@ -149,6 +149,16 @@ public class ClickhouseSampleMapperTest {
                 studyViewFilter, List.of(), studyViewFilter.getStudyIds(), null));
     // 7 genuine NA samples from study_genie_pub + 1 UNKNOWN sample
     assertEquals(8, filteredSamples6.size());
+
+    // null age filter (start, end, and value are null)
+    // should return all samples with age attribute
+    studyViewFilter.setClinicalDataFilters(
+        List.of(newClinicalDataFilter("age", List.of(newDataFilterValue(null, null, null)))));
+    var filteredSamples7 =
+        mapper.getFilteredSamples(
+            StudyViewFilterFactory.make(
+                studyViewFilter, List.of(), studyViewFilter.getStudyIds(), null));
+    assertEquals(27, filteredSamples7.size());
   }
 
   @Test

--- a/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/sample/ClickhouseSampleMapperTest.java
+++ b/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/sample/ClickhouseSampleMapperTest.java
@@ -159,6 +159,27 @@ public class ClickhouseSampleMapperTest {
             StudyViewFilterFactory.make(
                 studyViewFilter, List.of(), studyViewFilter.getStudyIds(), null));
     assertEquals(27, filteredSamples7.size());
+
+    // NA dead filter
+    studyViewFilter.setClinicalDataFilters(
+        List.of(newClinicalDataFilter("dead", List.of(newDataFilterValue(null, null, "NA")))));
+    var filteredSamples8 =
+        mapper.getFilteredSamples(
+            StudyViewFilterFactory.make(
+                studyViewFilter, List.of(), studyViewFilter.getStudyIds(), null));
+    assertEquals(17, filteredSamples8.size());
+
+    // null age filter + NA dead filter (test null numerical + any categorical filter)
+    // should return same as NA dead filter test
+    studyViewFilter.setClinicalDataFilters(
+        List.of(
+            newClinicalDataFilter("age", List.of(newDataFilterValue(null, null, null))),
+            newClinicalDataFilter("dead", List.of(newDataFilterValue(null, null, "NA")))));
+    var filteredSamples9 =
+        mapper.getFilteredSamples(
+            StudyViewFilterFactory.make(
+                studyViewFilter, List.of(), studyViewFilter.getStudyIds(), null));
+    assertEquals(17, filteredSamples9.size());
   }
 
   @Test


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/11633

Add special case where if null start and end values are passed in a numerical filter on study view, don't apply a filter. Prevents sql error where empty tuple () occurs.