### PR TITLE
Re-enable Docker image caching in GitHub Actions build workflow

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           images: |
             cbioportal/cbioportal
+          sep-tags: ","
           # The latest tag will also be generated on tag event with a valid semver tag
           tags: |
             type=ref,event=branch
@@ -44,19 +45,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Convert metadata tags for cache action
-        id: image_tags
-        run: |
-          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed "s|^cbioportal/cbioportal:||" | paste -sd "," -)
-          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
-
       - name: Publish Docker Image on Tag
         uses: whoan/docker-build-with-cache-action@v5
         with:
           username: "${{ secrets.DOCKER_USERNAME }}"
           password: "${{ secrets.DOCKER_PASSWORD }}"
           image_name: cbioportal/cbioportal
-          image_tag: ${{ steps.image_tags.outputs.tags }}
+          image_tag: ${{ steps.meta.outputs.tag-names }}
           context: .
           dockerfile: docker/web-and-data/Dockerfile
           build_extra_args: --platform linux/amd64,linux/arm64
@@ -76,6 +71,7 @@ jobs:
           with:
             images: |
               cbioportal/cbioportal
+            sep-tags: ","
             # Do not generate latest tag
             flavor: |
               latest=false
@@ -98,19 +94,13 @@ jobs:
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@v3
 
-        - name: Convert metadata tags for cache action
-          id: image_tags
-          run: |
-            TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed "s|^cbioportal/cbioportal:||" | paste -sd "," -)
-            echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
-
         - name: Publish Docker Image on Tag
           uses: whoan/docker-build-with-cache-action@v5
           with:
             username: "${{ secrets.DOCKER_USERNAME }}"
             password: "${{ secrets.DOCKER_PASSWORD }}"
             image_name: cbioportal/cbioportal
-            image_tag: ${{ steps.image_tags.outputs.tags }}
+            image_tag: ${{ steps.meta.outputs.tag-names }}
             context: .
             dockerfile: docker/web/Dockerfile
             build_extra_args: --platform linux/amd64,linux/arm64

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -44,16 +44,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Convert metadata tags for cache action
+        id: image_tags
+        run: |
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed "s|^cbioportal/cbioportal:||" | paste -sd "," -)
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
       - name: Publish Docker Image on Tag
-        uses: docker/build-push-action@v6
+        uses: whoan/docker-build-with-cache-action@v5
         with:
+          username: "${{ secrets.DOCKER_USERNAME }}"
+          password: "${{ secrets.DOCKER_PASSWORD }}"
+          image_name: cbioportal/cbioportal
+          image_tag: ${{ steps.image_tags.outputs.tags }}
           context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64,linux/arm64
-          file: docker/web-and-data/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha
+          dockerfile: docker/web-and-data/Dockerfile
+          build_extra_args: --platform linux/amd64,linux/arm64
 
   build_and_publish_web:
       if: github.repository == 'cBioPortal/cbioportal'
@@ -92,16 +98,22 @@ jobs:
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@v3
 
+        - name: Convert metadata tags for cache action
+          id: image_tags
+          run: |
+            TAGS=$(echo "${{ steps.meta.outputs.tags }}" | sed "s|^cbioportal/cbioportal:||" | paste -sd "," -)
+            echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
         - name: Publish Docker Image on Tag
-          uses: docker/build-push-action@v6
+          uses: whoan/docker-build-with-cache-action@v5
           with:
+            username: "${{ secrets.DOCKER_USERNAME }}"
+            password: "${{ secrets.DOCKER_PASSWORD }}"
+            image_name: cbioportal/cbioportal
+            image_tag: ${{ steps.image_tags.outputs.tags }}
             context: .
-            push: true
-            tags: ${{ steps.meta.outputs.tags }}
-            platforms: linux/amd64,linux/arm64
-            file: docker/web/Dockerfile
-            cache-from: type=gha
-            cache-to: type=gha
+            dockerfile: docker/web/Dockerfile
+            build_extra_args: --platform linux/amd64,linux/arm64
 
   update_dependency_graph:
       needs: build_and_publish_web

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -46,7 +46,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Publish Docker Image on Tag
-        uses: whoan/docker-build-with-cache-action@v5
+        uses: whoan/docker-build-with-cache-action@34edef5583fa265f0a1b6ad4b0aa800580168f7c # v5
         with:
           username: "${{ secrets.DOCKER_USERNAME }}"
           password: "${{ secrets.DOCKER_PASSWORD }}"
@@ -95,7 +95,7 @@ jobs:
           uses: docker/setup-buildx-action@v3
 
         - name: Publish Docker Image on Tag
-          uses: whoan/docker-build-with-cache-action@v5
+          uses: whoan/docker-build-with-cache-action@34edef5583fa265f0a1b6ad4b0aa800580168f7c # v5
           with:
             username: "${{ secrets.DOCKER_USERNAME }}"
             password: "${{ secrets.DOCKER_PASSWORD }}"


### PR DESCRIPTION
Fix #10450

Describe changes proposed in this pull request:
- Replaced `docker/build-push-action` with `whoan/docker-build-with-cache-action@v5` in `.github/workflows/dockerimage.yml` for both Docker image jobs.
- Added a tag-conversion step so existing `docker/metadata-action` outputs are passed correctly to `whoan` (`image_tag` as comma-separated tags), while preserving current trigger/tag/publish behavior.
- Kept multi-arch image builds enabled for both `linux/amd64` and `linux/arm64` via `build_extra_args`.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created.  
  This PR updates only GitHub Actions workflow config. No backend/frontend runtime code was changed. Validation is through CI workflow runs (first run warms cache, subsequent runs should show cache reuse).
- [x] Is this PR adding logic based on one or more **clinical** attributes?  
  No.
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
Not applicable (workflow/config-only change).

# Notify reviewers
Tagging @inodb since this issue was requested and scoped in #10450.