### PR TITLE
Enable run_api_tests job in CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -538,9 +538,9 @@ workflows:
             requires:
               - build_frontend
               - build_web_and_data_image
-#        - run_api_tests:
-#            requires:
-#              - build_web_image
+        - run_api_tests:
+            requires:
+              - build_web_image
         - run_security_tests:
             context:
               - docker-scout


### PR DESCRIPTION
## Summary
- Uncomment the `run_api_tests` job in the CircleCI workflow so that e2e API tests (`npm test` in `src/e2e/js/`) run against a live portal instance on every PR
- The job spins up a cBioPortal Docker container, validates it matches the PR commit, then runs the Mocha/Chai API tests

## Test plan
- [ ] Verify the CI pipeline triggers the `run_api_tests` job after `build_web_image` completes
- [ ] Confirm e2e tests pass against the spun-up portal instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)