### PR TITLE
Align dat.uuid.max_number_per_user default with documented value

### DIFF
--- a/src/main/java/org/cbioportal/legacy/service/impl/UuidDataAccessTokenServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/UuidDataAccessTokenServiceImpl.java
@@ -59,7 +59,7 @@ public class UuidDataAccessTokenServiceImpl implements DataAccessTokenService {
   @Value("${dat.ttl_seconds:-1}")
   private int datTtlSeconds;
 
-  @Value("${dat.uuid.max_number_per_user:-1}")
+  @Value("${dat.uuid.max_number_per_user:1}")
   private int maxNumberOfAccessTokens;
 
   private static final Logger log = LoggerFactory.getLogger(UuidDataAccessTokenServiceImpl.class);

--- a/src/test/java/org/cbioportal/legacy/service/impl/UuidDataAccessTokenServiceImplDefaultsTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/impl/UuidDataAccessTokenServiceImplDefaultsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.cbioportal.legacy.service.impl;
+
+import java.lang.reflect.Field;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Verifies the default values applied to {@link UuidDataAccessTokenServiceImpl} when neither {@code
+ * dat.uuid.max_number_per_user} nor {@code dat.ttl_seconds} are explicitly configured. The
+ * documented default for {@code dat.uuid.max_number_per_user} is {@code 1}; a default of {@code -1}
+ * leaves the service in a state where token creation would attempt to revoke an oldest token even
+ * when none exists.
+ */
+@TestPropertySource(
+    properties = {"dat.jwt.secret_key = +NbopXzb/AIQNrVEGzxzP5CF42e5drvrXTQot3gfW/s="},
+    inheritLocations = false)
+@ContextConfiguration(classes = UuidDataAccessTokenServiceImplTestConfiguration.class)
+@RunWith(SpringRunner.class)
+public class UuidDataAccessTokenServiceImplDefaultsTest {
+
+  @Autowired
+  @Qualifier("uuidDataAccessTokenServiceImpl")
+  private UuidDataAccessTokenServiceImpl uuidDataAccessTokenServiceImpl;
+
+  @Test
+  public void defaultMaxNumberPerUserMatchesDocumentedValue() throws Exception {
+    int actual = readPrivateInt(uuidDataAccessTokenServiceImpl, "maxNumberOfAccessTokens");
+    Assert.assertEquals(
+        "Default dat.uuid.max_number_per_user should match the documented value of 1.", 1, actual);
+  }
+
+  private static int readPrivateInt(Object target, String fieldName) throws Exception {
+    Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.getInt(target);
+  }
+}


### PR DESCRIPTION
Fix #11907

Describe changes proposed in this pull request:
- Change the Spring `@Value` default for `dat.uuid.max_number_per_user` in `UuidDataAccessTokenServiceImpl` from `-1` to `1`, matching the value documented in `Authenticating-Users-via-Tokens.md` and `security.properties-Reference.md`.
- Add a regression test (`UuidDataAccessTokenServiceImplDefaultsTest`) that verifies the resolved value is `1` when the property is left unset.

The previous default of `-1` produced an unusable configuration. `UuidDataAccessTokenServiceImpl.createDataAccessToken` performs `getNumberOfTokensForUsername(username) >= maxNumberOfAccessTokens` and then calls `revokeOldestDataAccessTokenForUsername` whenever the check passes. With `maxNumberOfAccessTokens = -1` the inequality is satisfied for any non-negative count, including zero, so the very first token request for a user triggers a revoke against an empty token list and raises `IndexOutOfBoundsException` from `allDataAccessTokens.get(0)`. Operators who deployed UUID tokens without explicitly setting the property were therefore broken in a way that did not match the docs (which state a default of `1` with permissible values "greater than zero"). Switching the default to `1` gives the "one outstanding token, replaced on new requests" behaviour the docs already promise.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [x] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)! (n/a)
- [x] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
Not applicable — backend default value change.

# Notify reviewers
Please use `git blame` and the normal review flow for `UuidDataAccessTokenServiceImpl.java` (most recent touches to the token service / token configuration). Related issue #11921 covers the analogous mismatch for `dat.ttl_seconds` and is already assigned, so it is intentionally left out of this PR.