### PR TITLE
docs: remove duplicated word in deployment procedure

### DIFF
--- a/docs/development/Deployment-Procedure.md
+++ b/docs/development/Deployment-Procedure.md
@@ -142,7 +142,7 @@ The following steps are used during releases/updates to build new importers with
 
 2. Merge this change into genome-nexus-annotation-pipeline/master.
 
-3. Set the commit hash [here](https://github.com/knowledgesystems/pipelines/blob/f6c52bbda86b3929222d42c9bc84581fd6333fb4/pom.xml#L76) in the pipelines codebase to the most most recent genome-nexus/genome-nexus-annotation-pipeline commit hash **(after merge specfied in step 2)**. Also ensure the db version in the pom [here](https://github.com/knowledgesystems/pipelines/blob/f6c52bbda86b3929222d42c9bc84581fd6333fb4/pom.xml#L76) matches the db schema version in the cbioportal codebase. 
+3. Set the commit hash [here](https://github.com/knowledgesystems/pipelines/blob/f6c52bbda86b3929222d42c9bc84581fd6333fb4/pom.xml#L76) in the pipelines codebase to the most recent genome-nexus/genome-nexus-annotation-pipeline commit hash **(after merge specfied in step 2)**. Also ensure the db version in the pom [here](https://github.com/knowledgesystems/pipelines/blob/f6c52bbda86b3929222d42c9bc84581fd6333fb4/pom.xml#L76) matches the db schema version in the cbioportal codebase. 
 
 4. Merge this change into pipelines/master.
 


### PR DESCRIPTION
Describe changes proposed in this pull request:
- Updated `docs/development/Deployment-Procedure.md` to remove duplicated wording (`most most` -> `most`) in the importer update steps.
- Documentation-only change; no behavior, API, or code-path changes.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test. (No tests added because this is a docs-only text correction.)
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)! (No clinical-attribute logic added.)
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
Not applicable (no visual feature changes).

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
