### PR TITLE
Include null correlation and pValue in co-expression JSON response

### DIFF
--- a/src/main/java/org/cbioportal/legacy/model/CoExpression.java
+++ b/src/main/java/org/cbioportal/legacy/model/CoExpression.java
@@ -1,5 +1,6 @@
 package org.cbioportal.legacy.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
@@ -9,8 +10,12 @@ public class CoExpression implements Serializable {
 
   @NotNull private String geneticEntityId;
   @NotNull private EntityType geneticEntityType;
-  @NotNull private BigDecimal spearmansCorrelation;
-  @NotNull private BigDecimal pValue;
+
+  @JsonInclude(JsonInclude.Include.ALWAYS)
+  private BigDecimal spearmansCorrelation;
+
+  @JsonInclude(JsonInclude.Include.ALWAYS)
+  private BigDecimal pValue;
 
   public String getGeneticEntityId() {
     return geneticEntityId;


### PR DESCRIPTION
## Summary

- Uncorrelatable genes (constant expression, near-constant, <3 samples) are returned with `null` `spearmansCorrelation` and `pValue` since #11991
- The global Jackson `NON_NULL` setting was causing these fields to be omitted entirely from the JSON response
- Add `@JsonInclude(ALWAYS)` to ensure they serialize as `null` so the frontend can display them as N/A

**Before:** `{"geneticEntityId": "3845", "geneticEntityType": "GENE"}`
**After:** `{"geneticEntityId": "3845", "geneticEntityType": "GENE", "spearmansCorrelation": null, "pValue": null}`

## Test plan

- [x] Unit tests pass (1270 tests, 0 failures)
- [x] Verify uncorrelatable genes appear with `null` values in API response

🤖 Generated with [Claude Code](https://claude.com/claude-code)