### PR TITLE
Add ORDER BY to StudyViewMapper ClickHouse queries for deterministic results

### DIFF
--- a/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
+++ b/src/main/resources/org/cbioportal/persistence/mybatisclickhouse/StudyViewMapper.xml
@@ -52,6 +52,7 @@
             </if>
         </where>
         GROUP BY entrez_gene_id, hugo_gene_symbol
+        ORDER BY totalCount DESC, hugo_gene_symbol ASC
     </select>
 
     <!-- /cna-genes/fetch (returns CopyNumberCountByGene) -->
@@ -74,6 +75,7 @@
             </if>
         </where>
         GROUP BY entrez_gene_id, hugo_gene_symbol, alteration, cytoband
+        ORDER BY totalCount DESC, hugo_gene_symbol ASC
     </select>
 
     <select id="getStructuralVariantGenes" resultType="org.cbioportal.legacy.model.AlterationCountByGene">
@@ -90,6 +92,7 @@
             </include>
         </where>
         GROUP BY entrez_gene_id, hugo_gene_symbol
+        ORDER BY totalCount DESC, hugo_gene_symbol ASC
     </select>
 
     <select id="getSampleClinicalDataFromStudyViewFilter" resultType="org.cbioportal.legacy.model.ClinicalData">


### PR DESCRIPTION
## Summary
- The `getMutatedGenes`, `getCnaGenes`, and `getStructuralVariantGenes` queries in `StudyViewMapper.xml` were missing `ORDER BY` clauses, causing non-deterministic result ordering from ClickHouse
- This led to flaky e2e screenshot diffs where genes (e.g. SAR1B) would appear in different positions across runs
- Adds `ORDER BY totalCount DESC, hugo_gene_symbol ASC` to match the equivalent queries in `ClickhouseAlterationMapper.xml`

## Test plan
- [x] Verify e2e screenshot tests pass consistently (no more flaky ordering diffs)
- [x] Confirm patient view CNA and mutation tables show consistent ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)