### PR TITLE
Make group auth check case-insensitive (including Copilot's recommendations regarding null pointer checks)

### DIFF
--- a/src/main/java/org/cbioportal/application/security/CancerStudyPermissionEvaluator.java
+++ b/src/main/java/org/cbioportal/application/security/CancerStudyPermissionEvaluator.java
@@ -368,7 +368,7 @@ public class CancerStudyPermissionEvaluator implements PermissionEvaluator {
         Arrays.stream(cancerStudy.getGroups().split(";"))
             .filter(g -> !g.isEmpty())
             .collect(Collectors.toSet());
-    if (!Collections.disjoint(groups, grantedAuthorities)) {
+    if (!caseInsensitiveDisjoint(groups, grantedAuthorities)) {
       if (log.isDebugEnabled()) {
         log.debug("hasAccessToCancerStudy(), user has access by groups return true");
       }
@@ -393,6 +393,15 @@ public class CancerStudyPermissionEvaluator implements PermissionEvaluator {
     return toReturn;
   }
 
+    private static boolean caseInsensitiveDisjoint(Collection<String> c1, Collection<String> c2) {
+        if (c1 == null || c2 == null) {
+            return true; // If either collection is null, they are considered disjoint.
+        }
+        Set<String> upperC1 = c1.stream().filter(Objects::nonNull).map(String::toUpperCase).collect(Collectors.toSet());
+        Set<String> upperC2 = c2.stream().filter(Objects::nonNull).map(String::toUpperCase).collect(Collectors.toSet());
+        return Collections.disjoint(upperC1, upperC2);
+    }
+  
   private boolean hasAccessToCancerStudy(
       Authentication authentication, String cancerStudyId, Object permission) {
     // everybody has access the 'all' cancer study


### PR DESCRIPTION
Same as pull request https://github.com/cBioPortal/cbioportal/pull/11610 but also including the Copilot's recommendations regarding null pointer checks.

@inodb and @haynescd 
Because the user "akulyakhtin" is not answering and not changing the code at his own pull request 11610, I have created a pull request on my on now.

**Description is still the same:**
Closes #11609

This request fixes the following issue:
if we have set authorities=true in app properties
and if we have a group value in cancer_study table sample_group
and if we have authority sample_group  (or cbioportal:sample_group, depending on the filtering option) in authorities table for a user.

Then the access to that cancer study is not granted to the user even though the authroity matches the cancer study group.

This happens because authorities are convereted to upper case while cancer group names are not.

To fix this the pull request changes Collections.disjoint (which is case-sensitive) to a case-insensitive utility method caseInsensitiveDisjoint.

