### PR TITLE
Update Architecture-Overview.md with corrected links

### DIFF
--- a/docs/Architecture-Overview.md
+++ b/docs/Architecture-Overview.md
@@ -21,7 +21,7 @@ cBioPortal consists of the following components:
 
 The [backend](https://github.com/cBioPortal/cbioportal) is written in Java and
 connects to a MySQL database to serve a REST API following the OpenAPI
-specification (https://www.cbioportal.org/api/swagger-ui/index.html). Note that the repo where this
+specification (https://www.cbioportal.org/api). Note that the repo where this
 lives in (https://github.com/cBioPortal/cbioportal) also contains Java classes
 to import data as well as the validator. The backend can be configured to
 connect to a Redis cache to store database query results for improved performance.

--- a/docs/Architecture-Overview.md
+++ b/docs/Architecture-Overview.md
@@ -7,7 +7,7 @@ cBioPortal consists of the following components:
     - Optional components for performance enhancements:
         - Clickhouse OLAP database for large cohorts (see [clickhouse mode](https://github.com/cbioPortal/cbioportal-docker-compose#clickhouse-mode))
         - Redis cache for storing study view initial load and other frequent queries and pages
-- [validator](https://github.com/cBioPortal/cbioportal/tree/master/core/src/main/scripts/importer)
+- [validator](https://github.com/cBioPortal/cbioportal-core/tree/main/scripts/importer)
   checks file formats before importing data into the database
 - [frontend](https://github.com/cBioPortal/cbioportal-frontend)
   built with React, Mobx and Bootstrap
@@ -21,7 +21,7 @@ cBioPortal consists of the following components:
 
 The [backend](https://github.com/cBioPortal/cbioportal) is written in Java and
 connects to a MySQL database to serve a REST API following the OpenAPI
-specification (https://www.cbioportal.org/api/). Note that the repo where this
+specification (https://www.cbioportal.org/api/swagger-ui/index.html). Note that the repo where this
 lives in (https://github.com/cBioPortal/cbioportal) also contains Java classes
 to import data as well as the validator. The backend can be configured to
 connect to a Redis cache to store database query results for improved performance.
@@ -31,7 +31,7 @@ See [cBioPortal backend code organization](./development/Backend-Code-Organizati
 
 ## Validator
 The
-[validator](https://github.com/cBioPortal/cbioportal/tree/master/core/src/main/scripts/importer)
+[validator](https://github.com/cBioPortal/cbioportal-core/tree/main/scripts/importer)
 checks file formats before importing data into the database. There is a wrapper
 script `metaImport.py` that validates the data and subsequently calls the
 relevant Java classes to import the data.
@@ -48,7 +48,7 @@ needs to be able to connect to it. The frontend does not connect to it
 directly. 
 
 ## Frontend
-The frontend is a single page app built with React, Mobx and Bootstrap. The
+The [frontend](https://github.com/cBioPortal/cbioportal-frontend) is a single page app built with React, Mobx and Bootstrap. The
 data gets pulled from the backend REST API. The frontend is by default included
 with the backend so no extra setup is required. 
 


### PR DESCRIPTION
This PR refreshes outdated links in Architecture-Overview.md.

Changes:
- Fix validator link to the current path
- Update API reference link
- Add missing frontend link to match other sections
