### PR TITLE
Add validation for virtual study request payloads

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/cbioportal/application/rest/error/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.cbioportal.legacy.service.exception.GenePanelNotFoundException;
 import org.cbioportal.legacy.service.exception.GeneWithMultipleEntrezIdsException;
 import org.cbioportal.legacy.service.exception.GenericAssayNotFoundException;
 import org.cbioportal.legacy.service.exception.GenesetNotFoundException;
+import org.cbioportal.legacy.service.exception.InvalidVirtualStudyDataException;
 import org.cbioportal.legacy.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.legacy.service.exception.PatientNotFoundException;
 import org.cbioportal.legacy.service.exception.ResourceDefinitionNotFoundException;
@@ -181,6 +182,12 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(
         new ErrorResponse(fieldError.getField() + " " + fieldError.getDefaultMessage()),
         HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(InvalidVirtualStudyDataException.class)
+  public ResponseEntity<ErrorResponse> handleInvalidVirtualStudyData(
+      InvalidVirtualStudyDataException ex) {
+    return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(AccessDeniedException.class)

--- a/src/main/java/org/cbioportal/legacy/service/VirtualStudyService.java
+++ b/src/main/java/org/cbioportal/legacy/service/VirtualStudyService.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.cbioportal.legacy.service.exception.CancerTypeNotFoundException;
 import org.cbioportal.legacy.service.exception.DuplicateVirtualStudyException;
+import org.cbioportal.legacy.service.exception.InvalidVirtualStudyDataException;
 import org.cbioportal.legacy.service.exception.StudyNotFoundException;
 import org.cbioportal.legacy.service.util.SessionServiceRequestHandler;
 import org.cbioportal.legacy.web.parameter.SampleIdentifier;
@@ -15,6 +16,7 @@ import org.cbioportal.legacy.web.parameter.VirtualStudy;
 import org.cbioportal.legacy.web.parameter.VirtualStudyData;
 import org.cbioportal.legacy.web.parameter.VirtualStudySamples;
 import org.cbioportal.legacy.web.util.StudyViewFilterApplier;
+import org.cbioportal.legacy.web.validation.VirtualStudyValidationMessages;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -146,6 +148,7 @@ public class VirtualStudyService {
       storedVirtualStudyData.setUsers(Set.of(ALL_USERS));
       sessionServiceRequestHandler.updateVirtualStudy(virtualStudyDataToPublish);
     } else {
+      validateResolvableVirtualStudyData(virtualStudyData);
       updateStudyMetadataFieldsIfSpecified(virtualStudyData, typeOfCancerId, pmid);
       virtualStudyData.setUsers(Set.of(ALL_USERS));
       try {
@@ -159,6 +162,19 @@ public class VirtualStudyService {
             "The study with id={} does not exist, proceeding to create a new virtual study.", id);
       }
       sessionServiceRequestHandler.createVirtualStudy(id, virtualStudyData);
+    }
+  }
+
+  private void validateResolvableVirtualStudyData(VirtualStudyData virtualStudyData) {
+    List<SampleIdentifier> sampleIdentifiers;
+    try {
+      sampleIdentifiers = studyViewFilterApplier.apply(virtualStudyData.getStudyViewFilter());
+    } catch (Exception e) {
+      LOG.error("Error while validating virtual study data", e);
+      throw new InvalidVirtualStudyDataException(VirtualStudyValidationMessages.INVALID_FILTERS);
+    }
+    if (sampleIdentifiers.isEmpty()) {
+      throw new InvalidVirtualStudyDataException(VirtualStudyValidationMessages.NO_FILTER_RESULTS);
     }
   }
 

--- a/src/main/java/org/cbioportal/legacy/service/exception/InvalidVirtualStudyDataException.java
+++ b/src/main/java/org/cbioportal/legacy/service/exception/InvalidVirtualStudyDataException.java
@@ -1,0 +1,8 @@
+package org.cbioportal.legacy.service.exception;
+
+public class InvalidVirtualStudyDataException extends RuntimeException {
+
+  public InvalidVirtualStudyDataException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/cbioportal/legacy/web/PublicVirtualStudiesController.java
+++ b/src/main/java/org/cbioportal/legacy/web/PublicVirtualStudiesController.java
@@ -3,6 +3,7 @@ package org.cbioportal.legacy.web;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import java.util.List;
 import org.cbioportal.legacy.service.VirtualStudyService;
 import org.cbioportal.legacy.service.exception.AccessForbiddenException;
@@ -61,7 +62,7 @@ public class PublicVirtualStudiesController {
       @RequestHeader(value = "X-PUBLISHER-API-KEY") String providedPublisherApiKey,
       @RequestParam(required = false) String typeOfCancerId,
       @RequestParam(required = false) String pmid,
-      @RequestBody(required = false) VirtualStudyData virtualStudyData) {
+      @Valid @RequestBody(required = false) VirtualStudyData virtualStudyData) {
     ensureProvidedPublisherApiKeyCorrect(providedPublisherApiKey);
     virtualStudyService.publishVirtualStudy(id, typeOfCancerId, pmid, virtualStudyData);
     return ResponseEntity.ok().build();

--- a/src/main/java/org/cbioportal/legacy/web/parameter/VirtualStudyData.java
+++ b/src/main/java/org/cbioportal/legacy/web/parameter/VirtualStudyData.java
@@ -1,18 +1,30 @@
 package org.cbioportal.legacy.web.parameter;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.cbioportal.legacy.web.validation.ValidVirtualStudyData;
+import org.cbioportal.legacy.web.validation.VirtualStudyValidationMessages;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@ValidVirtualStudyData
 public class VirtualStudyData implements Serializable {
 
+  @NotBlank(message = VirtualStudyValidationMessages.NAME_REQUIRED)
   private String name;
+
   private String description;
+
+  @NotEmpty(message = VirtualStudyValidationMessages.STUDIES_REQUIRED)
+  @Valid
   private Set<VirtualStudySamples> studies;
-  private StudyViewFilter studyViewFilter;
+
+  @Valid private StudyViewFilter studyViewFilter;
   private Float version = 1.0f;
   private String owner = "anonymous";
   private Set<String> origin = new HashSet<>();

--- a/src/main/java/org/cbioportal/legacy/web/parameter/VirtualStudySamples.java
+++ b/src/main/java/org/cbioportal/legacy/web/parameter/VirtualStudySamples.java
@@ -1,10 +1,14 @@
 package org.cbioportal.legacy.web.parameter;
 
+import jakarta.validation.constraints.NotBlank;
 import java.util.Set;
+import org.cbioportal.legacy.web.validation.VirtualStudyValidationMessages;
 
 public class VirtualStudySamples {
 
+  @NotBlank(message = VirtualStudyValidationMessages.STUDY_ID_REQUIRED)
   private String id;
+
   private Set<String> samples;
 
   public String getId() {

--- a/src/main/java/org/cbioportal/legacy/web/validation/ValidVirtualStudyData.java
+++ b/src/main/java/org/cbioportal/legacy/web/validation/ValidVirtualStudyData.java
@@ -1,0 +1,22 @@
+package org.cbioportal.legacy.web.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = VirtualStudyDataValidator.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ValidVirtualStudyData {
+
+  String message() default "Virtual study data is invalid";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/cbioportal/legacy/web/validation/VirtualStudyDataValidator.java
+++ b/src/main/java/org/cbioportal/legacy/web/validation/VirtualStudyDataValidator.java
@@ -1,0 +1,53 @@
+package org.cbioportal.legacy.web.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Set;
+import org.cbioportal.legacy.web.parameter.VirtualStudyData;
+import org.cbioportal.legacy.web.parameter.VirtualStudySamples;
+
+public class VirtualStudyDataValidator
+    implements ConstraintValidator<ValidVirtualStudyData, VirtualStudyData> {
+
+  @Override
+  public boolean isValid(VirtualStudyData value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return true;
+    }
+
+    Set<VirtualStudySamples> studies = value.getStudies();
+    if (studies == null || studies.isEmpty()) {
+      addViolation(context, "studies", VirtualStudyValidationMessages.STUDIES_REQUIRED);
+      return false;
+    }
+
+    if (Boolean.TRUE.equals(value.getDynamic())) {
+      if (value.getStudyViewFilter() == null) {
+        addViolation(
+            context, "studyViewFilter", VirtualStudyValidationMessages.DYNAMIC_FILTER_REQUIRED);
+        return false;
+      }
+      return true;
+    }
+
+    boolean hasStudyWithoutSamples =
+        studies.stream()
+            .anyMatch(
+                study ->
+                    study == null || study.getSamples() == null || study.getSamples().isEmpty());
+    if (hasStudyWithoutSamples) {
+      addViolation(context, "studies", VirtualStudyValidationMessages.STATIC_SAMPLES_REQUIRED);
+      return false;
+    }
+
+    return true;
+  }
+
+  private void addViolation(ConstraintValidatorContext context, String property, String message) {
+    context.disableDefaultConstraintViolation();
+    context
+        .buildConstraintViolationWithTemplate(message)
+        .addPropertyNode(property)
+        .addConstraintViolation();
+  }
+}

--- a/src/main/java/org/cbioportal/legacy/web/validation/VirtualStudyValidationMessages.java
+++ b/src/main/java/org/cbioportal/legacy/web/validation/VirtualStudyValidationMessages.java
@@ -1,0 +1,32 @@
+package org.cbioportal.legacy.web.validation;
+
+public final class VirtualStudyValidationMessages {
+
+  public static final String SCHEMA_HINT =
+      "See https://docs.cbioportal.org/virtual-study-data-schema/#virtual-study-json-schema";
+
+  public static final String NAME_REQUIRED =
+      "Virtual study name cannot be null or blank. Check that you are passing virtual study data only (data field content) and not the whole session object (with _id). "
+          + SCHEMA_HINT;
+
+  public static final String STUDIES_REQUIRED =
+      "Virtual study must contain at least one study with samples. " + SCHEMA_HINT;
+
+  public static final String STUDY_ID_REQUIRED =
+      "Each study in virtual study must have a non-null and non-blank id. " + SCHEMA_HINT;
+
+  public static final String DYNAMIC_FILTER_REQUIRED =
+      "Virtual study with dynamic=true must have a defined study view filter. " + SCHEMA_HINT;
+
+  public static final String STATIC_SAMPLES_REQUIRED =
+      "Static virtual study (dynamic=false) must contain at least one sample in each study. "
+          + SCHEMA_HINT;
+
+  public static final String INVALID_FILTERS =
+      "The provided virtual study data is not valid. Check that the filters are correct and that the studies and samples you are referring to in virtual study data exist in the system. "
+          + SCHEMA_HINT;
+
+  public static final String NO_FILTER_RESULTS = INVALID_FILTERS;
+
+  private VirtualStudyValidationMessages() {}
+}

--- a/src/test/java/org/cbioportal/legacy/service/VirtualStudyServiceTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/VirtualStudyServiceTest.java
@@ -2,17 +2,25 @@ package org.cbioportal.legacy.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.cbioportal.legacy.service.exception.InvalidVirtualStudyDataException;
+import org.cbioportal.legacy.service.exception.StudyNotFoundException;
 import org.cbioportal.legacy.service.impl.BaseServiceImplTest;
 import org.cbioportal.legacy.service.util.SessionServiceRequestHandler;
 import org.cbioportal.legacy.web.parameter.SampleIdentifier;
+import org.cbioportal.legacy.web.parameter.StudyViewFilter;
 import org.cbioportal.legacy.web.parameter.VirtualStudy;
 import org.cbioportal.legacy.web.parameter.VirtualStudyData;
 import org.cbioportal.legacy.web.parameter.VirtualStudySamples;
 import org.cbioportal.legacy.web.util.StudyViewFilterApplier;
+import org.cbioportal.legacy.web.validation.VirtualStudyValidationMessages;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -27,6 +35,8 @@ public class VirtualStudyServiceTest extends BaseServiceImplTest {
 
   @Mock SessionServiceRequestHandler sessionServiceRequestHandler;
   @Mock StudyViewFilterApplier studyViewFilterApplier;
+  @Mock CancerTypeService cancerTypeService;
+  @Mock StudyService studyService;
 
   SampleIdentifier sampleIdentifier1 = new SampleIdentifier();
 
@@ -82,5 +92,68 @@ public class VirtualStudyServiceTest extends BaseServiceImplTest {
         virtualStudy.getData().getStudies().stream()
             .map(VirtualStudySamples::getId)
             .collect(Collectors.toSet()));
+  }
+
+  @Test(expected = InvalidVirtualStudyDataException.class)
+  public void publishVirtualStudyShouldRejectFilterErrors() {
+    VirtualStudyData virtualStudyData = createPublishableVirtualStudyData();
+
+    Mockito.when(studyViewFilterApplier.apply(virtualStudyData.getStudyViewFilter()))
+        .thenThrow(new RuntimeException("boom"));
+
+    try {
+      virtualStudyService.publishVirtualStudy("virtual-study", null, null, virtualStudyData);
+    } catch (InvalidVirtualStudyDataException e) {
+      assertEquals(VirtualStudyValidationMessages.INVALID_FILTERS, e.getMessage());
+      verify(sessionServiceRequestHandler, never()).createVirtualStudy(any(), any());
+      throw e;
+    }
+  }
+
+  @Test(expected = InvalidVirtualStudyDataException.class)
+  public void publishVirtualStudyShouldRejectEmptyFilterResults() {
+    VirtualStudyData virtualStudyData = createPublishableVirtualStudyData();
+
+    Mockito.when(studyViewFilterApplier.apply(virtualStudyData.getStudyViewFilter()))
+        .thenReturn(List.of());
+
+    try {
+      virtualStudyService.publishVirtualStudy("virtual-study", null, null, virtualStudyData);
+    } catch (InvalidVirtualStudyDataException e) {
+      assertEquals(VirtualStudyValidationMessages.NO_FILTER_RESULTS, e.getMessage());
+      verify(sessionServiceRequestHandler, never()).createVirtualStudy(any(), any());
+      throw e;
+    }
+  }
+
+  @Test
+  public void publishVirtualStudyShouldCreateStudyWhenFilterResolvesSamples() throws Exception {
+    VirtualStudyData virtualStudyData = createPublishableVirtualStudyData();
+
+    Mockito.when(studyViewFilterApplier.apply(virtualStudyData.getStudyViewFilter()))
+        .thenReturn(List.of(sampleIdentifier1));
+    Mockito.when(studyService.getStudy("virtual-study"))
+        .thenThrow(new StudyNotFoundException("virtual-study"));
+
+    virtualStudyService.publishVirtualStudy("virtual-study", null, null, virtualStudyData);
+
+    verify(sessionServiceRequestHandler)
+        .createVirtualStudy(eq("virtual-study"), eq(virtualStudyData));
+  }
+
+  private VirtualStudyData createPublishableVirtualStudyData() {
+    VirtualStudyData virtualStudyData = new VirtualStudyData();
+    virtualStudyData.setName("Test");
+    virtualStudyData.setDynamic(true);
+
+    VirtualStudySamples virtualStudySamples = new VirtualStudySamples();
+    virtualStudySamples.setId("study_1");
+    virtualStudyData.setStudies(Set.of(virtualStudySamples));
+
+    StudyViewFilter studyViewFilter = new StudyViewFilter();
+    studyViewFilter.setStudyIds(List.of("study_1"));
+    virtualStudyData.setStudyViewFilter(studyViewFilter);
+
+    return virtualStudyData;
   }
 }

--- a/src/test/java/org/cbioportal/legacy/web/PublicVirtualStudiesControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/PublicVirtualStudiesControllerTest.java
@@ -1,0 +1,142 @@
+package org.cbioportal.legacy.web;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Set;
+import org.cbioportal.legacy.service.VirtualStudyService;
+import org.cbioportal.legacy.service.exception.InvalidVirtualStudyDataException;
+import org.cbioportal.legacy.web.config.TestConfig;
+import org.cbioportal.legacy.web.parameter.StudyViewFilter;
+import org.cbioportal.legacy.web.parameter.VirtualStudyData;
+import org.cbioportal.legacy.web.parameter.VirtualStudySamples;
+import org.cbioportal.legacy.web.validation.VirtualStudyValidationMessages;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
+@ContextConfiguration(classes = {PublicVirtualStudiesController.class, TestConfig.class})
+@TestPropertySource(properties = "session.endpoint.publisher-api-key=test-publisher-key")
+public class PublicVirtualStudiesControllerTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @MockBean private VirtualStudyService virtualStudyService;
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  @WithMockUser
+  public void publishVirtualStudyShouldRejectInvalidRequestBody() throws Exception {
+    VirtualStudyData virtualStudyData = createStaticVirtualStudyData();
+    virtualStudyData.setName(" ");
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/public_virtual_studies/virtual-study")
+                .with(csrf())
+                .header("X-PUBLISHER-API-KEY", "test-publisher-key")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(virtualStudyData)))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.message")
+                .value("name " + VirtualStudyValidationMessages.NAME_REQUIRED));
+
+    verify(virtualStudyService, never()).publishVirtualStudy(anyString(), any(), any(), any());
+  }
+
+  @Test
+  @WithMockUser
+  public void publishVirtualStudyShouldRejectMissingDynamicFilter() throws Exception {
+    VirtualStudyData virtualStudyData = createDynamicVirtualStudyData();
+    virtualStudyData.setStudyViewFilter(null);
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/public_virtual_studies/virtual-study")
+                .with(csrf())
+                .header("X-PUBLISHER-API-KEY", "test-publisher-key")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(virtualStudyData)))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.message")
+                .value(
+                    "studyViewFilter " + VirtualStudyValidationMessages.DYNAMIC_FILTER_REQUIRED));
+
+    verify(virtualStudyService, never()).publishVirtualStudy(anyString(), any(), any(), any());
+  }
+
+  @Test
+  @WithMockUser
+  public void publishVirtualStudyShouldReturnBadRequestForServiceValidationErrors()
+      throws Exception {
+    VirtualStudyData virtualStudyData = createDynamicVirtualStudyData();
+    doThrow(new InvalidVirtualStudyDataException(VirtualStudyValidationMessages.NO_FILTER_RESULTS))
+        .when(virtualStudyService)
+        .publishVirtualStudy(anyString(), any(), any(), any());
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/public_virtual_studies/virtual-study")
+                .with(csrf())
+                .header("X-PUBLISHER-API-KEY", "test-publisher-key")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(virtualStudyData)))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.message")
+                .value(VirtualStudyValidationMessages.NO_FILTER_RESULTS));
+  }
+
+  private VirtualStudyData createStaticVirtualStudyData() {
+    VirtualStudyData virtualStudyData = new VirtualStudyData();
+    virtualStudyData.setName("Static virtual study");
+    virtualStudyData.setDynamic(false);
+
+    VirtualStudySamples virtualStudySamples = new VirtualStudySamples();
+    virtualStudySamples.setId("study_1");
+    virtualStudySamples.setSamples(Set.of("sample_1"));
+    virtualStudyData.setStudies(Set.of(virtualStudySamples));
+
+    return virtualStudyData;
+  }
+
+  private VirtualStudyData createDynamicVirtualStudyData() {
+    VirtualStudyData virtualStudyData = new VirtualStudyData();
+    virtualStudyData.setName("Dynamic virtual study");
+    virtualStudyData.setDynamic(true);
+
+    VirtualStudySamples virtualStudySamples = new VirtualStudySamples();
+    virtualStudySamples.setId("study_1");
+    virtualStudyData.setStudies(Set.of(virtualStudySamples));
+
+    StudyViewFilter studyViewFilter = new StudyViewFilter();
+    studyViewFilter.setStudyIds(List.of("study_1"));
+    virtualStudyData.setStudyViewFilter(studyViewFilter);
+
+    return virtualStudyData;
+  }
+}

--- a/src/test/java/org/cbioportal/legacy/web/parameter/VirtualStudyDataValidationTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/parameter/VirtualStudyDataValidationTest.java
@@ -1,0 +1,151 @@
+package org.cbioportal.legacy.web.parameter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.List;
+import java.util.Set;
+import org.cbioportal.legacy.web.validation.VirtualStudyValidationMessages;
+import org.junit.Before;
+import org.junit.Test;
+
+public class VirtualStudyDataValidationTest {
+
+  private Validator validator;
+
+  @Before
+  public void setUp() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @Test
+  public void shouldRejectBlankName() {
+    VirtualStudyData virtualStudyData = createStaticVirtualStudyData();
+    virtualStudyData.setName("  ");
+
+    assertSingleViolation(virtualStudyData, "name", VirtualStudyValidationMessages.NAME_REQUIRED);
+  }
+
+  @Test
+  public void shouldRejectMissingStudies() {
+    VirtualStudyData virtualStudyData = createStaticVirtualStudyData();
+    virtualStudyData.setStudies(Set.of());
+
+    assertHasViolation(
+        virtualStudyData, "studies", VirtualStudyValidationMessages.STUDIES_REQUIRED);
+  }
+
+  @Test
+  public void shouldRejectStudyWithoutId() {
+    VirtualStudyData virtualStudyData = createStaticVirtualStudyData();
+    virtualStudyData.getStudies().iterator().next().setId(" ");
+
+    assertSingleViolation(
+        virtualStudyData, "studies[].id", VirtualStudyValidationMessages.STUDY_ID_REQUIRED);
+  }
+
+  @Test
+  public void shouldRejectDynamicVirtualStudyWithoutFilter() {
+    VirtualStudyData virtualStudyData = createDynamicVirtualStudyData();
+    virtualStudyData.setStudyViewFilter(null);
+
+    assertSingleViolation(
+        virtualStudyData,
+        "studyViewFilter",
+        VirtualStudyValidationMessages.DYNAMIC_FILTER_REQUIRED);
+  }
+
+  @Test
+  public void shouldRejectStaticVirtualStudyWithoutSamples() {
+    VirtualStudyData virtualStudyData = createStaticVirtualStudyData();
+    virtualStudyData.getStudies().iterator().next().setSamples(Set.of());
+
+    assertSingleViolation(
+        virtualStudyData, "studies", VirtualStudyValidationMessages.STATIC_SAMPLES_REQUIRED);
+  }
+
+  @Test
+  public void shouldRejectMissingSamplesWhenDynamicFlagIsNull() {
+    VirtualStudyData virtualStudyData = createStaticVirtualStudyData();
+    virtualStudyData.setDynamic(null);
+    virtualStudyData.getStudies().iterator().next().setSamples(Set.of());
+
+    assertSingleViolation(
+        virtualStudyData, "studies", VirtualStudyValidationMessages.STATIC_SAMPLES_REQUIRED);
+  }
+
+  @Test
+  public void shouldAcceptValidStaticVirtualStudy() {
+    Set<ConstraintViolation<VirtualStudyData>> violations =
+        validator.validate(createStaticVirtualStudyData());
+
+    assertTrue(violations.isEmpty());
+  }
+
+  @Test
+  public void shouldAcceptValidDynamicVirtualStudy() {
+    Set<ConstraintViolation<VirtualStudyData>> violations =
+        validator.validate(createDynamicVirtualStudyData());
+
+    assertTrue(violations.isEmpty());
+  }
+
+  private void assertSingleViolation(
+      VirtualStudyData virtualStudyData, String propertyPath, String message) {
+    Set<ConstraintViolation<VirtualStudyData>> violations = validator.validate(virtualStudyData);
+
+    List<String> actualViolations =
+        violations.stream()
+            .map(violation -> violation.getPropertyPath() + "|" + violation.getMessage())
+            .toList();
+
+    assertEquals(1, actualViolations.size());
+    assertEquals(propertyPath + "|" + message, actualViolations.getFirst());
+  }
+
+  private void assertHasViolation(
+      VirtualStudyData virtualStudyData, String propertyPath, String message) {
+    Set<ConstraintViolation<VirtualStudyData>> violations = validator.validate(virtualStudyData);
+
+    List<String> actualViolations =
+        violations.stream()
+            .map(violation -> violation.getPropertyPath() + "|" + violation.getMessage())
+            .toList();
+
+    assertTrue(actualViolations.contains(propertyPath + "|" + message));
+  }
+
+  private VirtualStudyData createStaticVirtualStudyData() {
+    VirtualStudyData virtualStudyData = new VirtualStudyData();
+    virtualStudyData.setName("Static virtual study");
+    virtualStudyData.setDynamic(false);
+
+    VirtualStudySamples virtualStudySamples = new VirtualStudySamples();
+    virtualStudySamples.setId("study_1");
+    virtualStudySamples.setSamples(Set.of("sample_1"));
+    virtualStudyData.setStudies(Set.of(virtualStudySamples));
+
+    return virtualStudyData;
+  }
+
+  private VirtualStudyData createDynamicVirtualStudyData() {
+    VirtualStudyData virtualStudyData = new VirtualStudyData();
+    virtualStudyData.setName("Dynamic virtual study");
+    virtualStudyData.setDynamic(true);
+
+    VirtualStudySamples virtualStudySamples = new VirtualStudySamples();
+    virtualStudySamples.setId("study_1");
+    virtualStudyData.setStudies(Set.of(virtualStudySamples));
+
+    StudyViewFilter studyViewFilter = new StudyViewFilter();
+    studyViewFilter.setStudyIds(List.of("study_1"));
+    virtualStudyData.setStudyViewFilter(studyViewFilter);
+
+    return virtualStudyData;
+  }
+}


### PR DESCRIPTION
## Summary

  Add validation for virtual study payloads using Jakarta Bean Validation.

  ## What changed

  - added field-level validation to VirtualStudyData and VirtualStudySamples
  - added nested validation for study entries
  - added a custom class-level validator for dynamic/static conditional rules
  - updated the controller to validate the request body with @Valid
  - kept service-backed validation in VirtualStudyService
  - added focused tests for DTO validation, controller validation, and service validation

  ## Why

  This separates structural payload validation from service-backed validation.

  - DTO annotations handle field-level rules
  - a custom validator handles cross-field rules
  - the service keeps external/system checks

  This makes the validation clearer, easier to maintain, and easier to test.

  ## Testing

  - `mvn -q -Dtest=VirtualStudyDataValidationTest,VirtualStudyServiceTest,PublicVirtualStudiesControllerTest test`


PR to the maintenance (MySQL) version https://github.com/cBioPortal/cbioportal/pull/12049