### PR TITLE
Exclude column-store endpoints from InvolvedCancerStudyExtractorInterceptor and remove redundant workarounds

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreClinicalDataController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreClinicalDataController.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.Collections;
 import java.util.List;
 import org.cbioportal.application.rest.mapper.ClinicalDataMapper;
 import org.cbioportal.application.rest.response.ClinicalDataDTO;
@@ -27,7 +26,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -121,9 +119,6 @@ public class ColumnStoreClinicalDataController {
       content =
           @Content(array = @ArraySchema(schema = @Schema(implementation = ClinicalData.class))))
   public ResponseEntity<List<ClinicalDataDTO>> fetchClinicalData(
-      @Parameter(hidden = true)
-          @RequestAttribute(required = false, value = "interceptedClinicalDataMultiStudyFilter")
-          ClinicalDataMultiStudyFilter interceptedClinicalDataMultiStudyFilter,
       @Parameter(description = "Type of the clinical data") @RequestParam(defaultValue = "SAMPLE")
           ClinicalDataType clinicalDataType,
       @Parameter(
@@ -136,27 +131,18 @@ public class ColumnStoreClinicalDataController {
           @RequestParam(defaultValue = "SUMMARY")
           ProjectionType projection) {
 
-    // Use the filter parsed by InvolvedCancerStudyExtractorInterceptor as fallback when
-    // @RequestBody
-    // is null (e.g. body already consumed by the interceptor before Spring MVC re-reads it).
-    ClinicalDataMultiStudyFilter filter =
-        clinicalDataMultiStudyFilter != null
-            ? clinicalDataMultiStudyFilter
-            : interceptedClinicalDataMultiStudyFilter;
-
-    if (filter == null) {
-      return ResponseEntity.ok(Collections.emptyList());
-    }
-
     if (projection == ProjectionType.META) {
       HttpHeaders responseHeaders = new HttpHeaders();
       responseHeaders.add(
           HeaderKeyConstants.TOTAL_COUNT,
-          fetchClinicalDataMetaUseCase.execute(filter, clinicalDataType).toString());
+          fetchClinicalDataMetaUseCase
+              .execute(clinicalDataMultiStudyFilter, clinicalDataType)
+              .toString());
       return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
     }
     return ResponseEntity.ok(
         ClinicalDataMapper.INSTANCE.toDTOs(
-            fetchClinicalDataUseCase.execute(filter, clinicalDataType, projection)));
+            fetchClinicalDataUseCase.execute(
+                clinicalDataMultiStudyFilter, clinicalDataType, projection)));
   }
 }

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreClinicalDataEnrichmentController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreClinicalDataEnrichmentController.java
@@ -86,7 +86,7 @@ public class ColumnStoreClinicalDataEnrichmentController {
   public ResponseEntity<List<ClinicalDataEnrichmentDTO>> fetchClinicalEnrichments(
       @Parameter(required = true, description = "Group filter with sample identifiers")
           @Valid
-          @RequestBody
+          @RequestBody(required = false)
           GroupFilter groupFilter) {
 
     return new ResponseEntity<>(

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreClinicalDataEnrichmentController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreClinicalDataEnrichmentController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.Collections;
 import java.util.List;
 import org.cbioportal.application.rest.mapper.ClinicalDataEnrichmentMapper;
 import org.cbioportal.application.rest.response.ClinicalDataEnrichmentDTO;
@@ -19,7 +18,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -86,21 +84,14 @@ public class ColumnStoreClinicalDataEnrichmentController {
               array =
                   @ArraySchema(schema = @Schema(implementation = ClinicalDataEnrichmentDTO.class))))
   public ResponseEntity<List<ClinicalDataEnrichmentDTO>> fetchClinicalEnrichments(
-      @Parameter(hidden = true)
-          @RequestAttribute(required = false, value = "interceptedGroupFilter")
-          GroupFilter interceptedGroupFilter,
       @Parameter(required = true, description = "Group filter with sample identifiers")
           @Valid
-          @RequestBody(required = false)
+          @RequestBody
           GroupFilter groupFilter) {
 
-    GroupFilter effectiveFilter = groupFilter != null ? groupFilter : interceptedGroupFilter;
-    if (effectiveFilter == null) {
-      return new ResponseEntity<>(Collections.emptyList(), HttpStatus.OK);
-    }
     return new ResponseEntity<>(
         ClinicalDataEnrichmentMapper.INSTANCE.toDTOs(
-            fetchClinicalDataEnrichmentsUseCase.execute(effectiveFilter)),
+            fetchClinicalDataEnrichmentsUseCase.execute(groupFilter)),
         HttpStatus.OK);
   }
 }

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreMutationController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreMutationController.java
@@ -65,8 +65,7 @@ public class ColumnStoreMutationController {
    * Fetch Mutation by exactly one sampleUniqueIdentifier or molecularProfileId must or
    * entrezGeneIds
    *
-   * @param interceptedMutationMultipleStudyFilter security-intercepted filter for permission
-   *     validation
+   * @param mutationMultipleStudyFilterFromBody request body filter used by this hidden endpoint
    * @param mutationMultipleStudyFilter filter containing patient/sample identifiers and attribute
    *     IDs
    * @param projection level of detail for the response data
@@ -85,14 +84,10 @@ public class ColumnStoreMutationController {
       @Parameter(hidden = true) // prevent reference to this attribute in the swagger-ui interface
           @RequestAttribute(required = false, value = "involvedCancerStudies")
           Collection<String> involvedCancerStudies,
-      @Parameter(
-              hidden =
-                  true) // prevent reference to this attribute in the swagger-ui interface. this
-          // attribute is needed for now but was needed previously for @PreAuthorize .
+      @Parameter(hidden = true) // prevent reference to this attribute in the swagger-ui interface
           @Valid
           @RequestBody(required = false)
-          MutationMultipleStudyFilter
-              interceptedMutationMultipleStudyFilter, // This is being intercepted will leave this
+          MutationMultipleStudyFilter mutationMultipleStudyFilterFromBody,
       @Parameter(
               required = true,
               description =
@@ -122,9 +117,7 @@ public class ColumnStoreMutationController {
     if (projection == ProjectionType.META) {
       HttpHeaders responseHeaders = new HttpHeaders();
       MutationMeta mutationMeta =
-          mutationUseCases
-              .fetchMetaMutationsUseCase()
-              .execute(interceptedMutationMultipleStudyFilter);
+          mutationUseCases.fetchMetaMutationsUseCase().execute(mutationMultipleStudyFilterFromBody);
       responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, mutationMeta.getTotalCount().toString());
       responseHeaders.add(
           HeaderKeyConstants.SAMPLE_COUNT, mutationMeta.getSampleCount().toString());
@@ -141,7 +134,7 @@ public class ColumnStoreMutationController {
         MutationMapper.INSTANCE.toDTOs(
             mutationUseCases
                 .fetchAllMutationsInProfileUseCase()
-                .execute(interceptedMutationMultipleStudyFilter, mutationQueryOptions));
+                .execute(mutationMultipleStudyFilterFromBody, mutationQueryOptions));
     return ResponseEntity.ok(mutations);
   }
 }

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreMutationController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreMutationController.java
@@ -65,9 +65,8 @@ public class ColumnStoreMutationController {
    * Fetch Mutation by exactly one sampleUniqueIdentifier or molecularProfileId must or
    * entrezGeneIds
    *
-   * @param mutationMultipleStudyFilterFromBody request body filter used by this hidden endpoint
-   * @param mutationMultipleStudyFilter filter containing patient/sample identifiers and attribute
-   *     IDs
+   * @param interceptedMutationMultipleStudyFilter security-intercepted filter for permission
+   *     validation
    * @param projection level of detail for the response data
    * @return ResponseEntity containing list of Mutation data DTOs, or empty body with count header
    *     for META projection
@@ -84,18 +83,14 @@ public class ColumnStoreMutationController {
       @Parameter(hidden = true) // prevent reference to this attribute in the swagger-ui interface
           @RequestAttribute(required = false, value = "involvedCancerStudies")
           Collection<String> involvedCancerStudies,
-      @Parameter(hidden = true) // prevent reference to this attribute in the swagger-ui interface
-          @Valid
-          @RequestBody(required = false)
-          MutationMultipleStudyFilter mutationMultipleStudyFilterFromBody,
       @Parameter(
-              required = true,
-              description =
-                  "List of Molecular Profile IDs or List of Molecular Profile ID / Sample ID pairs,"
-                      + " and List of Entrez Gene IDs")
+              hidden =
+                  true) // prevent reference to this attribute in the swagger-ui interface. this
+          // attribute is needed for now but was needed previously for @PreAuthorize .
           @Valid
           @RequestBody(required = false)
-          MutationMultipleStudyFilter mutationMultipleStudyFilter,
+          MutationMultipleStudyFilter
+              interceptedMutationMultipleStudyFilter, // This is being intercepted will leave this
       @Parameter(description = "Level of detail of the response")
           @RequestParam(defaultValue = "SUMMARY")
           ProjectionType projection,
@@ -117,7 +112,9 @@ public class ColumnStoreMutationController {
     if (projection == ProjectionType.META) {
       HttpHeaders responseHeaders = new HttpHeaders();
       MutationMeta mutationMeta =
-          mutationUseCases.fetchMetaMutationsUseCase().execute(mutationMultipleStudyFilterFromBody);
+          mutationUseCases
+              .fetchMetaMutationsUseCase()
+              .execute(interceptedMutationMultipleStudyFilter);
       responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, mutationMeta.getTotalCount().toString());
       responseHeaders.add(
           HeaderKeyConstants.SAMPLE_COUNT, mutationMeta.getSampleCount().toString());
@@ -134,7 +131,7 @@ public class ColumnStoreMutationController {
         MutationMapper.INSTANCE.toDTOs(
             mutationUseCases
                 .fetchAllMutationsInProfileUseCase()
-                .execute(mutationMultipleStudyFilterFromBody, mutationQueryOptions));
+                .execute(interceptedMutationMultipleStudyFilter, mutationQueryOptions));
     return ResponseEntity.ok(mutations);
   }
 }

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreMutationController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreMutationController.java
@@ -7,7 +7,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import org.cbioportal.application.rest.mapper.MutationMapper;
 import org.cbioportal.application.rest.response.MutationDTO;
@@ -89,10 +88,11 @@ public class ColumnStoreMutationController {
       @Parameter(
               hidden =
                   true) // prevent reference to this attribute in the swagger-ui interface. this
-          // attribute is set by InvolvedCancerStudyExtractorInterceptor and used as the primary
-          // source; @RequestBody is kept as fallback in case the attribute is not present.
-          @RequestAttribute(required = false, value = "interceptedMutationMultipleStudyFilter")
-          MutationMultipleStudyFilter interceptedMutationMultipleStudyFilter,
+          // attribute is needed for now but was needed previously for @PreAuthorize .
+          @Valid
+          @RequestBody(required = false)
+          MutationMultipleStudyFilter
+              interceptedMutationMultipleStudyFilter, // This is being intercepted will leave this
       @Parameter(
               required = true,
               description =
@@ -119,17 +119,12 @@ public class ColumnStoreMutationController {
       @Parameter(description = "Direction of the sort") @RequestParam(defaultValue = "ASC")
           Direction direction) {
 
-    MutationMultipleStudyFilter effectiveFilter =
-        interceptedMutationMultipleStudyFilter != null
-            ? interceptedMutationMultipleStudyFilter
-            : mutationMultipleStudyFilter;
-    if (effectiveFilter == null) {
-      return ResponseEntity.ok(Collections.emptyList());
-    }
     if (projection == ProjectionType.META) {
       HttpHeaders responseHeaders = new HttpHeaders();
       MutationMeta mutationMeta =
-          mutationUseCases.fetchMetaMutationsUseCase().execute(effectiveFilter);
+          mutationUseCases
+              .fetchMetaMutationsUseCase()
+              .execute(interceptedMutationMultipleStudyFilter);
       responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, mutationMeta.getTotalCount().toString());
       responseHeaders.add(
           HeaderKeyConstants.SAMPLE_COUNT, mutationMeta.getSampleCount().toString());
@@ -146,7 +141,7 @@ public class ColumnStoreMutationController {
         MutationMapper.INSTANCE.toDTOs(
             mutationUseCases
                 .fetchAllMutationsInProfileUseCase()
-                .execute(effectiveFilter, mutationQueryOptions));
+                .execute(interceptedMutationMultipleStudyFilter, mutationQueryOptions));
     return ResponseEntity.ok(mutations);
   }
 }

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreSampleController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreSampleController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import java.util.Collections;
 import java.util.List;
 import org.cbioportal.application.rest.mapper.SampleMapper;
 import org.cbioportal.application.rest.response.SampleDTO;
@@ -40,7 +39,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -151,9 +149,6 @@ public class ColumnStoreSampleController {
       description = "OK",
       content = @Content(array = @ArraySchema(schema = @Schema(implementation = Sample.class))))
   public ResponseEntity<List<SampleDTO>> fetchSamples(
-      @Parameter(hidden = true)
-          @RequestAttribute(required = false, value = "interceptedSampleFilter")
-          SampleFilter interceptedSampleFilter,
       @Parameter(required = true, description = "List of sample identifiers")
           @Valid
           @RequestBody(required = false)
@@ -161,16 +156,11 @@ public class ColumnStoreSampleController {
       @Parameter(description = "Level of detail of the response")
           @RequestParam(defaultValue = "SUMMARY")
           ProjectionType projection) {
-    SampleFilter effectiveFilter = sampleFilter != null ? sampleFilter : interceptedSampleFilter;
-    if (effectiveFilter == null) {
-      return new ResponseEntity<>(Collections.emptyList(), HttpStatus.OK);
-    }
     if (projection == ProjectionType.META) {
-      HttpHeaders responseHeaders = fetchMetaSamplesHeaders(effectiveFilter);
+      HttpHeaders responseHeaders = fetchMetaSamplesHeaders(sampleFilter);
       return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
     } else {
-      List<Sample> samples =
-          sampleUseCases.fetchSamplesUseCase().execute(effectiveFilter, projection);
+      List<Sample> samples = sampleUseCases.fetchSamplesUseCase().execute(sampleFilter, projection);
       return new ResponseEntity<>(SampleMapper.INSTANCE.toDtos(samples), HttpStatus.OK);
     }
   }

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreAlterationEnrichmentController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnarStoreAlterationEnrichmentController.java
@@ -9,14 +9,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.cbioportal.domain.alteration.usecase.GetAlterationEnrichmentsUseCase;
 import org.cbioportal.legacy.model.AlterationEnrichment;
-import org.cbioportal.legacy.model.AlterationFilter;
 import org.cbioportal.legacy.model.EnrichmentType;
 import org.cbioportal.legacy.model.MolecularProfileCaseIdentifier;
 import org.cbioportal.legacy.service.exception.MolecularProfileNotFoundException;
@@ -26,7 +24,6 @@ import org.cbioportal.legacy.web.parameter.MolecularProfileCasesGroupFilter;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -66,13 +63,6 @@ public class ColumnarStoreAlterationEnrichmentController {
       @Parameter(description = "Type of the enrichment e.g. SAMPLE or PATIENT")
           @RequestParam(defaultValue = "SAMPLE")
           EnrichmentType enrichmentType,
-      @Parameter(hidden = true)
-          @RequestAttribute(
-              required = false,
-              value = "interceptedMolecularProfileCasesGroupFilters")
-          List<MolecularProfileCasesGroupFilter> interceptedGroupFilters,
-      @Parameter(hidden = true) @RequestAttribute(required = false, value = "alterationEventTypes")
-          AlterationFilter interceptedAlterationEventTypes,
       @Parameter(
               required = true,
               description =
@@ -81,19 +71,8 @@ public class ColumnarStoreAlterationEnrichmentController {
           @RequestBody(required = false)
           MolecularProfileCasesGroupAndAlterationTypeFilter groupsAndAlterationTypes)
       throws MolecularProfileNotFoundException {
-    List<MolecularProfileCasesGroupFilter> effectiveGroupFilters =
-        groupsAndAlterationTypes != null
-            ? groupsAndAlterationTypes.getMolecularProfileCasesGroupFilter()
-            : interceptedGroupFilters;
-    AlterationFilter effectiveAlterationFilter =
-        groupsAndAlterationTypes != null
-            ? groupsAndAlterationTypes.getAlterationEventTypes()
-            : interceptedAlterationEventTypes;
-    if (effectiveGroupFilters == null) {
-      return ResponseEntity.ok(Collections.emptyList());
-    }
     Map<String, List<MolecularProfileCaseIdentifier>> groupCaseIdentifierSet =
-        effectiveGroupFilters.stream()
+        groupsAndAlterationTypes.getMolecularProfileCasesGroupFilter().stream()
             .collect(
                 Collectors.toMap(
                     MolecularProfileCasesGroupFilter::getName,
@@ -101,6 +80,8 @@ public class ColumnarStoreAlterationEnrichmentController {
 
     return ResponseEntity.ok(
         getAlterationEnrichmentsUseCase.execute(
-            groupCaseIdentifierSet, enrichmentType, effectiveAlterationFilter));
+            groupCaseIdentifierSet,
+            enrichmentType,
+            groupsAndAlterationTypes.getAlterationEventTypes()));
   }
 }

--- a/src/main/java/org/cbioportal/legacy/web/util/ContentCachingRequestWrapperFilter.java
+++ b/src/main/java/org/cbioportal/legacy/web/util/ContentCachingRequestWrapperFilter.java
@@ -12,7 +12,7 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
  * Filter that wraps the request in a {@link ContentCachingRequestWrapper} to allow multiple reads
  * of the request body. For controllers that receive study view data filters, the first read is done
  * by {@link InvolvedCancerStudyExtractorInterceptor} security interceptor to extract involved study
- * ids to apply autorization, and the second read will be done by the actual controller.
+ * ids to apply authorization, and the second read will be done by the actual controller.
  *
  * <p>Example of use: For controllers that receive study view data filters, the first read is
  * performed by the {@link InvolvedCancerStudyExtractorInterceptor} security interceptor. This

--- a/src/main/java/org/cbioportal/legacy/web/util/ContentCachingRequestWrapperFilter.java
+++ b/src/main/java/org/cbioportal/legacy/web/util/ContentCachingRequestWrapperFilter.java
@@ -2,22 +2,17 @@ package org.cbioportal.legacy.web.util;
 
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletRequestWrapper;
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 
 /**
- * Filter that wraps the request in a re-readable body wrapper to allow multiple reads of the
- * request body. For controllers that receive study view data filters, the first read is done by
- * {@link InvolvedCancerStudyExtractorInterceptor} security interceptor to extract involved study
- * ids to apply authorization, and the second read will be done by the actual controller.
+ * Filter that wraps the request in a {@link ContentCachingRequestWrapper} to allow multiple reads
+ * of the request body. For controllers that receive study view data filters, the first read is done
+ * by {@link InvolvedCancerStudyExtractorInterceptor} security interceptor to extract involved study
+ * ids to apply autorization, and the second read will be done by the actual controller.
  *
  * <p>Example of use: For controllers that receive study view data filters, the first read is
  * performed by the {@link InvolvedCancerStudyExtractorInterceptor} security interceptor. This
@@ -37,57 +32,9 @@ public class ContentCachingRequestWrapperFilter implements Filter {
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
       throws IOException, ServletException {
-    CachedBodyRequestWrapper wrappedRequest =
-        new CachedBodyRequestWrapper((HttpServletRequest) request);
+    ContentCachingRequestWrapper wrappedRequest =
+        new ContentCachingRequestWrapper((HttpServletRequest) request);
     LOG.trace("Wrapping request for multiple reads of request body");
     filterChain.doFilter(wrappedRequest, response);
-  }
-
-  /**
-   * Request wrapper that eagerly reads and caches the entire request body, then replays it on every
-   * {@link #getInputStream()} call. This ensures that both the {@link
-   * InvolvedCancerStudyExtractorInterceptor} (which consumes the body to extract study IDs) and the
-   * downstream controller (which uses {@code @RequestBody}) can each read the body independently.
-   */
-  static class CachedBodyRequestWrapper extends HttpServletRequestWrapper {
-    private final byte[] cachedBody;
-
-    CachedBodyRequestWrapper(HttpServletRequest request) throws IOException {
-      super(request);
-      this.cachedBody = request.getInputStream().readAllBytes();
-    }
-
-    @Override
-    public ServletInputStream getInputStream() {
-      ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(this.cachedBody);
-      return new ServletInputStream() {
-        @Override
-        public boolean isFinished() {
-          return byteArrayInputStream.available() == 0;
-        }
-
-        @Override
-        public boolean isReady() {
-          return true;
-        }
-
-        @Override
-        public void setReadListener(ReadListener readListener) {
-          throw new UnsupportedOperationException("Async reading is not supported");
-        }
-
-        @Override
-        public int read() throws IOException {
-          return byteArrayInputStream.read();
-        }
-      };
-    }
-
-    @Override
-    public BufferedReader getReader() throws IOException {
-      String encoding = getCharacterEncoding();
-      Charset charset = (encoding != null ? Charset.forName(encoding) : StandardCharsets.UTF_8);
-      return new BufferedReader(new InputStreamReader(getInputStream(), charset));
-    }
   }
 }

--- a/src/main/java/org/cbioportal/legacy/web/util/InvolvedCancerStudyExtractorInterceptor.java
+++ b/src/main/java/org/cbioportal/legacy/web/util/InvolvedCancerStudyExtractorInterceptor.java
@@ -79,6 +79,7 @@ import org.cbioportal.legacy.web.parameter.SurvivalRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 public class InvolvedCancerStudyExtractorInterceptor implements HandlerInterceptor {
@@ -89,6 +90,12 @@ public class InvolvedCancerStudyExtractorInterceptor implements HandlerIntercept
 
   private static final Logger LOG =
       LoggerFactory.getLogger(InvolvedCancerStudyExtractorInterceptor.class);
+
+  // Column-store (ClickHouse) controllers perform their own authorization and were never subject to
+  // this interceptor before they took over the legacy fetch paths. Skip them to avoid the
+  // unnecessary request-body parsing this interceptor performs.
+  private static final String COLUMN_STORE_CONTROLLER_PACKAGE =
+      "org.cbioportal.application.rest.vcolumnstore";
   public static final String PATIENT_FETCH_PATH = "/patients/fetch";
   public static final String SAMPLE_FETCH_PATH = "/samples/fetch";
   public static final String MOLECULAR_PROFILE_FETCH_PATH = "/molecular-profiles/fetch";
@@ -161,6 +168,14 @@ public class InvolvedCancerStudyExtractorInterceptor implements HandlerIntercept
   @Override
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
+    if (handler instanceof HandlerMethod
+        && ((HandlerMethod) handler)
+            .getBeanType()
+            .getPackageName()
+            .startsWith(COLUMN_STORE_CONTROLLER_PACKAGE)) {
+      return true; // column-store endpoints handle their own authorization; not subject to this
+      // interceptor
+    }
     if (!request.getMethod().equals("POST")) {
       return true; // no attribute extraction needed because all user supplied filter objects are in
       // POST requests

--- a/src/main/java/org/cbioportal/legacy/web/util/InvolvedCancerStudyExtractorInterceptor.java
+++ b/src/main/java/org/cbioportal/legacy/web/util/InvolvedCancerStudyExtractorInterceptor.java
@@ -168,8 +168,8 @@ public class InvolvedCancerStudyExtractorInterceptor implements HandlerIntercept
   @Override
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
-    if (handler instanceof HandlerMethod
-        && ((HandlerMethod) handler)
+    if (handler instanceof HandlerMethod handlerMethod
+        && handlerMethod
             .getBeanType()
             .getPackageName()
             .startsWith(COLUMN_STORE_CONTROLLER_PACKAGE)) {


### PR DESCRIPTION
## Problem

The recent ClickHouse import refactor moved the column-store controllers (package `org.cbioportal.application.rest.vcolumnstore`) onto the same fetch paths the legacy endpoints use (e.g. `/filtered-samples/fetch`, `/cna-genes/fetch`, `/clinical-data-counts/fetch`).

`InvolvedCancerStudyExtractorInterceptor` is registered globally in `WebAppConfig` (no path patterns) and dispatches purely by URL path. As a result, every column-store request now hits the interceptor, which deserializes the full POST body to extract involved cancer study IDs — work these endpoints never did before and don't need, since they perform their own `@PreAuthorize` authorization. This caused a performance regression.

After introducing the interceptor guard, several workaround changes that were previously added to handle interceptor body-consumption side effects became redundant.

## Fix

- Add a guard at the top of `preHandle`: if the resolved handler belongs to `org.cbioportal.application.rest.vcolumnstore`, return early before any body parsing.
- Revert redundant workaround changes that are no longer needed once column-store handlers are excluded from interception:
  - request-body/request-attribute fallback handling in affected `vcolumnstore` controllers
  - custom re-readable request wrapper changes in `ContentCachingRequestWrapperFilter`

This keeps behavior unchanged for non-column-store endpoints while removing now-unnecessary interceptor-related complexity from column-store paths.

Compiles clean and passes Spotless.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>