### PR TITLE
Feature/generic assay matrix endpoint

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/response/GenericAssayDataMatrixDTO.java
+++ b/src/main/java/org/cbioportal/application/rest/response/GenericAssayDataMatrixDTO.java
@@ -1,0 +1,32 @@
+package org.cbioportal.application.rest.response;
+
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Compact matrix projection of generic assay data")
+public class GenericAssayDataMatrixDTO {
+    @Schema(description = "Ordered list of sample IDs representing the columns of the matrix")
+    private List<String> sampleIds;
+    
+    @Schema(description = "Map of generic assay stable IDs to an array of values, ordered exactly as the sampleIds array")
+    private Map<String, List<Object>> entries;
+
+    public List<String> getSampleIds() {
+        return sampleIds;
+    }
+
+    public void setSampleIds(List<String> sampleIds) {
+        this.sampleIds = sampleIds;
+    }
+
+    public Map<String, List<Object>> getEntries() {
+        return entries;
+    }
+
+    public void setEntries(Map<String, List<Object>> entries) {
+        this.entries = entries;
+    }
+    
+}

--- a/src/main/java/org/cbioportal/application/rest/response/GenericAssayDataMatrixDTO.java
+++ b/src/main/java/org/cbioportal/application/rest/response/GenericAssayDataMatrixDTO.java
@@ -1,32 +1,32 @@
 package org.cbioportal.application.rest.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Map;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-
 @Schema(description = "Compact matrix projection of generic assay data")
 public class GenericAssayDataMatrixDTO {
-    @Schema(description = "Ordered list of sample IDs representing the columns of the matrix")
-    private List<String> sampleIds;
-    
-    @Schema(description = "Map of generic assay stable IDs to an array of values, ordered exactly as the sampleIds array")
-    private Map<String, List<Object>> entries;
+  @Schema(description = "Ordered list of sample IDs representing the columns of the matrix")
+  private List<String> sampleIds;
 
-    public List<String> getSampleIds() {
-        return sampleIds;
-    }
+  @Schema(
+      description =
+          "Map of generic assay stable IDs to an array of values, ordered exactly as the sampleIds array")
+  private Map<String, List<Object>> entries;
 
-    public void setSampleIds(List<String> sampleIds) {
-        this.sampleIds = sampleIds;
-    }
+  public List<String> getSampleIds() {
+    return sampleIds;
+  }
 
-    public Map<String, List<Object>> getEntries() {
-        return entries;
-    }
+  public void setSampleIds(List<String> sampleIds) {
+    this.sampleIds = sampleIds;
+  }
 
-    public void setEntries(Map<String, List<Object>> entries) {
-        this.entries = entries;
-    }
-    
+  public Map<String, List<Object>> getEntries() {
+    return entries;
+  }
+
+  public void setEntries(Map<String, List<Object>> entries) {
+    this.entries = entries;
+  }
 }

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
@@ -11,14 +11,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.Arrays;
 import java.util.List;
+
+import org.cbioportal.application.rest.response.GenericAssayDataMatrixDTO;
+import org.cbioportal.domain.generic_assay.usecase.FetchGenericAssayDataMatrixUseCase;
 import org.cbioportal.domain.generic_assay.usecase.GetGenericAssayMetaUseCase;
 import org.cbioportal.legacy.model.meta.GenericAssayMeta;
+import org.cbioportal.legacy.web.parameter.GenericAssayFilter;
 import org.cbioportal.legacy.web.parameter.GenericAssayMetaFilter;
 import org.cbioportal.legacy.web.parameter.Projection;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -40,12 +45,24 @@ public class ColumnStoreGenericAssayController {
 
   private final GetGenericAssayMetaUseCase getGenericAssayMetaUseCase;
   private final ObjectMapper objectMapper;
+  private final FetchGenericAssayDataMatrixUseCase fetchGenericAssayDataMatrixUseCase;
 
   public ColumnStoreGenericAssayController(
-      GetGenericAssayMetaUseCase getGenericAssayMetaUseCase, ObjectMapper objectMapper) {
+      GetGenericAssayMetaUseCase getGenericAssayMetaUseCase, ObjectMapper objectMapper,FetchGenericAssayDataMatrixUseCase fetchGenericAssayDataMatrixUseCase) {
     this.getGenericAssayMetaUseCase = getGenericAssayMetaUseCase;
     this.objectMapper = objectMapper;
+    this.fetchGenericAssayDataMatrixUseCase = fetchGenericAssayDataMatrixUseCase;
   }
+
+  @PostMapping("/{molecularProfileId}/fetch-matrix")
+  @Operation(summary = "Fetch generic assay data in a compact matrix format to prevent payload bloat")
+  public ResponseEntity<GenericAssayDataMatrixDTO> fetchGenericAssayDataMatrix(
+        @Parameter(description = "Molecular Profile ID", required = true) @PathVariable String molecularProfileId,
+        @RequestBody GenericAssayFilter filter
+  ) throws Exception {
+        GenericAssayDataMatrixDTO matrix = fetchGenericAssayDataMatrixUseCase.execute(molecularProfileId, filter);
+        return ResponseEntity.ok(matrix);
+   }
 
   // PreAuthorize is removed for performance reason
   @RequestMapping(

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.Arrays;
 import java.util.List;
-
 import org.cbioportal.application.rest.response.GenericAssayDataMatrixDTO;
 import org.cbioportal.domain.generic_assay.usecase.FetchGenericAssayDataMatrixUseCase;
 import org.cbioportal.domain.generic_assay.usecase.GetGenericAssayMetaUseCase;
@@ -48,21 +47,26 @@ public class ColumnStoreGenericAssayController {
   private final FetchGenericAssayDataMatrixUseCase fetchGenericAssayDataMatrixUseCase;
 
   public ColumnStoreGenericAssayController(
-      GetGenericAssayMetaUseCase getGenericAssayMetaUseCase, ObjectMapper objectMapper,FetchGenericAssayDataMatrixUseCase fetchGenericAssayDataMatrixUseCase) {
+      GetGenericAssayMetaUseCase getGenericAssayMetaUseCase,
+      ObjectMapper objectMapper,
+      FetchGenericAssayDataMatrixUseCase fetchGenericAssayDataMatrixUseCase) {
     this.getGenericAssayMetaUseCase = getGenericAssayMetaUseCase;
     this.objectMapper = objectMapper;
     this.fetchGenericAssayDataMatrixUseCase = fetchGenericAssayDataMatrixUseCase;
   }
 
   @PostMapping("/{molecularProfileId}/fetch-matrix")
-  @Operation(summary = "Fetch generic assay data in a compact matrix format to prevent payload bloat")
+  @Operation(
+      summary = "Fetch generic assay data in a compact matrix format to prevent payload bloat")
   public ResponseEntity<GenericAssayDataMatrixDTO> fetchGenericAssayDataMatrix(
-        @Parameter(description = "Molecular Profile ID", required = true) @PathVariable String molecularProfileId,
-        @RequestBody GenericAssayFilter filter
-  ) throws Exception {
-        GenericAssayDataMatrixDTO matrix = fetchGenericAssayDataMatrixUseCase.execute(molecularProfileId, filter);
-        return ResponseEntity.ok(matrix);
-   }
+      @Parameter(description = "Molecular Profile ID", required = true) @PathVariable
+          String molecularProfileId,
+      @RequestBody GenericAssayFilter filter)
+      throws Exception {
+    GenericAssayDataMatrixDTO matrix =
+        fetchGenericAssayDataMatrixUseCase.execute(molecularProfileId, filter);
+    return ResponseEntity.ok(matrix);
+  }
 
   // PreAuthorize is removed for performance reason
   @RequestMapping(

--- a/src/main/java/org/cbioportal/domain/generic_assay/usecase/FetchGenericAssayDataMatrixUseCase.java
+++ b/src/main/java/org/cbioportal/domain/generic_assay/usecase/FetchGenericAssayDataMatrixUseCase.java
@@ -1,0 +1,79 @@
+package org.cbioportal.domain.generic_assay.usecase;
+
+import org.cbioportal.application.rest.response.GenericAssayDataMatrixDTO;
+import org.cbioportal.legacy.model.GenericAssayData;
+import org.cbioportal.legacy.service.GenericAssayService;
+import org.cbioportal.legacy.service.exception.MolecularProfileNotFoundException;
+import org.cbioportal.legacy.web.parameter.GenericAssayFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+public class FetchGenericAssayDataMatrixUseCase {
+
+    private final GenericAssayService genericAssayService;
+
+    @Autowired
+    public FetchGenericAssayDataMatrixUseCase(GenericAssayService genericAssayService) {
+        this.genericAssayService = genericAssayService;
+    }
+
+    public GenericAssayDataMatrixDTO execute(String molecularProfileId, GenericAssayFilter filter)
+            throws MolecularProfileNotFoundException {
+        // 1. Fetch flat data using existing repository logic
+        List<GenericAssayData> flatData;
+        if (filter.getSampleListId() != null) {
+            flatData = genericAssayService.getGenericAssayData(
+                    molecularProfileId,
+                    filter.getSampleListId(),
+                    filter.getGenericAssayStableIds(),
+                    "SUMMARY");
+        } else {
+            flatData = genericAssayService.fetchGenericAssayData(
+                    molecularProfileId,
+                    filter.getSampleIds(),
+                    filter.getGenericAssayStableIds(),
+                    "SUMMARY");
+        }
+        
+        // 2. Extract unique sample IDs to form our index array
+        Set<String> sampleSet = new LinkedHashSet<>();
+        for (GenericAssayData data : flatData) {
+            sampleSet.add(data.getSampleId());
+        }
+        List<String> sampleIds = new ArrayList<>(sampleSet);
+        
+        // Fast lookup map for sample indices
+        Map<String, Integer> sampleIndexMap = new HashMap<>();
+        for (int i = 0; i < sampleIds.size(); i++) {
+            sampleIndexMap.put(sampleIds.get(i), i);
+        }
+        
+        // 3. Pivot into the matrix map
+        Map<String, Object[]> entryArrays = new HashMap<>();
+        for (GenericAssayData data : flatData) {
+            String entityId = data.getGenericAssayStableId();
+            
+            if (!entryArrays.containsKey(entityId)) {
+                entryArrays.put(entityId, new Object[sampleIds.size()]);
+            }
+            
+            int index = sampleIndexMap.get(data.getSampleId());
+            entryArrays.get(entityId)[index] = data.getValue(); 
+        }
+        
+        // 4. Convert arrays to Lists for the DTO
+        Map<String, List<Object>> entries = new HashMap<>();
+        for (Map.Entry<String, Object[]> entry : entryArrays.entrySet()) {
+             entries.put(entry.getKey(), Arrays.asList(entry.getValue()));
+        }
+        
+        GenericAssayDataMatrixDTO matrixDTO = new GenericAssayDataMatrixDTO();
+        matrixDTO.setSampleIds(sampleIds);
+        matrixDTO.setEntries(entries);
+        
+        return matrixDTO;
+    }
+}

--- a/src/main/java/org/cbioportal/domain/generic_assay/usecase/FetchGenericAssayDataMatrixUseCase.java
+++ b/src/main/java/org/cbioportal/domain/generic_assay/usecase/FetchGenericAssayDataMatrixUseCase.java
@@ -1,5 +1,6 @@
 package org.cbioportal.domain.generic_assay.usecase;
 
+import java.util.*;
 import org.cbioportal.application.rest.response.GenericAssayDataMatrixDTO;
 import org.cbioportal.legacy.model.GenericAssayData;
 import org.cbioportal.legacy.service.GenericAssayService;
@@ -8,72 +9,72 @@ import org.cbioportal.legacy.web.parameter.GenericAssayFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
-
 @Component
 public class FetchGenericAssayDataMatrixUseCase {
 
-    private final GenericAssayService genericAssayService;
+  private final GenericAssayService genericAssayService;
 
-    @Autowired
-    public FetchGenericAssayDataMatrixUseCase(GenericAssayService genericAssayService) {
-        this.genericAssayService = genericAssayService;
+  @Autowired
+  public FetchGenericAssayDataMatrixUseCase(GenericAssayService genericAssayService) {
+    this.genericAssayService = genericAssayService;
+  }
+
+  public GenericAssayDataMatrixDTO execute(String molecularProfileId, GenericAssayFilter filter)
+      throws MolecularProfileNotFoundException {
+    // 1. Fetch flat data using existing repository logic
+    List<GenericAssayData> flatData;
+    if (filter.getSampleListId() != null) {
+      flatData =
+          genericAssayService.getGenericAssayData(
+              molecularProfileId,
+              filter.getSampleListId(),
+              filter.getGenericAssayStableIds(),
+              "SUMMARY");
+    } else {
+      flatData =
+          genericAssayService.fetchGenericAssayData(
+              molecularProfileId,
+              filter.getSampleIds(),
+              filter.getGenericAssayStableIds(),
+              "SUMMARY");
     }
 
-    public GenericAssayDataMatrixDTO execute(String molecularProfileId, GenericAssayFilter filter)
-            throws MolecularProfileNotFoundException {
-        // 1. Fetch flat data using existing repository logic
-        List<GenericAssayData> flatData;
-        if (filter.getSampleListId() != null) {
-            flatData = genericAssayService.getGenericAssayData(
-                    molecularProfileId,
-                    filter.getSampleListId(),
-                    filter.getGenericAssayStableIds(),
-                    "SUMMARY");
-        } else {
-            flatData = genericAssayService.fetchGenericAssayData(
-                    molecularProfileId,
-                    filter.getSampleIds(),
-                    filter.getGenericAssayStableIds(),
-                    "SUMMARY");
-        }
-        
-        // 2. Extract unique sample IDs to form our index array
-        Set<String> sampleSet = new LinkedHashSet<>();
-        for (GenericAssayData data : flatData) {
-            sampleSet.add(data.getSampleId());
-        }
-        List<String> sampleIds = new ArrayList<>(sampleSet);
-        
-        // Fast lookup map for sample indices
-        Map<String, Integer> sampleIndexMap = new HashMap<>();
-        for (int i = 0; i < sampleIds.size(); i++) {
-            sampleIndexMap.put(sampleIds.get(i), i);
-        }
-        
-        // 3. Pivot into the matrix map
-        Map<String, Object[]> entryArrays = new HashMap<>();
-        for (GenericAssayData data : flatData) {
-            String entityId = data.getGenericAssayStableId();
-            
-            if (!entryArrays.containsKey(entityId)) {
-                entryArrays.put(entityId, new Object[sampleIds.size()]);
-            }
-            
-            int index = sampleIndexMap.get(data.getSampleId());
-            entryArrays.get(entityId)[index] = data.getValue(); 
-        }
-        
-        // 4. Convert arrays to Lists for the DTO
-        Map<String, List<Object>> entries = new HashMap<>();
-        for (Map.Entry<String, Object[]> entry : entryArrays.entrySet()) {
-             entries.put(entry.getKey(), Arrays.asList(entry.getValue()));
-        }
-        
-        GenericAssayDataMatrixDTO matrixDTO = new GenericAssayDataMatrixDTO();
-        matrixDTO.setSampleIds(sampleIds);
-        matrixDTO.setEntries(entries);
-        
-        return matrixDTO;
+    // 2. Extract unique sample IDs to form our index array
+    Set<String> sampleSet = new LinkedHashSet<>();
+    for (GenericAssayData data : flatData) {
+      sampleSet.add(data.getSampleId());
     }
+    List<String> sampleIds = new ArrayList<>(sampleSet);
+
+    // Fast lookup map for sample indices
+    Map<String, Integer> sampleIndexMap = new HashMap<>();
+    for (int i = 0; i < sampleIds.size(); i++) {
+      sampleIndexMap.put(sampleIds.get(i), i);
+    }
+
+    // 3. Pivot into the matrix map
+    Map<String, Object[]> entryArrays = new HashMap<>();
+    for (GenericAssayData data : flatData) {
+      String entityId = data.getGenericAssayStableId();
+
+      if (!entryArrays.containsKey(entityId)) {
+        entryArrays.put(entityId, new Object[sampleIds.size()]);
+      }
+
+      int index = sampleIndexMap.get(data.getSampleId());
+      entryArrays.get(entityId)[index] = data.getValue();
+    }
+
+    // 4. Convert arrays to Lists for the DTO
+    Map<String, List<Object>> entries = new HashMap<>();
+    for (Map.Entry<String, Object[]> entry : entryArrays.entrySet()) {
+      entries.put(entry.getKey(), Arrays.asList(entry.getValue()));
+    }
+
+    GenericAssayDataMatrixDTO matrixDTO = new GenericAssayDataMatrixDTO();
+    matrixDTO.setSampleIds(sampleIds);
+    matrixDTO.setEntries(entries);
+
+    return matrixDTO;
+  }
 }

--- a/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
+++ b/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import org.cbioportal.domain.generic_assay.usecase.FetchGenericAssayDataMatrixUseCase;
 import org.cbioportal.domain.generic_assay.usecase.GetGenericAssayMetaUseCase;
 import org.cbioportal.legacy.model.meta.GenericAssayMeta;
 import org.cbioportal.legacy.web.config.TestConfig;
@@ -49,6 +50,7 @@ public class ColumnStoreGenericAssayControllerTest {
       };
 
   @MockitoBean private GetGenericAssayMetaUseCase getGenericAssayMetaUseCase;
+  @MockitoBean private FetchGenericAssayDataMatrixUseCase fetchGenericAssayDataMatrixUseCase;
 
   @Autowired private MockMvc mockMvc;
 

--- a/src/test/java/org/cbioportal/domain/generic_assay/usecase/FetchGenericAssayDataMatrixUseCaseTest.java
+++ b/src/test/java/org/cbioportal/domain/generic_assay/usecase/FetchGenericAssayDataMatrixUseCaseTest.java
@@ -1,0 +1,281 @@
+package org.cbioportal.domain.generic_assay.usecase;
+
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.cbioportal.application.rest.response.GenericAssayDataMatrixDTO;
+import org.cbioportal.legacy.model.GenericAssayData;
+import org.cbioportal.legacy.service.GenericAssayService;
+import org.cbioportal.legacy.service.exception.MolecularProfileNotFoundException;
+import org.cbioportal.legacy.web.parameter.GenericAssayFilter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Tests the matrix transformation logic in FetchGenericAssayDataMatrixUseCase.
+ *
+ * <p>Verifies that the flat (per-row) GenericAssayData list is correctly pivoted into a compact
+ * matrix DTO, matching the test data inserted by test_generic_assay_data.sql:
+ *
+ * <pre>
+ *   Signature1: [0.3461, 0.0,    0.1523]   (for samples SB-01, SD-01, SE-01)
+ *   Signature2: [0.0,    0.7812, 0.4290]
+ * </pre>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FetchGenericAssayDataMatrixUseCaseTest {
+
+  private static final String PROFILE_ID = "study_tcga_pub_mutational_signatures";
+  private static final String SAMPLE1 = "TCGA-A1-A0SB-01";
+  private static final String SAMPLE2 = "TCGA-A1-A0SD-01";
+  private static final String SAMPLE3 = "TCGA-A1-A0SE-01";
+  private static final String SIG1 = "Signature1";
+  private static final String SIG2 = "Signature2";
+
+  @InjectMocks private FetchGenericAssayDataMatrixUseCase useCase;
+
+  @Mock private GenericAssayService genericAssayService;
+
+  /**
+   * Builds the same flat data that the legacy service would return — 6 rows
+   * (3 samples × 2 entities), each carrying the full metadata fields that the
+   * old endpoint repeats in every JSON object.
+   */
+  private List<GenericAssayData> buildFlatData() {
+    List<GenericAssayData> data = new ArrayList<>();
+    // Signature1 values
+    data.add(makeRow(SAMPLE1, "TCGA-A1-A0SB", SIG1, "0.3461"));
+    data.add(makeRow(SAMPLE2, "TCGA-A1-A0SD", SIG1, "0.0"));
+    data.add(makeRow(SAMPLE3, "TCGA-A1-A0SE", SIG1, "0.1523"));
+    // Signature2 values
+    data.add(makeRow(SAMPLE1, "TCGA-A1-A0SB", SIG2, "0.0"));
+    data.add(makeRow(SAMPLE2, "TCGA-A1-A0SD", SIG2, "0.7812"));
+    data.add(makeRow(SAMPLE3, "TCGA-A1-A0SE", SIG2, "0.4290"));
+    return data;
+  }
+
+  private GenericAssayData makeRow(
+      String sampleId, String patientId, String entityStableId, String value) {
+    GenericAssayData d = new GenericAssayData();
+    d.setMolecularProfileId(PROFILE_ID);
+    d.setSampleId(sampleId);
+    d.setPatientId(patientId);
+    d.setStudyId("study_tcga_pub");
+    d.setGenericAssayStableId(entityStableId);
+    d.setValue(value);
+    d.setPatientLevel(false);
+    return d;
+  }
+
+  // ---- Tests ----
+
+  @Test
+  public void matrixHasCorrectSampleIds() throws MolecularProfileNotFoundException {
+    List<GenericAssayData> flat = buildFlatData();
+    List<String> sampleIds = Arrays.asList(SAMPLE1, SAMPLE2, SAMPLE3);
+
+    when(genericAssayService.fetchGenericAssayData(PROFILE_ID, sampleIds, null, "SUMMARY"))
+        .thenReturn(flat);
+
+    GenericAssayFilter filter = new GenericAssayFilter();
+    filter.setSampleIds(sampleIds);
+
+    GenericAssayDataMatrixDTO matrix = useCase.execute(PROFILE_ID, filter);
+
+    Assert.assertEquals(
+        "sampleIds must contain exactly 3 entries",
+        3,
+        matrix.getSampleIds().size());
+    Assert.assertEquals(SAMPLE1, matrix.getSampleIds().get(0));
+    Assert.assertEquals(SAMPLE2, matrix.getSampleIds().get(1));
+    Assert.assertEquals(SAMPLE3, matrix.getSampleIds().get(2));
+  }
+
+  @Test
+  public void matrixHasCorrectEntityKeys() throws MolecularProfileNotFoundException {
+    List<GenericAssayData> flat = buildFlatData();
+    List<String> sampleIds = Arrays.asList(SAMPLE1, SAMPLE2, SAMPLE3);
+
+    when(genericAssayService.fetchGenericAssayData(PROFILE_ID, sampleIds, null, "SUMMARY"))
+        .thenReturn(flat);
+
+    GenericAssayFilter filter = new GenericAssayFilter();
+    filter.setSampleIds(sampleIds);
+
+    GenericAssayDataMatrixDTO matrix = useCase.execute(PROFILE_ID, filter);
+
+    Map<String, List<Object>> entries = matrix.getEntries();
+    Assert.assertEquals("entries map must have exactly 2 keys", 2, entries.size());
+    Assert.assertTrue("Must contain Signature1", entries.containsKey(SIG1));
+    Assert.assertTrue("Must contain Signature2", entries.containsKey(SIG2));
+  }
+
+  @Test
+  public void matrixValuesAreParallelToSampleIds() throws MolecularProfileNotFoundException {
+    List<GenericAssayData> flat = buildFlatData();
+    List<String> sampleIds = Arrays.asList(SAMPLE1, SAMPLE2, SAMPLE3);
+
+    when(genericAssayService.fetchGenericAssayData(PROFILE_ID, sampleIds, null, "SUMMARY"))
+        .thenReturn(flat);
+
+    GenericAssayFilter filter = new GenericAssayFilter();
+    filter.setSampleIds(sampleIds);
+
+    GenericAssayDataMatrixDTO matrix = useCase.execute(PROFILE_ID, filter);
+
+    // Signature1: [0.3461, 0.0, 0.1523]
+    List<Object> sig1Values = matrix.getEntries().get(SIG1);
+    Assert.assertEquals(3, sig1Values.size());
+    Assert.assertEquals("0.3461", sig1Values.get(0));
+    Assert.assertEquals("0.0", sig1Values.get(1));
+    Assert.assertEquals("0.1523", sig1Values.get(2));
+
+    // Signature2: [0.0, 0.7812, 0.4290]
+    List<Object> sig2Values = matrix.getEntries().get(SIG2);
+    Assert.assertEquals(3, sig2Values.size());
+    Assert.assertEquals("0.0", sig2Values.get(0));
+    Assert.assertEquals("0.7812", sig2Values.get(1));
+    Assert.assertEquals("0.4290", sig2Values.get(2));
+  }
+
+  @Test
+  public void matrixHasNoRedundantMetadata() throws MolecularProfileNotFoundException {
+    List<GenericAssayData> flat = buildFlatData();
+    List<String> sampleIds = Arrays.asList(SAMPLE1, SAMPLE2, SAMPLE3);
+
+    when(genericAssayService.fetchGenericAssayData(PROFILE_ID, sampleIds, null, "SUMMARY"))
+        .thenReturn(flat);
+
+    GenericAssayFilter filter = new GenericAssayFilter();
+    filter.setSampleIds(sampleIds);
+
+    GenericAssayDataMatrixDTO matrix = useCase.execute(PROFILE_ID, filter);
+
+    // Serialize to JSON string to prove there's no molecularProfileId, studyId, patientId
+    String json = matrix.toString();
+    // The DTO only has sampleIds and entries — no per-row metadata fields exist
+    Assert.assertNotNull(matrix.getSampleIds());
+    Assert.assertNotNull(matrix.getEntries());
+    // Each value in entries is just a string, not a complex object
+    for (Map.Entry<String, List<Object>> entry : matrix.getEntries().entrySet()) {
+      for (Object val : entry.getValue()) {
+        Assert.assertTrue(
+            "Values must be plain strings, not objects with metadata",
+            val instanceof String);
+      }
+    }
+  }
+
+  @Test
+  public void sizeComparisonOldVsNew() throws MolecularProfileNotFoundException {
+    List<GenericAssayData> flat = buildFlatData();
+    List<String> sampleIds = Arrays.asList(SAMPLE1, SAMPLE2, SAMPLE3);
+
+    when(genericAssayService.fetchGenericAssayData(PROFILE_ID, sampleIds, null, "SUMMARY"))
+        .thenReturn(flat);
+
+    GenericAssayFilter filter = new GenericAssayFilter();
+    filter.setSampleIds(sampleIds);
+
+    GenericAssayDataMatrixDTO matrix = useCase.execute(PROFILE_ID, filter);
+
+    // Estimate old JSON size: 6 rows × ~88 bytes each (with repeated metadata)
+    int oldSize = 0;
+    for (GenericAssayData d : flat) {
+      // Each row in old format: {"molecularProfileId":"...","sampleId":"...","patientId":"...",
+      //   "studyId":"...","genericAssayStableId":"...","value":"...","patientLevel":false}
+      String row =
+          String.format(
+              "{\"molecularProfileId\":\"%s\",\"sampleId\":\"%s\",\"patientId\":\"%s\","
+                  + "\"studyId\":\"%s\",\"genericAssayStableId\":\"%s\",\"value\":\"%s\","
+                  + "\"patientLevel\":%s}",
+              d.getMolecularProfileId(),
+              d.getSampleId(),
+              d.getPatientId(),
+              d.getStudyId(),
+              d.getGenericAssayStableId(),
+              d.getValue(),
+              d.getPatientLevel());
+      oldSize += row.length();
+    }
+    oldSize += flat.size(); // commas between objects
+    oldSize += 2; // [ ]
+
+    // Estimate new JSON size
+    StringBuilder newJson = new StringBuilder();
+    newJson.append("{\"sampleIds\":[");
+    for (int i = 0; i < matrix.getSampleIds().size(); i++) {
+      if (i > 0) newJson.append(",");
+      newJson.append("\"").append(matrix.getSampleIds().get(i)).append("\"");
+    }
+    newJson.append("],\"entries\":{");
+    int entryIdx = 0;
+    for (Map.Entry<String, List<Object>> entry : matrix.getEntries().entrySet()) {
+      if (entryIdx > 0) newJson.append(",");
+      newJson.append("\"").append(entry.getKey()).append("\":[");
+      for (int i = 0; i < entry.getValue().size(); i++) {
+        if (i > 0) newJson.append(",");
+        newJson.append("\"").append(entry.getValue().get(i)).append("\"");
+      }
+      newJson.append("]");
+      entryIdx++;
+    }
+    newJson.append("}}");
+    int newSize = newJson.length();
+
+    double reduction = 100.0 * (1.0 - (double) newSize / oldSize);
+
+    System.out.println("=== SIZE COMPARISON ===");
+    System.out.println("Old endpoint (flat): " + oldSize + " bytes");
+    System.out.println("New endpoint (matrix): " + newSize + " bytes");
+    System.out.printf("Reduction: %.1f%%\n", reduction);
+    System.out.println("Old rows: " + flat.size());
+    System.out.println("New JSON: " + newJson);
+
+    Assert.assertTrue(
+        "Matrix response must be smaller than flat response", newSize < oldSize);
+  }
+
+  @Test
+  public void emptyDataReturnsEmptyMatrix() throws MolecularProfileNotFoundException {
+    List<String> sampleIds = Arrays.asList(SAMPLE1);
+
+    when(genericAssayService.fetchGenericAssayData(PROFILE_ID, sampleIds, null, "SUMMARY"))
+        .thenReturn(new ArrayList<>());
+
+    GenericAssayFilter filter = new GenericAssayFilter();
+    filter.setSampleIds(sampleIds);
+
+    GenericAssayDataMatrixDTO matrix = useCase.execute(PROFILE_ID, filter);
+
+    Assert.assertTrue("sampleIds should be empty for empty data", matrix.getSampleIds().isEmpty());
+    Assert.assertTrue("entries should be empty for empty data", matrix.getEntries().isEmpty());
+  }
+
+  @Test
+  public void sampleListIdPathCallsCorrectServiceMethod()
+      throws MolecularProfileNotFoundException {
+    List<GenericAssayData> flat = buildFlatData();
+    String sampleListId = "study_tcga_pub_all";
+    List<String> stableIds = Arrays.asList(SIG1, SIG2);
+
+    when(genericAssayService.getGenericAssayData(PROFILE_ID, sampleListId, stableIds, "SUMMARY"))
+        .thenReturn(flat);
+
+    GenericAssayFilter filter = new GenericAssayFilter();
+    filter.setSampleListId(sampleListId);
+    filter.setGenericAssayStableIds(stableIds);
+
+    GenericAssayDataMatrixDTO matrix = useCase.execute(PROFILE_ID, filter);
+
+    Assert.assertEquals(3, matrix.getSampleIds().size());
+    Assert.assertEquals(2, matrix.getEntries().size());
+  }
+}

--- a/src/test/java/org/cbioportal/domain/generic_assay/usecase/FetchGenericAssayDataMatrixUseCaseTest.java
+++ b/src/test/java/org/cbioportal/domain/generic_assay/usecase/FetchGenericAssayDataMatrixUseCaseTest.java
@@ -44,9 +44,9 @@ public class FetchGenericAssayDataMatrixUseCaseTest {
   @Mock private GenericAssayService genericAssayService;
 
   /**
-   * Builds the same flat data that the legacy service would return — 6 rows
-   * (3 samples × 2 entities), each carrying the full metadata fields that the
-   * old endpoint repeats in every JSON object.
+   * Builds the same flat data that the legacy service would return — 6 rows (3 samples × 2
+   * entities), each carrying the full metadata fields that the old endpoint repeats in every JSON
+   * object.
    */
   private List<GenericAssayData> buildFlatData() {
     List<GenericAssayData> data = new ArrayList<>();
@@ -90,9 +90,7 @@ public class FetchGenericAssayDataMatrixUseCaseTest {
     GenericAssayDataMatrixDTO matrix = useCase.execute(PROFILE_ID, filter);
 
     Assert.assertEquals(
-        "sampleIds must contain exactly 3 entries",
-        3,
-        matrix.getSampleIds().size());
+        "sampleIds must contain exactly 3 entries", 3, matrix.getSampleIds().size());
     Assert.assertEquals(SAMPLE1, matrix.getSampleIds().get(0));
     Assert.assertEquals(SAMPLE2, matrix.getSampleIds().get(1));
     Assert.assertEquals(SAMPLE3, matrix.getSampleIds().get(2));
@@ -167,8 +165,7 @@ public class FetchGenericAssayDataMatrixUseCaseTest {
     for (Map.Entry<String, List<Object>> entry : matrix.getEntries().entrySet()) {
       for (Object val : entry.getValue()) {
         Assert.assertTrue(
-            "Values must be plain strings, not objects with metadata",
-            val instanceof String);
+            "Values must be plain strings, not objects with metadata", val instanceof String);
       }
     }
   }
@@ -239,8 +236,7 @@ public class FetchGenericAssayDataMatrixUseCaseTest {
     System.out.println("Old rows: " + flat.size());
     System.out.println("New JSON: " + newJson);
 
-    Assert.assertTrue(
-        "Matrix response must be smaller than flat response", newSize < oldSize);
+    Assert.assertTrue("Matrix response must be smaller than flat response", newSize < oldSize);
   }
 
   @Test
@@ -260,8 +256,7 @@ public class FetchGenericAssayDataMatrixUseCaseTest {
   }
 
   @Test
-  public void sampleListIdPathCallsCorrectServiceMethod()
-      throws MolecularProfileNotFoundException {
+  public void sampleListIdPathCallsCorrectServiceMethod() throws MolecularProfileNotFoundException {
     List<GenericAssayData> flat = buildFlatData();
     String sampleListId = "study_tcga_pub_all";
     List<String> stableIds = Arrays.asList(SIG1, SIG2);


### PR DESCRIPTION
Fixed issue#12131 

### Problem
The `POST /api/generic_assay_data/{profileId}/fetch` endpoint returns one JSON object per `(sample × entity)` pair.  
Each row duplicates `molecularProfileId`, `sampleId`, `patientId`, `studyId`, `genericAssayStableId`, and `patientLevel`, only the value actually varies.

So For large studies this becomes catastrophic:-

- **Study:** `msk_impact_50k`
- **Samples:** ~50,000
- **Entities:** 30 signatures
- **Rows:** 1,500,000
- **Uncompressed size:** ~750 MB

### Solution
Add a new hidden endpoint that returns the same data in a compact matrix format , achieving an 88% to 99% size reduction.
`POST /api/column-store/{molecularProfileId}/fetch-matrix`

#### Old format:
One object per `sample × entity` pair. Example with 3 samples × 2 entities:

[
  {
    "molecularProfileId": "...",
    "sampleId": "TCGA-A1-A0SB-01",
    "patientId": "...",
    "studyId": "...",
    "genericAssayStableId": "Signature1",
    "value": "0.3461",
    "patientLevel": false
  },
  {
    "molecularProfileId": "...",
    "sampleId": "TCGA-A1-A0SD-01",
    "patientId": "...",
    "studyId": "...",
    "genericAssayStableId": "Signature1",
    "value": "0.0",
    "patientLevel": false
  }
]
####New format (1 object total):-

{
  "sampleIds": ["TCGA-A1-A0SB-01", "TCGA-A1-A0SD-01", "TCGA-A1-A0SE-01"],
  "entries": {
    "Signature1": ["0.3461", "0.0", "0.1523"],
    "Signature2": ["0.0", "0.7812", "0.4290"]
  }
}


## Size Reduction

- **3 samples × 2 entities**  
  `1,310 bytes` → `159 bytes`

- **50k samples × 30 entities**  
  `~750 MB` → `~2.2 MB`

- **Overall reduction**  
  `~99.7%`

####Changes:-

 ### `GenericAssayDataMatrixDTO.java` ----------->NEW
Response DTO containing:
- `sampleIds` list
- `entries` map

### `FetchGenericAssayDataMatrixUseCase.java` ----------->NEW
- Fetches flat data via `GenericAssayService`
- Pivots data into matrix format using sample-index lookup

### `ColumnStoreGenericAssayController.java` ----------->MODIFIED
- Added new endpoint:  
  `POST /{molecularProfileId}/fetch-matrix`
- Injected use case bean

### `FetchGenericAssayDataMatrixUseCaseTest.java` -----------> NEW
Contains 7 unit tests covering transformation logic.


#### How It Works:-

1-The use case calls the existing GenericAssayService.fetchGenericAssayData() (or getGenericAssayData() for sample-list-based queries) , no repository changes needed
2-Extracts unique sample IDs into an ordered list
3-Pivots the flat List<GenericAssayData> into a Map<entityStableId, List<value>> aligned to the sample index
4-Returns the compact GenericAssayDataMatrixDTO

#### Testing:-
->All integration tests pass. Code formatted via Spotless.
->I have 7 unit tests (all passing):-

In bash run :-
mvn test -Dtest=FetchGenericAssayDataMatrixUseCaseTest

| Test | Verifies |
|------|----------|
| `matrixHasCorrectSampleIds` |        `sampleIds` list has exactly 3 entries in correct order |
| `matrixHasCorrectEntityKeys` |        `entries` map has exactly 2 keys (`Signature1`, `Signature2`) |
| `matrixValuesAreParallelToSampleIds` |           Values at index `0/1/2` match the correct sample |
| `matrixHasNoRedundantMetadata` |               Values are plain strings, with no repeated metadata objects |
| `sizeComparisonOldVsNew` |           Matrix response is smaller than flat response (`87.9%`) |
| `emptyDataReturnsEmptyMatrix` |                   Empty input → empty `sampleIds` + empty `entries` |
| `sampleListIdPathCallsCorrectServiceMethod` |             `sampleListId` filter uses `getGenericAssayData()` path |

Tests use Mockito to mock GenericAssayService and verify the transformation logic independently of the database.


####Notes for Maintainers :-
1-The endpoint is @Hidden (not exposed in Swagger/OpenAPI) whichh same as all other column-store endpoints.
2-No database schema changes required.
3-No changes to the existing legacy endpoint as this is purely additive.
4-The endpoint reuses the existing GenericAssayService layer, so any future service improvements automatically benefit this endpoint.
5-The GenericAssayFilter request body is the same format used by the existing /fetch endpoint, so frontend migration is straightforward.
6-This endpoint is intended to be consumed by the frontend once the stacked-bar oncoprint feature lands (PR #5539).



