### PR TITLE
Fix clinical priority formatting in file formats docs

### DIFF
--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -131,31 +131,32 @@ The first four rows of the clinical data file contain tab-delimited metadata abo
 - Row 2: **The attribute Descriptions**: Long(er) description of each clinical attribute
 - Row 3: **The attribute Datatype**: The datatype of each clinical attribute (must be one of:  STRING, NUMBER, BOOLEAN)
 - Row 4: **The attribute Priority**: A number which indicates the importance of each attribute.  In the future, higher priority attributes will appear in more prominent places than lower priority ones on relevant pages (such as the [Study View](https://www.cbioportal.org/study?id=brca_tcga)). A higher number indicates a higher priority.
-    ```
-    To promote certain chart in study view, please increase priority to a certain number. The higher the score, the higher priority it will be displayed in the study view.
-    If you want to hide chart, please set the priority to 0. For combination chart, as long as one of the clinical attribute has been set to 0, it will be hidden.
     
-    Currently, we preassigned priority to few charts, but as long as you assign a priority except than 1, these preassigned priorities will be overwritten.
+    To promote a chart in Study View, increase its priority value. To hide a chart, set its priority to 0. For combination charts, the chart is hidden when any of the clinical attributes used by the chart has priority 0.
     
-    CANCER_TYPE: 3000, CANCER_TYPE_DETAILED: 2000,
-    Overall survival plot: 400 (This is combination of OS_MONTH and OS_STATUS) 
-    Disease Free Survival Plot: 300 (This is combination of DFS_MONTH and DFS_STATUS) 
-    Mutation Count vs. CNA Scatter Plot: 200,
-    Mutated Genes Table: 90, CNA Genes Table: 80, study_id: 70, # of Samples Per Patient: 40,
-    With Mutation Data Pie Chart: 60, With CNA Data Pie Chart: 50, 
-    Mutation Count Bar Chart: 30, CNA Bar Chart: 20,
-    GENDER: 9, SEX: 9, AGE: 8
-    ```
+    cBioPortal preassigns priority values to a few charts. Assigning any priority other than 1 overrides these defaults:
     
-    Please note: 
-    Priority is not the sole factor determining which chart will be displayed first.
-    A layout algorithm in study view also makes a minor adjustment on the layout.
-    The algorithm tries to fit all charts into a 2 by 2 matrix (Mutated Genes Table occupies 2 by 2 space).
-    When a chart can not be fitted in the first matrix, the second matrixed will be generated. 
-    And the second matrix will have lower priority than the first one. 
-    If later chart can fit into the first matrix, then its priority will be promoted.
-    
-    Please see [here](/deployment/customization/Studyview.md) for more detailed information about how study view utilize priority and how the layout is calculated based on priority.
+    | Chart or attribute | Default priority |
+    | --- | --- |
+    | CANCER_TYPE | 3000 |
+    | CANCER_TYPE_DETAILED | 2000 |
+    | Overall survival plot (OS_MONTH and OS_STATUS) | 400 |
+    | Disease-free survival plot (DFS_MONTH and DFS_STATUS) | 300 |
+    | Mutation Count vs. CNA Scatter Plot | 200 |
+    | Mutated Genes Table | 90 |
+    | CNA Genes Table | 80 |
+    | study_id | 70 |
+    | With Mutation Data Pie Chart | 60 |
+    | With CNA Data Pie Chart | 50 |
+    | # of Samples Per Patient | 40 |
+    | Mutation Count Bar Chart | 30 |
+    | CNA Bar Chart | 20 |
+    | GENDER and SEX | 9 |
+    | AGE | 8 |
+
+    Priority is not the only factor determining which chart is displayed first. A layout algorithm in Study View also adjusts chart placement. The algorithm tries to fit charts into a 2 by 2 matrix (the Mutated Genes Table occupies 2 by 2 spaces). When a chart cannot fit into the first matrix, a second matrix is generated with lower priority than the first one. If a later chart can fit into the first matrix, then its priority is promoted.
+
+    See [Study View customization](/deployment/customization/Studyview.md) for more detailed information about how Study View uses priority and how the layout is calculated.
 - Row 5: **The attribute name for the database**: This name should be in upper case.
 - Row 6: This is the first row that contains actual data.
 

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -154,7 +154,7 @@ The first four rows of the clinical data file contain tab-delimited metadata abo
     | GENDER and SEX | 9 |
     | AGE | 8 |
 
-    Priority is not the only factor determining which chart is displayed first. A layout algorithm in Study View also adjusts chart placement. The algorithm tries to fit charts into a 2 by 2 matrix (the Mutated Genes Table occupies 2 by 2 spaces). When a chart cannot fit into the first matrix, a second matrix is generated with lower priority than the first one. If a later chart can fit into the first matrix, then its priority is promoted.
+    Priority is not the only factor determining which chart is displayed first. A layout algorithm in Study View also adjusts chart placement. The layout is arranged on a grid of chart slots: most charts occupy a single 1 by 1 slot, while the Mutated Genes Table spans a 2 by 2 block of slots. When a chart cannot be placed in the first grid, an additional grid is generated with lower priority than the first one. If a later chart can still fit into the first grid, then its priority is promoted.
 
     See [Study View customization](/deployment/customization/Studyview.md) for more detailed information about how Study View uses priority and how the layout is calculated.
 - Row 5: **The attribute name for the database**: This name should be in upper case.


### PR DESCRIPTION
Fix #10667

Describe changes proposed in this pull request:
- Convert the Study View clinical priority guidance from an accidental pseudo-code block into regular documentation prose.
- Present the default priority values in a Markdown table for easier scanning and rendering in the File Formats page.
- Preserve the documented default priorities and semantics.

# Checks
- [x] The commits in the pull request have descriptive commit messages, including a short title and a paragraph describing the change.
- [x] Documentation-only change validated with `git diff --check`.
- [x] No application logic based on clinical attributes is added.
- [ ] Apply the relevant release-drafter label for this pull request: `documentation`.
- [x] Screenshots are not applicable for this documentation formatting update.
- [x] Reviewers can be routed through the normal maintainer triage process.
