### PR TITLE
refactor: Replace PostMapping with RequestMapping across various controllers

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreClinicalDataController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreClinicalDataController.java
@@ -23,9 +23,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -101,8 +101,9 @@ public class ColumnStoreClinicalDataController {
   @Hidden
   @PreAuthorize(
       "hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
-  @PostMapping(
+  @RequestMapping(
       value = "/clinical-data/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Fetch clinical data by patient IDs or sample IDs (all studies)")

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreMutationController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreMutationController.java
@@ -71,8 +71,9 @@ public class ColumnStoreMutationController {
   @Hidden
   @PreAuthorize(
       "hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
-  @PostMapping(
+  @RequestMapping(
       value = "/mutations/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<List<MutationDTO>> fetchMutationsInMultipleMolecularProfiles(

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreSampleController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreSampleController.java
@@ -37,9 +37,9 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -131,8 +131,9 @@ public class ColumnStoreSampleController {
 
   @PreAuthorize(
       "hasPermission(#sampleFilter, 'SampleFilter', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
-  @PostMapping(
+  @RequestMapping(
       value = "/samples/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Fetch samples by ID")

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreStudyViewController.java
@@ -68,9 +68,9 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -105,8 +105,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden
-  @PostMapping(
+  @RequestMapping(
       value = "/filtered-samples/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize(
@@ -119,8 +120,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/mutated-genes/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize(
@@ -132,8 +134,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/molecular-profile-sample-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Fetch sample counts by study view filter")
@@ -154,8 +157,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/cna-genes/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize(
@@ -167,8 +171,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/structuralvariant-genes/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Fetch structural variant genes by study view filter")
@@ -190,8 +195,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/clinical-data-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize(
@@ -213,8 +219,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/sample-lists-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Fetch case list sample counts by study view filter")
@@ -230,8 +237,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/clinical-data-bin-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize(
@@ -246,8 +254,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/clinical-data-density-plot/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Fetch clinical data density plot bins by study view filter")
@@ -317,8 +326,9 @@ public class ColumnarStoreStudyViewController {
   @Hidden // should unhide when we remove legacy controller
   @PreAuthorize(
       "hasPermission(#studyViewFilter, 'StudyViewFilter', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
-  @PostMapping(
+  @RequestMapping(
       value = "/clinical-data-violin-plots/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(
@@ -405,8 +415,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/genomic-data-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Fetch genomic data counts by GenomicDataCountFilter")
@@ -446,8 +457,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/generic-assay-data-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Fetch generic assay data counts by study view filter")
@@ -484,8 +496,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/mutation-data-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Fetch mutation data counts by GenomicDataCountFilter")
@@ -523,8 +536,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/clinical-event-type-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Get Counts of Clinical Event Types by Study View Filter")
@@ -545,8 +559,9 @@ public class ColumnarStoreStudyViewController {
     return ResponseEntity.ok(studyViewService.getClinicalEventTypeCounts(studyViewFilter));
   }
 
-  @PostMapping(
+  @RequestMapping(
       value = "/treatments/patient-counts/fetch",
+      method = RequestMethod.POST,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Get all patient level treatments")
   @ApiResponse(
@@ -566,8 +581,9 @@ public class ColumnarStoreStudyViewController {
     return ResponseEntity.ok(studyViewService.getPatientTreatmentReport(studyViewFilter));
   }
 
-  @PostMapping(
+  @RequestMapping(
       value = "/treatments/sample-counts/fetch",
+      method = RequestMethod.POST,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @ApiResponse(
       responseCode = "200",
@@ -591,8 +607,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/custom-data-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Fetch custom data counts by study view filter")
@@ -641,8 +658,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/custom-data-bin-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Fetch custom data bin counts by study view filter")
@@ -666,8 +684,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/genomic-data-bin-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @ApiResponse(
@@ -686,8 +705,9 @@ public class ColumnarStoreStudyViewController {
   }
 
   @Hidden // should unhide when we remove legacy controller
-  @PostMapping(
+  @RequestMapping(
       value = "/generic-assay-data-bin-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @ApiResponse(

--- a/src/main/java/org/cbioportal/legacy/web/LoginPageController.java
+++ b/src/main/java/org/cbioportal/legacy/web/LoginPageController.java
@@ -19,7 +19,8 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequest
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 
 @Controller
 @ConditionalOnExpression("{'oauth2','saml','optional_oauth2'}.contains('${authenticate}')")
@@ -37,7 +38,10 @@ public class LoginPageController {
   @Value("${security.force_redirect_on_one_idp:true}")
   private boolean forceRedirectOnOneIdentityProvider;
 
-  @PostMapping(value = "/login", produces = MediaType.APPLICATION_JSON_VALUE)
+  @RequestMapping(
+      value = "/login",
+      produces = MediaType.APPLICATION_JSON_VALUE,
+      method = RequestMethod.POST)
   public String showLoginPagePost(
       HttpServletRequest request, Authentication authentication, Model model) {
     populateModel(request, model, new HashMap<>());

--- a/src/main/java/org/cbioportal/legacy/web/NamespaceAttributeController.java
+++ b/src/main/java/org/cbioportal/legacy/web/NamespaceAttributeController.java
@@ -15,9 +15,9 @@ import org.cbioportal.legacy.web.config.annotation.PublicApi;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @PublicApi
@@ -33,7 +33,7 @@ public class NamespaceAttributeController {
     this.namespaceAttributeService = namespaceAttributeService;
   }
 
-  @PostMapping(path = "/namespace-attributes/fetch")
+  @RequestMapping(path = "/namespace-attributes/fetch", method = RequestMethod.POST)
   @Operation(description = "Fetch namespace attributes")
   @ApiResponse(
       responseCode = "200",

--- a/src/main/java/org/cbioportal/legacy/web/NamespaceAttributeCountController.java
+++ b/src/main/java/org/cbioportal/legacy/web/NamespaceAttributeCountController.java
@@ -24,10 +24,10 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @InternalApi
@@ -46,8 +46,9 @@ public class NamespaceAttributeCountController {
 
   @PreAuthorize(
       "hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
-  @PostMapping(
+  @RequestMapping(
       path = "/namespace-attributes/counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(

--- a/src/main/java/org/cbioportal/legacy/web/NamespaceDataController.java
+++ b/src/main/java/org/cbioportal/legacy/web/NamespaceDataController.java
@@ -24,10 +24,10 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @InternalApi
@@ -46,8 +46,9 @@ public class NamespaceDataController {
 
   @PreAuthorize(
       "hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
-  @PostMapping(
+  @RequestMapping(
       value = "/namespace-data/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(

--- a/src/main/java/org/cbioportal/legacy/web/PublicVirtualStudiesController.java
+++ b/src/main/java/org/cbioportal/legacy/web/PublicVirtualStudiesController.java
@@ -19,10 +19,10 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
@@ -51,7 +51,7 @@ public class PublicVirtualStudiesController {
     return new ResponseEntity<>(virtualStudies, HttpStatus.OK);
   }
 
-  @PostMapping("/{id}")
+  @RequestMapping(value = "/{id}", method = RequestMethod.POST)
   @ApiResponse(
       responseCode = "200",
       description = "OK",

--- a/src/main/java/org/cbioportal/legacy/web/StudyViewController.java
+++ b/src/main/java/org/cbioportal/legacy/web/StudyViewController.java
@@ -97,7 +97,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -1657,8 +1656,9 @@ public class StudyViewController {
 
   @PreAuthorize(
       "hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
-  @PostMapping(
+  @RequestMapping(
       value = "/namespace-data-counts/fetch",
+      method = RequestMethod.POST,
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(description = "Fetch namespace data counts by study view filter")


### PR DESCRIPTION
Since our UpdateAPI scripts don’t process `PostMapping` accurately, we plan to replace it with `RequestMapping` to prevent potential issues for API clients.