### PR TITLE
Fix e2e tests

### DIFF
--- a/src/main/java/org/cbioportal/legacy/service/impl/GenePanelServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/GenePanelServiceImpl.java
@@ -219,7 +219,7 @@ public class GenePanelServiceImpl implements GenePanelService {
         return genePanelData.stream()
             .peek(
                 datum -> {
-                  if (!datum.getProfiled()) {
+                  if (!Boolean.TRUE.equals(datum.getProfiled())) {
                     datum.setProfiled(
                         sampleSequencedBySampleList.getOrDefault(datum.getSampleId(), false));
                   }

--- a/src/main/java/org/cbioportal/legacy/service/impl/StudyViewServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/StudyViewServiceImpl.java
@@ -116,7 +116,7 @@ public class StudyViewServiceImpl implements StudyViewService {
         genePanelService
             .fetchGenePanelDataInMultipleMolecularProfiles(molecularProfileSampleIdentifiers)
             .stream()
-            .filter(GenePanelData::getProfiled)
+            .filter(d -> Boolean.TRUE.equals(d.getProfiled()))
             .collect(Collectors.groupingBy(GenePanelData::getMolecularProfileId))
             .entrySet()
             .stream()

--- a/src/main/java/org/cbioportal/legacy/service/util/AlterationEnrichmentUtil.java
+++ b/src/main/java/org/cbioportal/legacy/service/util/AlterationEnrichmentUtil.java
@@ -211,7 +211,7 @@ public class AlterationEnrichmentUtil<T extends AlterationCountBase> {
         profiledCasesCounter.sampleUniqueIdentifier);
 
     return genePanelDataList.stream()
-        .filter(GenePanelData::getProfiled)
+        .filter(d -> Boolean.TRUE.equals(d.getProfiled()))
         .map(profiledCasesCounter.sampleUniqueIdentifier)
         .distinct()
         .count();
@@ -244,7 +244,7 @@ public class AlterationEnrichmentUtil<T extends AlterationCountBase> {
         profiledCasesCounter.patientUniqueIdentifier);
 
     return genePanelDataList.stream()
-        .filter(GenePanelData::getProfiled)
+        .filter(d -> Boolean.TRUE.equals(d.getProfiled()))
         .map(profiledCasesCounter.patientUniqueIdentifier)
         .distinct()
         .count();

--- a/src/main/java/org/cbioportal/legacy/service/util/ProfiledCasesCounter.java
+++ b/src/main/java/org/cbioportal/legacy/service/util/ProfiledCasesCounter.java
@@ -76,7 +76,9 @@ public class ProfiledCasesCounter<T extends AlterationCountBase> {
     }
 
     List<GenePanelData> genePanelData =
-        genePanelDataList.stream().filter(GenePanelData::getProfiled).collect(Collectors.toList());
+        genePanelDataList.stream()
+            .filter(d -> Boolean.TRUE.equals(d.getProfiled()))
+            .collect(Collectors.toList());
 
     Set<String> profiledCases =
         genePanelData.stream()

--- a/src/main/java/org/cbioportal/legacy/web/util/StudyViewFilterApplier.java
+++ b/src/main/java/org/cbioportal/legacy/web/util/StudyViewFilterApplier.java
@@ -381,7 +381,8 @@ public class StudyViewFilterApplier {
         // the profileMap contains that profile id
         genePanelData.forEach(
             datum -> {
-              if (datum.getProfiled() && profileMap.containsKey(datum.getMolecularProfileId())) {
+              if (Boolean.TRUE.equals(datum.getProfiled())
+                  && profileMap.containsKey(datum.getMolecularProfileId())) {
                 SampleIdentifier sampleIdentifier =
                     studyViewFilterUtil.buildSampleIdentifier(
                         datum.getStudyId(), datum.getSampleId());

--- a/src/main/java/org/cbioportal/legacy/web/util/StudyViewFilterApplier.java
+++ b/src/main/java/org/cbioportal/legacy/web/util/StudyViewFilterApplier.java
@@ -1536,7 +1536,7 @@ public class StudyViewFilterApplier {
     }
 
     List<GenePanelData> genePanelData =
-        genePanelDataList.stream().filter(GenePanelData::getProfiled).toList();
+        genePanelDataList.stream().filter(d -> Boolean.TRUE.equals(d.getProfiled())).toList();
 
     Set<SampleIdentifier> profiledCases =
         genePanelData.stream()

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/GenePanelMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/GenePanelMapper.xml
@@ -17,7 +17,7 @@
         patient.stable_id AS "patientId",
         cancer_study.cancer_study_identifier AS "studyId",
         genetic_profile.stable_id AS "molecularProfileId",
-        sample_profile.genetic_profile_id != 0 AS "profiled"
+        COALESCE(sample_profile.genetic_profile_id, 0) != 0 AS "profiled"
     </sql>
 
     <sql id="fromGenePanelData">


### PR DESCRIPTION
## Summary
 
 Fixes two CI failures in `run_e2e_localdb_tests` for the rfc100 ClickHouse migration.
 
 ### Fix — NullPointerException in gene panel data
 The remote ClickHouse Cloud uses `join_use_nulls=1`, so LEFT JOIN misses return `NULL` instead of `0`. The SQL expression `sample_profile.genetic_profile_id != 0` was producing `NULL`, which MyBatis mapped to a null `Boolean`, crashing on auto-unbox across 7 call sites.
 
 - **SQL** (`GenePanelMapper.xml`): `COALESCE(sample_profile.genetic_profile_id, 0) != 0`
 - **Java**: replaced all `filter(GenePanelData::getProfiled)` / `!datum.getProfiled()` with null-safe `Boolean.TRUE.equals()` in `GenePanelServiceImpl`, `ProfiledCasesCounter`, `AlterationEnrichmentUtil`, `StudyViewServiceImpl`, and `StudyViewFilterApplier`.
