### PR TITLE
Fix 500 error when genomicDataFilters is empty (#11206)

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -437,6 +438,13 @@ public class ColumnarStoreStudyViewController {
       throws StudyNotFoundException {
     List<GenomicDataFilter> genomicDataFilters = genomicDataCountFilter.getGenomicDataFilters();
     StudyViewFilter studyViewFilter = genomicDataCountFilter.getStudyViewFilter();
+
+    // If genomicDataFilters is null or empty, return an empty result list
+    // This prevents IndexOutOfBoundsException in the MyBatis mapper
+    if (genomicDataFilters == null || genomicDataFilters.isEmpty()) {
+      return ResponseEntity.ok(Collections.emptyList());
+    }
+
     // when there is only one filter, it means study view is doing a single chart filter operation
     // remove filter from studyViewFilter to return all data counts
     // the reason we do this is to make sure after chart get filtered, user can still see unselected
@@ -516,6 +524,13 @@ public class ColumnarStoreStudyViewController {
           boolean includeSampleIds) {
     List<GenomicDataFilter> genomicDataFilters = genomicDataCountFilter.getGenomicDataFilters();
     StudyViewFilter studyViewFilter = genomicDataCountFilter.getStudyViewFilter();
+
+    // If genomicDataFilters is null or empty, return an empty result list
+    // This prevents IndexOutOfBoundsException in the MyBatis mapper
+    if (genomicDataFilters == null || genomicDataFilters.isEmpty()) {
+      return ResponseEntity.ok(Collections.emptyList());
+    }
+
     // when there is only one filter, it means study view is doing a single chart filter operation
     // remove filter from studyViewFilter to return all data counts
     // the reason we do this is to make sure after chart get filtered, user can still see unselected

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewController.java
@@ -439,8 +439,6 @@ public class ColumnarStoreStudyViewController {
     List<GenomicDataFilter> genomicDataFilters = genomicDataCountFilter.getGenomicDataFilters();
     StudyViewFilter studyViewFilter = genomicDataCountFilter.getStudyViewFilter();
 
-    // If genomicDataFilters is null or empty, return an empty result list
-    // This prevents IndexOutOfBoundsException in the MyBatis mapper
     if (genomicDataFilters == null || genomicDataFilters.isEmpty()) {
       return ResponseEntity.ok(Collections.emptyList());
     }
@@ -525,8 +523,6 @@ public class ColumnarStoreStudyViewController {
     List<GenomicDataFilter> genomicDataFilters = genomicDataCountFilter.getGenomicDataFilters();
     StudyViewFilter studyViewFilter = genomicDataCountFilter.getStudyViewFilter();
 
-    // If genomicDataFilters is null or empty, return an empty result list
-    // This prevents IndexOutOfBoundsException in the MyBatis mapper
     if (genomicDataFilters == null || genomicDataFilters.isEmpty()) {
       return ResponseEntity.ok(Collections.emptyList());
     }

--- a/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewControllerTest.java
+++ b/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewControllerTest.java
@@ -1,0 +1,144 @@
+package org.cbioportal.application.rest.vcolumnstore;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.Collections;
+import org.cbioportal.domain.studyview.StudyViewService;
+import org.cbioportal.legacy.web.parameter.GenomicDataCountFilter;
+import org.cbioportal.legacy.web.parameter.StudyViewFilter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Unit tests for ColumnarStoreStudyViewController.
+ *
+ * When genomicDataFilters is empty or null, the endpoints should return
+ * an empty list instead of throwing an IndexOutOfBoundsException.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ColumnarStoreStudyViewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private StudyViewService studyViewService;
+
+    private static final String TEST_STUDY_ID = "test_study";
+
+    @Test
+    @WithMockUser
+    public void fetchGenomicDataCountsWithEmptyFiltersReturnsEmptyList() throws Exception {
+        GenomicDataCountFilter filter = new GenomicDataCountFilter();
+        filter.setGenomicDataFilters(Collections.emptyList());
+
+        StudyViewFilter studyViewFilter = new StudyViewFilter();
+        studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
+        filter.setStudyViewFilter(studyViewFilter);
+
+        mockMvc.perform(post("/api/column-store/genomic-data-counts/fetch")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(filter)))
+            .andExpect(status().isOk())
+            .andExpect(content().json("[]"));
+
+        // Verify that the service was never called (early return due to empty filters)
+        verify(studyViewService, never()).getCNACountsByGeneSpecific(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.anyList()
+        );
+    }
+
+    @Test
+    @WithMockUser
+    public void fetchGenomicDataCountsWithNullFiltersReturnsEmptyList() throws Exception {
+        GenomicDataCountFilter filter = new GenomicDataCountFilter();
+        filter.setGenomicDataFilters(null);
+
+        StudyViewFilter studyViewFilter = new StudyViewFilter();
+        studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
+        filter.setStudyViewFilter(studyViewFilter);
+
+        mockMvc.perform(post("/api/column-store/genomic-data-counts/fetch")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(filter)))
+            .andExpect(status().isOk())
+            .andExpect(content().json("[]"));
+
+        // Verify that the service was never called (early return due to null filters)
+        verify(studyViewService, never()).getCNACountsByGeneSpecific(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.anyList()
+        );
+    }
+
+    @Test
+    @WithMockUser
+    public void fetchMutationDataCountsWithEmptyFiltersReturnsEmptyList() throws Exception {
+        GenomicDataCountFilter filter = new GenomicDataCountFilter();
+        filter.setGenomicDataFilters(Collections.emptyList());
+
+        StudyViewFilter studyViewFilter = new StudyViewFilter();
+        studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
+        filter.setStudyViewFilter(studyViewFilter);
+
+        mockMvc.perform(post("/api/column-store/mutation-data-counts/fetch")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(filter)))
+            .andExpect(status().isOk())
+            .andExpect(content().json("[]"));
+
+        // Verify that the service was never called (early return due to empty filters)
+        verify(studyViewService, never()).getMutationCountsByGeneSpecific(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.anyList()
+        );
+    }
+
+    @Test
+    @WithMockUser
+    public void fetchMutationDataCountsWithNullFiltersReturnsEmptyList() throws Exception {
+        GenomicDataCountFilter filter = new GenomicDataCountFilter();
+        filter.setGenomicDataFilters(null);
+
+        StudyViewFilter studyViewFilter = new StudyViewFilter();
+        studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
+        filter.setStudyViewFilter(studyViewFilter);
+
+        mockMvc.perform(post("/api/column-store/mutation-data-counts/fetch")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(filter)))
+            .andExpect(status().isOk())
+            .andExpect(content().json("[]"));
+
+        // Verify that the service was never called (early return due to null filters)
+        verify(studyViewService, never()).getMutationCountsByGeneSpecific(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.anyList()
+        );
+    }
+}

--- a/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewControllerTest.java
+++ b/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewControllerTest.java
@@ -27,118 +27,119 @@ import org.springframework.test.web.servlet.MockMvc;
 /**
  * Unit tests for ColumnarStoreStudyViewController.
  *
- * When genomicDataFilters is empty or null, the endpoints should return
- * an empty list instead of throwing an IndexOutOfBoundsException.
+ * <p>When genomicDataFilters is empty or null, the endpoints should return an empty list instead of
+ * throwing an IndexOutOfBoundsException.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
 public class ColumnarStoreStudyViewControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
-    @MockBean
-    private StudyViewService studyViewService;
+  @MockBean private StudyViewService studyViewService;
 
-    private static final String TEST_STUDY_ID = "test_study";
+  private static final String TEST_STUDY_ID = "test_study";
 
-    @Test
-    @WithMockUser
-    public void fetchGenomicDataCountsWithEmptyFiltersReturnsEmptyList() throws Exception {
-        GenomicDataCountFilter filter = new GenomicDataCountFilter();
-        filter.setGenomicDataFilters(Collections.emptyList());
+  @Test
+  @WithMockUser
+  public void fetchGenomicDataCountsWithEmptyFiltersReturnsEmptyList() throws Exception {
+    GenomicDataCountFilter filter = new GenomicDataCountFilter();
+    filter.setGenomicDataFilters(Collections.emptyList());
 
-        StudyViewFilter studyViewFilter = new StudyViewFilter();
-        studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
-        filter.setStudyViewFilter(studyViewFilter);
+    StudyViewFilter studyViewFilter = new StudyViewFilter();
+    studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
+    filter.setStudyViewFilter(studyViewFilter);
 
-        mockMvc.perform(post("/api/column-store/genomic-data-counts/fetch")
+    mockMvc
+        .perform(
+            post("/api/column-store/genomic-data-counts/fetch")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(filter)))
-            .andExpect(status().isOk())
-            .andExpect(content().json("[]"));
+        .andExpect(status().isOk())
+        .andExpect(content().json("[]"));
 
-        // Verify that the service was never called (early return due to empty filters)
-        verify(studyViewService, never()).getCNACountsByGeneSpecific(
-            org.mockito.ArgumentMatchers.any(),
-            org.mockito.ArgumentMatchers.anyList()
-        );
-    }
+    // Verify that the service was never called (early return due to empty filters)
+    verify(studyViewService, never())
+        .getCNACountsByGeneSpecific(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyList());
+  }
 
-    @Test
-    @WithMockUser
-    public void fetchGenomicDataCountsWithNullFiltersReturnsEmptyList() throws Exception {
-        GenomicDataCountFilter filter = new GenomicDataCountFilter();
-        filter.setGenomicDataFilters(null);
+  @Test
+  @WithMockUser
+  public void fetchGenomicDataCountsWithNullFiltersReturnsEmptyList() throws Exception {
+    GenomicDataCountFilter filter = new GenomicDataCountFilter();
+    filter.setGenomicDataFilters(null);
 
-        StudyViewFilter studyViewFilter = new StudyViewFilter();
-        studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
-        filter.setStudyViewFilter(studyViewFilter);
+    StudyViewFilter studyViewFilter = new StudyViewFilter();
+    studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
+    filter.setStudyViewFilter(studyViewFilter);
 
-        mockMvc.perform(post("/api/column-store/genomic-data-counts/fetch")
+    mockMvc
+        .perform(
+            post("/api/column-store/genomic-data-counts/fetch")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(filter)))
-            .andExpect(status().isOk())
-            .andExpect(content().json("[]"));
+        .andExpect(status().isOk())
+        .andExpect(content().json("[]"));
 
-        // Verify that the service was never called (early return due to null filters)
-        verify(studyViewService, never()).getCNACountsByGeneSpecific(
-            org.mockito.ArgumentMatchers.any(),
-            org.mockito.ArgumentMatchers.anyList()
-        );
-    }
+    // Verify that the service was never called (early return due to null filters)
+    verify(studyViewService, never())
+        .getCNACountsByGeneSpecific(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyList());
+  }
 
-    @Test
-    @WithMockUser
-    public void fetchMutationDataCountsWithEmptyFiltersReturnsEmptyList() throws Exception {
-        GenomicDataCountFilter filter = new GenomicDataCountFilter();
-        filter.setGenomicDataFilters(Collections.emptyList());
+  @Test
+  @WithMockUser
+  public void fetchMutationDataCountsWithEmptyFiltersReturnsEmptyList() throws Exception {
+    GenomicDataCountFilter filter = new GenomicDataCountFilter();
+    filter.setGenomicDataFilters(Collections.emptyList());
 
-        StudyViewFilter studyViewFilter = new StudyViewFilter();
-        studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
-        filter.setStudyViewFilter(studyViewFilter);
+    StudyViewFilter studyViewFilter = new StudyViewFilter();
+    studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
+    filter.setStudyViewFilter(studyViewFilter);
 
-        mockMvc.perform(post("/api/column-store/mutation-data-counts/fetch")
+    mockMvc
+        .perform(
+            post("/api/column-store/mutation-data-counts/fetch")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(filter)))
-            .andExpect(status().isOk())
-            .andExpect(content().json("[]"));
+        .andExpect(status().isOk())
+        .andExpect(content().json("[]"));
 
-        // Verify that the service was never called (early return due to empty filters)
-        verify(studyViewService, never()).getMutationCountsByGeneSpecific(
-            org.mockito.ArgumentMatchers.any(),
-            org.mockito.ArgumentMatchers.anyList()
-        );
-    }
+    // Verify that the service was never called (early return due to empty filters)
+    verify(studyViewService, never())
+        .getMutationCountsByGeneSpecific(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyList());
+  }
 
-    @Test
-    @WithMockUser
-    public void fetchMutationDataCountsWithNullFiltersReturnsEmptyList() throws Exception {
-        GenomicDataCountFilter filter = new GenomicDataCountFilter();
-        filter.setGenomicDataFilters(null);
+  @Test
+  @WithMockUser
+  public void fetchMutationDataCountsWithNullFiltersReturnsEmptyList() throws Exception {
+    GenomicDataCountFilter filter = new GenomicDataCountFilter();
+    filter.setGenomicDataFilters(null);
 
-        StudyViewFilter studyViewFilter = new StudyViewFilter();
-        studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
-        filter.setStudyViewFilter(studyViewFilter);
+    StudyViewFilter studyViewFilter = new StudyViewFilter();
+    studyViewFilter.setStudyIds(Arrays.asList(TEST_STUDY_ID));
+    filter.setStudyViewFilter(studyViewFilter);
 
-        mockMvc.perform(post("/api/column-store/mutation-data-counts/fetch")
+    mockMvc
+        .perform(
+            post("/api/column-store/mutation-data-counts/fetch")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(filter)))
-            .andExpect(status().isOk())
-            .andExpect(content().json("[]"));
+        .andExpect(status().isOk())
+        .andExpect(content().json("[]"));
 
-        // Verify that the service was never called (early return due to null filters)
-        verify(studyViewService, never()).getMutationCountsByGeneSpecific(
-            org.mockito.ArgumentMatchers.any(),
-            org.mockito.ArgumentMatchers.anyList()
-        );
-    }
+    // Verify that the service was never called (early return due to null filters)
+    verify(studyViewService, never())
+        .getMutationCountsByGeneSpecific(
+            org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyList());
+  }
 }

--- a/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewControllerTest.java
+++ b/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewControllerTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
@@ -40,19 +40,19 @@ public class ColumnarStoreStudyViewControllerTest {
 
   private ObjectMapper objectMapper = new ObjectMapper();
 
-  @MockBean private StudyViewService studyViewService;
+  @MockitoBean private StudyViewService studyViewService;
 
-  @MockBean private BasicDataBinner basicDataBinner;
+  @MockitoBean private BasicDataBinner basicDataBinner;
 
-  @MockBean private ClinicalDataBinner clinicalDataBinner;
+  @MockitoBean private ClinicalDataBinner clinicalDataBinner;
 
-  @MockBean private ClinicalDataDensityPlotService clinicalDataDensityPlotService;
+  @MockitoBean private ClinicalDataDensityPlotService clinicalDataDensityPlotService;
 
-  @MockBean private ViolinPlotService violinPlotService;
+  @MockitoBean private ViolinPlotService violinPlotService;
 
-  @MockBean private CustomDataService customDataService;
+  @MockitoBean private CustomDataService customDataService;
 
-  @MockBean private CustomDataFilterUtil customDataFilterUtil;
+  @MockitoBean private CustomDataFilterUtil customDataFilterUtil;
 
   private static final String TEST_STUDY_ID = "test_study";
 

--- a/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewControllerTest.java
+++ b/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewControllerTest.java
@@ -11,35 +11,48 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.Collections;
 import org.cbioportal.domain.studyview.StudyViewService;
+import org.cbioportal.infrastructure.service.BasicDataBinner;
+import org.cbioportal.infrastructure.service.ClinicalDataBinner;
+import org.cbioportal.legacy.service.ClinicalDataDensityPlotService;
+import org.cbioportal.legacy.service.CustomDataService;
+import org.cbioportal.legacy.service.ViolinPlotService;
+import org.cbioportal.legacy.web.columnar.util.CustomDataFilterUtil;
+import org.cbioportal.legacy.web.config.TestConfig;
 import org.cbioportal.legacy.web.parameter.GenomicDataCountFilter;
 import org.cbioportal.legacy.web.parameter.StudyViewFilter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
-/**
- * Unit tests for ColumnarStoreStudyViewController.
- *
- * <p>When genomicDataFilters is empty or null, the endpoints should return an empty list instead of
- * throwing an IndexOutOfBoundsException.
- */
-@RunWith(SpringRunner.class)
-@SpringBootTest
-@AutoConfigureMockMvc
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
+@ContextConfiguration(classes = {ColumnarStoreStudyViewController.class, TestConfig.class})
 public class ColumnarStoreStudyViewControllerTest {
 
   @Autowired private MockMvc mockMvc;
 
-  @Autowired private ObjectMapper objectMapper;
+  private ObjectMapper objectMapper = new ObjectMapper();
 
   @MockBean private StudyViewService studyViewService;
+
+  @MockBean private BasicDataBinner basicDataBinner;
+
+  @MockBean private ClinicalDataBinner clinicalDataBinner;
+
+  @MockBean private ClinicalDataDensityPlotService clinicalDataDensityPlotService;
+
+  @MockBean private ViolinPlotService violinPlotService;
+
+  @MockBean private CustomDataService customDataService;
+
+  @MockBean private CustomDataFilterUtil customDataFilterUtil;
 
   private static final String TEST_STUDY_ID = "test_study";
 
@@ -62,7 +75,6 @@ public class ColumnarStoreStudyViewControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().json("[]"));
 
-    // Verify that the service was never called (early return due to empty filters)
     verify(studyViewService, never())
         .getCNACountsByGeneSpecific(
             org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyList());
@@ -87,7 +99,6 @@ public class ColumnarStoreStudyViewControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().json("[]"));
 
-    // Verify that the service was never called (early return due to null filters)
     verify(studyViewService, never())
         .getCNACountsByGeneSpecific(
             org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyList());
@@ -112,7 +123,6 @@ public class ColumnarStoreStudyViewControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().json("[]"));
 
-    // Verify that the service was never called (early return due to empty filters)
     verify(studyViewService, never())
         .getMutationCountsByGeneSpecific(
             org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyList());
@@ -137,7 +147,6 @@ public class ColumnarStoreStudyViewControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().json("[]"));
 
-    // Verify that the service was never called (early return due to null filters)
     verify(studyViewService, never())
         .getMutationCountsByGeneSpecific(
             org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyList());


### PR DESCRIPTION
Fix #11206

Describe changes proposed in this pull request:
- Add null/empty validation for `genomicDataFilters` in `fetchGenomicDataCounts` and `fetchMutationDataCounts` endpoints
- Return empty list instead of propagating IndexOutOfBoundsException from `MyBatis` mapper
- Add unit tests covering empty and null filter scenarios

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
NA

# Notify
@alisman @inodb 
