### PR TITLE
refactor: migrate InfoControllerTest to JUnit 5

### DIFF
--- a/src/test/java/org/cbioportal/legacy/web/InfoControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/InfoControllerTest.java
@@ -5,8 +5,8 @@ import static org.mockito.Mockito.when;
 import org.cbioportal.legacy.model.InfoDb;
 import org.cbioportal.legacy.service.InfoService;
 import org.cbioportal.legacy.web.config.TestConfig;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -14,12 +14,12 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest
 @ContextConfiguration(classes = {InfoController.class, TestConfig.class})
 @TestPropertySource(


### PR DESCRIPTION
## What This PR Does

Migrates `InfoControllerTest` from JUnit 4 to JUnit 5.

## Why I Made This Change

cBioPortal is in the process of migrating its test suite to JUnit 5. This PR helps advance that effort by migrating one of the controller tests in the legacy web package.

## Changes

- `src/test/java/org/cbioportal/legacy/web/InfoControllerTest.java`: updated annotations and imports.

Closes #11963