### PR TITLE
Fix 500 error when user has no data access token

### DIFF
--- a/src/main/java/org/cbioportal/legacy/service/impl/UuidDataAccessTokenServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/UuidDataAccessTokenServiceImpl.java
@@ -54,8 +54,7 @@ import org.springframework.stereotype.Component;
 @ConditionalOnProperty(name = "dat.method", havingValue = "uuid")
 public class UuidDataAccessTokenServiceImpl implements DataAccessTokenService {
 
-  @Autowired
-  private DataAccessTokenRepository dataAccessTokenRepository;
+  @Autowired private DataAccessTokenRepository dataAccessTokenRepository;
 
   @Value("${dat.ttl_seconds:-1}")
   private int datTtlSeconds;
@@ -85,7 +84,8 @@ public class UuidDataAccessTokenServiceImpl implements DataAccessTokenService {
     calendar.add(Calendar.SECOND, datTtlSeconds);
     Date expirationDate = calendar.getTime();
 
-    DataAccessToken dataAccessToken = new DataAccessToken(uuid, username, expirationDate, creationDate);
+    DataAccessToken dataAccessToken =
+        new DataAccessToken(uuid, username, expirationDate, creationDate);
     dataAccessTokenRepository.addDataAccessToken(dataAccessToken);
     return dataAccessToken;
   }
@@ -93,14 +93,16 @@ public class UuidDataAccessTokenServiceImpl implements DataAccessTokenService {
   // get all user tokens/uuids sorted from oldest to newest
   @Override
   public List<DataAccessToken> getAllDataAccessTokens(String username) {
-    List<DataAccessToken> allDataAccessTokens = dataAccessTokenRepository.getAllDataAccessTokensForUsername(username);
+    List<DataAccessToken> allDataAccessTokens =
+        dataAccessTokenRepository.getAllDataAccessTokensForUsername(username);
     return allDataAccessTokens;
   }
 
   // get newest data access token for a given username
   @Override
   public DataAccessToken getDataAccessToken(String username) {
-    List<DataAccessToken> allDataAccessTokens = dataAccessTokenRepository.getAllDataAccessTokensForUsername(username);
+    List<DataAccessToken> allDataAccessTokens =
+        dataAccessTokenRepository.getAllDataAccessTokensForUsername(username);
     if (allDataAccessTokens.isEmpty()) {
       return createDataAccessToken(username);
     }
@@ -162,13 +164,15 @@ public class UuidDataAccessTokenServiceImpl implements DataAccessTokenService {
   }
 
   private int getNumberOfTokensForUsername(String username) {
-    List<DataAccessToken> allDataAccessTokens = dataAccessTokenRepository.getAllDataAccessTokensForUsername(username);
+    List<DataAccessToken> allDataAccessTokens =
+        dataAccessTokenRepository.getAllDataAccessTokensForUsername(username);
     return allDataAccessTokens.size();
   }
 
   // revokes oldest token in token management system for a user
   private void revokeOldestDataAccessTokenForUsername(String username) {
-    List<DataAccessToken> allDataAccessTokens = dataAccessTokenRepository.getAllDataAccessTokensForUsername(username);
+    List<DataAccessToken> allDataAccessTokens =
+        dataAccessTokenRepository.getAllDataAccessTokensForUsername(username);
     DataAccessToken oldestDataAccessToken = allDataAccessTokens.get(0);
     dataAccessTokenRepository.removeDataAccessToken(oldestDataAccessToken.getToken());
   }

--- a/src/test/java/org/cbioportal/legacy/service/impl/UuidDataAccessTokenServiceImplTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/impl/UuidDataAccessTokenServiceImplTest.java
@@ -63,20 +63,22 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-@TestPropertySource(properties = {
-    "dat.jwt.secret_key = +NbopXzb/AIQNrVEGzxzP5CF42e5drvrXTQot3gfW/s=",
-    "dat.uuid.max_number_per_user = 1",
-    "dat.ttl_seconds = 2"
-}, inheritLocations = false)
+@TestPropertySource(
+    properties = {
+      "dat.jwt.secret_key = +NbopXzb/AIQNrVEGzxzP5CF42e5drvrXTQot3gfW/s=",
+      "dat.uuid.max_number_per_user = 1",
+      "dat.ttl_seconds = 2"
+    },
+    inheritLocations = false)
 @ContextConfiguration(classes = UuidDataAccessTokenServiceImplTestConfiguration.class)
 @RunWith(SpringRunner.class)
 public class UuidDataAccessTokenServiceImplTest {
 
   @Autowired
-  private UuidDataAccessTokenServiceImplTestConfiguration uuidDataAccessTokenServiceImplTestConfiguration;
+  private UuidDataAccessTokenServiceImplTestConfiguration
+      uuidDataAccessTokenServiceImplTestConfiguration;
 
-  @Autowired
-  private DataAccessTokenRepository dataAccessTokenRepository;
+  @Autowired private DataAccessTokenRepository dataAccessTokenRepository;
 
   @Autowired
   @Qualifier("uuidDataAccessTokenServiceImpl")
@@ -96,11 +98,14 @@ public class UuidDataAccessTokenServiceImplTest {
     // Testing for service with limit 1 token
     uuidDataAccessTokenServiceImplTestConfiguration.resetAddedDataAccessToken();
     uuidDataAccessTokenServiceImplTestConfiguration.resetDeletedDataAccessToken();
-    DataAccessToken newDataAccessToken = uuidDataAccessTokenServiceImpl.createDataAccessToken(
-        UuidDataAccessTokenServiceImplTestConfiguration.MOCK_USERNAME_WITH_ONE_TOKEN);
+    DataAccessToken newDataAccessToken =
+        uuidDataAccessTokenServiceImpl.createDataAccessToken(
+            UuidDataAccessTokenServiceImplTestConfiguration.MOCK_USERNAME_WITH_ONE_TOKEN);
     Date expectedExpirationDate = getExpectedExpirationDate();
-    String deletedDataAccessToken = uuidDataAccessTokenServiceImplTestConfiguration.getDeletedDataAccessToken();
-    DataAccessToken createdDataAccessToken = uuidDataAccessTokenServiceImplTestConfiguration.getAddedDataAccessToken();
+    String deletedDataAccessToken =
+        uuidDataAccessTokenServiceImplTestConfiguration.getDeletedDataAccessToken();
+    DataAccessToken createdDataAccessToken =
+        uuidDataAccessTokenServiceImplTestConfiguration.getAddedDataAccessToken();
     if (createdDataAccessTokenWithWrongInformation(
         createdDataAccessToken,
         UuidDataAccessTokenServiceImplTestConfiguration.MOCK_USERNAME_WITH_ONE_TOKEN,
@@ -116,7 +121,8 @@ public class UuidDataAccessTokenServiceImplTest {
               + expectedExpirationDate.toString()
               + ")");
     }
-    if (deletedDataAccessToken != uuidDataAccessTokenServiceImplTestConfiguration.OLDEST_TOKEN_UUID) {
+    if (deletedDataAccessToken
+        != uuidDataAccessTokenServiceImplTestConfiguration.OLDEST_TOKEN_UUID) {
       Assert.fail(
           "Expired token: "
               + deletedDataAccessToken
@@ -141,8 +147,9 @@ public class UuidDataAccessTokenServiceImplTest {
       createdDataAccessTokenWithWrongInformation = true;
     }
     if (Math.abs(
-        createdDataAccessToken.getExpiration().getTime() - expectedExpirationDate
-            .getTime()) > UuidDataAccessTokenServiceImplTestConfiguration.MAXIMUM_TIME_DIFFERENCE_BETWEEN_CREATED_AND_EXPECTED_TOKEN) {
+            createdDataAccessToken.getExpiration().getTime() - expectedExpirationDate.getTime())
+        > UuidDataAccessTokenServiceImplTestConfiguration
+            .MAXIMUM_TIME_DIFFERENCE_BETWEEN_CREATED_AND_EXPECTED_TOKEN) {
       createdDataAccessTokenWithWrongInformation = true;
     }
     return createdDataAccessTokenWithWrongInformation;
@@ -154,8 +161,9 @@ public class UuidDataAccessTokenServiceImplTest {
    */
   @Test
   public void validateNonexistantTokenTest() {
-    Boolean nonexistantTokenIsValid = uuidDataAccessTokenServiceImpl.isValid(
-        UuidDataAccessTokenServiceImplTestConfiguration.NONEXISTENT_TOKEN_STRING);
+    Boolean nonexistantTokenIsValid =
+        uuidDataAccessTokenServiceImpl.isValid(
+            UuidDataAccessTokenServiceImplTestConfiguration.NONEXISTENT_TOKEN_STRING);
     if (nonexistantTokenIsValid) {
       Assert.fail("Validation of nonexistant token returned true, expected false.");
     }
@@ -167,8 +175,9 @@ public class UuidDataAccessTokenServiceImplTest {
    */
   @Test
   public void validateFailedToGetToken() {
-    Boolean failedToGetTokenIsValid = uuidDataAccessTokenServiceImpl.isValid(
-        UuidDataAccessTokenServiceImplTestConfiguration.FAIL_TO_GET_TOKEN_STRING);
+    Boolean failedToGetTokenIsValid =
+        uuidDataAccessTokenServiceImpl.isValid(
+            UuidDataAccessTokenServiceImplTestConfiguration.FAIL_TO_GET_TOKEN_STRING);
     if (failedToGetTokenIsValid) {
       Assert.fail("Validation of token that we failed to look up returned true, expected false.");
     }
@@ -182,8 +191,9 @@ public class UuidDataAccessTokenServiceImplTest {
    */
   @Test
   public void validateExpiredTokenTest() {
-    Boolean expiredTokenIsValid = uuidDataAccessTokenServiceImpl.isValid(
-        UuidDataAccessTokenServiceImplTestConfiguration.EXPIRED_TOKEN_STRING);
+    Boolean expiredTokenIsValid =
+        uuidDataAccessTokenServiceImpl.isValid(
+            UuidDataAccessTokenServiceImplTestConfiguration.EXPIRED_TOKEN_STRING);
     if (expiredTokenIsValid) {
       Assert.fail("Validation of expired token returned true, expected false");
     }
@@ -197,8 +207,9 @@ public class UuidDataAccessTokenServiceImplTest {
    */
   @Test
   public void validateValidTokenTest() {
-    Boolean validTokenIsValid = uuidDataAccessTokenServiceImpl.isValid(
-        UuidDataAccessTokenServiceImplTestConfiguration.VALID_TOKEN_STRING);
+    Boolean validTokenIsValid =
+        uuidDataAccessTokenServiceImpl.isValid(
+            UuidDataAccessTokenServiceImplTestConfiguration.VALID_TOKEN_STRING);
     if (!validTokenIsValid) {
       Assert.fail("Validation of valid token returned false, expected true.");
     }
@@ -206,7 +217,8 @@ public class UuidDataAccessTokenServiceImplTest {
 
   @Test
   public void testGetDataAccessTokenWhenNoTokensExist() {
-    DataAccessToken token = uuidDataAccessTokenServiceImpl.getDataAccessToken("USER_WITH_NO_TOKENS");
+    DataAccessToken token =
+        uuidDataAccessTokenServiceImpl.getDataAccessToken("USER_WITH_NO_TOKENS");
     Assert.assertNotNull(token);
     Assert.assertEquals("USER_WITH_NO_TOKENS", token.getUsername());
   }


### PR DESCRIPTION
- Modified getDataAccessToken to check if token list is empty before accessing elements.
- If the list is empty, create a new token is created instead of throwing  an IndexOutOfBoundsException
- Added test case testGetDataAccessTokenWhenNoTokensExist to verify correct behaviour when no token exist

Fixes #11905

Fix # (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- Modified the `getDataAccessToken(String username)` method in `UuidDataAccessTokenServiceImpl.java` to check if the list of tokens is empty before accessing elements
-  If the list is empty, the method now calls `createDataAccessToken(username)` to generate a new token
-  Added comprehensive test case `testGetDataAccessTokenWhenNoTokensExist` to verify the fix handles the empty token list scenario correctly.

# Checks
- [ x ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [ x ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ x ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ x ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
Not applicable - this is a backend bug fix with no UI changes.

# Notify reviewers
@inodb @mavwolverine
