### PR TITLE
Prepare for release v6.4.0

### DIFF
--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update; apt-get install -y --no-install-recommends \
 RUN mkdir -p /cbioportal
 
 #Download core files
-RUN wget https://github.com/cBioPortal/cbioportal-core/releases/download/v1.0.10/core-1.0.10.jar -P core/ ; cd core ; jar -xf core-1.0.10.jar scripts/ requirements.txt ; chmod -R a+x scripts/ ; cd ..;
+RUN wget https://github.com/cBioPortal/cbioportal-core/releases/download/v1.0.10/core-1.0.11.jar -P core/ ; cd core ; jar -xf core-1.0.10.jar scripts/ requirements.txt ; chmod -R a+x scripts/ ; cd ..;
 
 
 COPY --from=build /cbioportal/src/main/resources/db-scripts /cbioportal/db-scripts

--- a/docs/Migration-Guide.md
+++ b/docs/Migration-Guide.md
@@ -2,6 +2,9 @@
 
 This page describes various changes deployers will need to make as they deploy newer versions of the portal.
 
+## v6.3 -> v6.4
+- The [v6.4.0](https://github.com/cBioPortal/cbioportal/releases/tag/v6.4.0) release includes database schema changes that aren’t backward compatible. Please review the [Database Migration Guide](https://docs.cbioportal.org/updating-your-cbioportal-installation/#running-the-migration-script) before upgrading.
+
 ## v6.2 -> v6.3
 - cBioPortal Database Migration: [v6.3.0](https://github.com/cBioPortal/cbioportal/releases/tag/v6.3.0) introduces breaking changes to the cBioPortal database schema. Please see the [Database Migration Guide](https://docs.cbioportal.org/updating-your-cbioportal-installation/#running-the-migration-script) before upgrading cBioPortal to v6.3.0.
 


### PR DESCRIPTION
Prepare for Release v6.4.0

- Updated `cbioportal-core` package version
- Update migration guide for `v6.4.0`