### PR TITLE
 Fix #11873 ci: remove non-existent public profile from core-test workflow (#11873)

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -81,7 +81,7 @@ jobs:
       - name: 'Run integration tests separately'
         working-directory: ./cbioportal
         run: |
-          mvn verify -Pintegration-test
+          mvn verify -Pintegration-test -Ddb.test.username=cbio_user -Ddb.test.password=somepassword
       - name: 'Run e2e tests separately'
         working-directory: ./cbioportal
         run: |


### PR DESCRIPTION
Fix #11873

Describe changes proposed in this pull request:
- Removed the non-existent Maven profile -Ppublic from the core-test.yml GitHub Actions workflow.
-Corrected three specific Maven commands (Build without tests, Build with tests, and Run tests separately) to prevent "profile not found" warnings in the CI pipeline.


# Checks
 The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/).
Has tests or has a separate issue that describes the types of test that should be created. (Note: This is a CI infrastructure fix; I have verified the fix by successfully running the modified workflow in my personal fork).
Is this PR adding logic based on one or more clinical attributes? No.
Make sure your PR has one of the labels defined in release-drafter.yml. (Please add the test or CI label).

# Any screenshots or GIFs?
Before: The logs showed: Warning: The requested profile "public" could not be activated because it does not exist.
After: The Maven command executes successfully without the warning: Run mvn --settings settings.xml -q -U -DskipTests clean install

# Notify reviewers
I am notifying @onursumer and @dippindots  regarding this fix
