### PR TITLE
Add single study endpoint to ColumnStore API

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreStudyController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreStudyController.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -129,6 +130,16 @@ public class ColumnStoreStudyController {
             : CancerStudyMetadataMapper.INSTANCE.toDtos(studies);
 
     return ResponseEntity.ok().headers(headers).body(responseBody);
+  }
+
+  @Hidden
+  @GetMapping(value = "/studies/{studyId}", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<CancerStudyMetadataDTO> getStudy(@PathVariable String studyId) {
+    var study = getCancerStudyMetadataUseCase.getStudy(studyId);
+    if (study == null) {
+      return ResponseEntity.notFound().build();
+    }
+    return ResponseEntity.ok(CancerStudyMetadataMapper.INSTANCE.toDto(study));
   }
 
   /**

--- a/src/main/java/org/cbioportal/domain/cancerstudy/repository/CancerStudyRepository.java
+++ b/src/main/java/org/cbioportal/domain/cancerstudy/repository/CancerStudyRepository.java
@@ -68,5 +68,7 @@ public interface CancerStudyRepository {
 
   List<String> getFilteredStudyIds(StudyViewFilterContext studyViewFilterContext);
 
+  CancerStudyMetadata getCancerStudyMetadata(String studyId);
+
   List<ResourceCount> getResourceCountsForAllStudies();
 }

--- a/src/main/java/org/cbioportal/domain/cancerstudy/usecase/GetCancerStudyMetadataUseCase.java
+++ b/src/main/java/org/cbioportal/domain/cancerstudy/usecase/GetCancerStudyMetadataUseCase.java
@@ -108,6 +108,19 @@ public class GetCancerStudyMetadataUseCase {
         .toList();
   }
 
+  public CancerStudyMetadata getStudy(String studyId) {
+    CancerStudyMetadata metadata = studyRepository.getCancerStudyMetadata(studyId);
+    if (metadata == null) {
+      return null;
+    }
+    List<ResourceCount> resourceCounts = studyRepository.getResourceCountsForAllStudies();
+    Map<String, List<ResourceCount>> resourceCountsMap =
+        resourceCounts.stream().collect(Collectors.groupingBy(rc -> rc.cancerStudyIdentifier()));
+    return new CancerStudyMetadata(
+        metadata,
+        resourceCountsMap.getOrDefault(metadata.cancerStudyIdentifier(), Collections.emptyList()));
+  }
+
   public List<ResourceCount> getResourceCountsForAllStudies(ProjectionType projectionType) {
     return switch (projectionType) {
       case DETAILED, SUMMARY -> studyRepository.getResourceCountsForAllStudies();

--- a/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/cancerstudy/ClickhouseCancerStudyRepository.java
+++ b/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/cancerstudy/ClickhouseCancerStudyRepository.java
@@ -69,6 +69,17 @@ public class ClickhouseCancerStudyRepository implements CancerStudyRepository {
   @Cacheable(
       cacheResolver = "staticRepositoryCacheOneResolver",
       condition = "@cacheEnabledConfig.getEnabled()")
+  public CancerStudyMetadata getCancerStudyMetadata(String studyId) {
+    List<CancerStudyMetadata> results =
+        cancerStudyMapper.getCancerStudiesMetadata(
+            new SortAndSearchCriteria(null, "", "ASC", null, null), List.of(studyId));
+    return results.isEmpty() ? null : results.getFirst();
+  }
+
+  @Override
+  @Cacheable(
+      cacheResolver = "staticRepositoryCacheOneResolver",
+      condition = "@cacheEnabledConfig.getEnabled()")
   public List<String> getFilteredStudyIds(StudyViewFilterContext studyViewFilterContext) {
     return cancerStudyMapper.getFilteredStudyIds(studyViewFilterContext);
   }


### PR DESCRIPTION
## Summary
- Add `GET /studies/{studyId}` endpoint to `ColumnStoreStudyController` that returns metadata for a single cancer study by identifier
- Add `getCancerStudyMetadata(String studyId)` to `CancerStudyRepository` interface and ClickHouse implementation (with caching)
- Add `getStudy(String studyId)` use case method that enriches study metadata with resource counts

## Test plan
- [ ] Verify `GET /column-store/studies/{studyId}` returns correct study metadata for a valid study ID
- [ ] Verify 404 response for a non-existent study ID
- [ ] Verify resource counts are included in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)