### PR TITLE
Stable-order fetchSamples queries (clickhouse + legacy)

### DIFF
--- a/src/main/resources/mappers/clickhouse/sample/ClickhouseSampleMapper.xml
+++ b/src/main/resources/mappers/clickhouse/sample/ClickhouseSampleMapper.xml
@@ -150,7 +150,7 @@
             <include refid="sampleColumnsDetailed" />
         <include refid="fromJoinedTable" />
         <include refid="filterBySampleListId" />
-        ORDER BY cancer_study_identifier ASC, sample_stable_id ASC
+        ORDER BY sample_derived.cancer_study_identifier ASC, sample_stable_id ASC
     </select>
 
     <select id="getMetaSamples" resultType="org.cbioportal.legacy.model.meta.BaseMeta">

--- a/src/main/resources/mappers/clickhouse/sample/ClickhouseSampleMapper.xml
+++ b/src/main/resources/mappers/clickhouse/sample/ClickhouseSampleMapper.xml
@@ -134,6 +134,7 @@
             <include refid="sampleColumnsId" />
         FROM sample_derived
         <include refid="filterBySampleListId" />
+        ORDER BY cancer_study_identifier ASC, sample_stable_id ASC
     </select>
 
     <select id="getSummarySamplesBySampleListIds" resultMap="SummarySampleResultMap">
@@ -141,6 +142,7 @@
             <include refid="sampleColumnsSummary" />
         FROM sample_derived
         <include refid="filterBySampleListId" />
+        ORDER BY cancer_study_identifier ASC, sample_stable_id ASC
     </select>
 
     <select id="getDetailedSamplesBySampleListIds" resultMap="DetailedSampleResultMap">
@@ -148,6 +150,7 @@
             <include refid="sampleColumnsDetailed" />
         <include refid="fromJoinedTable" />
         <include refid="filterBySampleListId" />
+        ORDER BY cancer_study_identifier ASC, sample_stable_id ASC
     </select>
 
     <select id="getMetaSamples" resultType="org.cbioportal.legacy.model.meta.BaseMeta">

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/SampleMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/SampleMapper.xml
@@ -101,6 +101,7 @@
             WHERE sample_list.stable_id IN
                 <foreach item="item" collection="sampleListIds" open="(" separator="," close=")">#{item}</foreach>
         )
+        ORDER BY cancer_study.cancer_study_identifier ASC, sample.stable_id ASC
     </select>
 
     <select id="getMetaSamples" resultType="org.cbioportal.legacy.model.meta.BaseMeta">


### PR DESCRIPTION
## Summary
- Adds `ORDER BY cancer_study_identifier, sample_stable_id` to the three `*SamplesBySampleListIds` queries in `ClickhouseSampleMapper.xml`.
- Mirrors the same `ORDER BY` on the legacy `SampleMapper.getSamplesBySampleListIds` for defense in depth.

## Why
ClickHouse MergeTree returns rows in arbitrary order when `ORDER BY` is omitted. `/api/samples/fetch` (projection=DETAILED) is backed by `getDetailedSamplesBySampleListIds`, which has no `ORDER BY`, so its row order varies between runs. Sibling queries (`getDetailedSamples`, etc.) already include the `sortAndLimit` snippet that provides an `ORDER BY` — this PR fixes the gap for the `*BySampleListIds` variants.

The non-determinism propagates straight through the frontend:
- `ResultsViewPageStore.samples` returns the backend list as-is (no client-side sort).
- `groupDataByCase` (`ResultsViewPageStoreUtils.ts`) seeds its grouping with `samples.map(s => s.uniqueSampleKey)`, preserving order.
- `generateCaseAlterationData` (`download/DownloadUtils.ts`) accumulates rows into an object keyed by `studyCaseId` and returns `_.values(...)` — JS insertion order.
- `CaseAlterationTable` initial sort is `Altered` desc with `sortBy = altered ? 1 : 0`; every altered row ties, and `LazyMobXTable`'s stable sort falls back to input position.

So whatever order the backend returns is exactly what the table renders. End result: a flaky screenshot test for the "Type of Genetic Alterations Across All Samples" table in the Download tab — same rows, different sequence.

## Repro / evidence
Failing Playwright test: `data_download tab` in `screenshot-results-excluding-unprofiled.spec.ts`, snapshot `excluding-unprofiled-download.png`. The diff showed the top tables stable and the bottom case-alteration table re-ordered.

## Test plan
- [ ] CI Playwright screenshot suite passes (specifically `screenshot-results-excluding-unprofiled.spec.ts`).
- [ ] Manually hit `POST /api/samples/fetch?projection=DETAILED` with body `{"sampleListIds":["gbm_tcga_all"]}` and confirm the returned order is stable across repeated requests.
- [ ] Existing unit/integration tests for `SampleMapper` / `ClickhouseSampleMapper` still pass.

## Notes / follow-ups
A broader audit of `src/main/resources/mappers/clickhouse/**/*.xml` for list-returning queries without `ORDER BY` should follow — this is a class-of-bug under clickhouse-only mode. Tracking that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)