### PR TITLE
clickhouse derived table performance improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <frontend.version>v6.4.1</frontend.version>
     <!-- THIS SHOULD BE KEPT IN SYNC TO VERSION IN CGDS.SQL -->
     <db.version>2.14.5</db.version>
-    <derived_table.version>1.0.2</derived_table.version>
+    <derived_table.version>1.0.3</derived_table.version>
 
     <!-- Version properties for dependencies that should have same version. -->
     <!-- The rest can be set in the dependencyManagement section -->

--- a/src/main/resources/db-scripts/clickhouse/clickhouse.sql
+++ b/src/main/resources/db-scripts/clickhouse/clickhouse.sql
@@ -1,4 +1,4 @@
--- version 1.0.2 of derived table schema and data definition
+-- version 1.0.3 of derived table schema and data definition
 -- when making updates:
 --     increment the version number here
 --     update pom.xml with the new version number
@@ -173,7 +173,7 @@ CREATE TABLE IF NOT EXISTS genomic_event_derived
     patient_unique_id         String,
     off_panel                 Boolean DEFAULT FALSE
 ) ENGINE = MergeTree
-      ORDER BY (variant_type, entrez_gene_id, hugo_gene_symbol, genetic_profile_stable_id, sample_unique_id);
+      ORDER BY (genetic_profile_stable_id, cancer_study_identifier, variant_type, entrez_gene_id, hugo_gene_symbol, sample_unique_id);
 
 INSERT INTO genomic_event_derived
 -- Insert Mutations
@@ -206,8 +206,9 @@ FROM mutation
          INNER JOIN cancer_study cs ON g.cancer_study_id = cs.cancer_study_id
          INNER JOIN sample ON mutation.sample_id = sample.internal_id
          INNER JOIN patient on sample.patient_id = patient.internal_id
-         LEFT JOIN gene ON mutation.entrez_gene_id = gene.entrez_gene_id
-UNION ALL
+         LEFT JOIN gene ON mutation.entrez_gene_id = gene.entrez_gene_id;
+
+INSERT INTO genomic_event_derived
 -- Insert CNA Genes
 SELECT concat(cs.cancer_study_identifier, '_', sample.stable_id) AS sample_unique_id,
        gene.hugo_gene_symbol                                     AS hugo_gene_symbol,
@@ -238,8 +239,9 @@ FROM cna_event ce
          INNER JOIN sample ON sce.sample_id = sample.internal_id
          INNER JOIN patient on sample.patient_id = patient.internal_id
          INNER JOIN gene ON ce.entrez_gene_id = gene.entrez_gene_id
-         INNER JOIN reference_genome_gene rgg ON rgg.entrez_gene_id = ce.entrez_gene_id  AND rgg.reference_genome_id = cs.reference_genome_id
-UNION ALL
+         INNER JOIN reference_genome_gene rgg ON rgg.entrez_gene_id = ce.entrez_gene_id  AND rgg.reference_genome_id = cs.reference_genome_id;
+
+INSERT INTO genomic_event_derived
 -- Insert Structural Variants Site1
 SELECT concat(cs.cancer_study_identifier, '_', s.stable_id) AS sample_unique_id,
        gene.hugo_gene_symbol                                AS hugo_gene_symbol,
@@ -268,8 +270,9 @@ FROM structural_variant sv
          INNER JOIN cancer_study cs ON gp.cancer_study_id = cs.cancer_study_id
          INNER JOIN gene ON sv.site1_entrez_gene_id = gene.entrez_gene_id
          INNER JOIN sample_profile ON s.internal_id = sample_profile.sample_id AND sample_profile.genetic_profile_id = sv.genetic_profile_id
-         LEFT JOIN gene_panel ON sample_profile.panel_id = gene_panel.internal_id
-UNION ALL
+         LEFT JOIN gene_panel ON sample_profile.panel_id = gene_panel.internal_id;
+
+INSERT INTO genomic_event_derived
 -- Insert Structural Variants Site2
 SELECT concat(cs.cancer_study_identifier, '_', s.stable_id) AS sample_unique_id,
        gene.hugo_gene_symbol                                AS hugo_gene_symbol,
@@ -373,8 +376,8 @@ SELECT
     ifNull(ce.stop_date, 0) AS stop_date,
     ce.event_type AS event_type,
     cs.cancer_study_identifier
-FROM clinical_event ce
-         LEFT JOIN clinical_event_data ced ON ce.clinical_event_id = ced.clinical_event_id
+FROM clinical_event_data ced
+         RIGHT JOIN clinical_event ce ON ced.clinical_event_id = ce.clinical_event_id
          INNER JOIN patient p ON ce.patient_id = p.internal_id
          INNER JOIN cancer_study cs ON p.cancer_study_id = cs.cancer_study_id;
 


### PR DESCRIPTION
Describe changes proposed in this pull request:
- changes to reduce memory footprint during derivation
    - clinical event table : 4 data types written separately (rather than UNION)
    - JOIN of clinical_event to clinical_event_data rearranged : clinical_event_data now referenced first
- changes to reduce runtime during query operations
    - clinical event table : re-order table part storage order (primary key)
        move genetic_profile_stable_id from rank #&NoBreak;4 to rank #&NoBreak;1, and add cancer_study_identifier as #&NoBreak;2

# Checks
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
