### PR TITLE
Add numeric-aware ORDER BY to ClickHouse generic assay meta queries

### DIFF
--- a/src/main/resources/mappers/clickhouse/generic_assay/GenericAssayMapper.xml
+++ b/src/main/resources/mappers/clickhouse/generic_assay/GenericAssayMapper.xml
@@ -161,7 +161,7 @@
         WHERE profile_stable_id IN
             <foreach item="item" collection="list" open="(" separator="," close=")">#{item}</foreach>
         <!-- Sort numerically by leading digits, then lexicographically (e.g. 1p, 2p, ... 10p, not 10p, 1p, 2p) -->
-        ORDER BY toUInt32OrZero(extract(entity_stable_id, '^\d+')) ASC, entity_stable_id ASC
+        ORDER BY toUInt32OrZero(extract(entity_stable_id, '^[0-9]+')) ASC, entity_stable_id ASC
     </select>
 
     <resultMap id="GenericAssayMetaResultMap" type="org.cbioportal.legacy.model.meta.GenericAssayMeta">
@@ -180,7 +180,7 @@
         WHERE entity_stable_id IN
             <foreach item="item" collection="list" open="(" separator="," close=")">#{item}</foreach>
         <!-- Sort numerically by leading digits, then lexicographically (e.g. 1p, 2p, ... 10p, not 10p, 1p, 2p) -->
-        ORDER BY toUInt32OrZero(extract(entity_stable_id, '^\d+')) ASC, entity_stable_id ASC
+        ORDER BY toUInt32OrZero(extract(entity_stable_id, '^[0-9]+')) ASC, entity_stable_id ASC
     </select>
 
     <select id="getGenericAssayMetaByProfileIds" resultMap="GenericAssayMetaResultMap">
@@ -200,7 +200,7 @@
                 <foreach item="item" collection="stableIds" open="(" separator="," close=")">#{item}</foreach>
         </if>
         <!-- Sort numerically by leading digits, then lexicographically (e.g. 1p, 2p, ... 10p, not 10p, 1p, 2p) -->
-        ORDER BY toUInt32OrZero(extract(gam.entity_stable_id, '^\d+')) ASC, gam.entity_stable_id ASC
+        ORDER BY toUInt32OrZero(extract(gam.entity_stable_id, '^[0-9]+')) ASC, gam.entity_stable_id ASC
     </select>
 
 </mapper>

--- a/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayMapperTest.java
+++ b/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayMapperTest.java
@@ -99,6 +99,16 @@ public class ClickhouseGenericAssayMapperTest {
   }
 
   @Test
+  public void getGenericAssayStableIdsByProfileIds_sortsNumerically() {
+    // Lexicographic order would be: 10p_status, 1p_status, 2p_status, 9p_status
+    // Numeric-aware order should be: 1p_status, 2p_status, 9p_status, 10p_status
+    List<String> stableIds =
+        mapper.getGenericAssayStableIdsByProfileIds(List.of(ACC_TCGA_ARMLEVEL_CNA_PROFILE));
+
+    assertThat(stableIds).containsExactly("1p_status", "2p_status", "9p_status", "10p_status");
+  }
+
+  @Test
   public void getGenericAssayMetaByStableIds_returnsMetaWithProperties() {
     List<GenericAssayMeta> result = mapper.getGenericAssayMetaByStableIds(List.of("1p_status"));
 
@@ -106,6 +116,20 @@ public class ClickhouseGenericAssayMapperTest {
     assertThat(result.get(0).getStableId()).isEqualTo("1p_status");
     assertThat(result.get(0).getEntityType()).isEqualTo("GENERIC_ASSAY");
     assertThat(result.get(0).getGenericEntityMetaProperties()).isNotNull();
+  }
+
+  @Test
+  public void getGenericAssayMetaByStableIds_sortsNumerically() {
+    // Input in reverse/lexicographic order; result should be numerically ordered
+    // Lexicographic order would be: 10p_status, 1p_status, 2p_status, 9p_status
+    // Numeric-aware order should be: 1p_status, 2p_status, 9p_status, 10p_status
+    List<GenericAssayMeta> result =
+        mapper.getGenericAssayMetaByStableIds(
+            List.of("10p_status", "9p_status", "2p_status", "1p_status"));
+
+    assertThat(result)
+        .extracting(GenericAssayMeta::getStableId)
+        .containsExactly("1p_status", "2p_status", "9p_status", "10p_status");
   }
 
   @Test
@@ -119,6 +143,18 @@ public class ClickhouseGenericAssayMapperTest {
         .allMatch(m -> m.getGenericEntityMetaProperties() != null)
         .extracting(GenericAssayMeta::getStableId)
         .contains("1p_status");
+  }
+
+  @Test
+  public void getGenericAssayMetaByProfileIds_sortsNumerically() {
+    // Lexicographic order would be: 10p_status, 1p_status, 2p_status, 9p_status
+    // Numeric-aware order should be: 1p_status, 2p_status, 9p_status, 10p_status
+    List<GenericAssayMeta> result =
+        mapper.getGenericAssayMetaByProfileIds(List.of(ACC_TCGA_ARMLEVEL_CNA_PROFILE), null);
+
+    assertThat(result)
+        .extracting(GenericAssayMeta::getStableId)
+        .containsExactly("1p_status", "2p_status", "9p_status", "10p_status");
   }
 
   @Test

--- a/src/test/resources/clickhouse_data.sql
+++ b/src/test/resources/clickhouse_data.sql
@@ -43,6 +43,9 @@ insert into genetic_entity (id,entity_type,stable_id) values (28,'generic_assay'
 insert into genetic_entity (id,entity_type,stable_id) values (29,'generic_assay','mean_2');
 insert into genetic_entity (id,entity_type,stable_id) values (30,'GENERIC_ASSAY','1p_status');
 insert into genetic_entity (id,entity_type,stable_id) values (31,'GENERIC_ASSAY','DMETS_DX_ADRENAL');
+insert into genetic_entity (id,entity_type,stable_id) values (32,'GENERIC_ASSAY','2p_status');
+insert into genetic_entity (id,entity_type,stable_id) values (33,'GENERIC_ASSAY','9p_status');
+insert into genetic_entity (id,entity_type,stable_id) values (34,'GENERIC_ASSAY','10p_status');
 
 -- hugo_gene_symbol should be UPPERCASE
 insert into gene (entrez_gene_id,hugo_gene_symbol,genetic_entity_id,type) values(207,'AKT1',1,'protein-coding');
@@ -598,6 +601,9 @@ insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) v
 insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (14,1,'1,-1,NA,2,0,-2,1,NA,-1,0,2,-2,');
 insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (15,1,'-0.8097,0.7360,-0.1260,NA,');
 insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (18,30,'Loss,Gain,Unchanged,NA,');
+insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (18,32,'Loss,Gain,Unchanged,NA,');
+insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (18,33,'Loss,Gain,Unchanged,NA,');
+insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (18,34,'Loss,Gain,Unchanged,NA,');
 insert into genetic_alteration (genetic_profile_id,genetic_entity_id,`values`) values (19,31,'No,NA,NA,NA,NA,NA,No,NA,NA,NA,No,No,NA,NA,NA,NA,NA,No,NA,No,No,NA,No,No,Yes,NA,No,');
 
 insert into cna_event (cna_event_id,entrez_gene_id,alteration) values (1,207,-2);


### PR DESCRIPTION
Sort results by leading numeric prefix first, then lexicographically, so that IDs like 1p, 2p, ... 10p sort naturally instead of the default ClickHouse lexicographic order (10p, 1p, 2p).