### PR TITLE
fix(ci): use --ignore-workspace for e2e test pnpm install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
             name: Build frontend tests
             command: |
               cd cbioportal-frontend/end-to-end-test
-              ls node_modules || pnpm install --frozen-lockfile
+              ls node_modules/.bin/wdio || pnpm install --frozen-lockfile --ignore-workspace
         - save_cache:
             name: Save dependency plus dist cache
             key: v6-dependencies-plus-dist-{{ checksum "cbioportal-frontend/has_source_changed" }}


### PR DESCRIPTION
pnpm v10 detects the workspace root (pnpm-workspace.yaml) when running in the end-to-end-test subdirectory, causing --frozen-lockfile to fail or behave unexpectedly since end-to-end-test is not a listed workspace package. The previous yarn install didn't have this issue.

Changes:
- Add --ignore-workspace so pnpm treats end-to-end-test as a standalone project using its own pnpm-lock.yaml
- Tighten the skip check from 'ls node_modules' to 'ls node_modules/.bin/wdio' to avoid skipping install when pnpm creates an empty placeholder node_modules

Fix # (see https://help.github.com/en/articles/closing-issues-using-keywords)

Describe changes proposed in this pull request:
- a
- b

# Checks
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
