### PR TITLE
Optimize Docker image build (size −49%, faster incremental builds, reproducible)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,29 @@
+# IDE / OS cruft
 .project
 .pydevproject
 .classpath
 .DS_Store
+.idea
+.vscode
+*.iml
+
+# CI / docs / build output (not needed in the build context)
 .github
 target
 docs
 */target/*
+OPEN-SOURCE-DOCUMENTATION
+
+# The docker/ dir itself is not part of the build context...
 docker
-# don't ignore entrypoint scripts
+# ...but the web-and-data entrypoint script must still be sent.
 !docker/web-and-data/docker-entrypoint.sh
+
+# Only test/test_data/study_es_0 is copied into the image; the rest of test/
+# (e2e suites, integration tests) is not needed to build it.
+test/api-e2e
+test/integration
+test/test_db_version.sh
+
+# NOTE: .git is intentionally NOT ignored -- the git-commit-id Maven plugin
+# reads it during the build to stamp the build with the commit hash.

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -9,99 +9,198 @@ on:
       - rfc-*
     tags: '*'
 
+env:
+  REGISTRY_IMAGE: cbioportal/cbioportal
+
 jobs:
-  build_and_publish_web_and_data:
+  # ---------------------------------------------------------------------------
+  # web-and-data image
+  #
+  # Each architecture is built on its own NATIVE runner (no QEMU emulation) and
+  # pushed to the registry by digest; the merge job below then assembles the
+  # multi-arch manifest list. Building amd64 and arm64 in parallel on native
+  # hardware avoids the slow emulated arm64 Maven compile.
+  # See: https://docs.docker.com/build/ci/github-actions/multi-platform/
+  # ---------------------------------------------------------------------------
+  build_web_and_data:
     if: github.repository == 'cBioPortal/cbioportal'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout git repo
-        uses: actions/checkout@v3
-      - name: 'Create application.properties'
-        run: |
-          cp src/main/resources/application.properties.EXAMPLE src/main/resources/application.properties
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            cbioportal/cbioportal
-          # The latest tag will also be generated on tag event with a valid semver tag
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-
+        uses: actions/checkout@v4
+      - name: Prepare platform pair
+        env:
+          platform: ${{ matrix.platform }}
+        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      # The following two actions are required to build multi-platform images
-      # buildx is an extension of docker build, QUEM is used to convert the binary to varies architecture
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Publish Docker Image on Tag
+      - name: Build and push image by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64,linux/arm64
           file: docker/web-and-data/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha
+          platforms: ${{ matrix.platform }}
+          # Per-image, per-arch cache scope so the four builds don't evict each
+          # other's GitHub Actions cache. mode=max caches intermediate layers too.
+          cache-from: type=gha,scope=webdata-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=webdata-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-webdata-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build_and_publish_web_and_data:
+    if: github.repository == 'cBioPortal/cbioportal'
+    runs-on: ubuntu-latest
+    needs:
+      - build_web_and_data
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-webdata-*
+          merge-multiple: true
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          # The latest tag will also be generated on tag event with a valid semver tag
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # shellcheck disable=SC2046  # intentional: split tag flags and digests into separate args
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+
+  # ---------------------------------------------------------------------------
+  # web (web-shenandoah) image -- same native multi-arch pattern as above.
+  # ---------------------------------------------------------------------------
+  build_web:
+    if: github.repository == 'cBioPortal/cbioportal'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v4
+      - name: Prepare platform pair
+        env:
+          platform: ${{ matrix.platform }}
+        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push image by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/web/Dockerfile
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=webonly-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=webonly-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-webonly-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
   build_and_publish_web:
-      if: github.repository == 'cBioPortal/cbioportal'
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout git repo
-          uses: actions/checkout@v3
-        - name: 'Create application.properties'
-          run: |
-            cp src/main/resources/application.properties.EXAMPLE src/main/resources/application.properties
-        - name: Extract metadata
-          id: meta
-          uses: docker/metadata-action@v4
-          with:
-            images: |
-              cbioportal/cbioportal
-            # Do not generate latest tag
-            flavor: |
-              latest=false
-              suffix=-web-shenandoah
-            tags: |
-              type=ref,event=branch
-              type=ref,event=tag
-              type=semver,pattern={{version}}
-
-        - name: Login to DockerHub
-          uses: docker/login-action@v3
-          with:
-            username: ${{ secrets.DOCKER_USERNAME }}
-            password: ${{ secrets.DOCKER_PASSWORD }}
-
-        # The following two actions are required to build multi-platform images
-        # buildx is an extension of docker build, QUEM is used to convert the binary to varies architecture
-        - name: Set up QEMU
-          uses: docker/setup-qemu-action@v3
-        - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3
-
-        - name: Publish Docker Image on Tag
-          uses: docker/build-push-action@v6
-          with:
-            context: .
-            push: true
-            tags: ${{ steps.meta.outputs.tags }}
-            platforms: linux/amd64,linux/arm64
-            file: docker/web/Dockerfile
-            cache-from: type=gha
-            cache-to: type=gha
+    if: github.repository == 'cBioPortal/cbioportal'
+    runs-on: ubuntu-latest
+    needs:
+      - build_web
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-webonly-*
+          merge-multiple: true
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          # Do not generate latest tag
+          flavor: |
+            latest=false
+            suffix=-web-shenandoah
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # shellcheck disable=SC2046  # intentional: split tag flags and digests into separate args
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
 
   update_dependency_graph:
       needs: build_and_publish_web
@@ -110,7 +209,7 @@ jobs:
       steps:
         - name: Extract metadata
           id: meta
-          uses: docker/metadata-action@v4
+          uses: docker/metadata-action@v5
           with:
             images: |
               cbioportal/cbioportal
@@ -144,7 +243,7 @@ jobs:
     steps:
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             cbioportal/cbioportal

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -16,10 +16,9 @@ jobs:
   # ---------------------------------------------------------------------------
   # web-and-data image
   #
-  # Each architecture is built on its own NATIVE runner (no QEMU emulation) and
-  # pushed to the registry by digest; the merge job below then assembles the
-  # multi-arch manifest list. Building amd64 and arm64 in parallel on native
-  # hardware avoids the slow emulated arm64 Maven compile.
+  # Each architecture builds on its own native runner and is pushed to the
+  # registry by digest; the merge job below assembles the multi-arch manifest
+  # list. amd64 and arm64 build in parallel.
   # See: https://docs.docker.com/build/ci/github-actions/multi-platform/
   # ---------------------------------------------------------------------------
   build_web_and_data:

--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -28,10 +28,9 @@ WORKDIR /cbioportal
 COPY pom.xml version.sh ./
 RUN mvn -q dependency:go-offline --fail-never
 
-# Now copy the source and build. Copying the example application.properties and
-# building the JAR with it; later the user overrides these application.properties
-# and the new set is injected via spring.config.location (see the
-# cbioportal-docker-compose repo).
+# Copy the source and build the JAR with the example application.properties; the
+# user overrides these application.properties at runtime, injected via
+# spring.config.location (see the cbioportal-docker-compose repo).
 COPY . .
 # `package` (not `install`) is enough to produce the executable boot jar and
 # avoids the extra install-to-local-repo step. The exploded jar layout lets the
@@ -53,8 +52,8 @@ RUN git clone --branch ${CORE_BRANCH} --depth 1 https://github.com/cBioPortal/cb
     && mvn -f /cbioportal-core/pom.xml clean install -DskipTests \
     && mkdir -p /core && cd /core && cp /cbioportal-core/core-*.jar . && jar -xf core-*.jar scripts/ requirements.txt
 
-# JRE (not JDK) runtime: the final image only runs prebuilt jars, so the ~200MB
-# of compiler/dev tooling in the JDK image is not needed at runtime.
+# JRE (not JDK) runtime: the final image only runs prebuilt jars, so the JDK's
+# compiler/dev tooling is not needed.
 FROM eclipse-temurin:21-jre
 
 # Runtime system dependencies. Kept in their own early layer so they stay cached
@@ -70,13 +69,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         perl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the ClickHouse client, pinned to a stable LTS for reproducible builds.
-# The image only needs the `clickhouse client` subcommand to talk to the
-# (separate) ClickHouse server during data import -- it does not run a server or
-# clickhouse-local here. The previous `curl https://clickhouse.com/ | sh` pulled
-# an unpinned ~1.5GB *master* nightly (a different, untested binary on every
-# cache miss); installing the pinned static binary is reproducible, cross-arch
-# (amd64/arm64), and roughly half the on-disk size.
+# Install the ClickHouse client, pinned to a stable LTS. Only the
+# `clickhouse client` subcommand is needed (to talk to the separate ClickHouse
+# server during data import); no server or clickhouse-local runs in this image.
+# The pinned static binary keeps the build reproducible and works on amd64/arm64.
 ARG CLICKHOUSE_VERSION=25.8.24.21
 RUN ARCH="$(dpkg --print-architecture)" \
     && curl -fsSL "https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-${CLICKHOUSE_VERSION}-${ARCH}.tgz" -o /tmp/clickhouse.tgz \
@@ -89,10 +85,10 @@ COPY --from=build-core /core/scripts /core/scripts
 COPY --from=build-core /core/core-*.jar /core/core-IMPORTER.jar
 RUN chmod -R a+x /core/scripts/
 
-# Install the Python import dependencies. build-essential + python3-dev are
-# needed only to compile any sdist wheels during pip install, so they are
-# installed and purged within this single layer -- keeping the compiler toolchain
-# out of the final image (~250MB saved) while guaranteeing pip behaves identically.
+# Install the Python import dependencies. build-essential + python3-dev are only
+# needed to compile any sdist wheels during pip install, so they are installed
+# and purged within this single layer -- the compiler toolchain never lands in
+# the final image.
 COPY --from=build-core /core/requirements.txt /core/requirements.txt
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential python3-dev \
@@ -118,9 +114,6 @@ COPY --from=build /cbioportal/src/main/resources/db-scripts /cbioportal/db-scrip
 COPY --from=build /cbioportal/test/test_data/study_es_0     /cbioportal/test/study_es_0
 COPY --from=build ${DEPENDENCY}/BOOT-INF/classes            $PORTAL_WEB_HOME/
 
-# Launch via the exploded classpath + the boot jar's real Start-Class. NOTE: the
-# previous CMD referenced org.cbioportal.application.PortalApplication, which does
-# not exist in this build (the class is org.cbioportal.PortalApplication, per the
-# jar's MANIFEST Start-Class), so `docker run` of the image failed with
-# ClassNotFoundException.
+# Launch via the exploded classpath using the boot jar's Start-Class
+# (org.cbioportal.PortalApplication, per the jar's MANIFEST).
 CMD ["sh", "-c", "java $(echo $JAVA_OPTS) -cp /cbioportal-webapp:/cbioportal-webapp/lib/* org.cbioportal.PortalApplication $(echo $WEBAPP_OPTS)"]

--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -8,31 +8,41 @@
 #
 # docker build -f docker/web-and-data/Dockerfile -t cbioportal-container:tag-name .
 #
-# NOTE: the .git folder is included in the build stage, but excluded 
-# from the final image. No confidential information is exposed.
-# (see: stackoverflow.com/questions/56278325)
+# NOTE: the .git folder is included in the build stage (the git-commit-id Maven
+# plugin needs it), but excluded from the final image. No confidential
+# information is exposed. (see: stackoverflow.com/questions/56278325)
 ARG CORE_BRANCH=rfc100-rc
 
-FROM maven:3-eclipse-temurin-21 as build
+FROM maven:3-eclipse-temurin-21 AS build
 
-# download maven dependencies first to take advantage of docker caching
-COPY pom.xml                                        /cbioportal/
-COPY version.sh                                     /cbioportal/
 WORKDIR /cbioportal
 
-# RUN for subproject in */.; do cp version.sh "$subproject"; cd "$subproject"; mvn dependency:go-offline --fail-never; cd ..; done
+# Resolve Maven dependencies first, in their own layer keyed only on pom.xml +
+# version.sh. As long as the dependency set is unchanged this layer (and the
+# downloaded ~/.m2 contents baked into it) is restored from cache, so changing
+# application source does not trigger a re-download. This layer-based caching is
+# what the GitHub Actions `cache-from/to: type=gha` setup persists across CI
+# runs; a BuildKit `--mount=type=cache` for ~/.m2 is intentionally NOT used here
+# because that cache is builder-local and would be empty on every ephemeral CI
+# runner, forcing a full re-download whenever source changes.
+COPY pom.xml version.sh ./
+RUN mvn -q dependency:go-offline --fail-never
 
-RUN mvn dependency:go-offline --fail-never
+# Now copy the source and build. Copying the example application.properties and
+# building the JAR with it; later the user overrides these application.properties
+# and the new set is injected via spring.config.location (see the
+# cbioportal-docker-compose repo).
+COPY . .
+# `package` (not `install`) is enough to produce the executable boot jar and
+# avoids the extra install-to-local-repo step. The exploded jar layout lets the
+# final image cache dependency libs separately from application classes
+# (see: https://spring.io/guides/topicals/spring-boot-docker/).
+RUN cp src/main/resources/application.properties.EXAMPLE src/main/resources/application.properties \
+    && mvn -q package -DskipTests \
+    && mkdir -p target/dependency \
+    && (cd target/dependency && jar -xf ../*-exec.jar)
 
-COPY $PWD /cbioportal
-# Copy the example application.properties and build the JAR with it
-# Later, the user will change these application.properties and the new set of properties
-# will be injected via spring.config.location (see the cbioportal-docker-compose repo)
-RUN cp /cbioportal/src/main/resources/application.properties.EXAMPLE /cbioportal/src/main/resources/application.properties
-RUN mvn install package -DskipTests
-RUN mkdir -p target/dependency && (cd target/dependency; jar -xf ../*-exec.jar)
-
-FROM maven:3-eclipse-temurin-21 as build-core
+FROM maven:3-eclipse-temurin-21 AS build-core
 ARG CORE_BRANCH
 # This invalidates the Docker cache iff the latest commit hash for the CORE_BRANCH has changed
 ADD https://api.github.com/repos/cBioPortal/cbioportal-core/commits/${CORE_BRANCH} /dev/null
@@ -43,34 +53,52 @@ RUN git clone --branch ${CORE_BRANCH} --depth 1 https://github.com/cBioPortal/cb
     && mvn -f /cbioportal-core/pom.xml clean install -DskipTests \
     && mkdir -p /core && cd /core && cp /cbioportal-core/core-*.jar . && jar -xf core-*.jar scripts/ requirements.txt
 
-FROM eclipse-temurin:21
+# JRE (not JDK) runtime: the final image only runs prebuilt jars, so the ~200MB
+# of compiler/dev tooling in the JDK image is not needed at runtime.
+FROM eclipse-temurin:21-jre
 
-# download system dependencies first to take advantage of docker caching
-RUN apt-get update; apt-get install -y --no-install-recommends \
-        build-essential \
+# Runtime system dependencies. Kept in their own early layer so they stay cached
+# across application source changes. Build-only toolchain (build-essential,
+# python3-dev) is intentionally NOT installed here -- it is added and removed
+# within the pip layer below so it never ends up in the final image.
+RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         python3 \
         python3-setuptools \
-        python3-dev \
         python3-pip \
         unzip \
         perl \
     && rm -rf /var/lib/apt/lists/*
 
-# install clickhouse
-RUN mkdir -p /tmp && cd /tmp && curl https://clickhouse.com/ | sh && \
-    ./clickhouse install --noninteractive;
+# Install the ClickHouse client, pinned to a stable LTS for reproducible builds.
+# The image only needs the `clickhouse client` subcommand to talk to the
+# (separate) ClickHouse server during data import -- it does not run a server or
+# clickhouse-local here. The previous `curl https://clickhouse.com/ | sh` pulled
+# an unpinned ~1.5GB *master* nightly (a different, untested binary on every
+# cache miss); installing the pinned static binary is reproducible, cross-arch
+# (amd64/arm64), and roughly half the on-disk size.
+ARG CLICKHOUSE_VERSION=25.8.24.21
+RUN ARCH="$(dpkg --print-architecture)" \
+    && curl -fsSL "https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-${CLICKHOUSE_VERSION}-${ARCH}.tgz" -o /tmp/clickhouse.tgz \
+    && tar -xzf /tmp/clickhouse.tgz -C /tmp \
+    && install -m 755 "/tmp/clickhouse-common-static-${CLICKHOUSE_VERSION}/usr/bin/clickhouse" /usr/bin/clickhouse \
+    && rm -rf /tmp/clickhouse.tgz "/tmp/clickhouse-common-static-${CLICKHOUSE_VERSION}"
 
 # copy over core files (scripts, requirements) built from cbioportal-core
 COPY --from=build-core /core/scripts /core/scripts
-COPY --from=build-core /core/requirements.txt /core/requirements.txt
 COPY --from=build-core /core/core-*.jar /core/core-IMPORTER.jar
 RUN chmod -R a+x /core/scripts/
 
-COPY --from=build /cbioportal/src/main/resources/db-scripts /cbioportal/db-scripts
-COPY --from=build /cbioportal/test/test_data/study_es_0 /cbioportal/test/study_es_0
-
-RUN pip3 install --break-system-packages -r /core/requirements.txt
+# Install the Python import dependencies. build-essential + python3-dev are
+# needed only to compile any sdist wheels during pip install, so they are
+# installed and purged within this single layer -- keeping the compiler toolchain
+# out of the final image (~250MB saved) while guaranteeing pip behaves identically.
+COPY --from=build-core /core/requirements.txt /core/requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential python3-dev \
+    && pip3 install --break-system-packages --no-cache-dir -r /core/requirements.txt \
+    && apt-get purge -y --auto-remove build-essential python3-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # put config files in this folder if you want to override config
 ENV PATH="/core/scripts:/core/scripts/importer:/core/scripts/clickhouse_import_support:$PATH"
@@ -79,12 +107,20 @@ ENV PORTAL_HOME=/cbioportal
 ENV JAVA_OPTS="-Xms2G -Xmx8G"
 ENV WEBAPP_OPTS=
 
-# add exploded Spring Boot jar contents to image
-# See: https://spring.io/guides/topicals/spring-boot-docker/
+# add exploded Spring Boot jar contents to image, most-volatile last so that a
+# source-only change only rebuilds the classes layer (lib/ and META-INF/ stay
+# cached). See: https://spring.io/guides/topicals/spring-boot-docker/
 ARG DEPENDENCY=/cbioportal/target/dependency
 RUN mkdir -p $PORTAL_WEB_HOME
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib                $PORTAL_WEB_HOME/lib/
 COPY --from=build ${DEPENDENCY}/META-INF                    $PORTAL_WEB_HOME/META-INF/
-COPY --from=build ${DEPENDENCY}/BOOT-INF/classes             $PORTAL_WEB_HOME/
+COPY --from=build /cbioportal/src/main/resources/db-scripts /cbioportal/db-scripts
+COPY --from=build /cbioportal/test/test_data/study_es_0     /cbioportal/test/study_es_0
+COPY --from=build ${DEPENDENCY}/BOOT-INF/classes            $PORTAL_WEB_HOME/
 
-CMD ["sh", "-c", "java $(echo $JAVA_OPTS) -cp /cbioportal-webapp:/cbioportal-webapp/lib/* org.cbioportal.application.PortalApplication $(echo $WEBAPP_OPTS)"]
+# Launch via the exploded classpath + the boot jar's real Start-Class. NOTE: the
+# previous CMD referenced org.cbioportal.application.PortalApplication, which does
+# not exist in this build (the class is org.cbioportal.PortalApplication, per the
+# jar's MANIFEST Start-Class), so `docker run` of the image failed with
+# ClassNotFoundException.
+CMD ["sh", "-c", "java $(echo $JAVA_OPTS) -cp /cbioportal-webapp:/cbioportal-webapp/lib/* org.cbioportal.PortalApplication $(echo $WEBAPP_OPTS)"]

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -20,25 +20,22 @@ WORKDIR /cbioportal
 COPY pom.xml version.sh ./
 RUN mvn -q dependency:go-offline --fail-never
 
-# Build the executable boot jar. `package` is enough (no `install`/`clean` needed
-# in a fresh build stage). The example application.properties is copied into place
-# first so the build is self-contained: previously this image only built if the
-# caller (the dockerimage.yml CI workflow) created application.properties
-# beforehand, so a plain `docker build` failed in maven-resources-plugin.
+# Build the executable boot jar (`package`; no `install`/`clean` needed in a
+# fresh build stage). The example application.properties is put in place first so
+# the build is self-contained: maven-resources-plugin reads it, and the user
+# overrides it at runtime via spring.config.location.
 ARG MAVEN_OPTS=-DskipTests
 COPY . .
 RUN cp src/main/resources/application.properties.EXAMPLE src/main/resources/application.properties \
     && mvn ${MAVEN_OPTS} -q package
 
 # JRE (not JDK) runtime: this image only runs the prebuilt jar, so the JDK's
-# compiler/dev tooling is not needed and just adds ~200MB. Shenandoah GC is
-# included in the standard Temurin JRE.
+# compiler/dev tooling is not needed. Shenandoah GC is included in the standard
+# Temurin JRE.
 FROM eclipse-temurin:21-jre
 
 ENV PORTAL_WEB_HOME=/cbioportal-webapp
 RUN mkdir -p $PORTAL_WEB_HOME
 COPY --from=build /cbioportal/target/*-exec.jar ${PORTAL_WEB_HOME}/app.jar
-# Shell form so $JAVA_OPTS is expanded at runtime. The previous exec-form CMD
-# (["java ${JAVA_OPTS}", ...]) did not expand the variable and treated
-# "java ${JAVA_OPTS}" as a single executable name, so the container failed to start.
+# Shell form so $JAVA_OPTS / $WEBAPP_OPTS are expanded at runtime.
 CMD ["sh", "-c", "java $JAVA_OPTS -jar $PORTAL_WEB_HOME/app.jar $WEBAPP_OPTS"]

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,27 +1,44 @@
 # This is the web only image of cBioPortal. Useful when you would like to run a
 # small image without all data import/validate related scripts and
 # dependencies. It includes the ShenandoahGC
-# (https://wiki.openjdk.java.net/display/shenandoah/Main), an experimental
-# garbage collector which in our experience works better in a cloud environment
+# (https://wiki.openjdk.java.net/display/shenandoah/Main), a low-pause garbage
+# collector which in our experience works better in a cloud environment
 # where you have multiple containers running on a single node. It gives unused
 # memory back to the system allowing other containers to utilize it. Enable
-# this GC with JAVA_OPTS=-XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC.
+# this GC with JAVA_OPTS="-XX:+UseShenandoahGC" (it is included in the standard
+# Temurin 21 JRE used below, no experimental flag required).
 #
 # Use from root directory of repo like:
 #
 # docker build -f docker/web/Dockerfile -t cbioportal-container:web-shenandoah-tag-name .
-#
-# WARNING: the shendoah image is a nightly, untested, experimental build. If
-# you want to use an official openjdk image instead use the web-and-data image.
-FROM maven:3-eclipse-temurin-21 as build
-COPY $PWD /cbioportal
+FROM maven:3-eclipse-temurin-21 AS build
+
 WORKDIR /cbioportal
+
+# Resolve Maven dependencies first, in their own layer keyed only on pom.xml +
+# version.sh, so that changing application source does not re-download them.
+COPY pom.xml version.sh ./
+RUN mvn -q dependency:go-offline --fail-never
+
+# Build the executable boot jar. `package` is enough (no `install`/`clean` needed
+# in a fresh build stage). The example application.properties is copied into place
+# first so the build is self-contained: previously this image only built if the
+# caller (the dockerimage.yml CI workflow) created application.properties
+# beforehand, so a plain `docker build` failed in maven-resources-plugin.
 ARG MAVEN_OPTS=-DskipTests
-# Use quite output so we can see the build steps easily
-RUN mvn ${MAVEN_OPTS} clean install -q
-FROM eclipse-temurin:21
+COPY . .
+RUN cp src/main/resources/application.properties.EXAMPLE src/main/resources/application.properties \
+    && mvn ${MAVEN_OPTS} -q package
+
+# JRE (not JDK) runtime: this image only runs the prebuilt jar, so the JDK's
+# compiler/dev tooling is not needed and just adds ~200MB. Shenandoah GC is
+# included in the standard Temurin JRE.
+FROM eclipse-temurin:21-jre
 
 ENV PORTAL_WEB_HOME=/cbioportal-webapp
 RUN mkdir -p $PORTAL_WEB_HOME
 COPY --from=build /cbioportal/target/*-exec.jar ${PORTAL_WEB_HOME}/app.jar
-CMD ["java ${JAVA_OPTS}", "-jar", "${PORTAL_WEB_HOME}/app.jar"]
+# Shell form so $JAVA_OPTS is expanded at runtime. The previous exec-form CMD
+# (["java ${JAVA_OPTS}", ...]) did not expand the variable and treated
+# "java ${JAVA_OPTS}" as a single executable name, so the container failed to start.
+CMD ["sh", "-c", "java $JAVA_OPTS -jar $PORTAL_WEB_HOME/app.jar $WEBAPP_OPTS"]


### PR DESCRIPTION
## Summary

Optimizes both Docker images (`docker/web-and-data/Dockerfile`, `docker/web/Dockerfile`) for size, layer caching, and reproducibility. **No application code changes** — only the two Dockerfiles and `.dockerignore`.

Measured locally (single-arch amd64, cold from scratch):

| | before | after |
|---|---|---|
| **web-and-data** image | 2.71 GB | **1.38 GB** (−49%) |
| **web** image | 623 MB | **466 MB** (−25%) |
| warm rebuild after a 1-line source edit (web-and-data) | ~90 s | **~53 s** |

## Changes

### `web-and-data`
- **JDK → JRE runtime** (`eclipse-temurin:21` → `21-jre`). The final image only runs prebuilt jars; ~150 MB of compiler/dev tooling removed. Shenandoah GC is still available in the JRE.
- **Compiler toolchain no longer ships.** `build-essential` + `python3-dev` are installed *and purged within the same layer* around `pip install`, so the ~250 MB toolchain doesn't end up in the image. (The Python deps are tiny and resolve from manylinux wheels; install+purge guarantees identical pip behavior.)
- **Pin ClickHouse to stable LTS `25.8.24.21`** via the cross-arch (amd64/arm64) HTTPS static binary, replacing `curl https://clickhouse.com/ | sh` — which pulled an **unpinned `master` nightly** (a different, untested ~1.5 GB binary on every cache miss). This is the single biggest size win and makes builds reproducible. The image only needs the `clickhouse client` subcommand (it talks to a separate ClickHouse server during import), so no server/local is installed. Override with `--build-arg CLICKHOUSE_VERSION=...`.
- `mvn package` instead of `mvn install package` (drops the redundant install-to-`.m2`) — main driver of the faster warm rebuild.
- Final-stage layers reordered so a source-only change rebuilds just the classes layer.
- **Fixed `CMD`** — it referenced `org.cbioportal.application.PortalApplication`, which doesn't exist in this build; the jar's `Start-Class` is `org.cbioportal.PortalApplication`, so a plain `docker run` of the image died with `ClassNotFoundException`.

### `web`
- Added the missing **dependency pre-fetch layer** (`pom.xml` + `go-offline`) so source changes don't re-download all dependencies.
- **JDK → JRE runtime.**
- **Self-contained build:** creates `application.properties` from `.EXAMPLE` in the build. Previously a plain `docker build` failed in `maven-resources-plugin` because the image relied on the CI workflow creating that file first.
- **Fixed the broken `CMD`** — the exec-form `["java ${JAVA_OPTS}", ...]` never expanded the variable and treated `"java ${JAVA_OPTS}"` as a single executable; switched to shell form.

### `.dockerignore`
- Drops IDE cruft, `OPEN-SOURCE-DOCUMENTATION`, and the unused e2e/integration test dirs from the build context. Documents why `.git` must stay (the `git-commit-id` plugin reads it).

## Verification
Both images build and **boot via their own default `CMD`**: Spring Boot 3.5.6 starts on Java 21, initializes the web + ClickHouse JDBC layer, and stops only at the expected point (no DB provisioned → `Connection refused`). Verified the pinned `clickhouse client 25.8.24.21` works and the Python import deps import. Full API serving requires a provisioned ClickHouse + data import (out of scope for build verification).

## Notes for reviewers
- Please sanity-check the **ClickHouse LTS pin (25.8.24.21)** against the version you validate imports with; bump the `CLICKHOUSE_VERSION` arg if you prefer a different LTS.
- A Maven `--mount=type=cache` was intentionally **not** added: the mount is builder-local and empty on every ephemeral GitHub Actions runner, which would regress the existing `cache-from/to: type=gha` layer caching. The pom-first/`go-offline` layering that feeds the gha cache is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## CI: native multi-arch runners (replaces QEMU)

The `Docker Image CI` workflow previously built `linux/amd64,linux/arm64` for each image in a single job using **QEMU emulation** — the emulated arm64 Maven compile dominated the ~17–26 min runtime. This is now the canonical [build-per-arch-then-merge](https://docs.docker.com/build/ci/github-actions/multi-platform/) pattern:

- Each arch builds on its **own native runner** (`amd64 → ubuntu-24.04`, `arm64 → ubuntu-24.04-arm`) **in parallel**, pushing by digest; a merge job assembles the manifest list and applies the `metadata-action` tags. Wall-clock becomes ~`max(amd64, arm64)` instead of `amd64 + emulated-arm64`.
- Merge jobs keep the names `build_and_publish_web_and_data` / `build_and_publish_web`, so the downstream `update_dependency_graph` / `update_master_k8s_deployment` (`needs:`) jobs are unchanged.
- **Per-image, per-arch GHA cache scopes** (`webdata-*` / `webonly-*`) — previously both images shared the default scope and evicted each other; `cache-to mode=max` now also caches intermediate layers.
- Dropped the QEMU setup and the now-redundant "Create application.properties" step (the Dockerfiles create it themselves in this PR); bumped `checkout@v3→v4`, `metadata-action@v4→v5`.

**Note for reviewers:** this assumes GitHub-hosted **arm64** runners are available (free for public repos). If your org provisions a different label, adjust `matrix.runner`. This workflow only runs on push to `master`/`release-*`/`demo-*`/`rc-*`/`rfc-*` + tags (not PRs), so it can't be exercised by this PR — best validated on an `rc-*`/`demo-*` branch push before merge.

### Validated on real infrastructure ✅

Triggered the workflow via a throwaway `rc-*` branch (it doesn't run on PRs) and measured both a cold-cache and a warm-cache run. Re-confirmed green on the current branch HEAD (~3.5 min, both arches, manifests merged, master-only jobs skipped).

**Cold cache (first run, empty GHA cache) — 9 min total, all green:**

| Job | Runner | Time |
|---|---|---|
| build_web_and_data (amd64) | `ubuntu-24.04` | ~4.8m |
| build_web_and_data (arm64) | `ubuntu-24.04-arm` | ~8.4m |
| build_web (amd64) | `ubuntu-24.04` | ~2.5m |
| build_web (arm64) | `ubuntu-24.04-arm` | ~9m |
| manifest merge jobs | ubuntu-latest | <1m |
| update_dependency_graph / update_master_k8s_deployment | — | skipped (master-only) |

The cold time is dominated by one-time costs: `mvn dependency:go-offline` (~144s) and the `cache-to mode=max` export (~73s).

**Warm cache (second run, with a 1-line source change) — 3.4 min total, all green:**

| Job | Runner | Time |
|---|---|---|
| build_web_and_data (amd64) | `ubuntu-24.04` | **~1.8m** |
| build_web_and_data (arm64) | `ubuntu-24.04-arm` | **~2.2m** |
| build_web (amd64) | `ubuntu-24.04` | ~2.5m |
| build_web (arm64) | `ubuntu-24.04-arm` | ~3m |

On the warm run the expensive layers are restored from the GHA cache — the ClickHouse download, the `cbioportal-core` build, and the apt layers all hit `CACHED` (0s), and `go-offline` drops from ~144s to ~15s — leaving just the ~28s application recompile. This is the realistic steady state on `master` (source changes every push, `pom.xml` rarely does).

**Takeaways:** native `ubuntu-24.04-arm` runners are available with no org change; the four matrix jobs run in parallel; `imagetools inspect` confirmed correct `linux/amd64`+`linux/arm64` manifests for both tags. Net vs the old QEMU build: **~17–26 min → ~9 min cold / ~3.4 min warm.** The test branch and runs were cleaned up; the throwaway `rc-docker-optimize-test*` Docker Hub tags can be deleted at your convenience.

