### PR TITLE
Gene-specific charts include sample ids

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewController.java
@@ -511,7 +511,9 @@ public class ColumnarStoreStudyViewController {
       @Parameter(required = true, description = "Genomic data count filter")
           @Valid
           @RequestBody(required = false)
-          GenomicDataCountFilter genomicDataCountFilter) {
+          GenomicDataCountFilter genomicDataCountFilter,
+      @Parameter(description = "Flag to include sample ids") @RequestParam(defaultValue = "false")
+          boolean includeSampleIds) {
     List<GenomicDataFilter> genomicDataFilters = genomicDataCountFilter.getGenomicDataFilters();
     StudyViewFilter studyViewFilter = genomicDataCountFilter.getStudyViewFilter();
     // when there is only one filter, it means study view is doing a single chart filter operation
@@ -530,7 +532,7 @@ public class ColumnarStoreStudyViewController {
         projection == Projection.SUMMARY
             ? studyViewService.getMutationCountsByGeneSpecific(studyViewFilter, genomicDataFilters)
             : studyViewService.getMutationTypeCountsByGeneSpecific(
-                studyViewFilter, genomicDataFilters);
+                studyViewFilter, genomicDataFilters, includeSampleIds);
 
     return ResponseEntity.ok(result);
   }

--- a/src/main/java/org/cbioportal/domain/genomic_data/repository/GenomicDataRepository.java
+++ b/src/main/java/org/cbioportal/domain/genomic_data/repository/GenomicDataRepository.java
@@ -75,9 +75,14 @@ public interface GenomicDataRepository {
    *     {@code null}.
    * @param genomicDataFilters a list of filters to apply to the genomic data. Must not be {@code
    *     null}.
+   * @param includeSampleIds flag to include sample ids
+   * @param hugoGeneSymbol a string representing the first gene from genomicDataFilters list
    * @return a list of {@link GenomicDataCountItem} objects representing the mutation counts by
    *     type.
    */
   List<GenomicDataCountItem> getMutationCountsByType(
-      StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters);
+      StudyViewFilterContext studyViewFilterContext,
+      List<GenomicDataFilter> genomicDataFilters,
+      boolean includeSampleIds,
+      String hugoGeneSymbol);
 }

--- a/src/main/java/org/cbioportal/domain/genomic_data/usecase/GetMutationCountsByTypeUseCase.java
+++ b/src/main/java/org/cbioportal/domain/genomic_data/usecase/GetMutationCountsByTypeUseCase.java
@@ -31,10 +31,26 @@ public class GetMutationCountsByTypeUseCase {
    *
    * @param studyViewFilterContext the context of the study view filter to apply
    * @param genomicDataFilters a list of genomic data filters to apply
+   * @param includeSampleIds flag to include sample ids
    * @return a list of {@link GenomicDataCountItem} representing the mutation counts by type
    */
   public List<GenomicDataCountItem> execute(
-      StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters) {
-    return repository.getMutationCountsByType(studyViewFilterContext, genomicDataFilters);
+      StudyViewFilterContext studyViewFilterContext,
+      List<GenomicDataFilter> genomicDataFilters,
+      boolean includeSampleIds) {
+    String hugoGeneSymbol = null;
+    // This is to enforce data accuracy and to avoid sending a list of genomicDataFilters when
+    // including sample id == true
+    if (includeSampleIds) {
+      if (genomicDataFilters == null || genomicDataFilters.size() != 1) {
+        throw new IllegalArgumentException(
+            "Only one gene allowed in GenomicDataFilter list when includeSampleIds is true");
+      }
+
+      hugoGeneSymbol = genomicDataFilters.getFirst().getHugoGeneSymbol();
+    }
+
+    return repository.getMutationCountsByType(
+        studyViewFilterContext, genomicDataFilters, includeSampleIds, hugoGeneSymbol);
   }
 }

--- a/src/main/java/org/cbioportal/domain/studyview/StudyViewService.java
+++ b/src/main/java/org/cbioportal/domain/studyview/StudyViewService.java
@@ -304,10 +304,13 @@ public class StudyViewService {
       condition =
           "@cacheEnabledConfig.getEnabledClickhouse() && @studyViewFilterUtil.isUnfilteredQuery(#studyViewFilter)")
   public List<GenomicDataCountItem> getMutationTypeCountsByGeneSpecific(
-      StudyViewFilter studyViewFilter, List<GenomicDataFilter> genomicDataFilters) {
+      StudyViewFilter studyViewFilter,
+      List<GenomicDataFilter> genomicDataFilters,
+      boolean includeSampleIds) {
     return genomicDataUseCases
         .getMutationCountsByTypeUseCase()
-        .execute(buildStudyViewFilterContext(studyViewFilter), genomicDataFilters);
+        .execute(
+            buildStudyViewFilterContext(studyViewFilter), genomicDataFilters, includeSampleIds);
   }
 
   @Cacheable(

--- a/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/genomic_data/ClickhouseGenomicDataMapper.java
+++ b/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/genomic_data/ClickhouseGenomicDataMapper.java
@@ -64,8 +64,13 @@ public interface ClickhouseGenomicDataMapper {
    *
    * @param studyViewFilterContext the context of the study view filter
    * @param genomicDataFilters the list of genomic data filters
+   * @param includeSampleIds a flag to include sample ids
+   * @param hugoGeneSymbol a string representing the first gene from genomicDataFilters list
    * @return a list of mutation counts by type
    */
   List<GenomicDataCountItem> getMutationCountsByType(
-      StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters);
+      StudyViewFilterContext studyViewFilterContext,
+      List<GenomicDataFilter> genomicDataFilters,
+      boolean includeSampleIds,
+      String hugoGeneSymbol);
 }

--- a/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/genomic_data/ClickhouseGenomicDataRepository.java
+++ b/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/genomic_data/ClickhouseGenomicDataRepository.java
@@ -47,7 +47,11 @@ public class ClickhouseGenomicDataRepository implements GenomicDataRepository {
 
   @Override
   public List<GenomicDataCountItem> getMutationCountsByType(
-      StudyViewFilterContext studyViewFilterContext, List<GenomicDataFilter> genomicDataFilters) {
-    return mapper.getMutationCountsByType(studyViewFilterContext, genomicDataFilters);
+      StudyViewFilterContext studyViewFilterContext,
+      List<GenomicDataFilter> genomicDataFilters,
+      boolean includeSampleIds,
+      String hugoGeneSymbol) {
+    return mapper.getMutationCountsByType(
+        studyViewFilterContext, genomicDataFilters, includeSampleIds, hugoGeneSymbol);
   }
 }

--- a/src/main/java/org/cbioportal/legacy/model/GenomicDataCount.java
+++ b/src/main/java/org/cbioportal/legacy/model/GenomicDataCount.java
@@ -1,6 +1,8 @@
 package org.cbioportal.legacy.model;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 public class GenomicDataCount implements Serializable {
@@ -9,6 +11,7 @@ public class GenomicDataCount implements Serializable {
   private String value;
   private Integer count;
   private Integer uniqueCount;
+  private List<String> sampleIds;
 
   public GenomicDataCount() {}
 
@@ -24,6 +27,14 @@ public class GenomicDataCount implements Serializable {
     this.count = count;
     this.uniqueCount = uniqueCount;
   }
+
+    public GenomicDataCount(String label, String value, Integer count, Integer uniqueCount, List<String> sampleIds) {
+        this.label = label;
+        this.value = value;
+        this.count = count;
+        this.uniqueCount = uniqueCount;
+        this.sampleIds = sampleIds;
+    }
 
   public String getLabel() {
     return label;
@@ -48,8 +59,18 @@ public class GenomicDataCount implements Serializable {
   public void setCount(Integer count) {
     this.count = count;
   }
+  
+  public List<String> getSampleIds() {
+      return sampleIds;
+  }
+  
+  public void setSampleIds(String sampleIdsStr) {
+      if (sampleIdsStr != null && !sampleIdsStr.isEmpty()) {
+          this.sampleIds = Arrays.asList(sampleIdsStr.split(","));
+      }
+  }
 
-  public Integer getUniqueCount() {
+    public Integer getUniqueCount() {
     return uniqueCount;
   }
 
@@ -66,10 +87,5 @@ public class GenomicDataCount implements Serializable {
         && Objects.equals(value, that.value)
         && Objects.equals(count, that.count)
         && Objects.equals(uniqueCount, that.uniqueCount);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(label, value, count, uniqueCount);
   }
 }

--- a/src/main/java/org/cbioportal/legacy/model/GenomicDataCount.java
+++ b/src/main/java/org/cbioportal/legacy/model/GenomicDataCount.java
@@ -28,13 +28,14 @@ public class GenomicDataCount implements Serializable {
     this.uniqueCount = uniqueCount;
   }
 
-    public GenomicDataCount(String label, String value, Integer count, Integer uniqueCount, List<String> sampleIds) {
-        this.label = label;
-        this.value = value;
-        this.count = count;
-        this.uniqueCount = uniqueCount;
-        this.sampleIds = sampleIds;
-    }
+  public GenomicDataCount(
+      String label, String value, Integer count, Integer uniqueCount, List<String> sampleIds) {
+    this.label = label;
+    this.value = value;
+    this.count = count;
+    this.uniqueCount = uniqueCount;
+    this.sampleIds = sampleIds;
+  }
 
   public String getLabel() {
     return label;
@@ -59,18 +60,18 @@ public class GenomicDataCount implements Serializable {
   public void setCount(Integer count) {
     this.count = count;
   }
-  
+
   public List<String> getSampleIds() {
-      return sampleIds;
-  }
-  
-  public void setSampleIds(String sampleIdsStr) {
-      if (sampleIdsStr != null && !sampleIdsStr.isEmpty()) {
-          this.sampleIds = Arrays.asList(sampleIdsStr.split(","));
-      }
+    return sampleIds;
   }
 
-    public Integer getUniqueCount() {
+  public void setSampleIds(String sampleIdsStr) {
+    if (sampleIdsStr != null && !sampleIdsStr.isEmpty()) {
+      this.sampleIds = Arrays.asList(sampleIdsStr.split(","));
+    }
+  }
+
+  public Integer getUniqueCount() {
     return uniqueCount;
   }
 
@@ -87,5 +88,10 @@ public class GenomicDataCount implements Serializable {
         && Objects.equals(value, that.value)
         && Objects.equals(count, that.count)
         && Objects.equals(uniqueCount, that.uniqueCount);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(label, value, count, uniqueCount);
   }
 }

--- a/src/main/resources/mappers/clickhouse/genomic_data/ClickhouseGenomicDataMapper.xml
+++ b/src/main/resources/mappers/clickhouse/genomic_data/ClickhouseGenomicDataMapper.xml
@@ -133,7 +133,8 @@
             replace(mutation_type, '_', ' ') as label,
             mutation_type as value,
             count(*) as count,
-            count(distinct(sample_unique_id)) as uniqueCount
+            count(distinct(sample_unique_id)) as uniqueCount,
+            arrayStringConcat(groupArray(DISTINCT sample_unique_id), ',') AS sampleIdsStr
             FROM genomic_event_derived
         <where>
             <include
@@ -156,6 +157,7 @@
             <result property="label" column="label"/>
             <result property="count" column="count"/>
             <result property="uniqueCount" column="uniqueCount"/>
+            <result property="sampleIds" column="sampleIdsStr"/>
         </collection>
     </resultMap>
 

--- a/src/main/resources/mappers/clickhouse/genomic_data/ClickhouseGenomicDataMapper.xml
+++ b/src/main/resources/mappers/clickhouse/genomic_data/ClickhouseGenomicDataMapper.xml
@@ -127,26 +127,97 @@
 
     <!-- for /mutation-data-counts/fetch - (returns GenomicDataCountItem objects) mutation type counts table part-->
     <select id="getMutationCountsByType" resultMap="GenomicDataCountItemResultMap">
-        SELECT
-            hugo_gene_symbol as hugoGeneSymbol,
-            'mutations' as profileType,
-            replace(mutation_type, '_', ' ') as label,
-            mutation_type as value,
-            count(*) as count,
-            count(distinct(sample_unique_id)) as uniqueCount,
-            arrayStringConcat(groupArray(DISTINCT sample_unique_id), ',') AS sampleIdsStr
-            FROM genomic_event_derived
-        <where>
+        WITH
+            <if test="includeSampleIds">
+                all_samples AS (
+                SELECT sample_unique_id
+                FROM sample_derived
+                WHERE cancer_study_identifier IN
+                <foreach collection="studyViewFilterContext.studyIds" item="studyId" open="(" separator="," close=")">
+                    #{studyId}
+                </foreach>
+                ),
+            </if>
+            mutated_samples AS (
+                SELECT
+                sample_unique_id,
+                hugo_gene_symbol,
+                mutation_type
+                FROM genomic_event_derived
+                <where>
+                    <include
+                        refid="org.cbioportal.infrastructure.repository.clickhouse.studyview.ClickhouseStudyViewFilterMapper.applyStudyViewFilterUsingSampleId"/>
+                    AND variant_type = 'mutation'
+                    <if test="includeSampleIds">
+                        AND hugo_gene_symbol = #{hugoGeneSymbol}
+                    </if>
+                    <if test="!includeSampleIds">
+                        <foreach item="genomicDataFilter" collection="genomicDataFilters" open=" AND (" separator=" OR " close=")">
+                            hugo_gene_symbol = #{genomicDataFilter.hugoGeneSymbol}
+                        </foreach>
+                    </if>
+                </where>
+            )
+        <if test="includeSampleIds">
+            ,
+            profiled_samples as (
+            SELECT DISTINCT sgp.sample_unique_id
+            FROM sample_to_gene_panel_derived sgp
+            JOIN gene_panel_to_gene_derived gpg ON sgp.gene_panel_id = gpg.gene_panel_id
+            WHERE
             <include
-                    refid="org.cbioportal.infrastructure.repository.clickhouse.studyview.ClickhouseStudyViewFilterMapper.applyStudyViewFilterUsingSampleId"/>
-            AND variant_type = 'mutation'
-            <foreach item="genomicDataFilter" collection="genomicDataFilters" open=" AND (" separator=" OR " close=")">
-                hugo_gene_symbol = #{genomicDataFilter.hugoGeneSymbol}
-            </foreach>
-        </where>
+                refid="org.cbioportal.infrastructure.repository.clickhouse.studyview.ClickhouseStudyViewFilterMapper.applyStudyViewFilterUsingSampleId"/>
+            AND gpg.gene = #{hugoGeneSymbol}
+            AND sgp.alteration_type = 'MUTATION_EXTENDED'
+            )
+        </if>
+               
+        SELECT
+            hugo_gene_symbol AS hugoGeneSymbol,
+            'mutations' AS profileType,
+            replace(mutation_type, '_', ' ') AS label,
+            mutation_type AS value,
+            COUNT(*) AS count,
+            COUNT(DISTINCT sample_unique_id) AS uniqueCount
+            <if test="includeSampleIds">
+                ,
+                arrayStringConcat(groupArray(DISTINCT sample_unique_id), ',') AS sampleIdsStr
+            </if>
+        FROM
+            mutated_samples
         GROUP BY
-        mutation_type,
-        hugo_gene_symbol
+            hugo_gene_symbol,
+            mutation_type
+
+        <if test="includeSampleIds">
+            UNION ALL
+
+            SELECT
+                #{hugoGeneSymbol} as hugoGeneSymbol,
+                'Not Mutated' AS profileType,
+                'Not Mutated' AS label,
+                'NOT_MUTATED' AS value,
+                COUNT(*) AS count,
+                COUNT(DISTINCT sample_unique_id) AS uniqueCount,
+                arrayStringConcat(groupArray(DISTINCT sample_unique_id), ',') AS sampleIdsStr
+            FROM profiled_samples
+            where sample_unique_id NOT in (SELECT sample_unique_id from mutated_samples)
+
+            UNION ALL
+
+            SELECT
+                #{hugoGeneSymbol} AS hugoGeneSymbol,
+                'Not Profiled' AS profileType,
+                'Not Profiled' AS label,
+                'NOT_PROFILED' AS value,
+                COUNT(*) AS count,
+                COUNT(DISTINCT sample_unique_id) AS uniqueCount,
+                arrayStringConcat(groupArray(DISTINCT sample_unique_id), ',') AS sampleIdsStr
+            FROM all_samples
+            WHERE
+            sample_unique_id NOT IN (  SELECT sample_unique_id FROM profiled_samples
+            )
+        </if>
     </select>
 
     <resultMap id="GenomicDataCountItemResultMap" type="org.cbioportal.legacy.model.GenomicDataCountItem">

--- a/src/test/java/org/cbioportal/domain/genomic_data/usecase/GetMutationCountsByTypeUseCaseTest.java
+++ b/src/test/java/org/cbioportal/domain/genomic_data/usecase/GetMutationCountsByTypeUseCaseTest.java
@@ -1,0 +1,75 @@
+package org.cbioportal.domain.genomic_data.usecase;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import org.cbioportal.domain.genomic_data.repository.GenomicDataRepository;
+import org.cbioportal.domain.studyview.StudyViewFilterContext;
+import org.cbioportal.legacy.model.GenomicDataCountItem;
+import org.cbioportal.legacy.web.parameter.GenomicDataFilter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GetMutationCountsByTypeUseCaseTest {
+
+  @InjectMocks private GetMutationCountsByTypeUseCase useCase;
+
+  @Mock private GenomicDataRepository repository;
+
+  @Mock private StudyViewFilterContext studyViewFilterContext;
+
+  @Test
+  public void execute_includeSampleIdsFalse_callsRepository() {
+
+    List<GenomicDataFilter> filters = List.of(new GenomicDataFilter("AKT1", "mutation"));
+
+    when(repository.getMutationCountsByType(any(), any(), anyBoolean(), any()))
+        .thenReturn(Collections.emptyList());
+
+    List<GenomicDataCountItem> result = useCase.execute(studyViewFilterContext, filters, false);
+
+    verify(repository).getMutationCountsByType(studyViewFilterContext, filters, false, null);
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void execute_includeSampleIdsTrue_singleGene_callsRepositoryWithHugo() {
+    GenomicDataFilter filter = new GenomicDataFilter("AKT1", "mutation");
+    List<GenomicDataFilter> filters = List.of(filter);
+
+    when(repository.getMutationCountsByType(any(), any(), anyBoolean(), any()))
+        .thenReturn(Collections.emptyList());
+
+    List<GenomicDataCountItem> result = useCase.execute(studyViewFilterContext, filters, true);
+
+    verify(repository).getMutationCountsByType(studyViewFilterContext, filters, true, "AKT1");
+
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void execute_includeSampleIdsTrue_nullFilters_throwsException() {
+    useCase.execute(studyViewFilterContext, null, true);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void execute_includeSampleIdsTrue_multipleGenes_throwsException() {
+    List<GenomicDataFilter> filters =
+        List.of(
+            new GenomicDataFilter("AKT1", "mutation"), new GenomicDataFilter("TP53", "mutation"));
+
+    useCase.execute(studyViewFilterContext, filters, true);
+  }
+}


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/11771
Describe changes proposed in this pull request:
-  This change adds optional support for including sample IDs in the mutation data counts response. When enabled, the backend populates sample IDs required by the comparison page on the frontend, while preserving existing behaviour when the flag is disabled. This extension is aimed at reducing the complexity required by the frontend to group and create a comparison session for gene-specific charts.

## Checks
- [x] Yes, the change has been tested to check the presence of a list of strings when **includeSampleId** is **true** and no list when **includeSampleId** is **false**. Additionally, the use case layer was tested to ensure that when **includeSampleId** is true, only a single gene should be present in the list.
- [x] Yes, the commit log is comprehensive.
- [x] No, it is not adding logic based on one or more clinical attributes

**_Note_**
**includeSampleId** is used exclusively for gene-specific comparison sessions. Although the summary and detailed projection accept multiple genes and render one chart per gene, the comparison feature operates at the individual chart level. Each chart represents a single gene, and comparison groups (Mutated vs Not Mutated) are defined relative to that gene. Therefore, I enforced exactly one gene when sample IDs are requested to maintain clear and consistent grouping behaviour.



