### PR TITLE
Add Spring Boot Actuator monitoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,14 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/org/cbioportal/legacy/web/GeneralControllerAdvice.java
+++ b/src/main/java/org/cbioportal/legacy/web/GeneralControllerAdvice.java
@@ -9,7 +9,7 @@ import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-@ControllerAdvice
+@ControllerAdvice(basePackages = "org.cbioportal.api")
 public class GeneralControllerAdvice implements ResponseBodyAdvice<Object> {
 
   @Override

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -431,6 +431,10 @@ server.max-http-request-header-size=16384
 #sentry.traces-sample-rate=1.0 Probably should change for prod
 #sentry.exception-resolver-order=-2147483647
 
+# Actuator Configuration
+management.endpoints.enabled-by-default=false
+management.endpoints.web.exposure.include=health,info
+
 # Swagger Configuration
 #springdoc.swagger-ui.disable-swagger-default-url=true
 #springdoc.swagger-ui.path=/api/swagger-ui


### PR DESCRIPTION
## Spring Boot Actuator 
PR introduces Actuator dependency which allows monitoring various operational information regarding the app. 