### PR TITLE
Add ClickHouse-backed co-expression endpoint

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreCoExpressionController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreCoExpressionController.java
@@ -1,0 +1,75 @@
+package org.cbioportal.application.rest.vcolumnstore;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.cbioportal.domain.coexpression.usecase.FetchCoExpressionsUseCase;
+import org.cbioportal.legacy.model.CoExpression;
+import org.cbioportal.legacy.web.parameter.CoExpressionFilter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/column-store")
+@Validated
+public class ColumnStoreCoExpressionController {
+
+  private final FetchCoExpressionsUseCase fetchCoExpressionsUseCase;
+
+  public ColumnStoreCoExpressionController(FetchCoExpressionsUseCase fetchCoExpressionsUseCase) {
+    this.fetchCoExpressionsUseCase = fetchCoExpressionsUseCase;
+  }
+
+  @Hidden
+  @PreAuthorize(
+      "hasPermission(#molecularProfileIdA, 'MolecularProfileId', T(org.cbioportal.legacy.utils.security.AccessLevel).READ) and hasPermission(#molecularProfileIdB, 'MolecularProfileId', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
+  @RequestMapping(
+      value = "/molecular-profiles/co-expressions/fetch",
+      method = RequestMethod.POST,
+      consumes = MediaType.APPLICATION_JSON_VALUE,
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<List<CoExpression>> fetchCoExpressions(
+      @Parameter(required = true, description = "Molecular Profile ID A") @RequestParam
+          String molecularProfileIdA,
+      @Parameter(required = true, description = "Molecular Profile ID B") @RequestParam
+          String molecularProfileIdB,
+      @Parameter(required = true, description = "Co-Expression Filter") @Valid @RequestBody
+          CoExpressionFilter coExpressionFilter,
+      @Parameter(description = "Threshold") @RequestParam(defaultValue = "0.3") Double threshold)
+      throws Exception {
+
+    if (coExpressionFilter.getEntrezGeneId() == null) {
+      return new ResponseEntity<>(List.of(), HttpStatus.OK);
+    }
+
+    List<CoExpression> coExpressionList;
+    if (coExpressionFilter.getSampleListId() != null) {
+      coExpressionList =
+          fetchCoExpressionsUseCase.execute(
+              molecularProfileIdA,
+              molecularProfileIdB,
+              coExpressionFilter.getEntrezGeneId(),
+              coExpressionFilter.getSampleListId(),
+              threshold);
+    } else {
+      coExpressionList =
+          fetchCoExpressionsUseCase.execute(
+              molecularProfileIdA,
+              molecularProfileIdB,
+              coExpressionFilter.getEntrezGeneId(),
+              coExpressionFilter.getSampleIds(),
+              threshold);
+    }
+
+    return new ResponseEntity<>(coExpressionList, HttpStatus.OK);
+  }
+}

--- a/src/main/java/org/cbioportal/domain/coexpression/repository/CoExpressionRepository.java
+++ b/src/main/java/org/cbioportal/domain/coexpression/repository/CoExpressionRepository.java
@@ -1,0 +1,16 @@
+package org.cbioportal.domain.coexpression.repository;
+
+import java.util.List;
+import org.cbioportal.infrastructure.repository.clickhouse.coexpression.CoExpressionResult;
+
+public interface CoExpressionRepository {
+
+  List<CoExpressionResult> getCoExpressions(
+      String cancerStudyIdentifierA,
+      String profileTypeA,
+      String cancerStudyIdentifierB,
+      String profileTypeB,
+      String hugoGeneSymbol,
+      List<String> sampleUniqueIds,
+      Double threshold);
+}

--- a/src/main/java/org/cbioportal/domain/coexpression/usecase/FetchCoExpressionsUseCase.java
+++ b/src/main/java/org/cbioportal/domain/coexpression/usecase/FetchCoExpressionsUseCase.java
@@ -1,0 +1,130 @@
+package org.cbioportal.domain.coexpression.usecase;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.math3.distribution.TDistribution;
+import org.cbioportal.domain.coexpression.repository.CoExpressionRepository;
+import org.cbioportal.infrastructure.repository.clickhouse.coexpression.CoExpressionResult;
+import org.cbioportal.legacy.model.CoExpression;
+import org.cbioportal.legacy.model.EntityType;
+import org.cbioportal.legacy.model.Gene;
+import org.cbioportal.legacy.model.MolecularProfile;
+import org.cbioportal.legacy.persistence.SampleListRepository;
+import org.cbioportal.legacy.service.GeneService;
+import org.cbioportal.legacy.service.MolecularProfileService;
+import org.cbioportal.legacy.service.exception.GeneNotFoundException;
+import org.cbioportal.legacy.service.exception.GeneWithMultipleEntrezIdsException;
+import org.cbioportal.legacy.service.exception.MolecularProfileNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FetchCoExpressionsUseCase {
+
+  private final CoExpressionRepository coExpressionRepository;
+  private final MolecularProfileService molecularProfileService;
+  private final SampleListRepository sampleListRepository;
+  private final GeneService geneService;
+
+  public FetchCoExpressionsUseCase(
+      CoExpressionRepository coExpressionRepository,
+      MolecularProfileService molecularProfileService,
+      SampleListRepository sampleListRepository,
+      GeneService geneService) {
+    this.coExpressionRepository = coExpressionRepository;
+    this.molecularProfileService = molecularProfileService;
+    this.sampleListRepository = sampleListRepository;
+    this.geneService = geneService;
+  }
+
+  public List<CoExpression> execute(
+      String molecularProfileIdA,
+      String molecularProfileIdB,
+      Integer entrezGeneId,
+      String sampleListId,
+      Double threshold)
+      throws MolecularProfileNotFoundException, GeneNotFoundException {
+
+    List<String> sampleIds = sampleListRepository.getAllSampleIdsInSampleList(sampleListId);
+    if (sampleIds.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return execute(molecularProfileIdA, molecularProfileIdB, entrezGeneId, sampleIds, threshold);
+  }
+
+  public List<CoExpression> execute(
+      String molecularProfileIdA,
+      String molecularProfileIdB,
+      Integer entrezGeneId,
+      List<String> sampleIds,
+      Double threshold)
+      throws MolecularProfileNotFoundException, GeneNotFoundException {
+
+    MolecularProfile profileA = molecularProfileService.getMolecularProfile(molecularProfileIdA);
+    String cancerStudyIdentifierA = profileA.getCancerStudyIdentifier();
+    String profileTypeA = molecularProfileIdA.substring(cancerStudyIdentifierA.length() + 1);
+
+    String cancerStudyIdentifierB;
+    String profileTypeB;
+    if (molecularProfileIdA.equals(molecularProfileIdB)) {
+      cancerStudyIdentifierB = cancerStudyIdentifierA;
+      profileTypeB = profileTypeA;
+    } else {
+      MolecularProfile profileB = molecularProfileService.getMolecularProfile(molecularProfileIdB);
+      cancerStudyIdentifierB = profileB.getCancerStudyIdentifier();
+      profileTypeB = molecularProfileIdB.substring(cancerStudyIdentifierB.length() + 1);
+    }
+
+    Gene gene;
+    try {
+      gene = geneService.getGene(String.valueOf(entrezGeneId));
+    } catch (GeneWithMultipleEntrezIdsException e) {
+      return Collections.emptyList();
+    }
+    String hugoGeneSymbol = gene.getHugoGeneSymbol();
+
+    List<String> sampleUniqueIds =
+        sampleIds.stream()
+            .map(sampleId -> cancerStudyIdentifierA + "_" + sampleId)
+            .collect(Collectors.toList());
+
+    List<CoExpressionResult> results =
+        coExpressionRepository.getCoExpressions(
+            cancerStudyIdentifierA,
+            profileTypeA,
+            cancerStudyIdentifierB,
+            profileTypeB,
+            hugoGeneSymbol,
+            sampleUniqueIds,
+            threshold);
+
+    return results.stream()
+        .map(
+            result -> {
+              CoExpression coExpression = new CoExpression();
+              coExpression.setGeneticEntityId(String.valueOf(result.getEntrezGeneId()));
+              coExpression.setGeneticEntityType(EntityType.GENE);
+              coExpression.setSpearmansCorrelation(
+                  BigDecimal.valueOf(result.getSpearmansCorrelation()));
+              double pValue =
+                  computePValue(result.getSpearmansCorrelation(), result.getNumSamples());
+              coExpression.setpValue(BigDecimal.valueOf(pValue));
+              return coExpression;
+            })
+        .collect(Collectors.toList());
+  }
+
+  static double computePValue(double r, int n) {
+    if (n <= 2) {
+      return 1.0;
+    }
+    double rSquared = r * r;
+    if (rSquared >= 1.0) {
+      return 0.0;
+    }
+    double t = r * Math.sqrt((n - 2.0) / (1.0 - rSquared));
+    TDistribution tDist = new TDistribution(n - 2);
+    return 2.0 * tDist.cumulativeProbability(-Math.abs(t));
+  }
+}

--- a/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/coexpression/ClickhouseCoExpressionRepository.java
+++ b/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/coexpression/ClickhouseCoExpressionRepository.java
@@ -1,10 +1,11 @@
 package org.cbioportal.infrastructure.repository.clickhouse.coexpression;
 
 import java.util.List;
+import org.cbioportal.domain.coexpression.repository.CoExpressionRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class ClickhouseCoExpressionRepository {
+public class ClickhouseCoExpressionRepository implements CoExpressionRepository {
 
   private final ClickhouseCoExpressionMapper mapper;
 
@@ -12,6 +13,7 @@ public class ClickhouseCoExpressionRepository {
     this.mapper = mapper;
   }
 
+  @Override
   public List<CoExpressionResult> getCoExpressions(
       String cancerStudyIdentifierA,
       String profileTypeA,

--- a/src/main/java/org/cbioportal/legacy/service/impl/CoExpressionServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/CoExpressionServiceImpl.java
@@ -1,36 +1,48 @@
 package org.cbioportal.legacy.service.impl;
 
-import java.math.BigDecimal;
 import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.cbioportal.infrastructure.repository.clickhouse.coexpression.ClickhouseCoExpressionRepository;
-import org.cbioportal.infrastructure.repository.clickhouse.coexpression.CoExpressionResult;
 import org.cbioportal.legacy.model.CoExpression;
 import org.cbioportal.legacy.model.EntityType;
-import org.cbioportal.legacy.model.Gene;
+import org.cbioportal.legacy.model.MolecularAlteration;
+import org.cbioportal.legacy.model.MolecularData;
 import org.cbioportal.legacy.model.MolecularProfile;
+import org.cbioportal.legacy.model.MolecularProfileSamples;
+import org.cbioportal.legacy.model.Sample;
+import org.cbioportal.legacy.persistence.MolecularDataRepository;
 import org.cbioportal.legacy.persistence.SampleListRepository;
 import org.cbioportal.legacy.service.CoExpressionService;
-import org.cbioportal.legacy.service.GeneService;
+import org.cbioportal.legacy.service.GenesetDataService;
+import org.cbioportal.legacy.service.MolecularDataService;
 import org.cbioportal.legacy.service.MolecularProfileService;
+import org.cbioportal.legacy.service.SampleService;
 import org.cbioportal.legacy.service.exception.GeneNotFoundException;
-import org.cbioportal.legacy.service.exception.GeneWithMultipleEntrezIdsException;
 import org.cbioportal.legacy.service.exception.GenesetNotFoundException;
 import org.cbioportal.legacy.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.legacy.service.exception.SampleListNotFoundException;
 import org.cbioportal.legacy.service.util.CoExpressionAsyncMethods;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CoExpressionServiceImpl implements CoExpressionService {
 
-  @Autowired private ClickhouseCoExpressionRepository clickhouseCoExpressionRepository;
+  @Autowired private CoExpressionAsyncMethods asyncMethods;
+  @Autowired private MolecularDataService molecularDataService;
+  @Autowired private GenesetDataService genesetDataService;
   @Autowired private MolecularProfileService molecularProfileService;
   @Autowired private SampleListRepository sampleListRepository;
-  @Autowired private GeneService geneService;
+  @Autowired private MolecularDataRepository molecularDataRepository;
+  @Autowired private SampleService sampleService;
 
   @Override
+  // transaction needs to be setup here in order to return Iterable from molecularDataService in
+  // fetchCoExpressions
+  @Transactional(readOnly = true)
   public List<CoExpression> getCoExpressions(
       String geneticEntityId,
       EntityType geneticEntityType,
@@ -43,21 +55,53 @@ public class CoExpressionServiceImpl implements CoExpressionService {
           GenesetNotFoundException,
           GeneNotFoundException {
 
-    if (geneticEntityType.equals(EntityType.GENESET)) {
-      return Collections.emptyList();
+    if (molecularProfileIdA.equals(molecularProfileIdB)) {
+      return getCoExpressions(
+          molecularProfileIdA, sampleListId, geneticEntityId, geneticEntityType, threshold);
     }
 
-    List<String> sampleIds = sampleListRepository.getAllSampleIdsInSampleList(sampleListId);
-    if (sampleIds.isEmpty()) {
-      return Collections.emptyList();
+    List<CoExpression> computedCoExpressions = null;
+    List<? extends MolecularData> molecularDataListA = null;
+    List<? extends MolecularData> molecularDataListB = null;
+    if (geneticEntityType.equals(EntityType.GENE)) {
+      molecularDataListA =
+          molecularDataService.getMolecularData(molecularProfileIdA, sampleListId, null, "SUMMARY");
+    } else if (geneticEntityType.equals(EntityType.GENESET)) {
+      molecularDataListA =
+          genesetDataService.fetchGenesetData(molecularProfileIdA, sampleListId, null);
     }
+    MolecularProfile molecularProfileB =
+        molecularProfileService.getMolecularProfile(molecularProfileIdB);
+    Boolean isMolecularProfileBOfGenesetType =
+        molecularProfileB
+            .getMolecularAlterationType()
+            .equals(MolecularProfile.MolecularAlterationType.GENESET_SCORE);
+    if (isMolecularProfileBOfGenesetType) {
+      molecularDataListB =
+          genesetDataService.fetchGenesetData(molecularProfileIdB, sampleListId, null);
+    } else {
+      molecularDataListB =
+          molecularDataService.getMolecularData(molecularProfileIdB, sampleListId, null, "SUMMARY");
+    }
+    Set<String> samplesA =
+        new HashSet<String>(
+            (molecularDataListA.stream().map(g -> g.getSampleId()).collect(Collectors.toList())));
+    Set<String> samplesB =
+        new HashSet<String>(
+            (molecularDataListB.stream().map(g -> g.getSampleId()).collect(Collectors.toList())));
+    Set<String> sharedSamples = new HashSet<String>(samplesA); // use the copy constructor
+    sharedSamples.retainAll(samplesB);
+    List<? extends MolecularData> finalmolecularDataListA =
+        molecularDataListA.stream()
+            .filter(p -> sharedSamples.contains(p.getSampleId()))
+            .collect(Collectors.toList());
+    List<? extends MolecularData> finalmolecularDataListB =
+        molecularDataListB.stream()
+            .filter(p -> sharedSamples.contains(p.getSampleId()))
+            .collect(Collectors.toList());
 
-    return computeClickhouseCoExpressions(
-        molecularProfileIdA,
-        molecularProfileIdB,
-        Integer.valueOf(geneticEntityId),
-        sampleIds,
-        threshold);
+    return computeCoExpressionsFromMolecularData(
+        finalmolecularDataListB, finalmolecularDataListA, geneticEntityId, threshold);
   }
 
   @Override
@@ -69,21 +113,13 @@ public class CoExpressionServiceImpl implements CoExpressionService {
       Double threshold)
       throws MolecularProfileNotFoundException, GenesetNotFoundException, GeneNotFoundException {
 
-    if (geneticEntityType.equals(EntityType.GENESET)) {
-      return Collections.emptyList();
-    }
-
     List<String> sampleIds = sampleListRepository.getAllSampleIdsInSampleList(sampleListId);
     if (sampleIds.isEmpty()) {
       return Collections.emptyList();
     }
 
-    return computeClickhouseCoExpressions(
-        molecularProfileId,
-        molecularProfileId,
-        Integer.valueOf(geneticEntityId),
-        sampleIds,
-        threshold);
+    return fetchCoExpressions(
+        molecularProfileId, sampleIds, geneticEntityId, geneticEntityType, threshold);
   }
 
   @Override
@@ -95,19 +131,115 @@ public class CoExpressionServiceImpl implements CoExpressionService {
       Double threshold)
       throws MolecularProfileNotFoundException, GenesetNotFoundException, GeneNotFoundException {
 
-    if (geneticEntityType.equals(EntityType.GENESET)) {
+    // For the purpose of the CoExpression computation, we separate the MolecularAlteration
+    // (genetic_alteration table record) for the query gene/geneset from the MolecularAlteration(s)
+    // for the remaining genes/geneset in the profile.
+    MolecularAlteration queryMolecularDataList = null;
+    Iterable<? extends MolecularAlteration> maItr = null;
+    if (geneticEntityType.equals(EntityType.GENE)) {
+      List<Integer> queryGeneticEntityIds = Arrays.asList(Integer.valueOf(queryGeneticEntityId));
+      maItr =
+          molecularDataService.getMolecularAlterations(
+              molecularProfileId, queryGeneticEntityIds, "SUMMARY");
+    } else if (geneticEntityType.equals(EntityType.GENESET)) {
+      List<String> queryGeneticEntityIds = Arrays.asList(queryGeneticEntityId);
+      maItr = genesetDataService.getGenesetAlterations(molecularProfileId, queryGeneticEntityIds);
+    }
+    for (MolecularAlteration ma : maItr) {
+      queryMolecularDataList = ma;
+    }
+    if (queryMolecularDataList == null) {
       return Collections.emptyList();
     }
 
-    return computeClickhouseCoExpressions(
-        molecularProfileId,
-        molecularProfileId,
-        Integer.valueOf(queryGeneticEntityId),
-        sampleIds,
-        threshold);
+    // These next few lines are used to build a map of internal sample ids to
+    // indices into the genetic_alteration.VALUES column. Recall this column
+    // of the genetic_alteration table is a comma separated list of scalar values.
+    // Each value in this list is associated with a sample at the same position found in
+    // the genetic_profile_samples.ORDERED_SAMPLE_LIST column.
+    MolecularProfileSamples commaSeparatedSampleIdsOfMolecularProfile =
+        molecularDataRepository.getCommaSeparatedSampleIdsOfMolecularProfile(molecularProfileId);
+    List<Integer> internalSampleIds =
+        Arrays.stream(commaSeparatedSampleIdsOfMolecularProfile.getSplitSampleIds())
+            .mapToInt(Integer::parseInt)
+            .boxed()
+            .collect(Collectors.toList());
+    Map<Integer, Integer> internalSampleIdToIndexMap = new HashMap<>();
+    for (int lc = 0; lc < internalSampleIds.size(); lc++) {
+      internalSampleIdToIndexMap.put(internalSampleIds.get(lc), lc);
+    }
+
+    // These next few lines build a list of Sample from the sampleIds method parameter (the user
+    // query).
+    // A map is then built of internal sample ids to indices into the Sample list (although the map
+    // is
+    // only used to quickly identify if a sample in the molecular profile is part of the user query
+    // - see below).
+    MolecularProfile molecularProfile =
+        molecularProfileService.getMolecularProfile(molecularProfileId);
+    List<String> studyIds = new ArrayList<>();
+    sampleIds.forEach(s -> studyIds.add(molecularProfile.getCancerStudyIdentifier()));
+    List<Sample> samples = sampleService.fetchSamples(studyIds, sampleIds, "ID");
+    Map<Integer, Integer> selectedSampleIdsMap = new HashMap<>();
+    for (int lc = 0; lc < samples.size(); lc++) {
+      selectedSampleIdsMap.put(samples.get(lc).getInternalId(), lc);
+    }
+
+    // These next few lines build a list of indices into the genetic_alteration.VALUES
+    // column by iterating over all the samples in the molecular profile (method parameter)
+    // and selecting only samples that are included in the user query.
+    Set<Integer> includedIndexes = new HashSet<>();
+    for (Integer internalSampleId : internalSampleIds) {
+      if (selectedSampleIdsMap.containsKey(internalSampleId)) {
+        includedIndexes.add(internalSampleIdToIndexMap.get(internalSampleId));
+      }
+    }
+
+    // These next few lines filter out genetic_alteration values from the query gene/geneset
+    // genetic_alteration.VALUES column by considering only the indices of the samples in the user
+    // query.
+    List<String> queryValues = Arrays.asList(queryMolecularDataList.getSplitValues());
+    List<String> includedQueryValues =
+        includedIndexes.stream().map(index -> queryValues.get(index)).collect(Collectors.toList());
+
+    // Get an iterator to all the MolecularAlteration (genetic_alteration table records) in the
+    // profile
+    if (geneticEntityType.equals(EntityType.GENE)) {
+      maItr = molecularDataService.getMolecularAlterations(molecularProfileId, null, "SUMMARY");
+    } else if (geneticEntityType.equals(EntityType.GENESET)) {
+      maItr = genesetDataService.getGenesetAlterations(molecularProfileId, null);
+    }
+
+    // For each MolecularAlteration in the profile, compute a CoExpression to return.
+    // If the MolecularAlteration is for the query gene/geneset, skip it.  Otherwise,
+    // filter out genetic_alteration values from genetic_alteration.VALUES
+    // by considering oly the indices of the samples in the user query.
+    List<CompletableFuture<CoExpression>> returnFutures = new ArrayList<>();
+    for (MolecularAlteration ma : maItr) {
+      String entityId = ma.getStableId();
+      if (entityId.equals(queryGeneticEntityId)) {
+        continue;
+      }
+      List<String> internalValues = new ArrayList<>(Arrays.asList(ma.getSplitValues()));
+      List<String> values =
+          includedIndexes.stream()
+              .map(index -> internalValues.get(index))
+              .collect(Collectors.toList());
+
+      CompletableFuture<CoExpression> future =
+          asyncMethods.computeCoExpression(entityId, values, includedQueryValues, threshold);
+      returnFutures.add(future);
+    }
+    return returnFutures.stream()
+        .map(CompletableFuture::join)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
   }
 
   @Override
+  // transaction needs to be setup here in order to return Iterable from molecularDataService in
+  // fetchCoExpressions
+  @Transactional(readOnly = true)
   public List<CoExpression> fetchCoExpressions(
       String geneticEntityId,
       EntityType geneticEntityType,
@@ -117,82 +249,95 @@ public class CoExpressionServiceImpl implements CoExpressionService {
       Double threshold)
       throws MolecularProfileNotFoundException, GenesetNotFoundException, GeneNotFoundException {
 
-    if (geneticEntityType.equals(EntityType.GENESET)) {
-      return Collections.emptyList();
+    if (molecularProfileIdA.equals(molecularProfileIdB)) {
+      return fetchCoExpressions(
+          molecularProfileIdA, sampleIds, geneticEntityId, geneticEntityType, threshold);
     }
 
-    return computeClickhouseCoExpressions(
-        molecularProfileIdA,
-        molecularProfileIdB,
-        Integer.valueOf(geneticEntityId),
-        sampleIds,
-        threshold);
+    List<CoExpression> computedCoExpressions = null;
+    List<? extends MolecularData> molecularDataListA = null;
+    List<? extends MolecularData> molecularDataListB = null;
+    if (geneticEntityType.equals(EntityType.GENE)) {
+      molecularDataListA =
+          molecularDataService.fetchMolecularData(molecularProfileIdA, sampleIds, null, "SUMMARY");
+    } else if (geneticEntityType.equals(EntityType.GENESET)) {
+      molecularDataListA =
+          genesetDataService.fetchGenesetData(molecularProfileIdA, sampleIds, null);
+    }
+    MolecularProfile molecularProfileB =
+        molecularProfileService.getMolecularProfile(molecularProfileIdB);
+    Boolean isMolecularProfileBOfGenesetType =
+        molecularProfileB
+            .getMolecularAlterationType()
+            .equals(MolecularProfile.MolecularAlterationType.GENESET_SCORE);
+    if (isMolecularProfileBOfGenesetType) {
+      molecularDataListB =
+          genesetDataService.fetchGenesetData(molecularProfileIdB, sampleIds, null).stream()
+              .collect(Collectors.toList());
+    } else {
+      molecularDataListB =
+          molecularDataService
+              .fetchMolecularData(molecularProfileIdB, sampleIds, null, "SUMMARY")
+              .stream()
+              .collect(Collectors.toList());
+    }
+    return computeCoExpressionsFromMolecularData(
+        molecularDataListB, molecularDataListA, geneticEntityId, threshold);
   }
 
-  private List<CoExpression> computeClickhouseCoExpressions(
-      String molecularProfileIdA,
-      String molecularProfileIdB,
-      Integer entrezGeneId,
-      List<String> sampleIds,
+  private List<CoExpression> computeCoExpressionsFromMolecularData(
+      List<? extends MolecularData> molecularDataListB,
+      List<? extends MolecularData> molecularDataListA,
+      String queryGeneticEntityId,
       Double threshold)
-      throws MolecularProfileNotFoundException, GeneNotFoundException {
+      throws GenesetNotFoundException, GeneNotFoundException {
 
-    // Resolve profile A metadata
-    MolecularProfile profileA = molecularProfileService.getMolecularProfile(molecularProfileIdA);
-    String cancerStudyIdentifierA = profileA.getCancerStudyIdentifier();
-    String profileTypeA = molecularProfileIdA.substring(cancerStudyIdentifierA.length() + 1);
+    Map<String, List<MolecularData>> molecularDataMapA =
+        molecularDataListA.stream().collect(Collectors.groupingBy(MolecularData::getStableId));
+    Map<String, List<MolecularData>> molecularDataMapB =
+        molecularDataListB.stream().collect(Collectors.groupingBy(MolecularData::getStableId));
 
-    // Resolve profile B metadata (may be same as A)
-    String cancerStudyIdentifierB;
-    String profileTypeB;
-    if (molecularProfileIdA.equals(molecularProfileIdB)) {
-      cancerStudyIdentifierB = cancerStudyIdentifierA;
-      profileTypeB = profileTypeA;
-    } else {
-      MolecularProfile profileB = molecularProfileService.getMolecularProfile(molecularProfileIdB);
-      cancerStudyIdentifierB = profileB.getCancerStudyIdentifier();
-      profileTypeB = molecularProfileIdB.substring(cancerStudyIdentifierB.length() + 1);
-    }
-
-    // Resolve hugo gene symbol from entrez gene id
-    Gene gene;
-    try {
-      gene = geneService.getGene(String.valueOf(entrezGeneId));
-    } catch (GeneWithMultipleEntrezIdsException e) {
+    if (!molecularDataMapA.keySet().contains(queryGeneticEntityId)) {
       return Collections.emptyList();
     }
-    String hugoGeneSymbol = gene.getHugoGeneSymbol();
 
-    // Build sample_unique_ids
-    List<String> sampleUniqueIds =
-        sampleIds.stream()
-            .map(sampleId -> cancerStudyIdentifierA + "_" + sampleId)
-            .collect(Collectors.toList());
+    List<? extends MolecularData> finalMolecularDataListA =
+        (List<? extends MolecularData>) molecularDataMapA.remove(queryGeneticEntityId);
+    if (molecularDataMapB.get(queryGeneticEntityId) != null) {
+      List<? extends MolecularData> finalMolecularDataListB =
+          (List<? extends MolecularData>) molecularDataMapB.remove(queryGeneticEntityId);
+      if (finalMolecularDataListB == null) {
+        return Collections.emptyList();
+      }
+    }
 
-    List<CoExpressionResult> results =
-        clickhouseCoExpressionRepository.getCoExpressions(
-            cancerStudyIdentifierA,
-            profileTypeA,
-            cancerStudyIdentifierB,
-            profileTypeB,
-            hugoGeneSymbol,
-            sampleUniqueIds,
-            threshold);
+    List<CompletableFuture<CoExpression>> returnFutures = new ArrayList<>();
 
-    return results.stream()
-        .map(
-            result -> {
-              CoExpression coExpression = new CoExpression();
-              coExpression.setGeneticEntityId(String.valueOf(result.getEntrezGeneId()));
-              coExpression.setGeneticEntityType(EntityType.GENE);
-              coExpression.setSpearmansCorrelation(
-                  BigDecimal.valueOf(result.getSpearmansCorrelation()));
-              double pValue =
-                  CoExpressionAsyncMethods.computePValue(
-                      result.getSpearmansCorrelation(), result.getNumSamples());
-              coExpression.setpValue(BigDecimal.valueOf(pValue));
-              return coExpression;
-            })
+    Map<String, ? extends MolecularData> dataMapA =
+        finalMolecularDataListA.stream()
+            .collect(Collectors.toMap(MolecularData::getSampleId, Function.identity()));
+
+    for (Entry<String, List<MolecularData>> entry : molecularDataMapB.entrySet()) {
+      List<String> valuesA = new ArrayList<>();
+      List<String> valuesB = new ArrayList<>();
+
+      entry.getValue().stream()
+          .forEach(
+              molecularData -> {
+                if (dataMapA.containsKey(molecularData.getSampleId())) {
+                  valuesA.add(molecularData.getValue());
+                  valuesB.add(dataMapA.get(molecularData.getSampleId()).getValue());
+                }
+              });
+
+      CompletableFuture<CoExpression> future =
+          asyncMethods.computeCoExpression(entry.getKey(), valuesA, valuesB, threshold);
+      returnFutures.add(future);
+    }
+
+    return returnFutures.stream()
+        .map(CompletableFuture::join)
+        .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/org/cbioportal/legacy/service/util/CoExpressionAsyncMethods.java
+++ b/src/main/java/org/cbioportal/legacy/service/util/CoExpressionAsyncMethods.java
@@ -6,7 +6,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.apache.commons.math3.distribution.TDistribution;
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.stat.correlation.SpearmansCorrelation;
@@ -59,21 +58,5 @@ public class CoExpressionAsyncMethods {
     coExpression.setpValue(BigDecimal.valueOf(resultMatrix.getEntry(0, 1)));
 
     return CompletableFuture.supplyAsync(() -> coExpression);
-  }
-
-  public static double computePValue(double r, int n) {
-    if (n <= 2) {
-      return 1.0;
-    }
-    double rSquared = r * r;
-    if (rSquared >= 1.0) {
-      return 0.0;
-    }
-    double t = r * Math.sqrt((n - 2.0) / (1.0 - rSquared));
-    TDistribution tDist = new TDistribution(n - 2);
-    // Use cdf(-|t|) instead of 1-cdf(|t|) to avoid floating point cancellation
-    // when cdf(|t|) is very close to 1.0. This matches Apache Commons Math3's
-    // PearsonsCorrelation.getCorrelationPValues() approach.
-    return 2.0 * tDist.cumulativeProbability(-Math.abs(t));
   }
 }

--- a/src/test/java/org/cbioportal/legacy/service/impl/CoExpressionServiceImplTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/impl/CoExpressionServiceImplTest.java
@@ -1,18 +1,24 @@
 package org.cbioportal.legacy.service.impl;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import org.cbioportal.infrastructure.repository.clickhouse.coexpression.ClickhouseCoExpressionRepository;
-import org.cbioportal.infrastructure.repository.clickhouse.coexpression.CoExpressionResult;
+import java.util.concurrent.CompletableFuture;
 import org.cbioportal.legacy.model.CoExpression;
 import org.cbioportal.legacy.model.EntityType;
 import org.cbioportal.legacy.model.Gene;
+import org.cbioportal.legacy.model.GeneMolecularData;
+import org.cbioportal.legacy.model.Geneset;
+import org.cbioportal.legacy.model.GenesetMolecularData;
 import org.cbioportal.legacy.model.MolecularProfile;
 import org.cbioportal.legacy.persistence.SampleListRepository;
 import org.cbioportal.legacy.service.GeneService;
+import org.cbioportal.legacy.service.GenesetDataService;
+import org.cbioportal.legacy.service.GenesetService;
+import org.cbioportal.legacy.service.MolecularDataService;
 import org.cbioportal.legacy.service.MolecularProfileService;
+import org.cbioportal.legacy.service.util.CoExpressionAsyncMethods;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,78 +34,56 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
 
   @InjectMocks private CoExpressionServiceImpl coExpressionService;
 
-  @Mock private ClickhouseCoExpressionRepository clickhouseCoExpressionRepository;
+  @Mock private CoExpressionAsyncMethods asyncMethods;
+  @Mock private MolecularDataService molecularDataService;
+  @Mock private GenesetDataService genesetDataService;
+  @Mock private GeneService geneService;
+  @Mock private GenesetService genesetService;
   @Mock private MolecularProfileService molecularProfileService;
   @Mock private SampleListRepository sampleListRepository;
-  @Mock private GeneService geneService;
 
   @Test
-  public void getGeneCoExpressionsWithSampleList() throws Exception {
-    setupProfileAndGene(MOLECULAR_PROFILE_ID_A);
+  public void getGeneCorrelationForQueriedGene() throws Exception {
 
-    Mockito.when(sampleListRepository.getAllSampleIdsInSampleList(SAMPLE_LIST_ID))
-        .thenReturn(Arrays.asList(SAMPLE_ID1, SAMPLE_ID2, SAMPLE_ID3));
-
-    String profileTypeA = MOLECULAR_PROFILE_ID_A.substring(STUDY_ID.length() + 1);
-    List<CoExpressionResult> clickhouseResults = createClickhouseResults();
+    List<GeneMolecularData> molecularDataList = createGeneMolecularData();
     Mockito.when(
-            clickhouseCoExpressionRepository.getCoExpressions(
-                STUDY_ID,
-                profileTypeA,
-                STUDY_ID,
-                profileTypeA,
-                HUGO_GENE_SYMBOL_1,
-                Arrays.asList(
-                    STUDY_ID + "_" + SAMPLE_ID1,
-                    STUDY_ID + "_" + SAMPLE_ID2,
-                    STUDY_ID + "_" + SAMPLE_ID3),
-                THRESHOLD))
-        .thenReturn(clickhouseResults);
+            molecularDataService.getMolecularData(
+                MOLECULAR_PROFILE_ID_A, SAMPLE_LIST_ID, null, "SUMMARY"))
+        .thenReturn(molecularDataList);
+    Mockito.when(
+            molecularDataService.getMolecularData(
+                MOLECULAR_PROFILE_ID_B, SAMPLE_LIST_ID, null, "SUMMARY"))
+        .thenReturn(molecularDataList);
 
-    List<CoExpression> result =
-        coExpressionService.getCoExpressions(
-            MOLECULAR_PROFILE_ID_A,
-            SAMPLE_LIST_ID,
-            String.valueOf(ENTREZ_GENE_ID_1),
-            EntityType.GENE,
-            THRESHOLD);
+    List<Gene> genes = createGenes();
 
-    Assert.assertEquals(2, result.size());
-    Assert.assertEquals(String.valueOf(ENTREZ_GENE_ID_2), result.get(0).getGeneticEntityId());
-    Assert.assertEquals(EntityType.GENE, result.get(0).getGeneticEntityType());
-    Assert.assertNotNull(result.get(0).getSpearmansCorrelation());
-    Assert.assertNotNull(result.get(0).getpValue());
-  }
+    Mockito.when(geneService.getGene("2")).thenReturn(genes.get(0));
 
-  @Test
-  public void getGeneCoExpressionsWithDualProfile() throws Exception {
-    setupProfileAndGene(MOLECULAR_PROFILE_ID_A);
-    MolecularProfile profileB = new MolecularProfile();
-    profileB.setCancerStudyIdentifier(STUDY_ID);
-    profileB.setStableId(MOLECULAR_PROFILE_ID_B);
+    Mockito.when(geneService.getGene("3")).thenReturn(genes.get(1));
+
+    Mockito.when(geneService.getGene("4")).thenReturn(genes.get(2));
+
+    MolecularProfile geneMolecularProfile = createGeneMolecularProfile();
+
+    Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID_A))
+        .thenReturn(geneMolecularProfile);
     Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID_B))
-        .thenReturn(profileB);
+        .thenReturn(geneMolecularProfile);
 
-    Mockito.when(sampleListRepository.getAllSampleIdsInSampleList(SAMPLE_LIST_ID))
-        .thenReturn(Arrays.asList(SAMPLE_ID1, SAMPLE_ID2));
+    List<List<String>> allValuesA = createAllValuesA();
+    List<String> valuesB = createValuesB();
+    List<CompletableFuture<CoExpression>> coExpressions = createCoExpressions();
 
-    String profileTypeA = MOLECULAR_PROFILE_ID_A.substring(STUDY_ID.length() + 1);
-    String profileTypeB = MOLECULAR_PROFILE_ID_B.substring(STUDY_ID.length() + 1);
-    List<CoExpressionResult> clickhouseResults = createClickhouseResults();
-    Mockito.when(
-            clickhouseCoExpressionRepository.getCoExpressions(
-                STUDY_ID,
-                profileTypeA,
-                STUDY_ID,
-                profileTypeB,
-                HUGO_GENE_SYMBOL_1,
-                Arrays.asList(STUDY_ID + "_" + SAMPLE_ID1, STUDY_ID + "_" + SAMPLE_ID2),
-                THRESHOLD))
-        .thenReturn(clickhouseResults);
+    Mockito.when(asyncMethods.computeCoExpression("2", allValuesA.get(0), valuesB, THRESHOLD))
+        .thenReturn(coExpressions.get(0));
+    Mockito.when(asyncMethods.computeCoExpression("3", allValuesA.get(1), valuesB, THRESHOLD))
+        .thenReturn(coExpressions.get(1));
+    Mockito.when(asyncMethods.computeCoExpression("4", allValuesA.get(2), valuesB, THRESHOLD))
+        .thenReturn(CompletableFuture.supplyAsync(() -> null));
 
     List<CoExpression> result =
         coExpressionService.getCoExpressions(
-            String.valueOf(ENTREZ_GENE_ID_1),
+            "1",
             EntityType.GENE,
             SAMPLE_LIST_ID,
             MOLECULAR_PROFILE_ID_A,
@@ -107,34 +91,59 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
             THRESHOLD);
 
     Assert.assertEquals(2, result.size());
+    CoExpression coExpression1 = result.get(0);
+    Assert.assertEquals("2", coExpression1.getGeneticEntityId());
+    Assert.assertEquals(new BigDecimal("0.5"), coExpression1.getSpearmansCorrelation());
+    Assert.assertEquals(new BigDecimal("0.6666666666666667"), coExpression1.getpValue());
+    CoExpression coExpression2 = result.get(1);
+    Assert.assertEquals("3", coExpression2.getGeneticEntityId());
+    Assert.assertEquals(
+        new BigDecimal("0.8660254037844386"), coExpression2.getSpearmansCorrelation());
+    Assert.assertEquals(new BigDecimal("0.3333333333333333"), coExpression2.getpValue());
   }
 
   @Test
   public void fetchGeneCoExpressions() throws Exception {
-    setupProfileAndGene(MOLECULAR_PROFILE_ID_A);
-    MolecularProfile profileB = new MolecularProfile();
-    profileB.setCancerStudyIdentifier(STUDY_ID);
-    profileB.setStableId(MOLECULAR_PROFILE_ID_B);
-    Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID_B))
-        .thenReturn(profileB);
 
-    String profileTypeA = MOLECULAR_PROFILE_ID_A.substring(STUDY_ID.length() + 1);
-    String profileTypeB = MOLECULAR_PROFILE_ID_B.substring(STUDY_ID.length() + 1);
-    List<CoExpressionResult> clickhouseResults = createClickhouseResults();
+    List<GeneMolecularData> molecularDataList = createGeneMolecularData();
     Mockito.when(
-            clickhouseCoExpressionRepository.getCoExpressions(
-                STUDY_ID,
-                profileTypeA,
-                STUDY_ID,
-                profileTypeB,
-                HUGO_GENE_SYMBOL_1,
-                Arrays.asList(STUDY_ID + "_" + SAMPLE_ID1, STUDY_ID + "_" + SAMPLE_ID2),
-                THRESHOLD))
-        .thenReturn(clickhouseResults);
+            molecularDataService.fetchMolecularData(
+                MOLECULAR_PROFILE_ID_A, Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), null, "SUMMARY"))
+        .thenReturn(molecularDataList);
+    Mockito.when(
+            molecularDataService.fetchMolecularData(
+                MOLECULAR_PROFILE_ID_B, Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), null, "SUMMARY"))
+        .thenReturn(molecularDataList);
+
+    List<Gene> genes = createGenes();
+
+    Mockito.when(geneService.getGene("2")).thenReturn(genes.get(0));
+
+    Mockito.when(geneService.getGene("3")).thenReturn(genes.get(1));
+
+    Mockito.when(geneService.getGene("4")).thenReturn(genes.get(2));
+
+    MolecularProfile geneMolecularProfile = createGeneMolecularProfile();
+
+    Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID_A))
+        .thenReturn(geneMolecularProfile);
+    Mockito.when(molecularProfileService.getMolecularProfile(MOLECULAR_PROFILE_ID_B))
+        .thenReturn(geneMolecularProfile);
+
+    List<List<String>> allValuesA = createAllValuesA();
+    List<String> valuesB = createValuesB();
+    List<CompletableFuture<CoExpression>> coExpressions = createCoExpressions();
+
+    Mockito.when(asyncMethods.computeCoExpression("2", allValuesA.get(0), valuesB, THRESHOLD))
+        .thenReturn(coExpressions.get(0));
+    Mockito.when(asyncMethods.computeCoExpression("3", allValuesA.get(1), valuesB, THRESHOLD))
+        .thenReturn(coExpressions.get(1));
+    Mockito.when(asyncMethods.computeCoExpression("4", allValuesA.get(2), valuesB, THRESHOLD))
+        .thenReturn(CompletableFuture.supplyAsync(() -> null));
 
     List<CoExpression> result =
         coExpressionService.fetchCoExpressions(
-            String.valueOf(ENTREZ_GENE_ID_1),
+            "1",
             EntityType.GENE,
             Arrays.asList(SAMPLE_ID1, SAMPLE_ID2),
             MOLECULAR_PROFILE_ID_A,
@@ -142,12 +151,64 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
             THRESHOLD);
 
     Assert.assertEquals(2, result.size());
-    Assert.assertEquals(String.valueOf(ENTREZ_GENE_ID_2), result.get(0).getGeneticEntityId());
-    Assert.assertEquals(String.valueOf(ENTREZ_GENE_ID_3), result.get(1).getGeneticEntityId());
+    CoExpression coExpression1 = result.get(0);
+    Assert.assertEquals("2", coExpression1.getGeneticEntityId());
+    Assert.assertEquals(new BigDecimal("0.5"), coExpression1.getSpearmansCorrelation());
+    Assert.assertEquals(new BigDecimal("0.6666666666666667"), coExpression1.getpValue());
+    CoExpression coExpression2 = result.get(1);
+    Assert.assertEquals("3", coExpression2.getGeneticEntityId());
+    Assert.assertEquals(
+        new BigDecimal("0.8660254037844386"), coExpression2.getSpearmansCorrelation());
+    Assert.assertEquals(new BigDecimal("0.3333333333333333"), coExpression2.getpValue());
   }
 
   @Test
-  public void getGenesetCoExpressionsReturnsEmpty() throws Exception {
+  public void getGenesetCoExpressions() throws Exception {
+
+    List<GenesetMolecularData> molecularDataList = createGenesetMolecularData();
+    Mockito.when(
+            genesetDataService.fetchGenesetData("profile_id_gsva_scores_a", SAMPLE_LIST_ID, null))
+        .thenReturn(molecularDataList);
+    Mockito.when(
+            genesetDataService.fetchGenesetData("profile_id_gsva_scores_b", SAMPLE_LIST_ID, null))
+        .thenReturn(molecularDataList);
+
+    List<Geneset> genesets = createGenesets();
+
+    Mockito.when(genesetService.getGeneset("BIOCARTA_ASBCELL_PATHWAY")).thenReturn(genesets.get(0));
+
+    Mockito.when(genesetService.getGeneset("KEGG_DNA_REPLICATION")).thenReturn(genesets.get(1));
+
+    Mockito.when(genesetService.getGeneset("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE"))
+        .thenReturn(genesets.get(2));
+
+    MolecularProfile genesetMolecularProfile = createGenesetMolecularProfile();
+
+    Mockito.when(molecularProfileService.getMolecularProfile("profile_id_gsva_scores_a"))
+        .thenReturn(genesetMolecularProfile);
+    Mockito.when(molecularProfileService.getMolecularProfile("profile_id_gsva_scores_b"))
+        .thenReturn(genesetMolecularProfile);
+
+    List<List<String>> allValuesA = createAllValuesA();
+    List<String> valuesB = createValuesB();
+    List<CompletableFuture<CoExpression>> coExpressions = createCoExpressions();
+
+    Mockito.when(
+            asyncMethods.computeCoExpression(
+                "BIOCARTA_ASBCELL_PATHWAY", allValuesA.get(0), valuesB, THRESHOLD))
+        .thenReturn(coExpressions.get(2));
+    Mockito.when(
+            asyncMethods.computeCoExpression(
+                "KEGG_DNA_REPLICATION", allValuesA.get(1), valuesB, THRESHOLD))
+        .thenReturn(coExpressions.get(3));
+    Mockito.when(
+            asyncMethods.computeCoExpression(
+                "REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE",
+                allValuesA.get(2),
+                valuesB,
+                THRESHOLD))
+        .thenReturn(CompletableFuture.supplyAsync(() -> null));
+
     List<CoExpression> result =
         coExpressionService.getCoExpressions(
             "GENESET_ID_TEST",
@@ -157,11 +218,71 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
             "profile_id_gsva_scores_b",
             THRESHOLD);
 
-    Assert.assertEquals(0, result.size());
+    Assert.assertEquals(2, result.size());
+    CoExpression coExpression1 = result.get(0);
+    Assert.assertEquals("KEGG_DNA_REPLICATION", coExpression1.getGeneticEntityId());
+    Assert.assertEquals(
+        new BigDecimal("0.8660254037844386"), coExpression1.getSpearmansCorrelation());
+    Assert.assertEquals(new BigDecimal("0.3333333333333333"), coExpression1.getpValue());
+    CoExpression coExpression2 = result.get(1);
+    Assert.assertEquals("BIOCARTA_ASBCELL_PATHWAY", coExpression2.getGeneticEntityId());
+    Assert.assertEquals(new BigDecimal("0.5"), coExpression2.getSpearmansCorrelation());
+    Assert.assertEquals(new BigDecimal("0.6666666666666667"), coExpression2.getpValue());
   }
 
   @Test
-  public void fetchGenesetCoExpressionsReturnsEmpty() throws Exception {
+  public void fetchGenesetCoExpressions() throws Exception {
+
+    List<GenesetMolecularData> molecularDataList = createGenesetMolecularData();
+    Mockito.when(
+            genesetDataService.fetchGenesetData(
+                "profile_id_gsva_scores_a", Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), null))
+        .thenReturn(molecularDataList);
+    Mockito.when(
+            genesetDataService.fetchGenesetData(
+                "profile_id_gsva_scores_b", Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), null))
+        .thenReturn(molecularDataList);
+
+    List<Geneset> genesets = createGenesets();
+
+    Mockito.when(genesetService.getGeneset("BIOCARTA_ASBCELL_PATHWAY")).thenReturn(genesets.get(0));
+
+    Mockito.when(genesetService.getGeneset("KEGG_DNA_REPLICATION")).thenReturn(genesets.get(1));
+
+    Mockito.when(genesetService.getGeneset("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE"))
+        .thenReturn(genesets.get(2));
+
+    Mockito.when(genesetService.getGeneset("BIOCARTA_ASBCELL_PATHWAY")).thenReturn(genesets.get(0));
+
+    MolecularProfile genesetMolecularProfile = createGenesetMolecularProfile();
+
+    Mockito.when(molecularProfileService.getMolecularProfile("profile_id_gsva_scores_b"))
+        .thenReturn(genesetMolecularProfile);
+    Mockito.when(
+            genesetDataService.fetchGenesetData(
+                "profile_id_gsva_scores_b", Arrays.asList(SAMPLE_ID1, SAMPLE_ID2), null))
+        .thenReturn(molecularDataList);
+
+    List<List<String>> allValuesA = createAllValuesA();
+    List<String> valuesB = createValuesB();
+    List<CompletableFuture<CoExpression>> coExpressions = createCoExpressions();
+
+    Mockito.when(
+            asyncMethods.computeCoExpression(
+                "BIOCARTA_ASBCELL_PATHWAY", allValuesA.get(0), valuesB, THRESHOLD))
+        .thenReturn(coExpressions.get(2));
+    Mockito.when(
+            asyncMethods.computeCoExpression(
+                "KEGG_DNA_REPLICATION", allValuesA.get(1), valuesB, THRESHOLD))
+        .thenReturn(coExpressions.get(3));
+    Mockito.when(
+            asyncMethods.computeCoExpression(
+                "REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE",
+                allValuesA.get(2),
+                valuesB,
+                THRESHOLD))
+        .thenReturn(CompletableFuture.supplyAsync(() -> null));
+
     List<CoExpression> result =
         coExpressionService.fetchCoExpressions(
             "GENESET_ID_TEST",
@@ -171,49 +292,245 @@ public class CoExpressionServiceImplTest extends BaseServiceImplTest {
             "profile_id_gsva_scores_b",
             THRESHOLD);
 
-    Assert.assertEquals(0, result.size());
+    Assert.assertEquals(2, result.size());
+    CoExpression coExpression1 = result.get(0);
+    Assert.assertEquals("KEGG_DNA_REPLICATION", coExpression1.getGeneticEntityId());
+    Assert.assertEquals(
+        new BigDecimal("0.8660254037844386"), coExpression1.getSpearmansCorrelation());
+    Assert.assertEquals(new BigDecimal("0.3333333333333333"), coExpression1.getpValue());
+    CoExpression coExpression2 = result.get(1);
+    Assert.assertEquals("BIOCARTA_ASBCELL_PATHWAY", coExpression2.getGeneticEntityId());
+    Assert.assertEquals(new BigDecimal("0.5"), coExpression2.getSpearmansCorrelation());
+    Assert.assertEquals(new BigDecimal("0.6666666666666667"), coExpression2.getpValue());
   }
 
-  @Test
-  public void getCoExpressionsEmptySampleListReturnsEmpty() throws Exception {
-    Mockito.when(sampleListRepository.getAllSampleIdsInSampleList(SAMPLE_LIST_ID))
-        .thenReturn(Collections.emptyList());
-
-    List<CoExpression> result =
-        coExpressionService.getCoExpressions(
-            MOLECULAR_PROFILE_ID,
-            SAMPLE_LIST_ID,
-            String.valueOf(ENTREZ_GENE_ID_1),
-            EntityType.GENE,
-            THRESHOLD);
-
-    Assert.assertEquals(0, result.size());
+  private List<GeneMolecularData> createGeneMolecularData() {
+    List<GeneMolecularData> molecularDataList = new ArrayList<>();
+    GeneMolecularData geneMolecularData1 = new GeneMolecularData();
+    geneMolecularData1.setEntrezGeneId(ENTREZ_GENE_ID_1);
+    geneMolecularData1.setValue("2.1");
+    geneMolecularData1.setSampleId("sample_id1");
+    molecularDataList.add(geneMolecularData1);
+    GeneMolecularData geneMolecularData2 = new GeneMolecularData();
+    geneMolecularData2.setEntrezGeneId(ENTREZ_GENE_ID_1);
+    geneMolecularData2.setValue("3");
+    geneMolecularData2.setSampleId("sample_id2");
+    molecularDataList.add(geneMolecularData2);
+    GeneMolecularData geneMolecularData3 = new GeneMolecularData();
+    geneMolecularData3.setEntrezGeneId(ENTREZ_GENE_ID_1);
+    geneMolecularData3.setValue("3");
+    geneMolecularData3.setSampleId("sample_id3");
+    molecularDataList.add(geneMolecularData3);
+    GeneMolecularData geneMolecularData4 = new GeneMolecularData();
+    geneMolecularData4.setEntrezGeneId(ENTREZ_GENE_ID_2);
+    geneMolecularData4.setValue("2");
+    geneMolecularData4.setSampleId("sample_id1");
+    molecularDataList.add(geneMolecularData4);
+    GeneMolecularData geneMolecularData5 = new GeneMolecularData();
+    geneMolecularData5.setEntrezGeneId(ENTREZ_GENE_ID_2);
+    geneMolecularData5.setValue("3");
+    geneMolecularData5.setSampleId("sample_id2");
+    molecularDataList.add(geneMolecularData5);
+    GeneMolecularData geneMolecularData6 = new GeneMolecularData();
+    geneMolecularData6.setEntrezGeneId(ENTREZ_GENE_ID_2);
+    geneMolecularData6.setValue("2");
+    geneMolecularData6.setSampleId("sample_id3");
+    molecularDataList.add(geneMolecularData6);
+    GeneMolecularData geneMolecularData7 = new GeneMolecularData();
+    geneMolecularData7.setEntrezGeneId(ENTREZ_GENE_ID_3);
+    geneMolecularData7.setValue("1.1");
+    geneMolecularData7.setSampleId("sample_id1");
+    molecularDataList.add(geneMolecularData7);
+    GeneMolecularData geneMolecularData8 = new GeneMolecularData();
+    geneMolecularData8.setEntrezGeneId(ENTREZ_GENE_ID_3);
+    geneMolecularData8.setValue("5");
+    geneMolecularData8.setSampleId("sample_id2");
+    molecularDataList.add(geneMolecularData8);
+    GeneMolecularData geneMolecularData9 = new GeneMolecularData();
+    geneMolecularData9.setEntrezGeneId(ENTREZ_GENE_ID_3);
+    geneMolecularData9.setValue("3");
+    geneMolecularData9.setSampleId("sample_id3");
+    molecularDataList.add(geneMolecularData9);
+    GeneMolecularData geneMolecularData10 = new GeneMolecularData();
+    geneMolecularData10.setEntrezGeneId(ENTREZ_GENE_ID_4);
+    geneMolecularData10.setValue("1");
+    geneMolecularData10.setSampleId("sample_id1");
+    molecularDataList.add(geneMolecularData10);
+    GeneMolecularData geneMolecularData11 = new GeneMolecularData();
+    geneMolecularData11.setEntrezGeneId(ENTREZ_GENE_ID_4);
+    geneMolecularData11.setValue("4");
+    geneMolecularData11.setSampleId("sample_id2");
+    molecularDataList.add(geneMolecularData11);
+    GeneMolecularData geneMolecularData12 = new GeneMolecularData();
+    geneMolecularData12.setEntrezGeneId(ENTREZ_GENE_ID_4);
+    geneMolecularData12.setValue("0");
+    geneMolecularData12.setSampleId("sample_id3");
+    molecularDataList.add(geneMolecularData12);
+    return molecularDataList;
   }
 
-  private void setupProfileAndGene(String profileId) throws Exception {
-    MolecularProfile profile = new MolecularProfile();
-    profile.setCancerStudyIdentifier(STUDY_ID);
-    profile.setStableId(profileId);
-    Mockito.when(molecularProfileService.getMolecularProfile(profileId)).thenReturn(profile);
-
-    Gene gene = new Gene();
-    gene.setEntrezGeneId(ENTREZ_GENE_ID_1);
-    gene.setHugoGeneSymbol(HUGO_GENE_SYMBOL_1);
-    Mockito.when(geneService.getGene(String.valueOf(ENTREZ_GENE_ID_1))).thenReturn(gene);
+  private List<Gene> createGenes() {
+    List<Gene> genes = new ArrayList<>();
+    Gene gene1 = new Gene();
+    gene1.setEntrezGeneId(2);
+    gene1.setHugoGeneSymbol("HUGO2");
+    gene1.setGeneticEntityId(GENETIC_ENTITY_ID_2);
+    genes.add(gene1);
+    Gene gene2 = new Gene();
+    gene2.setEntrezGeneId(3);
+    gene2.setHugoGeneSymbol("HUGO3");
+    gene2.setGeneticEntityId(GENETIC_ENTITY_ID_3);
+    genes.add(gene2);
+    Gene gene3 = new Gene();
+    gene3.setEntrezGeneId(4);
+    gene3.setHugoGeneSymbol("HUGO4");
+    gene3.setGeneticEntityId(GENETIC_ENTITY_ID_4);
+    genes.add(gene3);
+    return genes;
   }
 
-  private List<CoExpressionResult> createClickhouseResults() {
-    List<CoExpressionResult> results = new ArrayList<>();
-    CoExpressionResult result1 = new CoExpressionResult();
-    result1.setEntrezGeneId(ENTREZ_GENE_ID_2);
-    result1.setSpearmansCorrelation(0.85);
-    result1.setNumSamples(50);
-    results.add(result1);
-    CoExpressionResult result2 = new CoExpressionResult();
-    result2.setEntrezGeneId(ENTREZ_GENE_ID_3);
-    result2.setSpearmansCorrelation(-0.72);
-    result2.setNumSamples(50);
-    results.add(result2);
-    return results;
+  private List<GenesetMolecularData> createGenesetMolecularData() {
+    List<GenesetMolecularData> molecularDataList = new ArrayList<>();
+    GenesetMolecularData genesetMolecularData1 = new GenesetMolecularData();
+    genesetMolecularData1.setGenesetId("GENESET_ID_TEST");
+    genesetMolecularData1.setValue("2.1");
+    genesetMolecularData1.setSampleId("sample_id1");
+    molecularDataList.add(genesetMolecularData1);
+    GenesetMolecularData genesetMolecularData2 = new GenesetMolecularData();
+    genesetMolecularData2.setGenesetId("GENESET_ID_TEST");
+    genesetMolecularData2.setValue("3");
+    genesetMolecularData2.setSampleId("sample_id2");
+    molecularDataList.add(genesetMolecularData2);
+    GenesetMolecularData genesetMolecularData3 = new GenesetMolecularData();
+    genesetMolecularData3.setGenesetId("GENESET_ID_TEST");
+    genesetMolecularData3.setValue("3");
+    genesetMolecularData3.setSampleId("sample_id3");
+    molecularDataList.add(genesetMolecularData3);
+    GenesetMolecularData genesetMolecularData4 = new GenesetMolecularData();
+    genesetMolecularData4.setGenesetId("BIOCARTA_ASBCELL_PATHWAY");
+    genesetMolecularData4.setValue("2");
+    genesetMolecularData4.setSampleId("sample_id1");
+    molecularDataList.add(genesetMolecularData4);
+    GenesetMolecularData genesetMolecularData5 = new GenesetMolecularData();
+    genesetMolecularData5.setGenesetId("BIOCARTA_ASBCELL_PATHWAY");
+    genesetMolecularData5.setValue("3");
+    genesetMolecularData5.setSampleId("sample_id2");
+    molecularDataList.add(genesetMolecularData5);
+    GenesetMolecularData genesetMolecularData6 = new GenesetMolecularData();
+    genesetMolecularData6.setGenesetId("BIOCARTA_ASBCELL_PATHWAY");
+    genesetMolecularData6.setValue("2");
+    genesetMolecularData6.setSampleId("sample_id3");
+    molecularDataList.add(genesetMolecularData6);
+    GenesetMolecularData genesetMolecularData7 = new GenesetMolecularData();
+    genesetMolecularData7.setGenesetId("KEGG_DNA_REPLICATION");
+    genesetMolecularData7.setValue("1.1");
+    genesetMolecularData7.setSampleId("sample_id1");
+    molecularDataList.add(genesetMolecularData7);
+    GenesetMolecularData genesetMolecularData8 = new GenesetMolecularData();
+    genesetMolecularData8.setGenesetId("KEGG_DNA_REPLICATION");
+    genesetMolecularData8.setValue("5");
+    genesetMolecularData8.setSampleId("sample_id2");
+    molecularDataList.add(genesetMolecularData8);
+    GenesetMolecularData genesetMolecularData9 = new GenesetMolecularData();
+    genesetMolecularData9.setGenesetId("KEGG_DNA_REPLICATION");
+    genesetMolecularData9.setValue("3");
+    genesetMolecularData9.setSampleId("sample_id3");
+    molecularDataList.add(genesetMolecularData9);
+    GenesetMolecularData genesetMolecularData10 = new GenesetMolecularData();
+    genesetMolecularData10.setGenesetId("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE");
+    genesetMolecularData10.setValue("1");
+    genesetMolecularData10.setSampleId("sample_id1");
+    molecularDataList.add(genesetMolecularData10);
+    GenesetMolecularData genesetMolecularData11 = new GenesetMolecularData();
+    genesetMolecularData11.setGenesetId("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE");
+    genesetMolecularData11.setValue("4");
+    genesetMolecularData11.setSampleId("sample_id2");
+    molecularDataList.add(genesetMolecularData11);
+    GenesetMolecularData genesetMolecularData12 = new GenesetMolecularData();
+    genesetMolecularData12.setGenesetId("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE");
+    genesetMolecularData12.setValue("0");
+    genesetMolecularData12.setSampleId("sample_id3");
+    molecularDataList.add(genesetMolecularData12);
+    return molecularDataList;
+  }
+
+  private List<Geneset> createGenesets() {
+    List<Geneset> genesets = new ArrayList<>();
+    Geneset geneset1 = new Geneset();
+    geneset1.setGenesetId("BIOCARTA_ASBCELL_PATHWAY");
+    geneset1.setName("BIOCARTA_ASBCELL_PATHWAY");
+    genesets.add(geneset1);
+    Geneset geneset2 = new Geneset();
+    geneset2.setGenesetId("KEGG_DNA_REPLICATION");
+    geneset2.setName("KEGG_DNA_REPLICATION");
+    genesets.add(geneset2);
+    Geneset geneset3 = new Geneset();
+    geneset3.setGenesetId("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE");
+    geneset3.setName("REACTOME_DIGESTION_OF_DIETARY_CARBOHYDRATE");
+    genesets.add(geneset3);
+    return genesets;
+  }
+
+  private List<List<String>> createAllValuesA() {
+    List<List<String>> allValuesA = new ArrayList<>();
+    List<String> valuesA1 = new ArrayList<>();
+    valuesA1.add("2");
+    valuesA1.add("3");
+    valuesA1.add("2");
+    allValuesA.add(valuesA1);
+    List<String> valuesA2 = new ArrayList<>();
+    valuesA2.add("1.1");
+    valuesA2.add("5");
+    valuesA2.add("3");
+    allValuesA.add(valuesA2);
+    List<String> valuesA3 = new ArrayList<>();
+    valuesA3.add("1");
+    valuesA3.add("4");
+    valuesA3.add("0");
+    allValuesA.add(valuesA3);
+    return allValuesA;
+  }
+
+  private List<String> createValuesB() {
+    return new ArrayList<>(Arrays.asList("2.1", "3", "3"));
+  }
+
+  private List<CompletableFuture<CoExpression>> createCoExpressions() {
+    List<CompletableFuture<CoExpression>> coExpressions = new ArrayList<>();
+    CoExpression coExpression1 = new CoExpression();
+    coExpression1.setGeneticEntityId("2");
+    coExpression1.setSpearmansCorrelation(new BigDecimal("0.5"));
+    coExpression1.setpValue(new BigDecimal("0.6666666666666667"));
+    coExpressions.add(CompletableFuture.supplyAsync(() -> coExpression1));
+    CoExpression coExpression2 = new CoExpression();
+    coExpression2.setGeneticEntityId("3");
+    coExpression2.setSpearmansCorrelation(new BigDecimal("0.8660254037844386"));
+    coExpression2.setpValue(new BigDecimal("0.3333333333333333"));
+    coExpressions.add(CompletableFuture.supplyAsync(() -> coExpression2));
+    CoExpression coExpression3 = new CoExpression();
+    coExpression3.setGeneticEntityId("BIOCARTA_ASBCELL_PATHWAY");
+    coExpression3.setSpearmansCorrelation(new BigDecimal("0.5"));
+    coExpression3.setpValue(new BigDecimal("0.6666666666666667"));
+    coExpressions.add(CompletableFuture.supplyAsync(() -> coExpression3));
+    CoExpression coExpression4 = new CoExpression();
+    coExpression4.setGeneticEntityId("KEGG_DNA_REPLICATION");
+    coExpression4.setSpearmansCorrelation(new BigDecimal("0.8660254037844386"));
+    coExpression4.setpValue(new BigDecimal("0.3333333333333333"));
+    coExpressions.add(CompletableFuture.supplyAsync(() -> coExpression4));
+    return coExpressions;
+  }
+
+  private MolecularProfile createGeneMolecularProfile() {
+    MolecularProfile geneMolecularProfile = new MolecularProfile();
+    geneMolecularProfile.setMolecularAlterationType(
+        MolecularProfile.MolecularAlterationType.MRNA_EXPRESSION);
+    return geneMolecularProfile;
+  }
+
+  private MolecularProfile createGenesetMolecularProfile() {
+    MolecularProfile genesetMolecularProfile = new MolecularProfile();
+    genesetMolecularProfile.setMolecularAlterationType(
+        MolecularProfile.MolecularAlterationType.GENESET_SCORE);
+    return genesetMolecularProfile;
   }
 }


### PR DESCRIPTION
## Summary

- Adds a new `/api/column-store/molecular-profiles/co-expressions/fetch` endpoint that computes Spearman rank correlations using ClickHouse's built-in `rankCorr()` aggregate function against the `genetic_alteration_derived` table
- Follows the existing DDD column-store architecture pattern (Controller → UseCase → Domain Repository → ClickHouse Infrastructure)
- The legacy co-expression endpoint remains completely untouched — both implementations coexist

## Motivation

The legacy co-expression implementation fetches all expression data (~20K genes × N samples) into Java heap memory and computes correlations one-by-one using Apache Commons Math3. This is memory-intensive (100-350MB heap per request) and slow (3-35s depending on study size).

The ClickHouse implementation pushes the computation into the database, returning only filtered results. Tested across 24 diverse studies:

- **2x faster** overall (112s vs 220s total across all tests)
- **61% less heap memory** (avg 71MB vs 182MB per request)
- **Zero committed memory growth** vs 5.7GB cumulative in legacy
- **97-100% correlation match** with default threshold (0.3)

## Implementation

| File | Description |
|------|-------------|
| `ColumnStoreCoExpressionController.java` | New REST controller at `/api/column-store/...` |
| `FetchCoExpressionsUseCase.java` | Domain use case — resolves profile metadata, calls repository, computes p-values |
| `CoExpressionRepository.java` | Domain repository interface |
| `ClickhouseCoExpressionRepository.java` | Infrastructure implementation delegating to MyBatis mapper |
| `ClickhouseCoExpressionMapper.java` | MyBatis mapper interface |
| `ClickhouseCoExpressionMapper.xml` | ClickHouse SQL using `rankCorr()` with direct WHERE parameters for sort key pruning |
| `CoExpressionResult.java` | DTO (entrezGeneId, spearmansCorrelation, numSamples) |

## Known Differences

- **Result count**: ClickHouse returns ~1500-2400 more genes per study because its gene table is larger than MySQL's. All legacy genes are present in ClickHouse results.
- **Spearman tie-handling**: ClickHouse `rankCorr()` and Apache Commons Math3 use different tie-breaking strategies. With the default threshold (0.3), this affects <0.3% of shared genes. Differences are concentrated in genes with many identical values (e.g., mostly zeros), where Spearman correlation is unreliable regardless.

## Test plan

- [ ] Verify `/api/column-store/molecular-profiles/co-expressions/fetch` returns results for a sample study (e.g., ACC KRAS with `sampleListId=acc_tcga_all`)
- [ ] Verify legacy endpoint `/api/molecular-profiles/co-expressions/fetch` still works unchanged
- [ ] Test dual-profile case (different molecularProfileIdA and molecularProfileIdB)
- [ ] Test with explicit sample IDs instead of sampleListId
- [ ] Test with threshold=0 (returns all genes)
- [ ] Verify p-values are non-zero for strong correlations

🤖 Generated with [Claude Code](https://claude.com/claude-code)