### PR TITLE
Add UptimeRobot integration configuration and documentation

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -49,6 +49,7 @@
     * [Utilize priority setting from database to visualize charts](deployment/customization/Studyview.md)
   * [Integration with Other Webservices]()
     * [OncoKB Data Access](deployment/integration-with-other-webservices/OncoKB-Data-Access.md)
+    * [UptimeRobot Integration](deployment/integration-with-other-webservices/UptimeRobot-Integration.md)
   * [Data Loading Overview](Data-Loading.md)
     * [Downloads](Downloads.md)
     * [Using the Dataset Validator](Using-the-dataset-validator.md)

--- a/docs/deployment/customization/application.properties-Reference.md
+++ b/docs/deployment/customization/application.properties-Reference.md
@@ -809,3 +809,16 @@ Custom Buttons can be defined which will conditionally appear in all group compa
 ```
 download_custom_buttons_json=classpath:custom_buttons/download_custom_button_avm.json
 ```
+
+## UptimeRobot Integration
+
+Display automatic service status banners when incidents or maintenance are detected from UptimeRobot.
+
+```properties
+uptime_robot_status_page_url=https://status.cbioportal.org
+uptime_robot_api_key=RlrzpsmAn
+```
+
+Both properties are required to enable the integration. When configured, the portal will automatically fetch and display active events as banners at the top of the page.
+
+See [UptimeRobot Integration](../integration-with-other-webservices/UptimeRobot-Integration.md) for setup instructions.

--- a/docs/deployment/integration-with-other-webservices/UptimeRobot-Integration.md
+++ b/docs/deployment/integration-with-other-webservices/UptimeRobot-Integration.md
@@ -1,0 +1,42 @@
+# UptimeRobot Integration
+
+## Configuration
+
+Both configuration properties must be set to enable the integration:
+
+```properties
+uptime_robot_status_page_url=https://status.cbioportal.org
+uptime_robot_api_key=YOUR_API_KEY_HERE
+```
+
+Add these to your `application.properties` file.
+
+### Getting Your UptimeRobot API Key
+
+1. Log in to your [UptimeRobot account](https://uptimerobot.com/)
+2. Navigate to "Status Pages"
+3. Open your status page settings
+4. Look for the "Event Feed" or "API" section
+5. Copy the API key (e.g., `RlrzpsmAn`)
+6. Note your status page URL (e.g., `https://status.cbioportal.org`)
+
+### Testing the Configuration
+
+You can test your API endpoint manually:
+
+```bash
+curl https://status.cbioportal.org/api/getEventFeed/YOUR_API_KEY
+```
+
+You should receive a JSON response containing event data.
+
+## Disabling the Integration
+
+To disable the integration, simply remove or comment out both configuration properties:
+
+```properties
+# uptime_robot_status_page_url=https://status.cbioportal.org
+# uptime_robot_api_key=YOUR_API_KEY_HERE
+```
+
+The integration will automatically disable if either property is missing.

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -129,6 +129,12 @@ skin.study_view.link_text=To build your own case set, try out our enhanced Study
 ## setting controlling whether Download tabs and download/copy-to-clipboard controls should be shown
 # skin.hide_download_controls=false
 
+## UptimeRobot Status Page Integration
+## Automatically displays service status banners for ongoing events from UptimeRobot
+## Both properties are required to enable the integration
+# uptime_robot_status_page_url=https://status.cbioportal.org
+# uptime_robot_api_key=YOUR_API_KEY_HERE
+
 ## enable and set this property to specify a study group to be used to identify public studies for which no specific authorization entries are needed in the `authorities` table
 # always_show_study_group=
 


### PR DESCRIPTION
Adds configuration properties for the UptimeRobot status page integration that automatically displays service status banners in the frontend.

Changes:
- Add uptime_robot_status_page_url and uptime_robot_api_key properties to application.properties.EXAMPLE
- Create comprehensive UptimeRobot-Integration.md documentation
- Update application.properties-Reference.md with UptimeRobot section

Configuration:
Both properties are required to enable the integration:
- uptime_robot_status_page_url: URL of the UptimeRobot status page
- uptime_robot_api_key: API key for the event feed endpoint

Documentation covers:
- Setup and configuration instructions
- How to obtain API key from UptimeRobot

Related frontend PR: https://github.com/cBioPortal/cbioportal-frontend/pull/5282