### PR TITLE
fix: resolve type mismatch and replace printStackTrace in GlobalExceptionHandler

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/cbioportal/application/rest/error/GlobalExceptionHandler.java
@@ -6,6 +6,8 @@ import jakarta.validation.ElementKind;
 import jakarta.validation.Path;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.cbioportal.legacy.service.exception.AccessForbiddenException;
 import org.cbioportal.legacy.service.exception.CacheNotFoundException;
 import org.cbioportal.legacy.service.exception.CacheOperationException;
@@ -42,6 +44,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 // - check controllers for not catching exceptions themselves
 @ControllerAdvice({"org.cbioportal.legacy.web", "org.cbioportal.application.rest.vcolumnstore"})
 public class GlobalExceptionHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
   @ExceptionHandler(UnsupportedOperationException.class)
   public ResponseEntity<ErrorResponse> handleUnsupportedOperation() {
@@ -218,7 +222,7 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(CacheOperationException.class)
-  public ResponseEntity<ErrorResponse> handleCacheOperationException(CacheNotFoundException ex) {
+  public ResponseEntity<ErrorResponse> handleCacheOperationException(CacheOperationException ex) {
     ErrorResponse response =
         new ErrorResponse(
             "Error evicting caches. Please try again or validate correct operation of your configured caching implementation.");
@@ -242,7 +246,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(BadSqlGrammarException.class)
   public ResponseEntity<ErrorResponse> handleBadSqlGrammar(BadSqlGrammarException ex) {
-    ex.printStackTrace(); // we still want this to show up in the logs
+    log.error("SQL grammar exception", ex);
     return new ResponseEntity<>(
         new ErrorResponse(
             "SQL exception. If you are a maintainer of this instance, see logs for details."),


### PR DESCRIPTION
## What This PR Does

Fixes two bugs in `GlobalExceptionHandler.java` that I spotted while reading through the exception handling layer.

## Research / Trace

While exploring how cBioPortal surfaces API errors, I noticed:

1. **Type mismatch** — `handleCacheOperationException` has `@ExceptionHandler(CacheOperationException.class)` on it, but the method parameter is typed as `CacheNotFoundException`. Spring injects the exception based on the method signature, not the annotation, so the wrong object would be injected and any context from `CacheOperationException` is silently lost.

2. **`ex.printStackTrace()` bypasses structured logging** — The comment says *"we still want this to show up in the logs"*, but `printStackTrace()` writes to stderr directly, bypassing SLF4J/Logback entirely. In environments with log aggregation (ELK, Cloud Logging), this trace is never captured. Replaced with `log.error("SQL grammar exception", ex)` which achieves the same goal correctly.

## Changes

```java
// Bug 1 — type mismatch (before)
public ResponseEntity<ErrorResponse> handleCacheOperationException(CacheNotFoundException ex)

// Bug 1 — fixed
public ResponseEntity<ErrorResponse> handleCacheOperationException(CacheOperationException ex)
```

```java
// Bug 2 — before
ex.printStackTrace(); // we still want this to show up in the logs

// Bug 2 — fixed
log.error("SQL grammar exception", ex);
```

Also added the `Logger log` field (SLF4J) required for the fix.

## Testing

Existing handler behaviour is unchanged; only the exception injection type and logging mechanism are corrected.

Closes #11987