### PR TITLE
fix(model): add missing shortName to CancerType export and fix toRow …

### DIFF
--- a/src/main/java/org/cbioportal/application/file/export/exporters/CancerTypeDataTypeExporter.java
+++ b/src/main/java/org/cbioportal/application/file/export/exporters/CancerTypeDataTypeExporter.java
@@ -2,6 +2,7 @@ package org.cbioportal.application.file.export.exporters;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.SequencedSet;
 import java.util.Set;
 import org.cbioportal.application.file.export.services.CancerStudyMetadataService;
 import org.cbioportal.application.file.model.CancerType;
@@ -12,7 +13,6 @@ import org.cbioportal.application.file.utils.CloseableIterator;
 
 public class CancerTypeDataTypeExporter
     extends DataTypeExporter<ClinicalAttributesMetadata, Table> {
-
   private final CancerStudyMetadataService cancerStudyMetadataService;
 
   public CancerTypeDataTypeExporter(CancerStudyMetadataService cancerStudyMetadataService) {
@@ -43,7 +43,8 @@ public class CancerTypeDataTypeExporter
         new CloseableIterator<>() {
           @Override
           public void close() {
-            // This method is intentionally left empty because the iterator does not require any
+            // This method is intentionally left empty because the iterator does not require
+            // any
             // resources to be closed.
           }
 
@@ -56,6 +57,7 @@ public class CancerTypeDataTypeExporter
           public TableRow next() {
             return iterator.next();
           }
-        });
+        },
+        CancerType.getHeader());
   }
 }

--- a/src/main/java/org/cbioportal/application/file/model/CancerType.java
+++ b/src/main/java/org/cbioportal/application/file/model/CancerType.java
@@ -1,7 +1,10 @@
 package org.cbioportal.application.file.model;
 
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.SequencedMap;
+import java.util.SequencedSet;
+import java.util.function.Function;
 
 public class CancerType implements TableRow {
   private String typeOfCancerId;
@@ -50,13 +53,24 @@ public class CancerType implements TableRow {
     this.typeOfCancerId = typeOfCancerId;
   }
 
+  private static final LinkedHashMap<String, Function<CancerType, String>> ROW = new LinkedHashMap<>();
+
+  static {
+    ROW.put("TYPE_OF_CANCER_ID", CancerType::getTypeOfCancerId);
+    ROW.put("NAME", CancerType::getName);
+    ROW.put("DEDICATED_COLOR", CancerType::getDedicatedColor);
+    ROW.put("PARENT", CancerType::getParent);
+    ROW.put("SHORT_NAME", CancerType::getShortName);
+  }
+
+  public static SequencedSet<String> getHeader() {
+    return new LinkedHashSet<>(ROW.sequencedKeySet());
+  }
+
   @Override
   public SequencedMap<String, String> toRow() {
-    var row = new LinkedHashMap<String, String>();
-    row.put("TYPE_OF_CANCER_ID", typeOfCancerId);
-    row.put("NAME", name);
-    row.put("DEDICATED_COLOR", dedicatedColor);
-    row.put("PARENT", parent);
+    LinkedHashMap<String, String> row = new LinkedHashMap<>();
+    ROW.forEach((key, value) -> row.put(key, value.apply(this)));
     return row;
   }
 }

--- a/src/test/java/org/cbioportal/application/file/model/CancerTypeTest.java
+++ b/src/test/java/org/cbioportal/application/file/model/CancerTypeTest.java
@@ -1,0 +1,42 @@
+package org.cbioportal.application.file.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.SequencedMap;
+import org.junit.Test;
+
+public class CancerTypeTest {
+
+  @Test
+  public void testToRow() {
+    CancerType cancerType = new CancerType();
+    cancerType.setTypeOfCancerId("brca");
+    cancerType.setName("Breast Invasive Carcinoma");
+    cancerType.setShortName("Breast");
+    cancerType.setDedicatedColor("HotPink");
+    cancerType.setParent("tissue");
+
+    SequencedMap<String, String> row = cancerType.toRow();
+
+    // Assert values
+    assertEquals("brca", row.get("TYPE_OF_CANCER_ID"));
+    assertEquals("Breast Invasive Carcinoma", row.get("NAME"));
+    assertEquals("Breast", row.get("SHORT_NAME"));
+    assertEquals("HotPink", row.get("DEDICATED_COLOR"));
+    assertEquals("tissue", row.get("PARENT"));
+    assertEquals(5, row.size());
+
+    // Assert column order (important for TSV export)
+    assertEquals(
+        List.of("TYPE_OF_CANCER_ID", "NAME", "DEDICATED_COLOR", "PARENT", "SHORT_NAME"),
+        row.sequencedKeySet().stream().toList());
+  }
+
+  @Test
+  public void testGetHeader() {
+    assertEquals(
+        List.of("TYPE_OF_CANCER_ID", "NAME", "DEDICATED_COLOR", "PARENT", "SHORT_NAME"),
+        CancerType.getHeader().stream().toList());
+  }
+}


### PR DESCRIPTION

Fix #11858

Describe changes proposed in this pull request:
This pull request improves the export logic and structure of the `CancerType` model to ensure consistency with other `TableRow` implementations in the codebase.

Key updates include:

- Refactored `CancerType.java` to adopt a static `ROW` mapping pattern, aligning it with existing implementations such as `StructuralVariant` and `CnaSegment`. This change improves code consistency and maintainability across the export models.
- Added the missing `SHORT_NAME` field to the `CancerType` export logic within the toRow() method. This ensures that all required fields are correctly mapped and aligned with the database schema and mapper requirements.
- Introduced a new unit test `(CancerTypeTest.java)` to validate the correct mapping of all five cancer type fields, ensuring the reliability of the export logic.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
Not applicable. This change affects backend logic and is validated through unit tests.
                                                                                                                                                                                               
## Testing
The changes were verified by running the following command:

```bash
mvn test -Dtest=CancerTypeTest
```

Test execution was performed using Java 21, and all tests passed successfully.

# Notify reviewers
@alisman  @zainasir 