### PR TITLE
Add Datadog RUM configuration properties

### DIFF
--- a/src/main/java/org/cbioportal/legacy/service/FrontendPropertiesServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/FrontendPropertiesServiceImpl.java
@@ -27,7 +27,8 @@ public class FrontendPropertiesServiceImpl implements FrontendPropertiesService 
   private final Logger log = LoggerFactory.getLogger(FrontendPropertiesServiceImpl.class);
 
   // This enum holds properties exposed to the frontend reactapp.
-  // Format: <name of property known in frontend>("<name of property in properties file>", "<default
+  // Format: <name of property known in frontend>("<name of property in properties
+  // file>", "<default
   // value>")
   // There are some properties that require processing before being exposed to the frontend.
   public enum FrontendProperty {
@@ -51,6 +52,12 @@ public class FrontendPropertiesServiceImpl implements FrontendPropertiesService 
     genomenexus_isoform_override_source("genomenexus.isoform_override_source", null),
     google_analytics_profile_id("google_analytics_profile_id", null),
     google_tag_manager_id("google_tag_manager_id", null),
+    datadog_rum_application_id("datadog_rum_application_id", null),
+    datadog_rum_client_token("datadog_rum_client_token", null),
+    datadog_rum_site("datadog_rum_site", null),
+    datadog_rum_env("datadog_rum_env", null),
+    datadog_rum_session_sample_rate("datadog_rum_session_sample_rate", null),
+    datadog_rum_session_replay_sample_rate("datadog_rum_session_replay_sample_rate", null),
     analytics_report_url("analytics_report_url", null),
     oncoprint_hide_vus_default("oncoprint.hide_vus.default", null),
     oncokb_public_api_url("oncokb.public_api.url", null),

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -228,6 +228,14 @@ bitly.access.token=
 # google_analytics_profile_id=
 # google_tag_manager_id=
 
+# Datadog RUM (Real User Monitoring)
+# datadog_rum_application_id=
+# datadog_rum_client_token=
+# datadog_rum_site=
+# datadog_rum_env=
+# datadog_rum_session_sample_rate=
+# datadog_rum_session_replay_sample_rate=
+
 # genomespace linking
 genomespace=true
 


### PR DESCRIPTION
- Add 6 Datadog RUM properties to FrontendPropertiesServiceImpl enum
- Add example configuration to application.properties.EXAMPLE
- All properties default to null (frontend handles defaults)
- Properties: application_id, client_token, site, env, session_sample_rate, session_replay_sample_rate
