### PR TITLE
Fix case-insensitive group auth check

### DIFF
--- a/src/main/java/org/cbioportal/application/security/CancerStudyPermissionEvaluator.java
+++ b/src/main/java/org/cbioportal/application/security/CancerStudyPermissionEvaluator.java
@@ -474,6 +474,7 @@ public class CancerStudyPermissionEvaluator implements PermissionEvaluator {
     Set<String> groups =
         Arrays.stream(cancerStudy.getGroups().split(";"))
             .filter(g -> !g.isEmpty())
+            .map(String::toUpperCase)
             .collect(Collectors.toSet());
     if (!Collections.disjoint(groups, grantedAuthorities)) {
       if (log.isDebugEnabled()) {


### PR DESCRIPTION
## Summary
Closes #11609

- Normalizes cancer study group names to uppercase before comparing with granted authorities, fixing the case-sensitivity bug in group-based access control
- This is a simpler alternative to #11687 / #11610 — instead of introducing a `caseInsensitiveDisjoint` utility method, it adds a single `.map(String::toUpperCase)` to the existing stream, consistent with how the rest of the method already handles case normalization (e.g. `stableStudyID.toUpperCase()`, `ALL_CANCER_STUDIES_ID.toUpperCase()`)

## Test plan
- [ ] Verify that a user with authority `sample_group` (or `cbioportal:sample_group`) can access a cancer study whose `groups` column contains `SAMPLE_GROUP`, `sample_group`, or `Sample_Group`
- [ ] Verify that existing uppercase group/authority matches continue to work
- [ ] Run existing authorization unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)