### PR TITLE
Optimize PatientMapper IN clauses for ClickHouse JDBC performance

### DIFF
--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/util/SqlUtils.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/util/SqlUtils.java
@@ -1,0 +1,30 @@
+package org.cbioportal.legacy.persistence.mybatis.util;
+
+import java.util.List;
+
+/** Utility class for SQL operations in MyBatis mappers */
+public class SqlUtils {
+
+  /**
+   * Combines study IDs and patient/sample IDs into unique keys for efficient array parameter usage.
+   * This helps optimize ClickHouse JDBC performance by reducing the number of prepared statement
+   * parameters.
+   *
+   * @param studyIds List of study identifiers
+   * @param entityIds List of patient or sample identifiers (corresponding to studyIds by index)
+   * @return Array of combined unique keys in format "studyId:entityId"
+   */
+  public static String[] combineStudyAndPatientIds(List<String> studyIds, List<String> entityIds) {
+    if (studyIds == null || entityIds == null || studyIds.size() != entityIds.size()) {
+      throw new IllegalArgumentException(
+          "studyIds and entityIds must be non-null and have the same size");
+    }
+
+    String[] combinedKeys = new String[studyIds.size()];
+    for (int i = 0; i < studyIds.size(); i++) {
+      combinedKeys[i] = studyIds.get(i) + ":" + entityIds.get(i);
+    }
+
+    return combinedKeys;
+  }
+}

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/PatientMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/PatientMapper.xml
@@ -38,8 +38,10 @@
                     cancer_study.cancer_study_identifier = #{studyIds[0]}
                 </if>
                 <if test="patientIds != null">
-                    (cancer_study.cancer_study_identifier,patient.stable_id) IN
-                        <foreach index="i" collection="patientIds" open="(" separator="," close=")">(#{studyIds[${i}]},#{patientIds[${i}]})</foreach>
+                    <bind name="patientUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, patientIds)" />
+                    CONCAT(cancer_study.cancer_study_identifier, ':', patient.stable_id) IN (
+                        #{patientUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
+                    )
                 </if>
             </if>
             <if test="keyword != null">
@@ -110,8 +112,10 @@
                 <foreach item="item" collection="sampleIds" open="(" separator="," close=")">#{item}</foreach>
         </if>
         <if test="@java.util.Arrays@stream(studyIds.toArray()).distinct().count() > 1">
-            (cancer_study.cancer_study_identifier,sample.stable_id) IN
-                <foreach index="i" collection="sampleIds" open="(" separator="," close=")">(#{studyIds[${i}]},#{sampleIds[${i}]})</foreach>
+            <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, sampleIds)" />
+            CONCAT(cancer_study.cancer_study_identifier, ':', sample.stable_id) IN (
+                #{sampleUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
+            )
         </if>
         <if test="@java.util.Arrays@stream(studyIds.toArray()).distinct().count() == 0">
             FALSE


### PR DESCRIPTION
Replace foreach loops generating multiple prepared statement parameters with single array parameter using ArrayTypeHandler. This significantly improves performance with ClickHouse JDBC connections by reducing parameter overhead.

- Use CONCAT(study_id, ':', patient_id) with ArrayTypeHandler
- Add SqlUtils.combineStudyAndPatientIds() utility method
- Apply optimization to both patient and sample lookup queries
- Maintain security through proper parameter binding

🤖 Generated with [Claude Code](https://claude.ai/code)
