### PR TITLE
Fix save-track requests for OncoPrint clinical gap settings

### DIFF
--- a/src/main/java/org/cbioportal/legacy/web/parameter/ClinicalTrackConfig.java
+++ b/src/main/java/org/cbioportal/legacy/web/parameter/ClinicalTrackConfig.java
@@ -8,6 +8,7 @@ class ClinicalTrackConfig implements Serializable {
   private String stableId;
   private String sortOrder;
   private Boolean gapOn;
+  private String gapMode;
 
   public String getStableId() {
     return stableId;
@@ -31,5 +32,13 @@ class ClinicalTrackConfig implements Serializable {
 
   public void setGapOn(Boolean gapOn) {
     this.gapOn = gapOn;
+  }
+
+  public String getGapMode() {
+    return gapMode;
+  }
+
+  public void setGapMode(String gapMode) {
+    this.gapMode = gapMode;
   }
 }

--- a/src/main/java/org/cbioportal/legacy/web/parameter/ClinicalTrackConfig.java
+++ b/src/main/java/org/cbioportal/legacy/web/parameter/ClinicalTrackConfig.java
@@ -1,8 +1,10 @@
 package org.cbioportal.legacy.web.parameter;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.io.Serializable;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.ALWAYS)
 class ClinicalTrackConfig implements Serializable {
   private String stableId;

--- a/src/test/java/org/cbioportal/legacy/web/parameter/ResultsPageSettingsDeserializationTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/parameter/ResultsPageSettingsDeserializationTest.java
@@ -1,0 +1,45 @@
+package org.cbioportal.legacy.web.parameter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.cbioportal.legacy.web.config.CustomObjectMapper;
+import org.junit.Test;
+
+public class ResultsPageSettingsDeserializationTest {
+
+  private final ObjectMapper objectMapper = new CustomObjectMapper();
+
+  @Test
+  public void shouldDeserializeClinicalTrackGapModeFromResultsViewSettings() throws Exception {
+    String payload =
+        """
+        {
+          "page": "results_view",
+          "origin": ["study_es_0"],
+          "clinicallist": [
+            {
+              "stableId": "SUBTYPE",
+              "sortOrder": "ASC",
+              "gapOn": true,
+              "gapMode": "HIDE_GAPS"
+            }
+          ]
+        }
+        """;
+
+    PageSettingsData pageSettingsData = objectMapper.readValue(payload, PageSettingsData.class);
+
+    assertTrue(pageSettingsData instanceof ResultsPageSettings);
+
+    ResultsPageSettings resultsPageSettings = (ResultsPageSettings) pageSettingsData;
+    assertEquals(1, resultsPageSettings.getClinicallist().size());
+
+    ClinicalTrackConfig clinicalTrackConfig = resultsPageSettings.getClinicallist().getFirst();
+    assertEquals("SUBTYPE", clinicalTrackConfig.getStableId());
+    assertEquals("ASC", clinicalTrackConfig.getSortOrder());
+    assertEquals(Boolean.TRUE, clinicalTrackConfig.getGapOn());
+    assertEquals("HIDE_GAPS", clinicalTrackConfig.getGapMode());
+  }
+}

--- a/src/test/java/org/cbioportal/legacy/web/parameter/ResultsPageSettingsDeserializationTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/parameter/ResultsPageSettingsDeserializationTest.java
@@ -23,7 +23,8 @@ public class ResultsPageSettingsDeserializationTest {
               "stableId": "SUBTYPE",
               "sortOrder": "ASC",
               "gapOn": true,
-              "gapMode": "HIDE_GAPS"
+              "gapMode": "HIDE_GAPS",
+              "futureField": "ignored"
             }
           ]
         }


### PR DESCRIPTION
Fix #12083

Describe changes proposed in this pull request:
- accept `gapMode` in saved results-view clinical track settings so `/api/session/settings` can deserialize current OncoPrint payloads
- add a regression test covering `results_view` session settings with `gapMode`

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
Not applicable.

# Notify reviewers
Please use `git blame` and normal review assignment flow as needed for the session-settings parameter classes touched here.