### PR TITLE
FIX:cacheENabledConfig restructured

### DIFF
--- a/src/main/java/org/cbioportal/legacy/persistence/CacheEnabledConfig.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/CacheEnabledConfig.java
@@ -33,9 +33,11 @@ public class CacheEnabledConfig {
   @PostConstruct
   public void init() {
     this.enabled = enableCache(cacheType);
-    LOG.info("Cache is enabled: " + this.enabled);
-    this.enabledClickhouse = enableCache(cacheTypeClickhouse);
-    LOG.info("Cache is enabled for clickhouse: " + this.enabledClickhouse);
+    // for cpu performance purpose, the logged info styling was changed is changed
+      LOG.info("Cache is enabled: {}", this.enabled);
+      this.enabledClickhouse = enableCache(cacheTypeClickhouse);
+      // for cpu performance purpose, the logged info styling was changed is changed
+      LOG.info("Cache is enabled for clickhouse: {}", this.enabledClickhouse);
   }
 
   public static boolean enableCache(String cacheType) {

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/PatientMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/PatientMyBatisRepository.java
@@ -1,6 +1,6 @@
 package org.cbioportal.legacy.persistence.mybatis;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.cbioportal.legacy.model.Patient;
 import org.cbioportal.legacy.model.meta.BaseMeta;
@@ -50,7 +50,7 @@ public class PatientMyBatisRepository implements PatientRepository {
       String direction) {
 
     return patientMapper.getPatients(
-        Arrays.asList(studyId),
+        Collections.singletonList(studyId),
         null,
         null,
         projection,
@@ -63,7 +63,7 @@ public class PatientMyBatisRepository implements PatientRepository {
   @Override
   public BaseMeta getMetaPatientsInStudy(String studyId) {
 
-    return patientMapper.getMetaPatients(Arrays.asList(studyId), null, null);
+    return patientMapper.getMetaPatients(Collections.singletonList(studyId), null, null);
   }
 
   @Override


### PR DESCRIPTION
FIX:cacheENabledConfig restructured

I changed
LOG.info("Cache is enabled: " + this.enabled); to LOG.info("Cache is enabled: {}", this.enabled) because of efficiency, the first one will execute whether there is something to log or not, but the second one won't log anything unless the log is necessary
