### PR TITLE
Update study specific cache invalidation endpoint URL to include '/api'

### DIFF
--- a/src/main/java/org/cbioportal/legacy/web/CacheController.java
+++ b/src/main/java/org/cbioportal/legacy/web/CacheController.java
@@ -67,7 +67,7 @@ public class CacheController {
   }
 
   @RequestMapping(
-      value = "/cache/{studyId}",
+      value = "/api/cache/{studyId}",
       method = RequestMethod.DELETE,
       produces = MediaType.TEXT_PLAIN_VALUE)
   @Operation(summary = "Clear and reinitialize caches after import/removal/update of a study")


### PR DESCRIPTION
Study specific cache invalidation endpoint is missing `/api`. This fixes it.

There are no existing tests for this. 


