### PR TITLE
Disable legacy co-expression endpoint by default

### DIFF
--- a/src/main/java/org/cbioportal/legacy/web/CoExpressionController.java
+++ b/src/main/java/org/cbioportal/legacy/web/CoExpressionController.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.cbioportal.legacy.model.CoExpression;
 import org.cbioportal.legacy.model.EntityType;
 import org.cbioportal.legacy.service.CoExpressionService;
+import org.cbioportal.legacy.utils.config.annotation.ConditionalOnProperty;
 import org.cbioportal.legacy.web.config.annotation.InternalApi;
 import org.cbioportal.legacy.web.parameter.CoExpressionFilter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController()
 @RequestMapping("/api")
 @Validated
+@ConditionalOnProperty(name = "coexpression_enabled", havingValue = "true")
 @Tag(name = "Co-Expressions", description = " ")
 public class CoExpressionController {
 

--- a/src/test/java/org/cbioportal/legacy/web/CoExpressionControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/CoExpressionControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -30,6 +31,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebMvcTest
 @ContextConfiguration(classes = {CoExpressionController.class, TestConfig.class})
+@TestPropertySource(properties = "coexpression_enabled=true")
 public class CoExpressionControllerTest {
 
   private static final String TEST_ENTREZ_GENE_ID_1 = "1";


### PR DESCRIPTION
## Summary
- Gates the legacy `CoExpressionController` (`POST /api/molecular-profiles/co-expressions/fetch`) behind a new `coexpression_enabled` property, defaulting to off, so the endpoint returns 404 unless explicitly enabled.
- Column-store equivalent (`POST /api/column-store/molecular-profiles/co-expressions/fetch`) is unchanged and remains always-on.
- Updates `CoExpressionControllerTest` with `@TestPropertySource(properties = "coexpression_enabled=true")` so the existing test still loads the bean.

To re-enable the legacy endpoint, set `coexpression_enabled=true` in `application.properties`.

## Test plan
- [ ] `mvn test -Dtest=CoExpressionControllerTest` passes
- [ ] With no property set, `POST /api/molecular-profiles/co-expressions/fetch` returns 404
- [ ] With `coexpression_enabled=true`, the endpoint behaves as before
- [ ] Column-store endpoint continues to work in both states

🤖 Generated with [Claude Code](https://claude.com/claude-code)