### PR TITLE
Remove Font Awesome from backend index.jsp

### DIFF
--- a/src/main/resources/webapp/index.jsp
+++ b/src/main/resources/webapp/index.jsp
@@ -98,8 +98,6 @@
     
     <%@include file="./tracking_include.jsp" %>
 
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css" rel="stylesheet" />
-
 </head>
 
 <body>


### PR DESCRIPTION
## Remove Font Awesome loading from backend

Font Awesome is now loaded by the frontend, eliminating the brittle dependency on the backend to provide the correct version.

### Changes
- Remove Font Awesome 4.7.0 CDN link from `index.jsp`

### Context
- Frontend now bundles Font Awesome 6.7.2 in `appBootstrapper.tsx`
- Related frontend commit: [cBioPortal/cbioportal-frontend@1b0920b](https://github.com/cBioPortal/cbioportal-frontend/commit/1b0920b1f)
- This eliminates version conflicts and gives frontend full control over Font Awesome

### Benefits
- Frontend controls Font Awesome version via package.json
- No more manual sync needed between frontend and backend
- Eliminates loading two different versions (4.7.0 from backend, 6.7.2 from frontend)