### PR TITLE
Rename combineStudyAndPatientIds to combineStudyAndEntityIds

### DIFF
--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/util/SqlUtils.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/util/SqlUtils.java
@@ -14,7 +14,7 @@ public class SqlUtils {
    * @param entityIds List of patient or sample identifiers (corresponding to studyIds by index)
    * @return Array of combined unique keys in format "studyId:entityId"
    */
-  public static String[] combineStudyAndPatientIds(List<String> studyIds, List<String> entityIds) {
+  public static String[] combineStudyAndEntityIds(List<String> studyIds, List<String> entityIds) {
     if (studyIds == null || entityIds == null || studyIds.size() != entityIds.size()) {
       throw new IllegalArgumentException(
           "studyIds and entityIds must be non-null and have the same size");

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/ClinicalAttributeMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/ClinicalAttributeMapper.xml
@@ -43,7 +43,7 @@
                     )
                 </if>
                 <if test="@java.util.Arrays@stream(studyIds.toArray()).distinct().count() > 1">
-                    <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, sampleIds)" />
+                    <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(studyIds, sampleIds)" />
                     CONCAT(cancer_study.cancer_study_identifier, ':', sample.stable_id) IN (
                         #{sampleUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                     )

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/ClinicalDataMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/ClinicalDataMapper.xml
@@ -72,7 +72,7 @@
                         )
                     </when>
                     <otherwise>
-                        <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, sampleIds)" />
+                        <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(studyIds, sampleIds)" />
                         CONCAT(cancer_study.cancer_study_identifier, ':', sample.stable_id) IN (
                             #{sampleUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                         )
@@ -101,7 +101,7 @@
                         )
                     </when>
                     <otherwise>
-                        <bind name="patientUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, patientIds)" />
+                        <bind name="patientUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(studyIds, patientIds)" />
                         CONCAT(cancer_study.cancer_study_identifier, ':', patient.stable_id) IN (
                             #{patientUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                         )

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/ClinicalEventMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/ClinicalEventMapper.xml
@@ -118,7 +118,7 @@
                     )
                 </if>
                 <if test="@java.util.Arrays@stream(studyIds.toArray()).distinct().count() > 1">
-                    <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, sampleIds)" />
+                    <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(studyIds, sampleIds)" />
                     CONCAT(cancer_study.cancer_study_identifier, ':', sample.stable_id) IN (
                         #{sampleUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                     )
@@ -148,7 +148,7 @@
                     )
                 </if>
                 <if test="@java.util.Arrays@stream(patientIds.toArray()).distinct().count() > 1">
-                    <bind name="patientUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, patientIds)" />
+                    <bind name="patientUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(studyIds, patientIds)" />
                     CONCAT(cancer_study.cancer_study_identifier, ':', patient.stable_id) IN (
                         #{patientUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                     )

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/CopyNumberSegmentMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/CopyNumberSegmentMapper.xml
@@ -26,7 +26,7 @@
     <sql id="where">
         <where>
             <if test="sampleIds != null and !sampleIds.isEmpty()">
-                <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, sampleIds)" />
+                <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(studyIds, sampleIds)" />
                 CONCAT(cancer_study.cancer_study_identifier, ':', sample.stable_id) IN (
                     #{sampleUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                 )

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/DiscreteCopyNumberMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/DiscreteCopyNumberMapper.xml
@@ -92,7 +92,7 @@
                 )
             </if>
             <if test="@java.util.Arrays@stream(molecularProfileIds.toArray()).distinct().count() > 1">
-                <bind name="sampleProfileKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(sampleIds, molecularProfileIds)" />
+                <bind name="sampleProfileKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(sampleIds, molecularProfileIds)" />
                 CONCAT(sample.stable_id, ':', genetic_profile.stable_id) IN (
                     #{sampleProfileKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                 )

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/MutationMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/MutationMapper.xml
@@ -123,7 +123,7 @@
                     )
                 </if>
                 <if test="@java.util.Arrays@stream(molecularProfileIds.toArray()).distinct().count() > 1">
-                    <bind name="sampleProfileKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(sampleIds, molecularProfileIds)" />
+                    <bind name="sampleProfileKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(sampleIds, molecularProfileIds)" />
                     CONCAT(sample.stable_id, ':', genetic_profile.stable_id) IN (
                         #{sampleProfileKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                     )

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/NamespaceMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/NamespaceMapper.xml
@@ -35,7 +35,7 @@
                     )
                 </if>
                 <if test="@java.util.Arrays@stream(studyIds.toArray()).distinct().count() > 1">
-                    <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, sampleIds)" />
+                    <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(studyIds, sampleIds)" />
                     CONCAT(cancer_study.CANCER_STUDY_IDENTIFIER, ':', sample.STABLE_ID) IN (
                         #{sampleUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                     )

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/PatientMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/PatientMapper.xml
@@ -39,7 +39,7 @@
                     cancer_study.cancer_study_identifier = #{studyIds[0]}
                 </if>
                 <if test="patientIds != null">
-                    <bind name="patientUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, patientIds)" />
+                    <bind name="patientUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(studyIds, patientIds)" />
                     CONCAT(cancer_study.cancer_study_identifier, ':', patient.stable_id) IN (
                         #{patientUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                     )
@@ -113,7 +113,7 @@
                 <foreach item="item" collection="sampleIds" open="(" separator="," close=")">#{item}</foreach>
         </if>
         <if test="@java.util.Arrays@stream(studyIds.toArray()).distinct().count() > 1">
-            <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, sampleIds)" />
+            <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(studyIds, sampleIds)" />
             CONCAT(cancer_study.cancer_study_identifier, ':', sample.stable_id) IN (
                 #{sampleUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
             )

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/SampleMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/SampleMapper.xml
@@ -44,7 +44,7 @@
                     )
                 </if>
                 <if test="@java.util.Arrays@stream(studyIds.toArray()).distinct().count() > 1">
-                    <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, sampleIds)" />
+                    <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(studyIds, sampleIds)" />
                     CONCAT(cancer_study.cancer_study_identifier, ':', sample.stable_id) IN (
                         #{sampleUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                     )
@@ -177,7 +177,7 @@
             )
         </if>
         <if test="@java.util.Arrays@stream(studyIds.toArray()).distinct().count() > 1">
-            <bind name="patientUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, patientIds)" />
+            <bind name="patientUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(studyIds, patientIds)" />
             CONCAT(cancer_study.cancer_study_identifier, ':', patient.stable_id) IN (
                 #{patientUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
             )

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/StructuralVariantMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/StructuralVariantMapper.xml
@@ -68,7 +68,7 @@
                     )
                 </if>
                 <if test="@java.util.Arrays@stream(molecularProfileIds.toArray()).distinct().count() > 1">
-                    <bind name="sampleProfileKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(sampleIds, molecularProfileIds)" />
+                    <bind name="sampleProfileKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(sampleIds, molecularProfileIds)" />
                     CONCAT(sample.stable_id, ':', genetic_profile.stable_id) IN (
                         #{sampleProfileKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                     )

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/TreatmentMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/TreatmentMapper.xml
@@ -95,7 +95,7 @@
                     )
                 </if>
                 <if test="@java.util.Arrays@stream(studyIds.toArray()).distinct().count() > 1">
-                    <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndPatientIds(studyIds, sampleIds)" />
+                    <bind name="sampleUniqueKeys" value="@org.cbioportal.legacy.persistence.mybatis.util.SqlUtils@combineStudyAndEntityIds(studyIds, sampleIds)" />
                     CONCAT(cancer_study.cancer_study_identifier, ':', sample.stable_id) IN (
                         #{sampleUniqueKeys, typeHandler=org.apache.ibatis.type.ArrayTypeHandler}
                     )


### PR DESCRIPTION
The method name combineStudyAndPatientIds was confusing because it was often used with sampleIds and molecularProfileIds, not just patientIds. Renamed to combineStudyAndEntityIds to better reflect its generic purpose of combining study IDs with any type of entity IDs.

Updated all 15 usages across MyBatis mapper XML files:
- TreatmentMapper.xml
- CopyNumberSegmentMapper.xml
- DiscreteCopyNumberMapper.xml
- MutationMapper.xml
- ClinicalEventMapper.xml (2 usages)
- NamespaceMapper.xml
- StructuralVariantMapper.xml
- ClinicalDataMapper.xml (2 usages)
- SampleMapper.xml (2 usages)
- PatientMapper.xml (2 usages)
- ClinicalAttributeMapper.xml

🤖 Generated with [Claude Code](https://claude.com/claude-code)
