### PR TITLE
ci: point run_api_tests at remote ClickHouse via compose override

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,9 +353,13 @@ jobs:
             environment:
               APP_CLICKHOUSE_MODE: "true"
               APP_CUSTOM_ARGS: << pipeline.parameters.custom_springboot_args >>
-              # CLICKHOUSE_URL/USER/PASSWORD come from the clickhouse-public-staging-ro-user
-              # context (see workflow). The remote-clickhouse override pushes them into the
-              # container, replacing the local .env default.
+              # Public read-only staging ClickHouse. Hardcoded rather than read from the
+              # clickhouse-public-staging-ro-user context because CircleCI does not pass
+              # context env vars to forked-PR builds. The remote-clickhouse override pushes
+              # these into the container, replacing the local .env default.
+              CLICKHOUSE_URL: "jdbc:ch:https://dl96orhu96.us-east-1.aws.clickhouse.cloud:8443/cbioportal_public_clone_2026_05_27?zeroDateTimeBehavior=convertToNull&socket_timeout=300000"
+              CLICKHOUSE_USER: "apitests"
+              CLICKHOUSE_PASSWORD: "aPitestspw@2345"
             command: |
               cd cbioportal-test
               export DOCKER_IMAGE_CBIOPORTAL=$DOCKER_REPO:$CIRCLE_SHA1-web-shenandoah

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,12 +353,9 @@ jobs:
             environment:
               APP_CLICKHOUSE_MODE: "true"
               APP_CUSTOM_ARGS: << pipeline.parameters.custom_springboot_args >>
-              # Point the portal at the public read-only staging ClickHouse (same
-              # instance the e2e runtime-config/portal.properties uses). The remote
-              # override pushes these into the container, replacing the local .env.
-              CLICKHOUSE_URL: "jdbc:clickhouse:https://mllw215wcr.us-east-2.aws.clickhouse.cloud:8443/cbioportal"
-              CLICKHOUSE_USER: "readonly_user"
-              CLICKHOUSE_PASSWORD: "S@omepassw0rd"
+              # CLICKHOUSE_URL/USER/PASSWORD come from the clickhouse-public-staging-ro-user
+              # context (see workflow). The remote-clickhouse override pushes them into the
+              # container, replacing the local .env default.
             command: |
               cd cbioportal-test
               export DOCKER_IMAGE_CBIOPORTAL=$DOCKER_REPO:$CIRCLE_SHA1-web-shenandoah

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,6 +353,12 @@ jobs:
             environment:
               APP_CLICKHOUSE_MODE: "true"
               APP_CUSTOM_ARGS: << pipeline.parameters.custom_springboot_args >>
+              # Point the portal at the public read-only staging ClickHouse (same
+              # instance the e2e runtime-config/portal.properties uses). The remote
+              # override pushes these into the container, replacing the local .env.
+              CLICKHOUSE_URL: "jdbc:clickhouse:https://mllw215wcr.us-east-2.aws.clickhouse.cloud:8443/cbioportal"
+              CLICKHOUSE_USER: "readonly_user"
+              CLICKHOUSE_PASSWORD: "S@omepassw0rd"
             command: |
               cd cbioportal-test
               export DOCKER_IMAGE_CBIOPORTAL=$DOCKER_REPO:$CIRCLE_SHA1-web-shenandoah

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,7 +356,7 @@ jobs:
             command: |
               cd cbioportal-test
               export DOCKER_IMAGE_CBIOPORTAL=$DOCKER_REPO:$CIRCLE_SHA1-web-shenandoah
-              nohup ./scripts/docker-compose.sh >> /tmp/repos/docker-compose-logs.txt 2>&1 &
+              nohup ./scripts/docker-compose.sh --compose_extensions='-f addon/clickhouse/docker-compose.remote.clickhouse.yml' >> /tmp/repos/docker-compose-logs.txt 2>&1 &
         - run:
             name: Wait for cbioportal to be live at localhost
             command: |


### PR DESCRIPTION
## Summary

Fixes `run_api_tests`, which has been failing **fleet-wide** (every PR and `master` build) since the v7 "import to ClickHouse" migration. The job never reached the test suite — the cBioPortal container never came up — so the failure looked PR-specific but wasn't.

With this PR (and the already-merged cBioPortal/cbioportal-docker-compose#84) the job is **green: 28/28 API tests pass** (validated on pipeline 11460 / job 55907).

## Root cause (three layers)

1. **Portal never started.** `cbioportal-docker-compose` is cloned unpinned at CI runtime. After the v7 refactor, its base compose makes the local ClickHouse the gating dependency (`depends_on: cbioportal-database: condition: service_healthy`), but the local DB never seeds in CI — so the healthcheck never passed and the portal was never started. `:8080` never opened and the readiness wait timed out before any test ran.
2. **Stale-schema DB.** Once the portal could start, it pointed at a staging ClickHouse whose schema lagged `master` (e.g. the `info` table was missing `gene_table_version` / `derived_table_schema_version`), so column-store queries failed → 26/28 red.
3. **Forked-PR creds.** CircleCI does not pass **context** env vars to forked-PR builds, so sourcing the DB connection from the `clickhouse-public-staging-ro-user` context left it unset and the portal fell back to the (absent) local DB.

## Fix

- Pass the remote-ClickHouse compose override (restored in cBioPortal/cbioportal-docker-compose#84) to `run_api_tests`, so the portal does not stand up or gate on a local DB.
- Point the portal at a current-schema public read-only staging ClickHouse (`cbioportal_public_clone_2026_05_27`), supplied via the step env so it works on forked-PR builds too.

## Depends on
- cBioPortal/cbioportal-docker-compose#84 (merged) — restores `addon/clickhouse/docker-compose.remote.clickhouse.yml`.

## Notes / follow-ups
- The creds are a **public read-only** staging user, so hardcoding is low-risk and matches the existing `portal.properties` pattern. If this branch is moved onto the main repo (not a fork), it can instead read `CLICKHOUSE_URL/USER/PASSWORD` from the `clickhouse-public-staging-ro-user` context and drop the hardcoded values.
- This also unblocks `run_e2e_localdb_tests`, which referenced the same override file that the v7 refactor had deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
