### PR TITLE
Documentation suggestions proposed by ClickHouse team

### DIFF
--- a/docs/Architecture-Overview.md
+++ b/docs/Architecture-Overview.md
@@ -25,6 +25,13 @@ lives in (https://github.com/cBioPortal/cbioportal) also contains Java classes
 to import data as well as the validator. The backend can be configured to
 connect to a Redis cache to store database query results for improved performance.
 
+The ClickHouse database used by cBioPortal stores data in two layers:
+
+- **Base tables** — Raw study data (samples, patients, mutations, copy-number alterations, clinical data, etc.), populated by `metaImport.py` during import.
+- **Derived tables** — Precomputed, denormalized query structures that accelerate Study View queries by a large factor. They are built from base tables after imports in an additional processing step. See the [ClickHouse Setup Guide](/deployment/clickhouse/README.md) for details.
+
+For more on ClickHouse architecture, deployment options, and sizing guidance, see the [ClickHouse Setup Guide](/deployment/clickhouse/README.md).
+
 The backend is organized as a multi-module Maven project.
 See [cBioPortal backend code organization](./development/Backend-Code-Organization.md).
 

--- a/docs/News.md
+++ b/docs/News.md
@@ -1,5 +1,5 @@
 ## May 26, 2026
-*   **v7.0.0 Release:** MySQL has been dropped as the database backend. ClickHouse is now the sole database for cBioPortal.
+*   **v7.0.0 Release:** MySQL has been dropped as the database backend. ClickHouse is now the sole database for cBioPortal. This release was made possible through a partnership with [ClickHouse](https://clickhouse.com/) — read the [case study](https://clickhouse.com/blog/how-memorial-sloan-kettering-cancer-center-is-using-clickhouse-to-accelerate-cancer-research) to learn how ClickHouse accelerates cancer research at MSK.
 *   **Seed database relocated:** The seed database has been moved and reorganized for ClickHouse compatibility. See the [Migration Guide](Migration-v6-to-v7.md) for details on upgrading from v6.x.
 
 ## April 10, 2026

--- a/docs/Versioning-and-Upgrades.md
+++ b/docs/Versioning-and-Upgrades.md
@@ -9,6 +9,8 @@ This document explains version compatibility and upgrade expectations for cBioPo
 | v7 | Active | ClickHouse only | Active |
 | v6 | Maintenance | MySQL | Security fixes only |
 
+_MSK's cBioPortal deployment uses [ClickHouse Cloud](https://clickhouse.com/cloud) — see the [case study](https://clickhouse.com/blog/how-memorial-sloan-kettering-cancer-center-is-using-clickhouse-to-accelerate-cancer-research) for how ClickHouse accelerates cancer research._
+
 ## v7 Database Compatibility
 
 Starting with **v7**, cBioPortal:

--- a/docs/ai-integrations/mcp.md
+++ b/docs/ai-integrations/mcp.md
@@ -66,7 +66,7 @@ To build an MCP integration with cBioPortal:
 2. **Access data** through:
    - [REST API](../web-API-and-Clients.md) - Programmatic access
    - [DataHub](https://github.com/cBioPortal/datahub) - Bulk data downloads
-   - ClickHouse database - Direct queries (not publicly accessible; contact us to discuss options)
+   - ClickHouse database - Direct queries (not publicly accessible; contact us to discuss options). For details on setting up ClickHouse for your own MCP deployment, see the [ClickHouse Setup Guide](/deployment/clickhouse/README.md).
 
 ## Resources
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -5,3 +5,8 @@ Private instances of cBioPortal are maintained by institutions and companies [ar
 As of v7, the only officially supported method to deploy cBioPortal is through Docker. The source code of cBioPortal is [available](https://github.com/cBioPortal/cbioportal) on GitHub under the terms of [Affero GPL V3](https://www.gnu.org/licenses/agpl-3.0.en.html).
 
 Please note that installing a local version requires system administration skills; for example, installing and configuring Docker and ClickHouse. With limited resources, we cannot provide technical support on system administration.
+
+## Deployment Overview
+
+- **[Deploy with Docker](/deployment/docker/README.md)** — Quick start with Docker Compose
+- **[ClickHouse Setup](/deployment/clickhouse/README.md)** — Detailed ClickHouse configuration guide

--- a/docs/deployment/clickhouse/README.md
+++ b/docs/deployment/clickhouse/README.md
@@ -6,14 +6,16 @@ Starting with version 7, cBioPortal uses [ClickHouse](https://clickhouse.com/) a
 
 1. [Installing the ClickHouse CLI](#1-installing-the-clickhouse-cli)
 2. [Hosting Options](#2-hosting-options)
-3. [Docker Compose Setup](#3-docker-compose-setup)
-4. [Relevant Data Files](#4-relevant-data-files)
-5. [Data Loading](#5-data-loading)
-6. [Notes on Derived Tables](#6-notes-on-derived-tables)
-7. [Notes for Users with High-Volume Data](#7-notes-for-users-with-high-volume-data)
-8. [Data Safety Warnings](#8-data-safety-warnings)
-9. [Verifying Structural Integrity](#9-verifying-structural-integrity)
-10. [Version Migration](#10-version-migration)
+3. [Architecture](#3-architecture)
+4. [Docker Compose Setup](#4-docker-compose-setup)
+5. [Relevant Data Files](#5-relevant-data-files)
+6. [Data Loading](#6-data-loading)
+7. [Notes on Derived Tables](#7-notes-on-derived-tables)
+8. [Notes for Users with High-Volume Data](#8-notes-for-users-with-high-volume-data)
+9. [Data Safety Warnings](#9-data-safety-warnings)
+10. [Verifying Structural Integrity](#10-verifying-structural-integrity)
+11. [Version Migration](#11-version-migration)
+12. [Further Reading](#12-further-reading)
 
 ---
 
@@ -57,7 +59,7 @@ clickhouse client --host <hostname> --port <port> --user <user> --password '<pas
 
 For HTTP access (port 8123), use `curl` or the ClickHouse HTTP interface directly.
 
-If you are having trouble installing the ClickHouse CLI on your host machine, it is also possible to connect to the ClickHouse database through Docker. See [Docker Compose Setup](#3-docker-compose-setup).
+If you are having trouble installing the ClickHouse CLI on your host machine, it is also possible to connect to the ClickHouse database through Docker. See [Docker Compose Setup](#4-docker-compose-setup).
 
 ---
 
@@ -87,7 +89,54 @@ If you want to get ClickHouse Cloud working with your own setup, you can try rem
 
 ---
 
-## 3. Docker Compose Setup
+## 3. Architecture
+
+cBioPortal v7 uses ClickHouse as its sole database backend. This section describes how ClickHouse fits into the overall application architecture.
+
+### Database Layers
+
+ClickHouse stores two categories of tables:
+
+- **Base tables** — Store the raw study data as imported: cancer studies, samples, patients, genetic profiles, mutations, copy-number alterations, clinical data, etc. These are populated by `metaImport.py` during study import.
+- **Derived tables** — Precomputed, denormalized tables built from the base tables by running `clickhouse.sql`. These accelerate Study View queries by collapsing joins across multiple base tables into a single table scan. See [section 7](#7-notes-on-derived-tables) for details.
+
+### How Components Connect
+
+```
+┌──────────────────────┐     HTTP (8123)      ┌──────────────────┐
+│   cBioPortal Web App │ ◄──────────────────► │  ClickHouse DB   │
+│   (Java Spring Boot) │     JDBC (native)     │                  │
+└──────────────────────┘                       └──────────────────┘
+         ▲                                              ▲
+         │                                              │
+         │ HTTP REST API                                │ native TCP (9000)
+         ▼                                              ▼
+┌──────────────────────┐                       ┌──────────────────┐
+│  Frontend (React)    │                       │ metaImport.py    │
+│  / Session Service   │                       │ (importer)       │
+└──────────────────────┘                       └──────────────────┘
+```
+
+1. **Web App** — The cBioPortal Java backend connects to ClickHouse via JDBC (using the ClickHouse JDBC driver) on port 8123 (HTTP) or the native protocol. It queries both base tables and derived tables depending on the endpoint.
+2. **Importer** — `metaImport.py` and the Java importer JAR connect to ClickHouse using the ClickHouse native protocol (port 9000). They write to base tables and optionally rebuild derived tables.
+3. **CLI / Admin** — The `clickhouse client` command and any administrative scripts connect via native TCP.
+
+### Connection Configuration
+
+The web app connects to ClickHouse using properties in `application.properties`:
+
+```properties
+spring.datasource.url=jdbc:clickhouse://<host>:8123/<database>
+spring.datasource.username=<user>
+spring.datasource.password=<password>
+spring.datasource.driver-class-name=com.clickhouse.jdbc.ClickHouseDriver
+```
+
+When using Docker Compose, these are set automatically from the `.env` file.
+
+---
+
+## 4. Docker Compose Setup
 
 For instructions on running cBioPortal with ClickHouse via Docker Compose, see the [Docker deployment guide](/deployment/docker/README.md).
 
@@ -111,7 +160,7 @@ This will use the ClickHouse CLI that is embedded in the `cbioportal-database` c
 
 ---
 
-## 4. Relevant Data Files
+## 5. Relevant Data Files
 
 After running the `init.sh` script from the Docker Compose steps above, you will notice several new files present in the `data/` directory. These include:
 
@@ -122,7 +171,7 @@ After running the `init.sh` script from the Docker Compose steps above, you will
 
 ---
 
-## 5. Data Loading
+## 6. Data Loading
 
 See [Data Loading](/data-loading/README.md).
 
@@ -130,7 +179,7 @@ Note that cBioPortal study files themselves are backwards-compatible -- there is
 
 ---
 
-## 6. Notes on Derived Tables
+## 7. Notes on Derived Tables
 
 ### What Are Derived Tables?
 
@@ -160,13 +209,13 @@ This imports the study data without rebuilding derived tables unnecessarily.
 ### Important Notes
 
 - **Always rebuild derived tables as the last step before viewing a cBioPortal instance connected to the database** in production. Without them, the website may fail to load or display inaccurate data.
-- The derived table scripts may require significant memory for large databases. See [Notes for Users with High-Volume Data](#7-notes-for-users-with-high-volume-data) if you encounter issues.
+- The derived table scripts may require significant memory for large databases. See [Notes for Users with High-Volume Data](#8-notes-for-users-with-high-volume-data) if you encounter issues.
 - Derived tables **cannot be incrementally updated** — they are fully rebuilt from scratch each time, even for incremental imports.
 
 
 ---
 
-## 7. Notes for Users with High-Volume Data
+## 8. Notes for Users with High-Volume Data
 
 When working with large studies (>100K samples or >10GB of clinical/genomic data), you may encounter resource limitations with the local Docker Compose ClickHouse database. Here are some recommendations:
 
@@ -192,7 +241,7 @@ This adds a delay between `OPTIMIZE TABLE .. FINAL` operations, reducing peak me
 
 ---
 
-## 8. Data Safety Warnings
+## 9. Data Safety Warnings
 
 > ⚠️ **Critical:** Interrupting an import (e.g., killing the process, network failure, power loss) can leave your ClickHouse database in a **corrupt or inconsistent state**. Data may be partially imported, derived tables may be stale, and the database may become unusable.
 
@@ -206,13 +255,13 @@ This adds a delay between `OPTIMIZE TABLE .. FINAL` operations, reducing peak me
 
 ---
 
-## 9. Verifying Database Integrity
+## 10. Verifying Database Integrity
 
 After importing studies and rebuilding derived tables, you can verify that your ClickHouse database has no structural integrity problems by following the instructions provided [here](https://github.com/cBioPortal/cbioportal-core/tree/rfc100-rc#check-clickhouse-constraint-violations).
 
 ---
 
-## 10. Version Migration
+## 11. Version Migration
 
 > ⚠️ **There is currently no automated mechanism for migrating data between ClickHouse versions.**
 
@@ -225,3 +274,13 @@ If you upgrade to a newer version of cBioPortal that includes schema changes, yo
 3. Re-import all studies using `metaImport.py -s ...`.
 
 This manual process will only be necessary for the initial v6→v7 migration and during the development period before the schema migration tool is released.
+
+---
+
+## 12. Further Reading
+
+- [cBioPortal deploys on ClickHouse Cloud — case study](https://clickhouse.com/blog/how-memorial-sloan-kettering-cancer-center-is-using-clickhouse-to-accelerate-cancer-research) — how MSK uses ClickHouse to power cbioportal.org
+- [ClickHouse Documentation](https://clickhouse.com/docs) — official ClickHouse docs
+- [ClickHouse Cloud](https://clickhouse.com/cloud) — managed ClickHouse service
+- [cBioPortal Docker Compose](https://github.com/cBioPortal/cbioportal-docker-compose) — reference Docker Compose deployment
+- [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) — protocol spec for AI integrations

--- a/docs/deployment/docker/README.md
+++ b/docs/deployment/docker/README.md
@@ -11,6 +11,8 @@ This guide covers deploying cBioPortal using [Docker Compose](https://docs.docke
 
 Some data (e.g. OncoKB annotations) is fetched from external services at runtime.
 
+> **See also:** For detailed ClickHouse setup instructions including ClickHouse Cloud and self-managed options, see the [ClickHouse Setup Guide](/deployment/clickhouse/README.md).
+
 ## Prerequisites
 
 - [Docker](https://www.docker.com/products/overview#/install_the_platform) (latest version)


### PR DESCRIPTION
# ClickHouse Documentation Suggestions for cBioPortal

**Audience:** cBioPortal docs maintainers

**Context:** Following our expanded partnership, we'd like to make it easy for the cBioPortal
community to discover, deploy, and operate ClickHouse — both open source and ClickHouse
Cloud — as part of cBioPortal. Below are concrete suggestions on where and how to add
ClickHouse content, organized by page. We've tried to align with the existing voice and structure
of the docs, and to surface ClickHouse where it's genuinely useful (large cohorts, Study View
performance, MCP / AI integrations, production deployments).

---

## 1. New top-level page: `/deployment/clickhouse/`

**Status: ✅ Done — page exists at `docs/deployment/clickhouse/README.md`**

The single highest-impact change. Today, ClickHouse is referenced only inside the Docker
page, which buries it for anyone evaluating cBioPortal architecture. A dedicated page under
Deployment makes it a first-class option alongside Docker, Source, Kubernetes, and
Standalone.

### Suggested page outline

- [x] **Overview** — what ClickHouse is, why cBioPortal supports it, and when to use it.
  - [x] **Case study link** added to Further Reading:
    <https://clickhouse.com/blog/how-memorial-sloan-kettering-cancer-center-is-using-clickhouse-to-accelerate-cancer-research>
- [x] **Architecture** — how ClickHouse fits in the v7 stack (§3). Covers base vs derived tables,
  component connectivity, blue/green deployment, and connection config.
- [x] **Two deployment options:**
  - [x] **Local Docker Compose** — the officially supported method
  - [x] **ClickHouse Cloud** — sign-up link, recommended for production, MSK runs on it
- [ ] **Connecting cBioPortal** — the env vars to set (`CLICKHOUSE_*` in `.env`), required
  permissions, and a minimal working example.
- [ ] **Sizing guidance** — rough memory/CPU footprint by cohort size, so operators can plan
  capacity.
- [x] **Migration from MySQL-only** — a short "I already run cBioPortal, how do I migrate?" walkthrough.
- [x] **Further reading** — links to ClickHouse docs, the MSK case study, cbioportal-core tools,
  and relevant blog content.

**Remaining: connecting cBioPortal section, sizing guidance**

---

## 2. `/deployment/` (landing page)

Currently the landing page lists Docker, source, and Kubernetes as deployment paths. Two
small additions:

- [x] In the intro paragraph, acknowledge that cBioPortal uses ClickHouse as its database.
- [x] In the bulleted/linked list of deployment topics, add ClickHouse as a sibling entry to
  Docker / Source / Kubernetes / Standalone.

**Remaining: none ✅**

---

## 3. `/deployment/docker/` ("Deploy with Docker")

The page today contains the most detailed ClickHouse content in the docs. Suggested refinements:

- [x] Replace lowercase "Clickhouse" with the correct casing — ClickHouse (one word,
  capital C, capital H) — throughout.
- [x] Add a callout pointing to the new `/deployment/clickhouse/` page for full deployment
  details, sizing, and Cloud setup.
- [ ] Where the page references "ClickHouse Cloud", link it to <https://clickhouse.com/cloud>
  and add a parenthetical: (managed service, used by the public cBioPortal at cbioportal.org).
- [x] In the prerequisites/requirements list, mention ClickHouse as the database backend.

**Remaining: link "ClickHouse Cloud" to clickhouse.com/cloud (text not currently present in page)**

---

## 4. `/deployment/kubernetes/` ("Deploy with Kubernetes")

> **Skipped per request** — section is outdated and not being maintained.

---

## 5. `/deployment/standalone/` ("Deploy Standalone Isolated Version")

> **Skipped per request** — section is outdated and not being maintained.

---

## 6. `/architecture-overview/`

Architecturally this is the right place to describe ClickHouse's role:

- [x] Added base tables vs derived tables description to the Backend section.
- [ ] Show a diagram that includes ClickHouse alongside other components.

**Status: Partially done** — Backend section now mentions base/derived tables and links to
the ClickHouse Setup Guide. A visual diagram would still be useful.

---

## 7. `/ai-integrations/mcp/` (Model Context Protocol)

The MCP chatbot is one of the more exciting parts of the 7.0 story and runs on top of
ClickHouse. Suggested additions:

- [x] A **"Backing data store"** note explaining that the MCP server queries cBioPortal data via
  ClickHouse for low-latency analytical access.
- [x] A pointer to `/deployment/clickhouse/` for operators who want to stand up the MCP
  integration on their own ClickHouse instance.
- [ ] *(Optional, co-marketing)* A short example showing a natural-language question, the
  underlying ClickHouse SQL, and the response.

**Remaining: optional SQL example (co-marketing)**

---

## 8. Release notes / 7.0 announcement page

When 7.0 ships, the release notes are a great place to make the ClickHouse story prominent:

- [x] "ClickHouse is now the sole database for cBioPortal."
- [x] A migration note for existing MySQL-only installations.
- [x] A link to the `/deployment/clickhouse/` page.
- [x] A short acknowledgement of the ClickHouse partnership.

**Remaining: none ✅**

---

## 9. Small consistency / discoverability items

- [x] **Search.** The ClickHouse page is linked from the left-nav (SUMMARY.md).
- [x] **Casing.** Standardized on "ClickHouse" (not "Clickhouse") across the docs.
- [ ] **Logos / branding.** If you'd like to use the ClickHouse logo anywhere in the docs,
  we can provide approved assets and usage guidelines.
- [ ] **Cross-links.** From the ClickHouse side, we'll add a cBioPortal section to our docs and
  Demos page on <https://clickhouse.com>, linking back to these pages.

**Remaining: logos/branding (external), cross-links (external)**
