### PR TITLE
feat(#11980): add configurable API rate limiting filter

### DIFF
--- a/src/main/java/org/cbioportal/application/security/config/ApiSecurityConfig.java
+++ b/src/main/java/org/cbioportal/application/security/config/ApiSecurityConfig.java
@@ -1,11 +1,15 @@
 package org.cbioportal.application.security.config;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.cbioportal.application.security.ratelimit.RateLimitFilter;
 import org.cbioportal.application.security.token.RestAuthenticationEntryPoint;
 import org.cbioportal.application.security.token.TokenAuthenticationFilter;
 import org.cbioportal.application.security.token.TokenAuthenticationSuccessHandler;
 import org.cbioportal.legacy.service.DataAccessTokenService;
 import org.cbioportal.legacy.utils.config.annotation.ConditionalOnProperty;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -35,6 +39,20 @@ public class ApiSecurityConfig {
   // see: "Creating and Customizing Filter Chains" @
   // https://spring.io/guides/topicals/spring-security-architecture
 
+  @Value("${api.access.token.required:false}")
+  private boolean accessTokenRequired;
+
+  @Autowired(required = false)
+  private RateLimitFilter rateLimitFilter;
+
+  static final String[] PUBLIC_API_MATCHERS = {
+    "/api/swagger-resources/**",
+    "/api/swagger-ui.html",
+    "/api/health",
+    "/api/public_virtual_studies/**",
+    "/api/cache/**"
+  };
+
   @Bean
   @Order(Ordered.HIGHEST_PRECEDENCE)
   public SecurityFilterChain securityFilterChain(
@@ -45,12 +63,7 @@ public class ApiSecurityConfig {
         .authorizeHttpRequests(
             authorize ->
                 authorize
-                    .requestMatchers(
-                        "/api/swagger-resources/**",
-                        "/api/swagger-ui.html",
-                        "/api/health",
-                        "/api/public_virtual_studies/**",
-                        "/api/cache/**")
+                    .requestMatchers(PUBLIC_API_MATCHERS)
                     .permitAll()
                     .anyRequest()
                     .authenticated())
@@ -61,6 +74,11 @@ public class ApiSecurityConfig {
                 eh.defaultAuthenticationEntryPointFor(
                     new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
                     AntPathRequestMatcher.antMatcher("/api/**")));
+    // When rate limiting is enabled, add the rate limit filter early in the chain
+    // to reject abusive requests before any authentication processing.
+    if (rateLimitFilter != null) {
+      http.addFilterBefore(rateLimitFilter, SecurityContextHolderFilter.class);
+    }
     // When dat.method is not 'none' and a tokenService bean is present,
     // the apiTokenAuthenticationFilter is added to the filter chain.
     if (tokenService != null) {

--- a/src/main/java/org/cbioportal/application/security/ratelimit/RateLimitConfig.java
+++ b/src/main/java/org/cbioportal/application/security/ratelimit/RateLimitConfig.java
@@ -1,0 +1,24 @@
+package org.cbioportal.application.security.ratelimit;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring configuration for the API rate limiting feature.
+ *
+ * <p>This configuration is only active when {@code rate.limit.enabled=true} is set in {@code
+ * application.properties}. When not enabled, no rate limiting beans are created and the application
+ * behaves exactly as before.
+ */
+@Configuration
+@EnableConfigurationProperties(RateLimitProperties.class)
+@ConditionalOnProperty(name = "rate.limit.enabled", havingValue = "true")
+public class RateLimitConfig {
+
+  @Bean
+  public RateLimitFilter rateLimitFilter(RateLimitProperties properties) {
+    return new RateLimitFilter(properties);
+  }
+}

--- a/src/main/java/org/cbioportal/application/security/ratelimit/RateLimitFilter.java
+++ b/src/main/java/org/cbioportal/application/security/ratelimit/RateLimitFilter.java
@@ -1,0 +1,131 @@
+package org.cbioportal.application.security.ratelimit;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * A rate limiting filter that restricts the number of API requests per client.
+ *
+ * <p>Uses a token bucket algorithm with per-client buckets identified by IP address. Buckets are
+ * stored in-memory and periodically cleaned up to prevent memory leaks.
+ *
+ * <p>When rate limiting is disabled via configuration, this filter passes all requests through
+ * without any processing.
+ *
+ * @see TokenBucket
+ * @see RateLimitProperties
+ */
+public class RateLimitFilter extends OncePerRequestFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RateLimitFilter.class);
+  private static final String RATE_LIMIT_RESPONSE =
+      "{\"message\":\"Rate limit exceeded. Please try again later.\"}";
+
+  private final ConcurrentHashMap<String, TokenBucket> buckets = new ConcurrentHashMap<>();
+  private final RateLimitProperties properties;
+  private final ScheduledExecutorService cleanupExecutor;
+
+  public RateLimitFilter(RateLimitProperties properties) {
+    this.properties = properties;
+    this.cleanupExecutor =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread t = new Thread(r, "rate-limit-cleanup");
+              t.setDaemon(true);
+              return t;
+            });
+    scheduleCleanup();
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    if (!properties.isEnabled()) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    String clientId = resolveClientId(request);
+    TokenBucket bucket =
+        buckets.computeIfAbsent(
+            clientId,
+            k -> new TokenBucket(properties.getRequestsPerMinute(), properties.getBurstCapacity()));
+
+    if (bucket.tryConsume()) {
+      filterChain.doFilter(request, response);
+    } else {
+      LOG.warn(
+          "Rate limit exceeded for client '{}' on {} {}",
+          clientId,
+          request.getMethod(),
+          request.getRequestURI());
+      long retryAfter = bucket.getSecondsUntilRefill();
+      response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      response.setHeader("Retry-After", String.valueOf(retryAfter));
+      response.getWriter().write(RATE_LIMIT_RESPONSE);
+    }
+  }
+
+  /**
+   * Resolves the client identifier from the request. Uses the {@code X-Forwarded-For} header if
+   * present (for clients behind a proxy), otherwise falls back to {@code getRemoteAddr()}.
+   *
+   * @param request the HTTP request
+   * @return the client identifier string
+   */
+  String resolveClientId(HttpServletRequest request) {
+    String xForwardedFor = request.getHeader("X-Forwarded-For");
+    if (xForwardedFor != null && !xForwardedFor.isBlank()) {
+      // Take the first IP in the chain (original client)
+      return xForwardedFor.split(",")[0].trim();
+    }
+    return request.getRemoteAddr();
+  }
+
+  /** Schedules periodic cleanup of stale token buckets to prevent memory leaks. */
+  private void scheduleCleanup() {
+    long intervalMinutes = properties.getCleanupIntervalMinutes();
+    cleanupExecutor.scheduleAtFixedRate(
+        this::cleanupStaleBuckets, intervalMinutes, intervalMinutes, TimeUnit.MINUTES);
+  }
+
+  /** Removes token buckets that have not been accessed within the cleanup interval. */
+  void cleanupStaleBuckets() {
+    long staleThresholdMillis = TimeUnit.MINUTES.toMillis(properties.getCleanupIntervalMinutes());
+    long now = System.currentTimeMillis();
+    int removed = 0;
+    Iterator<Map.Entry<String, TokenBucket>> iterator = buckets.entrySet().iterator();
+    while (iterator.hasNext()) {
+      Map.Entry<String, TokenBucket> entry = iterator.next();
+      if (now - entry.getValue().getLastAccessTimeMillis() > staleThresholdMillis) {
+        iterator.remove();
+        removed++;
+      }
+    }
+    if (removed > 0) {
+      LOG.info("Rate limit cleanup: removed {} stale client buckets", removed);
+    }
+  }
+
+  /** Returns the current number of tracked client buckets. Visible for testing. */
+  int getBucketCount() {
+    return buckets.size();
+  }
+}

--- a/src/main/java/org/cbioportal/application/security/ratelimit/RateLimitProperties.java
+++ b/src/main/java/org/cbioportal/application/security/ratelimit/RateLimitProperties.java
@@ -1,0 +1,66 @@
+package org.cbioportal.application.security.ratelimit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for API rate limiting.
+ *
+ * <p>Rate limiting is disabled by default. To enable, set {@code rate.limit.enabled=true} in {@code
+ * application.properties}.
+ *
+ * <p>Example configuration:
+ *
+ * <pre>
+ * rate.limit.enabled=true
+ * rate.limit.requests-per-minute=120
+ * rate.limit.burst-capacity=20
+ * rate.limit.cleanup-interval-minutes=60
+ * </pre>
+ */
+@ConfigurationProperties(prefix = "rate.limit")
+public class RateLimitProperties {
+
+  /** Whether rate limiting is enabled. Default: false. */
+  private boolean enabled = false;
+
+  /** Maximum sustained requests per minute per client. Default: 120. */
+  private int requestsPerMinute = 120;
+
+  /** Maximum burst capacity (tokens available for short bursts). Default: 20. */
+  private int burstCapacity = 20;
+
+  /** Interval in minutes for cleaning up stale rate limit buckets. Default: 60. */
+  private int cleanupIntervalMinutes = 60;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public int getRequestsPerMinute() {
+    return requestsPerMinute;
+  }
+
+  public void setRequestsPerMinute(int requestsPerMinute) {
+    this.requestsPerMinute = requestsPerMinute;
+  }
+
+  public int getBurstCapacity() {
+    return burstCapacity;
+  }
+
+  public void setBurstCapacity(int burstCapacity) {
+    this.burstCapacity = burstCapacity;
+  }
+
+  public int getCleanupIntervalMinutes() {
+    return cleanupIntervalMinutes;
+  }
+
+  public void setCleanupIntervalMinutes(int cleanupIntervalMinutes) {
+    this.cleanupIntervalMinutes = cleanupIntervalMinutes;
+  }
+}

--- a/src/main/java/org/cbioportal/application/security/ratelimit/TokenBucket.java
+++ b/src/main/java/org/cbioportal/application/security/ratelimit/TokenBucket.java
@@ -1,0 +1,85 @@
+package org.cbioportal.application.security.ratelimit;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A thread-safe token bucket implementation for rate limiting.
+ *
+ * <p>Tokens are refilled at a steady rate up to a maximum capacity. Each request consumes one
+ * token. When no tokens are available, the request is rate-limited.
+ */
+public class TokenBucket {
+
+  private final int maxTokens;
+  private final long refillIntervalNanos;
+  private final AtomicLong availableTokens;
+  private final AtomicLong lastRefillTimestamp;
+  private final AtomicLong lastAccessTimestamp;
+
+  /**
+   * Creates a new TokenBucket.
+   *
+   * @param requestsPerMinute the maximum sustained request rate
+   * @param burstCapacity the maximum number of tokens (burst allowance)
+   */
+  public TokenBucket(int requestsPerMinute, int burstCapacity) {
+    this.maxTokens = burstCapacity;
+    this.refillIntervalNanos =
+        (requestsPerMinute > 0) ? (60L * 1_000_000_000L) / requestsPerMinute : Long.MAX_VALUE;
+    this.availableTokens = new AtomicLong(burstCapacity);
+    this.lastRefillTimestamp = new AtomicLong(System.nanoTime());
+    this.lastAccessTimestamp = new AtomicLong(System.currentTimeMillis());
+  }
+
+  /**
+   * Attempts to consume a single token from the bucket.
+   *
+   * @return {@code true} if a token was available and consumed, {@code false} if rate-limited
+   */
+  public boolean tryConsume() {
+    refill();
+    lastAccessTimestamp.set(System.currentTimeMillis());
+    long currentTokens = availableTokens.get();
+    while (currentTokens > 0) {
+      if (availableTokens.compareAndSet(currentTokens, currentTokens - 1)) {
+        return true;
+      }
+      currentTokens = availableTokens.get();
+    }
+    return false;
+  }
+
+  /**
+   * Returns the estimated number of seconds until the next token becomes available.
+   *
+   * @return seconds until next refill, minimum 1
+   */
+  public long getSecondsUntilRefill() {
+    long nanosUntilRefill = refillIntervalNanos - (System.nanoTime() - lastRefillTimestamp.get());
+    return Math.max(1, nanosUntilRefill / 1_000_000_000L);
+  }
+
+  /**
+   * Returns the last time this bucket was accessed, in milliseconds since epoch.
+   *
+   * @return last access timestamp in milliseconds
+   */
+  public long getLastAccessTimeMillis() {
+    return lastAccessTimestamp.get();
+  }
+
+  /** Refills tokens based on elapsed time since the last refill. */
+  private void refill() {
+    long now = System.nanoTime();
+    long last = lastRefillTimestamp.get();
+    long elapsed = now - last;
+    long tokensToAdd = elapsed / refillIntervalNanos;
+    if (tokensToAdd > 0) {
+      if (lastRefillTimestamp.compareAndSet(last, last + tokensToAdd * refillIntervalNanos)) {
+        long currentTokens = availableTokens.get();
+        long newTokens = Math.min(maxTokens, currentTokens + tokensToAdd);
+        availableTokens.set(newTokens);
+      }
+    }
+  }
+}

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -242,6 +242,14 @@ bitly.access.token=
 # datadog_rum_session_sample_rate=
 # datadog_rum_session_replay_sample_rate=
 
+# API Rate Limiting (disabled by default)
+# When enabled, limits the number of API requests per client using a token bucket algorithm.
+# Clients are identified by IP address (via X-Forwarded-For header or remote address).
+# rate.limit.enabled=true
+# rate.limit.requests-per-minute=120
+# rate.limit.burst-capacity=20
+# rate.limit.cleanup-interval-minutes=60
+
 # genomespace linking
 genomespace=true
 

--- a/src/test/java/org/cbioportal/application/security/ratelimit/RateLimitFilterTest.java
+++ b/src/test/java/org/cbioportal/application/security/ratelimit/RateLimitFilterTest.java
@@ -1,0 +1,128 @@
+package org.cbioportal.application.security.ratelimit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class RateLimitFilterTest {
+
+  private RateLimitProperties properties;
+  private RateLimitFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    properties = new RateLimitProperties();
+    properties.setEnabled(true);
+    properties.setRequestsPerMinute(60);
+    properties.setBurstCapacity(3);
+    properties.setCleanupIntervalMinutes(60);
+    filter = new RateLimitFilter(properties);
+  }
+
+  @Test
+  void shouldPassRequestWhenDisabled() throws Exception {
+    properties.setEnabled(false);
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/studies");
+
+    // Send many requests — all should pass when disabled
+    for (int i = 0; i < 10; i++) {
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      MockFilterChain chain = new MockFilterChain();
+      filter.doFilter(request, response, chain);
+      assertEquals(200, response.getStatus());
+    }
+  }
+
+  @Test
+  void shouldAllowRequestsWithinLimit() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/studies");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    MockFilterChain chain = new MockFilterChain();
+
+    for (int i = 0; i < 3; i++) {
+      response = new MockHttpServletResponse();
+      chain = new MockFilterChain();
+      filter.doFilter(request, response, chain);
+      assertEquals(200, response.getStatus(), "Request " + (i + 1) + " should pass");
+    }
+  }
+
+  @Test
+  void shouldReturn429WhenRateLimited() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/studies");
+
+    // Exhaust the burst capacity (3)
+    for (int i = 0; i < 3; i++) {
+      filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+    }
+
+    // 4th request should be rate-limited
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    filter.doFilter(request, response, new MockFilterChain());
+
+    assertEquals(429, response.getStatus());
+    assertEquals("application/json", response.getContentType());
+    assertTrue(response.getContentAsString().contains("Rate limit exceeded"));
+    assertTrue(response.getHeader("Retry-After") != null);
+  }
+
+  @Test
+  void shouldTrackDifferentClientsSeparately() throws Exception {
+    MockHttpServletRequest request1 = new MockHttpServletRequest("GET", "/api/studies");
+    request1.setRemoteAddr("192.168.1.1");
+
+    MockHttpServletRequest request2 = new MockHttpServletRequest("GET", "/api/studies");
+    request2.setRemoteAddr("192.168.1.2");
+
+    // Exhaust client 1's tokens
+    for (int i = 0; i < 3; i++) {
+      filter.doFilter(request1, new MockHttpServletResponse(), new MockFilterChain());
+    }
+
+    // Client 2 should still be allowed
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    filter.doFilter(request2, response, new MockFilterChain());
+    assertEquals(200, response.getStatus(), "Different client should not be rate-limited");
+  }
+
+  @Test
+  void shouldUseXForwardedForHeader() {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/studies");
+    request.setRemoteAddr("10.0.0.1");
+    request.addHeader("X-Forwarded-For", "203.0.113.50, 70.41.3.18, 150.172.238.178");
+
+    String clientId = filter.resolveClientId(request);
+    assertEquals("203.0.113.50", clientId, "Should use first IP from X-Forwarded-For");
+  }
+
+  @Test
+  void shouldFallbackToRemoteAddrWhenNoForwardedHeader() {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/studies");
+    request.setRemoteAddr("192.168.1.100");
+
+    String clientId = filter.resolveClientId(request);
+    assertEquals("192.168.1.100", clientId);
+  }
+
+  @Test
+  void shouldCleanupStaleBuckets() throws Exception {
+    properties.setCleanupIntervalMinutes(0); // immediate threshold for testing
+
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/studies");
+    request.setRemoteAddr("10.0.0.1");
+    filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+    assertEquals(1, filter.getBucketCount(), "Should have 1 tracked client");
+
+    // Wait a bit so the bucket becomes stale (cleanup interval = 0 minutes = immediate)
+    Thread.sleep(10);
+    filter.cleanupStaleBuckets();
+
+    assertEquals(0, filter.getBucketCount(), "Stale bucket should be cleaned up");
+  }
+}

--- a/src/test/java/org/cbioportal/application/security/ratelimit/TokenBucketTest.java
+++ b/src/test/java/org/cbioportal/application/security/ratelimit/TokenBucketTest.java
@@ -1,0 +1,87 @@
+package org.cbioportal.application.security.ratelimit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class TokenBucketTest {
+
+  @Test
+  void shouldAllowRequestsWithinLimit() {
+    TokenBucket bucket = new TokenBucket(60, 5);
+
+    for (int i = 0; i < 5; i++) {
+      assertTrue(bucket.tryConsume(), "Request " + (i + 1) + " should be allowed");
+    }
+  }
+
+  @Test
+  void shouldRejectRequestsOverBurstCapacity() {
+    TokenBucket bucket = new TokenBucket(60, 3);
+
+    assertTrue(bucket.tryConsume());
+    assertTrue(bucket.tryConsume());
+    assertTrue(bucket.tryConsume());
+    assertFalse(bucket.tryConsume(), "4th request should be rate-limited");
+  }
+
+  @Test
+  void shouldRefillTokensOverTime() throws InterruptedException {
+    // 6000 requests per minute = 100 per second = 1 token every 10ms
+    TokenBucket bucket = new TokenBucket(6000, 1);
+
+    assertTrue(bucket.tryConsume(), "First request should be allowed");
+    assertFalse(bucket.tryConsume(), "Second request should be rate-limited (no tokens)");
+
+    // Wait for refill (at least 10ms for one token at 6000 req/min)
+    Thread.sleep(20);
+
+    assertTrue(bucket.tryConsume(), "Request after refill should be allowed");
+  }
+
+  @Test
+  void shouldReturnPositiveSecondsUntilRefill() {
+    TokenBucket bucket = new TokenBucket(60, 1);
+
+    bucket.tryConsume(); // exhaust tokens
+    long retryAfter = bucket.getSecondsUntilRefill();
+
+    assertTrue(retryAfter >= 0, "Retry-After should be non-negative");
+  }
+
+  @Test
+  void shouldTrackLastAccessTime() throws InterruptedException {
+    TokenBucket bucket = new TokenBucket(60, 5);
+
+    long beforeAccess = System.currentTimeMillis();
+    Thread.sleep(5);
+    bucket.tryConsume();
+    long afterAccess = System.currentTimeMillis();
+
+    assertTrue(bucket.getLastAccessTimeMillis() >= beforeAccess);
+    assertTrue(bucket.getLastAccessTimeMillis() <= afterAccess);
+  }
+
+  @Test
+  void shouldNotExceedMaxTokensOnRefill() throws InterruptedException {
+    // 6000 requests per minute, burst capacity of 3
+    TokenBucket bucket = new TokenBucket(6000, 3);
+
+    // Exhaust all tokens
+    bucket.tryConsume();
+    bucket.tryConsume();
+    bucket.tryConsume();
+    assertFalse(bucket.tryConsume());
+
+    // Wait long enough for many tokens to refill
+    Thread.sleep(100);
+
+    // Should have at most 3 tokens (burst capacity)
+    int consumed = 0;
+    while (bucket.tryConsume()) {
+      consumed++;
+    }
+    assertTrue(consumed <= 3, "Should not exceed burst capacity, got " + consumed);
+  }
+}


### PR DESCRIPTION
Fix #11980 (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- **Implemented a zero-dependency API rate limiting mechanism** using a Token Bucket algorithm to protect REST API endpoints from abuse and excessive request rates.
- **Added `RateLimitFilter`**: A `OncePerRequestFilter` integrated into the `ApiSecurityConfig` chain, processing requests early to minimize server load from blocked traffic.
- **Client Identification**: Supports identification via both `remoteAddr` and `X-Forwarded-For` headers (taking the original client IP in a chain), making it robust for deployments behind proxies or load balancers.
- **Configurable Opt-in Support**: Introduced `RateLimitProperties` allowing administrators to enable/disable the feature and tune `requests-per-minute`, `burst-capacity`, and `cleanup-interval-minutes` via `application.properties`.
- **Proactive Memory Management**: Implemented a scheduled cleanup task to remove stale client buckets, preventing memory leaks in high-traffic instances.
- **RFC 6585 Compliance**: Returns `429 Too Many Requests` with a descriptive JSON message and a `Retry-After` header indicating the required wait time in seconds.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/).
- [x] Has tests. Added 13 new unit tests across `TokenBucketTest` and `RateLimitFilterTest` covering limit enforcement, refill logic, client isolation, and cleanup.
- [x] Is this PR adding logic based on one or more **clinical** attributes? No.
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
N/A (Backend feature). Manual verification shows the following response on rate limit triggers:


{
  "message": "Rate limit exceeded. Please try again later."
}

#  Notify reviewers

Based on recent contributions to the security configuration and token authentication logic, notifying:

@alisman
@inodb 
@dippindots 
