### PR TITLE
Fix #11731: Add batched discrete copy number fetch endpoint for multiple profile/sample filters

### DIFF
--- a/src/main/java/org/cbioportal/legacy/persistence/DiscreteCopyNumberRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/DiscreteCopyNumberRepository.java
@@ -51,6 +51,15 @@ public interface DiscreteCopyNumberRepository {
   @Cacheable(
       cacheResolver = "generalRepositoryCacheResolver",
       condition = "@cacheEnabledConfig.getEnabled()")
+  BaseMeta getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+      List<String> molecularProfileIds,
+      List<String> sampleIds,
+      List<Integer> entrezGeneIds,
+      List<Integer> alterationTypes);
+
+  @Cacheable(
+      cacheResolver = "generalRepositoryCacheResolver",
+      condition = "@cacheEnabledConfig.getEnabled()")
   List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
       List<String> molecularProfileIds,
       List<String> sampleIds,

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/DiscreteCopyNumberMapper.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/DiscreteCopyNumberMapper.java
@@ -35,6 +35,12 @@ public interface DiscreteCopyNumberMapper {
       List<Integer> alterationTypes,
       String projection);
 
+  BaseMeta getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+      List<String> molecularProfileIds,
+      List<String> sampleIds,
+      List<Integer> entrezGeneIds,
+      List<Integer> alterationTypes);
+
   List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
       List<String> molecularProfileIds,
       List<String> sampleIds,

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/DiscreteCopyNumberMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/DiscreteCopyNumberMyBatisRepository.java
@@ -61,6 +61,16 @@ public class DiscreteCopyNumberMyBatisRepository implements DiscreteCopyNumberRe
   }
 
   @Override
+  public BaseMeta getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+      List<String> molecularProfileIds,
+      List<String> sampleIds,
+      List<Integer> entrezGeneIds,
+      List<Integer> alterationTypes) {
+    return discreteCopyNumberMapper.getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+        molecularProfileIds, sampleIds, entrezGeneIds, alterationTypes);
+  }
+
+  @Override
   public List<DiscreteCopyNumberData>
       getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
           List<String> molecularProfileIds,

--- a/src/main/java/org/cbioportal/legacy/service/DiscreteCopyNumberService.java
+++ b/src/main/java/org/cbioportal/legacy/service/DiscreteCopyNumberService.java
@@ -40,6 +40,12 @@ public interface DiscreteCopyNumberService {
       List<Integer> alterationTypes,
       String projection);
 
+  BaseMeta getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+      List<String> molecularProfileIds,
+      List<String> sampleIds,
+      List<Integer> entrezGeneIds,
+      List<Integer> alterationTypes);
+
   List<DiscreteCopyNumberData> getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
       List<String> molecularProfileIds,
       List<String> sampleIds,

--- a/src/main/java/org/cbioportal/legacy/service/impl/DiscreteCopyNumberServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/DiscreteCopyNumberServiceImpl.java
@@ -126,6 +126,31 @@ public class DiscreteCopyNumberServiceImpl implements DiscreteCopyNumberService 
   }
 
   @Override
+  public BaseMeta getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+      List<String> molecularProfileIds,
+      List<String> sampleIds,
+      List<Integer> entrezGeneIds,
+      List<Integer> alterationTypes) {
+
+    if (isHomdelOrAmpOnly(alterationTypes)) {
+      return discreteCopyNumberRepository.getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+          molecularProfileIds, sampleIds, entrezGeneIds, alterationTypes);
+    }
+
+    long totalCount =
+        molecularDataService
+            .getMolecularDataInMultipleMolecularProfiles(
+                molecularProfileIds, sampleIds, entrezGeneIds, "ID")
+            .stream()
+            .filter(g -> isValidAlteration(alterationTypes, g))
+            .count();
+
+    BaseMeta baseMeta = new BaseMeta();
+    baseMeta.setTotalCount(Math.toIntExact(totalCount));
+    return baseMeta;
+  }
+
+  @Override
   public List<DiscreteCopyNumberData>
       getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries(
           List<String> molecularProfileIds,

--- a/src/main/java/org/cbioportal/legacy/service/impl/DiscreteCopyNumberServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/DiscreteCopyNumberServiceImpl.java
@@ -131,23 +131,8 @@ public class DiscreteCopyNumberServiceImpl implements DiscreteCopyNumberService 
       List<String> sampleIds,
       List<Integer> entrezGeneIds,
       List<Integer> alterationTypes) {
-
-    if (isHomdelOrAmpOnly(alterationTypes)) {
-      return discreteCopyNumberRepository.getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
-          molecularProfileIds, sampleIds, entrezGeneIds, alterationTypes);
-    }
-
-    long totalCount =
-        molecularDataService
-            .getMolecularDataInMultipleMolecularProfiles(
-                molecularProfileIds, sampleIds, entrezGeneIds, "ID")
-            .stream()
-            .filter(g -> isValidAlteration(alterationTypes, g))
-            .count();
-
-    BaseMeta baseMeta = new BaseMeta();
-    baseMeta.setTotalCount(Math.toIntExact(totalCount));
-    return baseMeta;
+    return discreteCopyNumberRepository.getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+        molecularProfileIds, sampleIds, entrezGeneIds, alterationTypes);
   }
 
   @Override

--- a/src/main/java/org/cbioportal/legacy/web/DiscreteCopyNumberController.java
+++ b/src/main/java/org/cbioportal/legacy/web/DiscreteCopyNumberController.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import org.cbioportal.legacy.model.DiscreteCopyNumberData;
 import org.cbioportal.legacy.model.meta.BaseMeta;
@@ -17,8 +19,10 @@ import org.cbioportal.legacy.web.config.PublicApiTags;
 import org.cbioportal.legacy.web.config.annotation.PublicApi;
 import org.cbioportal.legacy.web.parameter.DiscreteCopyNumberEventType;
 import org.cbioportal.legacy.web.parameter.DiscreteCopyNumberFilter;
+import org.cbioportal.legacy.web.parameter.DiscreteCopyNumberMultipleStudyFilter;
 import org.cbioportal.legacy.web.parameter.HeaderKeyConstants;
 import org.cbioportal.legacy.web.parameter.Projection;
+import org.cbioportal.legacy.web.parameter.SampleMolecularIdentifier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -27,6 +31,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -171,6 +176,92 @@ public class DiscreteCopyNumberController {
       }
 
       return new ResponseEntity<>(discreteCopyNumberDataList, HttpStatus.OK);
+    }
+  }
+
+  @PreAuthorize(
+      "hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
+  @RequestMapping(
+      value = "/discrete-copy-number/fetch",
+      method = RequestMethod.POST,
+      consumes = MediaType.APPLICATION_JSON_VALUE,
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(
+      description =
+          "Fetch discrete copy number alterations by molecular profile IDs or molecular profile and sample pairs")
+  @ApiResponse(
+      responseCode = "200",
+      description = "OK",
+      content =
+          @Content(
+              array =
+                  @ArraySchema(schema = @Schema(implementation = DiscreteCopyNumberData.class))))
+  public ResponseEntity<List<DiscreteCopyNumberData>>
+      fetchDiscreteCopyNumbersInMultipleMolecularProfiles(
+          @Parameter(hidden = true)
+              @RequestAttribute(required = false, value = "involvedCancerStudies")
+              Collection<String> involvedCancerStudies,
+          @Parameter(hidden = true)
+              @Valid
+              @RequestAttribute(
+                  required = false,
+                  value = "interceptedDiscreteCopyNumberMultipleStudyFilter")
+              DiscreteCopyNumberMultipleStudyFilter interceptedDiscreteCopyNumberMultipleStudyFilter,
+          @Parameter(
+                  required = true,
+                  description =
+                      "List of molecular profile IDs and entrez gene IDs or list of molecular"
+                          + " profile and sample pairs and entrez gene IDs")
+              @Valid
+              @RequestBody(required = false)
+              DiscreteCopyNumberMultipleStudyFilter discreteCopyNumberMultipleStudyFilter,
+          @Parameter(description = "Type of the copy number event")
+              @RequestParam(defaultValue = "HOMDEL_AND_AMP")
+              DiscreteCopyNumberEventType discreteCopyNumberEventType,
+          @Parameter(description = "Level of detail of the response")
+              @RequestParam(defaultValue = "SUMMARY")
+              Projection projection) {
+
+    List<DiscreteCopyNumberData> result;
+    if (interceptedDiscreteCopyNumberMultipleStudyFilter.getMolecularProfileIds() != null) {
+      result =
+          discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfiles(
+              interceptedDiscreteCopyNumberMultipleStudyFilter.getMolecularProfileIds(),
+              null,
+              interceptedDiscreteCopyNumberMultipleStudyFilter.getEntrezGeneIds(),
+              discreteCopyNumberEventType.getAlterationTypes(),
+              projection.name());
+    } else {
+      List<String> molecularProfileIds = new ArrayList<>();
+      List<String> sampleIds = new ArrayList<>();
+      extractMolecularProfileAndSampleIds(
+          interceptedDiscreteCopyNumberMultipleStudyFilter, molecularProfileIds, sampleIds);
+      result =
+          discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfiles(
+              molecularProfileIds,
+              sampleIds,
+              interceptedDiscreteCopyNumberMultipleStudyFilter.getEntrezGeneIds(),
+              discreteCopyNumberEventType.getAlterationTypes(),
+              projection.name());
+    }
+
+    if (projection == Projection.META) {
+      HttpHeaders responseHeaders = new HttpHeaders();
+      responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, String.valueOf(result.size()));
+      return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
+    }
+    return new ResponseEntity<>(result, HttpStatus.OK);
+  }
+
+  private void extractMolecularProfileAndSampleIds(
+      DiscreteCopyNumberMultipleStudyFilter discreteCopyNumberMultipleStudyFilter,
+      List<String> molecularProfileIds,
+      List<String> sampleIds) {
+
+    for (SampleMolecularIdentifier sampleMolecularIdentifier :
+        discreteCopyNumberMultipleStudyFilter.getSampleMolecularIdentifiers()) {
+      molecularProfileIds.add(sampleMolecularIdentifier.getMolecularProfileId());
+      sampleIds.add(sampleMolecularIdentifier.getSampleId());
     }
   }
 }

--- a/src/main/java/org/cbioportal/legacy/web/DiscreteCopyNumberController.java
+++ b/src/main/java/org/cbioportal/legacy/web/DiscreteCopyNumberController.java
@@ -206,7 +206,8 @@ public class DiscreteCopyNumberController {
               @RequestAttribute(
                   required = false,
                   value = "interceptedDiscreteCopyNumberMultipleStudyFilter")
-              DiscreteCopyNumberMultipleStudyFilter interceptedDiscreteCopyNumberMultipleStudyFilter,
+              DiscreteCopyNumberMultipleStudyFilter
+                  interceptedDiscreteCopyNumberMultipleStudyFilter,
           @Parameter(
                   required = true,
                   description =
@@ -222,34 +223,37 @@ public class DiscreteCopyNumberController {
               @RequestParam(defaultValue = "SUMMARY")
               Projection projection) {
 
-    List<DiscreteCopyNumberData> result;
+    List<String> molecularProfileIds;
+    List<String> sampleIds = null;
     if (interceptedDiscreteCopyNumberMultipleStudyFilter.getMolecularProfileIds() != null) {
-      result =
-          discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfiles(
-              interceptedDiscreteCopyNumberMultipleStudyFilter.getMolecularProfileIds(),
-              null,
-              interceptedDiscreteCopyNumberMultipleStudyFilter.getEntrezGeneIds(),
-              discreteCopyNumberEventType.getAlterationTypes(),
-              projection.name());
+      molecularProfileIds =
+          interceptedDiscreteCopyNumberMultipleStudyFilter.getMolecularProfileIds();
     } else {
-      List<String> molecularProfileIds = new ArrayList<>();
-      List<String> sampleIds = new ArrayList<>();
+      molecularProfileIds = new ArrayList<>();
+      sampleIds = new ArrayList<>();
       extractMolecularProfileAndSampleIds(
           interceptedDiscreteCopyNumberMultipleStudyFilter, molecularProfileIds, sampleIds);
-      result =
-          discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfiles(
-              molecularProfileIds,
-              sampleIds,
-              interceptedDiscreteCopyNumberMultipleStudyFilter.getEntrezGeneIds(),
-              discreteCopyNumberEventType.getAlterationTypes(),
-              projection.name());
     }
 
     if (projection == Projection.META) {
+      BaseMeta baseMeta =
+          discreteCopyNumberService.getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+              molecularProfileIds,
+              sampleIds,
+              interceptedDiscreteCopyNumberMultipleStudyFilter.getEntrezGeneIds(),
+              discreteCopyNumberEventType.getAlterationTypes());
       HttpHeaders responseHeaders = new HttpHeaders();
-      responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, String.valueOf(result.size()));
+      responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, baseMeta.getTotalCount().toString());
       return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
     }
+
+    List<DiscreteCopyNumberData> result =
+        discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfiles(
+            molecularProfileIds,
+            sampleIds,
+            interceptedDiscreteCopyNumberMultipleStudyFilter.getEntrezGeneIds(),
+            discreteCopyNumberEventType.getAlterationTypes(),
+            projection.name());
     return new ResponseEntity<>(result, HttpStatus.OK);
   }
 

--- a/src/main/java/org/cbioportal/legacy/web/GenericAssayDataController.java
+++ b/src/main/java/org/cbioportal/legacy/web/GenericAssayDataController.java
@@ -30,6 +30,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.CollectionUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
@@ -178,6 +179,11 @@ public class GenericAssayDataController {
           Projection projection)
       throws MolecularProfileNotFoundException {
 
+    if (!hasValidGenericAssayDataMultipleStudyFilter(
+        interceptedGenericAssayDataMultipleStudyFilter)) {
+      return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    }
+
     List<GenericAssayData> result;
     if (interceptedGenericAssayDataMultipleStudyFilter.getMolecularProfileIds() != null) {
       result =
@@ -227,5 +233,17 @@ public class GenericAssayDataController {
     return genericAssayDataList.stream()
         .filter(g -> StringUtils.isNotEmpty(g.getValue()) && !g.getValue().equals("NA"))
         .collect(Collectors.toList());
+  }
+
+  private boolean hasValidGenericAssayDataMultipleStudyFilter(
+      GenericAssayDataMultipleStudyFilter genericAssayDataMultipleStudyFilter) {
+    boolean hasGenericAssayStableIds =
+        !CollectionUtils.isEmpty(genericAssayDataMultipleStudyFilter.getGenericAssayStableIds());
+    boolean hasMolecularProfileIds =
+        !CollectionUtils.isEmpty(genericAssayDataMultipleStudyFilter.getMolecularProfileIds());
+    boolean hasSampleMolecularIdentifiers =
+        !CollectionUtils.isEmpty(
+            genericAssayDataMultipleStudyFilter.getSampleMolecularIdentifiers());
+    return hasGenericAssayStableIds && (hasMolecularProfileIds ^ hasSampleMolecularIdentifiers);
   }
 }

--- a/src/main/java/org/cbioportal/legacy/web/parameter/DiscreteCopyNumberFilter.java
+++ b/src/main/java/org/cbioportal/legacy/web/parameter/DiscreteCopyNumberFilter.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class DiscreteCopyNumberFilter {
 
-  private static final int DISCRETE_COPY_NUMBER_MAX_PAGE_SIZE = 50000;
+  public static final int DISCRETE_COPY_NUMBER_MAX_PAGE_SIZE = 50000;
 
   @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
   private List<String> sampleIds;

--- a/src/main/java/org/cbioportal/legacy/web/parameter/DiscreteCopyNumberMultipleStudyFilter.java
+++ b/src/main/java/org/cbioportal/legacy/web/parameter/DiscreteCopyNumberMultipleStudyFilter.java
@@ -1,0 +1,48 @@
+package org.cbioportal.legacy.web.parameter;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Size;
+import java.io.Serializable;
+import java.util.List;
+
+public class DiscreteCopyNumberMultipleStudyFilter implements Serializable {
+
+  @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
+  private List<SampleMolecularIdentifier> sampleMolecularIdentifiers;
+
+  @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
+  private List<String> molecularProfileIds;
+
+  @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
+  private List<Integer> entrezGeneIds;
+
+  @AssertTrue
+  private boolean isEitherMolecularProfileIdsOrSampleMolecularIdentifiersPresent() {
+    return molecularProfileIds != null ^ sampleMolecularIdentifiers != null;
+  }
+
+  public List<SampleMolecularIdentifier> getSampleMolecularIdentifiers() {
+    return sampleMolecularIdentifiers;
+  }
+
+  public void setSampleMolecularIdentifiers(
+      List<SampleMolecularIdentifier> sampleMolecularIdentifiers) {
+    this.sampleMolecularIdentifiers = sampleMolecularIdentifiers;
+  }
+
+  public List<String> getMolecularProfileIds() {
+    return molecularProfileIds;
+  }
+
+  public void setMolecularProfileIds(List<String> molecularProfileIds) {
+    this.molecularProfileIds = molecularProfileIds;
+  }
+
+  public List<Integer> getEntrezGeneIds() {
+    return entrezGeneIds;
+  }
+
+  public void setEntrezGeneIds(List<Integer> entrezGeneIds) {
+    this.entrezGeneIds = entrezGeneIds;
+  }
+}

--- a/src/main/java/org/cbioportal/legacy/web/parameter/DiscreteCopyNumberMultipleStudyFilter.java
+++ b/src/main/java/org/cbioportal/legacy/web/parameter/DiscreteCopyNumberMultipleStudyFilter.java
@@ -13,10 +13,12 @@ public class DiscreteCopyNumberMultipleStudyFilter implements Serializable {
   @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
   private List<String> molecularProfileIds;
 
-  @Size(min = 1, max = PagingConstants.MAX_PAGE_SIZE)
+  @Size(min = 1, max = DiscreteCopyNumberFilter.DISCRETE_COPY_NUMBER_MAX_PAGE_SIZE)
   private List<Integer> entrezGeneIds;
 
-  @AssertTrue
+  @AssertTrue(
+      message =
+          "Exactly one of molecularProfileIds or sampleMolecularIdentifiers must be provided, and not both")
   private boolean isEitherMolecularProfileIdsOrSampleMolecularIdentifiersPresent() {
     return molecularProfileIds != null ^ sampleMolecularIdentifiers != null;
   }

--- a/src/main/java/org/cbioportal/legacy/web/util/InvolvedCancerStudyExtractorInterceptor.java
+++ b/src/main/java/org/cbioportal/legacy/web/util/InvolvedCancerStudyExtractorInterceptor.java
@@ -54,6 +54,7 @@ import org.cbioportal.legacy.web.parameter.ClinicalDataCountFilter;
 import org.cbioportal.legacy.web.parameter.ClinicalDataIdentifier;
 import org.cbioportal.legacy.web.parameter.ClinicalDataMultiStudyFilter;
 import org.cbioportal.legacy.web.parameter.ClinicalEventAttributeRequest;
+import org.cbioportal.legacy.web.parameter.DiscreteCopyNumberMultipleStudyFilter;
 import org.cbioportal.legacy.web.parameter.GenePanelDataMultipleStudyFilter;
 import org.cbioportal.legacy.web.parameter.GenericAssayDataBinCountFilter;
 import org.cbioportal.legacy.web.parameter.GenericAssayDataCountFilter;
@@ -99,6 +100,8 @@ public class InvolvedCancerStudyExtractorInterceptor implements HandlerIntercept
   public static final String CLINICAL_DATA_FETCH_PATH = "/clinical-data/fetch";
   public static final String GENE_PANEL_DATA_FETCH_PATH = "/gene-panel-data/fetch";
   public static final String MOLECULAR_DATA_MULTIPLE_STUDY_FETCH_PATH = "/molecular-data/fetch";
+  public static final String DISCRETE_COPY_NUMBER_MULTIPLE_STUDY_FETCH_PATH =
+      "/discrete-copy-number/fetch";
   public static final String MUTATION_MULTIPLE_STUDY_FETCH_PATH = "/mutations/fetch";
   public static final String COPY_NUMBER_SEG_FETCH_PATH = "/copy-number-segments/fetch";
   public static final String STUDY_VIEW_CLINICAL_DATA_BIN_COUNTS_PATH =
@@ -187,6 +190,8 @@ public class InvolvedCancerStudyExtractorInterceptor implements HandlerIntercept
       return extractAttributesFromGenePanelDataMultipleStudyFilter(request);
     } else if (requestPathInfo.equals(MOLECULAR_DATA_MULTIPLE_STUDY_FETCH_PATH)) {
       return extractAttributesFromMolecularDataMultipleStudyFilter(request);
+    } else if (requestPathInfo.equals(DISCRETE_COPY_NUMBER_MULTIPLE_STUDY_FETCH_PATH)) {
+      return extractAttributesFromDiscreteCopyNumberMultipleStudyFilter(request);
     } else if (requestPathInfo.equals(MUTATION_MULTIPLE_STUDY_FETCH_PATH)) {
       return extractAttributesFromMutationMultipleStudyFilter(request);
     } else if (requestPathInfo.equals(COPY_NUMBER_SEG_FETCH_PATH)) {
@@ -535,6 +540,50 @@ public class InvolvedCancerStudyExtractorInterceptor implements HandlerIntercept
     } else {
       extractCancerStudyIdsFromSampleMolecularIdentifiers(
           molecularDataMultipleStudyFilter.getSampleMolecularIdentifiers(), studyIdSet);
+    }
+    return studyIdSet;
+  }
+
+  private boolean extractAttributesFromDiscreteCopyNumberMultipleStudyFilter(
+      HttpServletRequest request) {
+    try {
+      DiscreteCopyNumberMultipleStudyFilter discreteCopyNumberMultipleStudyFilter =
+          objectMapper.readValue(
+              request.getInputStream(), DiscreteCopyNumberMultipleStudyFilter.class);
+      LOG.debug(
+          "extracted discreteCopyNumberMultipleStudyFilter: {}",
+          discreteCopyNumberMultipleStudyFilter);
+      LOG.debug(
+          "setting interceptedDiscreteCopyNumberMultipleStudyFilter to {}",
+          discreteCopyNumberMultipleStudyFilter);
+      request.setAttribute(
+          "interceptedDiscreteCopyNumberMultipleStudyFilter",
+          discreteCopyNumberMultipleStudyFilter);
+      if (cacheMapUtil.hasCacheEnabled()) {
+        Collection<String> cancerStudyIdCollection =
+            extractCancerStudyIdsFromDiscreteCopyNumberMultipleStudyFilter(
+                discreteCopyNumberMultipleStudyFilter);
+        LOG.debug("setting involvedCancerStudies to {}", cancerStudyIdCollection);
+        request.setAttribute("involvedCancerStudies", cancerStudyIdCollection);
+      }
+    } catch (Exception e) {
+      LOG.error(
+          "exception thrown during extraction of discreteCopyNumberMultipleStudyFilter: {}",
+          e.getMessage());
+      return false;
+    }
+    return true;
+  }
+
+  private Collection<String> extractCancerStudyIdsFromDiscreteCopyNumberMultipleStudyFilter(
+      DiscreteCopyNumberMultipleStudyFilter discreteCopyNumberMultipleStudyFilter) {
+    Set<String> studyIdSet = new HashSet<>();
+    if (discreteCopyNumberMultipleStudyFilter.getMolecularProfileIds() != null) {
+      extractCancerStudyIdsFromMolecularProfileIds(
+          discreteCopyNumberMultipleStudyFilter.getMolecularProfileIds(), studyIdSet);
+    } else {
+      extractCancerStudyIdsFromSampleMolecularIdentifiers(
+          discreteCopyNumberMultipleStudyFilter.getSampleMolecularIdentifiers(), studyIdSet);
     }
     return studyIdSet;
   }

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/DiscreteCopyNumberMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/DiscreteCopyNumberMapper.xml
@@ -222,6 +222,13 @@
         ORDER BY cna_event.entrez_gene_id ASC, cna_event.alteration ASC, sample.stable_id ASC
     </select>
 
+    <select id="getMetaDiscreteCopyNumbersInMultipleMolecularProfiles" resultType="org.cbioportal.legacy.model.meta.BaseMeta">
+        SELECT
+        COUNT(*) AS "totalCount"
+        <include refid="from"/>
+        <include refid="whereInMultipleMolecularProfiles"/>
+    </select>
+
     <select id="getDiscreteCopyNumbersInMultipleMolecularProfilesByGeneQueries" resultType="org.cbioportal.legacy.model.DiscreteCopyNumberData">
         SELECT
         <include refid="select"/>

--- a/src/test/java/org/cbioportal/legacy/service/impl/DiscreteCopyNumberServiceImplTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/impl/DiscreteCopyNumberServiceImplTest.java
@@ -142,6 +142,53 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
   }
 
   @Test
+  public void getMetaDiscreteCopyNumbersInMultipleMolecularProfilesHomdelOrAmp() {
+    List<String> profiles = Arrays.asList("profile1", "profile2");
+    List<String> samples = Arrays.asList("sample1", "sample2");
+    List<Integer> geneIds = Arrays.asList(0, 1);
+    List<Integer> alterationTypes = Arrays.asList(-2, 2);
+    BaseMeta expectedMeta = new BaseMeta();
+    expectedMeta.setTotalCount(3);
+
+    Mockito.when(
+            discreteCopyNumberRepository.getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+                profiles, samples, geneIds, alterationTypes))
+        .thenReturn(expectedMeta);
+
+    BaseMeta actual =
+        discreteCopyNumberService.getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+            profiles, samples, geneIds, alterationTypes);
+
+    Assert.assertEquals(expectedMeta.getTotalCount(), actual.getTotalCount());
+  }
+
+  @Test
+  public void getMetaDiscreteCopyNumbersInMultipleMolecularProfilesAllAlterationTypes() {
+    List<String> profiles = Arrays.asList("profile1", "profile2");
+    List<String> samples = Arrays.asList("sample1", "sample2");
+    List<Integer> geneIds = Arrays.asList(0, 1);
+    List<Integer> alterationTypes = Arrays.asList(-2, -1, 0, 1, 2);
+    List<GeneMolecularData> returned =
+        Arrays.asList(
+            geneMolecularData("sample1", "study1", "-2"),
+            geneMolecularData("sample2", "study1", "-1"),
+            geneMolecularData("sample3", "study1", "0"),
+            geneMolecularData("sample4", "study1", "1"),
+            geneMolecularData("sample5", "study2", "2"));
+
+    Mockito.when(
+            molecularDataService.getMolecularDataInMultipleMolecularProfiles(
+                profiles, samples, geneIds, "ID"))
+        .thenReturn(returned);
+
+    BaseMeta actual =
+        discreteCopyNumberService.getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+            profiles, samples, geneIds, alterationTypes);
+
+    Assert.assertEquals((Integer) 5, actual.getTotalCount());
+  }
+
+  @Test
   public void getDiscreteCopyNumbersInMultipleMolecularProfilesEmptyAlterationTypes() {
     List<GeneMolecularData> returned =
         Arrays.asList(

--- a/src/test/java/org/cbioportal/legacy/service/impl/DiscreteCopyNumberServiceImplTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/impl/DiscreteCopyNumberServiceImplTest.java
@@ -168,24 +168,19 @@ public class DiscreteCopyNumberServiceImplTest extends BaseServiceImplTest {
     List<String> samples = Arrays.asList("sample1", "sample2");
     List<Integer> geneIds = Arrays.asList(0, 1);
     List<Integer> alterationTypes = Arrays.asList(-2, -1, 0, 1, 2);
-    List<GeneMolecularData> returned =
-        Arrays.asList(
-            geneMolecularData("sample1", "study1", "-2"),
-            geneMolecularData("sample2", "study1", "-1"),
-            geneMolecularData("sample3", "study1", "0"),
-            geneMolecularData("sample4", "study1", "1"),
-            geneMolecularData("sample5", "study2", "2"));
+    BaseMeta expectedMeta = new BaseMeta();
+    expectedMeta.setTotalCount(5);
 
     Mockito.when(
-            molecularDataService.getMolecularDataInMultipleMolecularProfiles(
-                profiles, samples, geneIds, "ID"))
-        .thenReturn(returned);
+            discreteCopyNumberRepository.getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+                profiles, samples, geneIds, alterationTypes))
+        .thenReturn(expectedMeta);
 
     BaseMeta actual =
         discreteCopyNumberService.getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
             profiles, samples, geneIds, alterationTypes);
 
-    Assert.assertEquals((Integer) 5, actual.getTotalCount());
+    Assert.assertEquals(expectedMeta.getTotalCount(), actual.getTotalCount());
   }
 
   @Test

--- a/src/test/java/org/cbioportal/legacy/web/DiscreteCopyNumberControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/DiscreteCopyNumberControllerTest.java
@@ -4,6 +4,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.cbioportal.legacy.model.DiscreteCopyNumberData;
 import org.cbioportal.legacy.model.Gene;
@@ -12,7 +13,10 @@ import org.cbioportal.legacy.service.DiscreteCopyNumberService;
 import org.cbioportal.legacy.web.config.TestConfig;
 import org.cbioportal.legacy.web.parameter.DiscreteCopyNumberEventType;
 import org.cbioportal.legacy.web.parameter.DiscreteCopyNumberFilter;
+import org.cbioportal.legacy.web.parameter.DiscreteCopyNumberMultipleStudyFilter;
 import org.cbioportal.legacy.web.parameter.HeaderKeyConstants;
+import org.cbioportal.legacy.web.parameter.Projection;
+import org.cbioportal.legacy.web.parameter.SampleMolecularIdentifier;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -352,6 +356,88 @@ public class DiscreteCopyNumberControllerTest {
         .andExpect(MockMvcResultMatchers.header().string(HeaderKeyConstants.TOTAL_COUNT, "2"));
   }
 
+  @Test
+  @WithMockUser
+  public void fetchDiscreteCopyNumbersInMultipleMolecularProfiles() throws Exception {
+
+    List<DiscreteCopyNumberData> discreteCopyNumberDataList = createExampleDiscreteCopyNumberData();
+
+    Mockito.when(
+            discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfiles(
+                Mockito.anyList(),
+                Mockito.isNull(),
+                Mockito.anyList(),
+                Mockito.anyList(),
+                Mockito.anyString()))
+        .thenReturn(discreteCopyNumberDataList);
+
+    DiscreteCopyNumberMultipleStudyFilter discreteCopyNumberMultipleStudyFilter =
+        new DiscreteCopyNumberMultipleStudyFilter();
+    discreteCopyNumberMultipleStudyFilter.setMolecularProfileIds(
+        Arrays.asList(TEST_MOLECULAR_PROFILE_STABLE_ID_1, TEST_MOLECULAR_PROFILE_STABLE_ID_2));
+    discreteCopyNumberMultipleStudyFilter.setEntrezGeneIds(
+        Arrays.asList(TEST_ENTREZ_GENE_ID_1, TEST_ENTREZ_GENE_ID_2));
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/discrete-copy-number/fetch")
+                .with(csrf())
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(discreteCopyNumberMultipleStudyFilter)))
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andExpect(
+            MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$[0].molecularProfileId")
+                .value(TEST_MOLECULAR_PROFILE_STABLE_ID_1))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].sampleId").value(TEST_SAMPLE_STABLE_ID_1))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].entrezGeneId").value(TEST_ENTREZ_GENE_ID_1))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].alteration").value(TEST_ALTERATION_1))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].gene").doesNotExist())
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$[1].molecularProfileId")
+                .value(TEST_MOLECULAR_PROFILE_STABLE_ID_2))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[1].sampleId").value(TEST_SAMPLE_STABLE_ID_2))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[1].entrezGeneId").value(TEST_ENTREZ_GENE_ID_2))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[1].alteration").value(TEST_ALTERATION_2))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[1].gene").doesNotExist());
+  }
+
+  @Test
+  @WithMockUser
+  public void fetchDiscreteCopyNumbersInMultipleMolecularProfilesMetaProjection() throws Exception {
+
+    List<DiscreteCopyNumberData> discreteCopyNumberDataList = createExampleDiscreteCopyNumberData();
+
+    Mockito.when(
+            discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfiles(
+                Mockito.anyList(),
+                Mockito.anyList(),
+                Mockito.anyList(),
+                Mockito.anyList(),
+                Mockito.anyString()))
+        .thenReturn(discreteCopyNumberDataList);
+
+    DiscreteCopyNumberMultipleStudyFilter discreteCopyNumberMultipleStudyFilter =
+        new DiscreteCopyNumberMultipleStudyFilter();
+    discreteCopyNumberMultipleStudyFilter.setSampleMolecularIdentifiers(
+        createSampleMolecularIdentifiers());
+    discreteCopyNumberMultipleStudyFilter.setEntrezGeneIds(
+        Arrays.asList(TEST_ENTREZ_GENE_ID_1, TEST_ENTREZ_GENE_ID_2));
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/discrete-copy-number/fetch")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(discreteCopyNumberMultipleStudyFilter))
+                .param("projection", Projection.META.name()))
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andExpect(MockMvcResultMatchers.header().string(HeaderKeyConstants.TOTAL_COUNT, "2"));
+  }
+
   private DiscreteCopyNumberFilter createDiscreteCopyNumberFilter() {
 
     List<String> sampleIds = new ArrayList<>();
@@ -401,5 +487,21 @@ public class DiscreteCopyNumberControllerTest {
     gene2.setType(TEST_TYPE_2);
     discreteCopyNumberDataList.get(1).setGene(gene2);
     return discreteCopyNumberDataList;
+  }
+
+  private List<SampleMolecularIdentifier> createSampleMolecularIdentifiers() {
+    List<SampleMolecularIdentifier> sampleMolecularIdentifiers = new ArrayList<>();
+
+    SampleMolecularIdentifier sampleMolecularIdentifier1 = new SampleMolecularIdentifier();
+    sampleMolecularIdentifier1.setMolecularProfileId(TEST_MOLECULAR_PROFILE_STABLE_ID_1);
+    sampleMolecularIdentifier1.setSampleId(TEST_SAMPLE_STABLE_ID_1);
+    sampleMolecularIdentifiers.add(sampleMolecularIdentifier1);
+
+    SampleMolecularIdentifier sampleMolecularIdentifier2 = new SampleMolecularIdentifier();
+    sampleMolecularIdentifier2.setMolecularProfileId(TEST_MOLECULAR_PROFILE_STABLE_ID_2);
+    sampleMolecularIdentifier2.setSampleId(TEST_SAMPLE_STABLE_ID_2);
+    sampleMolecularIdentifiers.add(sampleMolecularIdentifier2);
+
+    return sampleMolecularIdentifiers;
   }
 }

--- a/src/test/java/org/cbioportal/legacy/web/DiscreteCopyNumberControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/DiscreteCopyNumberControllerTest.java
@@ -409,16 +409,13 @@ public class DiscreteCopyNumberControllerTest {
   @WithMockUser
   public void fetchDiscreteCopyNumbersInMultipleMolecularProfilesMetaProjection() throws Exception {
 
-    List<DiscreteCopyNumberData> discreteCopyNumberDataList = createExampleDiscreteCopyNumberData();
+    BaseMeta baseMeta = new BaseMeta();
+    baseMeta.setTotalCount(2);
 
     Mockito.when(
-            discreteCopyNumberService.getDiscreteCopyNumbersInMultipleMolecularProfiles(
-                Mockito.anyList(),
-                Mockito.anyList(),
-                Mockito.anyList(),
-                Mockito.anyList(),
-                Mockito.anyString()))
-        .thenReturn(discreteCopyNumberDataList);
+            discreteCopyNumberService.getMetaDiscreteCopyNumbersInMultipleMolecularProfiles(
+                Mockito.anyList(), Mockito.anyList(), Mockito.anyList(), Mockito.anyList()))
+        .thenReturn(baseMeta);
 
     DiscreteCopyNumberMultipleStudyFilter discreteCopyNumberMultipleStudyFilter =
         new DiscreteCopyNumberMultipleStudyFilter();

--- a/src/test/java/org/cbioportal/legacy/web/GenericAssayDataControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/GenericAssayDataControllerTest.java
@@ -118,6 +118,12 @@ public class GenericAssayDataControllerTest {
         new GenericAssayDataMultipleStudyFilter();
     genericAssayDataMultipleStudyFilter.setSampleMolecularIdentifiers(
         createSampleMolecularIdentifiers());
+    genericAssayDataMultipleStudyFilter.setGenericAssayStableIds(
+        Arrays.asList(
+            GENERIC_ASSAY_STABLE_ID_1,
+            GENERIC_ASSAY_STABLE_ID_2,
+            GENERIC_ASSAY_STABLE_ID_3,
+            GENERIC_ASSAY_STABLE_ID_4));
 
     Mockito.when(
             genericAssayService.fetchGenericAssayData(

--- a/src/test/java/org/cbioportal/legacy/web/GenericAssayDataControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/GenericAssayDataControllerTest.java
@@ -148,6 +148,22 @@ public class GenericAssayDataControllerTest {
         .andExpect(MockMvcResultMatchers.jsonPath("$[1].value").value(VALUE_2));
   }
 
+  @Test
+  public void testGenericAssayDataFetchInMultipleMolecularProfilesInvalidFilter() throws Exception {
+    GenericAssayDataMultipleStudyFilter genericAssayDataMultipleStudyFilter =
+        new GenericAssayDataMultipleStudyFilter();
+    genericAssayDataMultipleStudyFilter.setSampleMolecularIdentifiers(
+        createSampleMolecularIdentifiers());
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/generic_assay_data/fetch")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(genericAssayDataMultipleStudyFilter)))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+  }
+
   public void testGenericAssayDataGet() throws Exception {
     List<GenericAssayData> genericAssayDataItems = createGenericAssayDataItemsList();
     Mockito.when(


### PR DESCRIPTION
Fix #11731 

# Describe changes proposed in this pull request:
- add a new endpoint `POST /api/discrete-copy-number/fetch` to support batched requests across multiple molecular profiles or sample+molecular-profile pairs in a single call
- add `DiscreteCopyNumberMultipleStudyFilter` and wire `InvolvedCancerStudyExtractorInterceptor` so `involvedCancerStudies` authorization extraction works for the new endpoint
- reuse existing service path `getDiscreteCopyNumbersInMultipleMolecularProfiles(...)` to execute one backend query path instead of per-study requests
- add controller tests for the new endpoint, including both default response and `projection=META` total-count header behavior

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
N/A (backend/API-only change; no UI changes)
