### PR TITLE
Refactor: Migrate InfoControllerTest to JUnit 5

### DIFF
--- a/src/test/java/org/cbioportal/legacy/web/InfoControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/InfoControllerTest.java
@@ -5,8 +5,8 @@ import static org.mockito.Mockito.when;
 import org.cbioportal.legacy.model.InfoDb;
 import org.cbioportal.legacy.service.InfoService;
 import org.cbioportal.legacy.web.config.TestConfig;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -14,12 +14,12 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest
 @ContextConfiguration(classes = {InfoController.class, TestConfig.class})
 @TestPropertySource(
@@ -30,9 +30,11 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
     })
 public class InfoControllerTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired 
+  private MockMvc mockMvc;
 
-  @MockBean private InfoService infoService;
+  @MockBean 
+  private InfoService infoService;
 
   @Test
   @WithMockUser
@@ -41,9 +43,14 @@ public class InfoControllerTest {
         .perform(MockMvcRequestBuilders.get("/api/info").accept(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(
-            MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-        .andExpect(MockMvcResultMatchers.jsonPath("$.portalVersion").value("test_portal_version"))
-        .andExpect(MockMvcResultMatchers.jsonPath("$.dbVersion").value("test_db_version"))
+            MockMvcResultMatchers.content()
+                .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.portalVersion")
+                .value("test_portal_version"))
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.dbVersion")
+                .value("test_db_version"))
         .andExpect(
             MockMvcResultMatchers.jsonPath("$.derivedTableVersion")
                 .value("test_derived_table_version"));
@@ -63,15 +70,22 @@ public class InfoControllerTest {
         .perform(MockMvcRequestBuilders.get("/api/info").accept(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(
-            MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            MockMvcResultMatchers.content()
+                .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         // property overrides should win for db and derived
-        .andExpect(MockMvcResultMatchers.jsonPath("$.dbVersion").value("test_db_version"))
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.dbVersion")
+                .value("test_db_version"))
         .andExpect(
             MockMvcResultMatchers.jsonPath("$.derivedTableVersion")
                 .value("test_derived_table_version"))
         // geneTableVersion and genesetVersion should be present from DB
-        .andExpect(MockMvcResultMatchers.jsonPath("$.geneTableVersion").value("gene_table_from_db"))
-        .andExpect(MockMvcResultMatchers.jsonPath("$.genesetVersion").value("geneset_from_db"));
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.geneTableVersion")
+                .value("gene_table_from_db"))
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.genesetVersion")
+                .value("geneset_from_db"));
   }
 
   @Test
@@ -84,15 +98,24 @@ public class InfoControllerTest {
         .perform(MockMvcRequestBuilders.get("/api/info").accept(MediaType.APPLICATION_JSON))
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(
-            MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            MockMvcResultMatchers.content()
+                .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         // Should fall back to property values when DB is unavailable
-        .andExpect(MockMvcResultMatchers.jsonPath("$.portalVersion").value("test_portal_version"))
-        .andExpect(MockMvcResultMatchers.jsonPath("$.dbVersion").value("test_db_version"))
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.portalVersion")
+                .value("test_portal_version"))
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.dbVersion")
+                .value("test_db_version"))
         .andExpect(
             MockMvcResultMatchers.jsonPath("$.derivedTableVersion")
                 .value("test_derived_table_version"))
         // DB fields should not be present when schema mismatch
-        .andExpect(MockMvcResultMatchers.jsonPath("$.geneTableVersion").doesNotExist())
-        .andExpect(MockMvcResultMatchers.jsonPath("$.genesetVersion").doesNotExist());
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.geneTableVersion")
+                .doesNotExist())
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.genesetVersion")
+                .doesNotExist());
   }
 }


### PR DESCRIPTION
Migrates `InfoControllerTest` from JUnit 4 to JUnit 5.

## Changes
- Removed JUnit 4 imports and `@RunWith(SpringJUnit4ClassRunner.class)`
- Added JUnit 5 `@ExtendWith(SpringExtension.class)`
- Updated `org.junit.Test` to `org.junit.jupiter.api.Test`
- No behavioral or functional changes

The project currently contains a mix of JUnit 4 and JUnit 5 tests.
This change aligns with the `CODE_STYLE.md` goal to standardize on JUnit 5.

Fixes #11949
