### PR TITLE
Fix 500 error when user has no data access token

### DIFF
--- a/src/main/java/org/cbioportal/legacy/service/impl/UuidDataAccessTokenServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/UuidDataAccessTokenServiceImpl.java
@@ -102,8 +102,12 @@ public class UuidDataAccessTokenServiceImpl implements DataAccessTokenService {
   public DataAccessToken getDataAccessToken(String username) {
     List<DataAccessToken> allDataAccessTokens =
         dataAccessTokenRepository.getAllDataAccessTokensForUsername(username);
-    DataAccessToken newestDataAccessToken = allDataAccessTokens.get(allDataAccessTokens.size() - 1);
-    return newestDataAccessToken;
+
+    if (allDataAccessTokens == null || allDataAccessTokens.isEmpty()) {
+      return createDataAccessToken(username);
+    }
+
+    return allDataAccessTokens.get(allDataAccessTokens.size() - 1);
   }
 
   @Override

--- a/src/test/java/org/cbioportal/legacy/service/impl/UuidDataAccessTokenServiceImplTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/impl/UuidDataAccessTokenServiceImplTest.java
@@ -193,6 +193,23 @@ public class UuidDataAccessTokenServiceImplTest {
     }
   }
 
+  /* Tests getDataAccessToken when user has no existing tokens
+   * Should create and return a new token instead of throwing an exception
+   */
+  @Test
+  public void getDataAccessTokenCreatesTokenWhenNoneExist() {
+    uuidDataAccessTokenServiceImplTestConfiguration.resetAddedDataAccessToken();
+
+    DataAccessToken token =
+        uuidDataAccessTokenServiceImpl.getDataAccessToken(
+            UuidDataAccessTokenServiceImplTestConfiguration.MOCK_USERNAME);
+
+    Assert.assertNotNull("Returned token should not be null", token);
+    Assert.assertNotNull(
+        "Token should be persisted when none exist",
+        uuidDataAccessTokenServiceImplTestConfiguration.getAddedDataAccessToken());
+  }
+
   /* Tests validation of a valid token
    * Mock is configured to test a token with expiration date 100000 seconds after current time
    * Should return true


### PR DESCRIPTION
### Problem
Calling getDataAccessToken for a user with no existing data access tokens
throws an IndexOutOfBoundsException, resulting in a 500 response.

### Solution
Guard against an empty token list and create a new data access token
when none exists.

### Impact
Prevents server error and aligns behavior with expected token lifecycle.

### Tests
- mvn test -Dtest=UuidDataAccessTokenServiceImplTest

Fixes #11905