### PR TITLE
Return 404 instead of 500 for missing reference genome gene

### DIFF
--- a/src/main/java/org/cbioportal/legacy/web/ReferenceGenomeGeneController.java
+++ b/src/main/java/org/cbioportal/legacy/web/ReferenceGenomeGeneController.java
@@ -69,7 +69,7 @@ public class ReferenceGenomeGeneController {
       responseCode = "200",
       description = "OK",
       content = @Content(schema = @Schema(implementation = ReferenceGenomeGene.class)))
-  @ApiResponse(responseCode = "404", description = "Gene not found")
+  @ApiResponse(responseCode = "404", description = "Reference genome or gene not found")
   public ResponseEntity<ReferenceGenomeGene> getReferenceGenomeGene(
       @Parameter(required = true, description = "Name of Reference Genome hg19") @PathVariable
           String genomeName,


### PR DESCRIPTION
### Problem
Requesting a reference genome gene that does not exist results in a 500 server error.

### Solution
Add explicit null handling in ReferenceGenomeGeneController and return HTTP 404 when the gene is missing.

