### PR TITLE
Use latest database schema to avoid importer mismatch errors in PRs with schema updates

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -50,9 +50,9 @@ jobs:
               sed 's|feature.study.export=.*|feature.study.export=true|' | \
               sed 's|#\?session.endpoint.publisher-api-key=.*|session.endpoint.publisher-api-key=TEST|' \
               > application.properties && \
-          DB_VERSION=$(mvn -q -DforceStdout -Dexpression=db.version -f $PORTAL_SOURCE_DIR/pom.xml help:evaluate) && \
-          echo "db.version=${DB_VERSION}" > maven.properties && \
-          echo "Wrote maven.properties with db.version=${DB_VERSION}"
+          DB_VERSION=$(mvn -q -DforceStdout -Dexpression=db.version -f $PORTAL_SOURCE_DIR/pom.xml help:evaluate || true) && \
+          if [ -n "$DB_VERSION" ]; then echo "db.version=${DB_VERSION}" > maven.properties; else : > maven.properties; fi && \
+          echo "maven.properties => $(cat maven.properties | tr -d '\n' || echo '(empty)')"
       - name: 'Dump Properties'
         working-directory: ./cbioportal-docker-compose
         run: cat config/application.properties

--- a/test/integration/docker-compose-localbuild.yml
+++ b/test/integration/docker-compose-localbuild.yml
@@ -16,3 +16,5 @@ services:
      - $PORTAL_SOURCE_DIR/src/main/resources/db-scripts:/cbioportal/db-scripts
      - $PORTAL_SOURCE_DIR/docker/web-and-data/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
      - $PORTAL_SOURCE_DIR/test/integration/integration_test_oncokb_import.sh:/cbioportal/integration_test_oncokb_import.sh
+     # Mount maven.properties alongside application.properties in /cbioportal-webapp
+     - ./config/maven.properties:/cbioportal-webapp/maven.properties:ro


### PR DESCRIPTION
This PR ensures integration tests use the **latest database schema** from `pom.xml` and properly mount `maven.properties` inside the container to prevent importer version mismatches in PRs with schema updates

## Changes
- Generate `maven.properties` during integration test setup:
  - Reads `db.version` dynamically from `pom.xml` using the Maven Help Plugin.  
  - Creates an empty file if `db.version` is not found (to avoid mount errors).  
- Mount `maven.properties` into `/cbioportal-webapp` in the container via `docker-compose-localbuild.yml`, alongside `application.properties`.  

## Result
- Integration tests now correctly run when PRs include **database schema updates**.  
- Prevents importer mismatch errors due to outdated schema versions.  
- Keeps both `application.properties` and `maven.properties` in the same container directory (`/cbioportal-webapp`) for consistency.

