### PR TITLE
fix: enable SAML SP metadata endpoint in v6

### DIFF
--- a/src/main/java/org/cbioportal/application/security/config/Saml2AndBasicConfig.java
+++ b/src/main/java/org/cbioportal/application/security/config/Saml2AndBasicConfig.java
@@ -72,6 +72,7 @@ public class Saml2AndBasicConfig {
                 securityContext.securityContextRepository(
                     new HttpSessionSecurityContextRepository()))
         .saml2Login(withDefaults())
+        .saml2Metadata(withDefaults())
         .sessionManagement(
             sessionManagement -> sessionManagement.sessionFixation().migrateSession())
         // SAML logout configuration

--- a/src/main/java/org/cbioportal/application/security/config/Saml2SecurityConfig.java
+++ b/src/main/java/org/cbioportal/application/security/config/Saml2SecurityConfig.java
@@ -60,6 +60,7 @@ public class Saml2SecurityConfig {
                     new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
                     AntPathRequestMatcher.antMatcher("/api/**")))
         .saml2Login(withDefaults())
+        .saml2Metadata(withDefaults())
         // NOTE: I did not get the official .saml2Logout() DSL to work as
         // described at
         // https://docs.spring.io/spring-security/reference/6.1/servlet/saml2/logout.html


### PR DESCRIPTION
Fixes #11818

## Description

Fixes missing SAML SP metadata endpoint after v5→v6 upgrade by adding `.saml2Metadata(withDefaults())` to both SAML security config files.

This enables the metadata endpoints (`/saml2/metadata`) needed for IdP configuration, following Spring Security 6.x documentation.

## Checks
- [x] The commit log is comprehensible
- [x] Has tests or separate issue *(requires SAML environment - can test by accessing `/saml2/metadata` after deployment)*
- [ ] Clinical attributes? *(N/A)*
- [ ] PR labels added

## Testing

```bash
curl http://localhost:8080/saml2/metadata
```

Should return XML with `<EntityDescriptor>` and `<SPSSODescriptor>`.

cc: @zainasir 