### PR TITLE
Fix typos in CONTRIBUTING.md and Versioning-and-Upgrades.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We are curious to learn more about you! We would love to help you get started! T
 2. Knowledge about cancer genomics but no to little engineering experience
 3. No engineering nor cancer genomics experience but an eagerness to contribute
 
-if you feel like you don't fall into any of these categories, please reach out so you can help us update the above list 🙂! Note that there are many contributions that can be made to an open source commmunity without coding a single line of code. You can reach us through our [public slack channel](https://slack.cbioportal.org).
+if you feel like you don't fall into any of these categories, please reach out so you can help us update the above list 🙂! Note that there are many contributions that can be made to an open source community without coding a single line of code. You can reach us through our [public slack channel](https://slack.cbioportal.org).
 
 # Join the Slack!
 
@@ -37,7 +37,7 @@ From the [GitHub Help Page of Using Pull Requests](https://help.github.com/artic
  * Familiarize yourself with the [project documentation](https://docs.cbioportal.org), including the [Feature Development Guide](https://docs.cbioportal.org/development/feature-development-guide/), the [Architecture docs](https://docs.cbioportal.org/2.1-deployment/architecture-overview), the [backend code organization](https://docs.cbioportal.org/development/backend-code-organization/) and [backend development guidelines](https://docs.cbioportal.org/development/backend-development-guidelines/).
  * Find a [good first issue](https://github.com/cBioPortal/cbioportal/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22) to start with
  * Check if the issue will require frontend or backend changes. If it is for the frontend look at how to set up the [frontend repo](https://github.com/cbioPortal/cbioportal-frontend/) instead
- * Fork the cbioportal or cbioportal-frontend project on GitHub depending on what your working on.  For general instructions on forking a GitHub project, see [Forking a Repo](https://help.github.com/articles/fork-a-repo/) and [Syncing a fork](https://help.github.com/articles/syncing-a-fork/).
+ * Fork the cbioportal or cbioportal-frontend project on GitHub depending on what you're working on.  For general instructions on forking a GitHub project, see [Forking a Repo](https://help.github.com/articles/fork-a-repo/) and [Syncing a fork](https://help.github.com/articles/syncing-a-fork/).
  * Reach out on slack or our [Google user group](https://groups.google.com/g/cbioportal) if you run into any issues
 
 ### Documentation

--- a/docs/Architecture-Overview.md
+++ b/docs/Architecture-Overview.md
@@ -95,6 +95,6 @@ https://github.com/genome-nexus/g2s.
 
 cBioPortal calls these services with variant information from the cBioPortal
 database. It however does not send over information that links a variant to a
-particular sample or patient. If this is a concern for your use case we recommmend
+particular sample or patient. If this is a concern for your use case we recommend
 to deploy your own versions of these services. See the sections above to
 linkouts for instructions on how to do this.

--- a/docs/Importer-Tool.md
+++ b/docs/Importer-Tool.md
@@ -2,7 +2,7 @@
 
 :warning:  ***Warning: this way of loading data is deprecated. See [Data loading](Data-Loading.md) for the recommended method.***
 
-The page describes how to import data into the cBioPortal using Python scripts found in our [scripts](https://github.com/cBioPortal/cbioportal/tree/stable/core/src/main/scripts) directory.  The follow assumptions have been made:
+This page describes how to import data into the cBioPortal using Python scripts found in our [scripts](https://github.com/cBioPortal/cbioportal/tree/stable/core/src/main/scripts) directory.  The following assumptions have been made:
 
 1. The cBioPortal software has been correctly [built from source](/deployment/deploy-without-docker/Build-from-Source.md).
 2. The data to import is in the proper [File Format](/File-Formats.md).
@@ -40,7 +40,7 @@ The [meta_study.txt](File-Formats.md#cancer-study) file should conform to the fi
 
 ## Import Study Data
 
-The following command is used to import all types of genomic and clinicla data described on our [File Formats](File-Formats.md) wiki page.  Below are examples of import copy number and mutation data:
+The following command is used to import all types of genomic and clinical data described on our [File Formats](File-Formats.md) wiki page.  Below are examples of import copy number and mutation data:
 
 ```
 $PORTAL_HOME/core/src/main/scripts/cbioportalImporter.py --jvm-args "-Dspring.profiles.active=dbcp -cp $PORTAL_HOME/core/target/core-1.0-SNAPSHOT.jar" --command import-study-data --meta-filename /path-to-meta_CNA.txt/meta_CNA.txt --data-filename /path-to-data_CNA.txt/data_CNA.txt

--- a/docs/Migration-Guide.md
+++ b/docs/Migration-Guide.md
@@ -28,7 +28,7 @@ This page describes various changes deployers will need to make as they deploy n
 - `portal.properties` migration needed:
   - `portal.properties` has been renamed to `application.properties`. This is the Spring Boot default name 
   - `authenticate` values of `googleplus`, `social_auth_google` and `social_auth_microsoft` have been replaced by `optional_oauth2`
-    - If you used this property before without authorization (unlikely, only the public cBioPortal instance uses this), add the property `always_show_study_group=PUBLIC` and confirm  that all studies in your database you'd like to be be public have `GROUPS` values set to `PUBLIC`
+    - If you used this property before without authorization (unlikely, only the public cBioPortal instance uses this), add the property `always_show_study_group=PUBLIC` and confirm  that all studies in your database you'd like to be public have `GROUPS` values set to `PUBLIC`
 - `Redis HTTP Session`
   - To disable redis session (Must be disabled if redis is not setup) `spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration`
   - To enable `spring.data.redis.host=localhost` `spring.data.redis.port=6379`

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -61,7 +61,7 @@ _Cgds-test.sql_ should be generated with `/db-scripts/src/main/resources/gen-cgd
 SET GLOBAL local_infile=1;
 CREATE DATABASE cgds_test;
 CREATE USER 'cbio_user'@'localhost' IDENTIFIED BY 'somepassword';
-GRANT ALL ON cgds_test.* TO 'cbio_user'@'localhost'";
+GRANT ALL ON cgds_test.* TO 'cbio_user'@'localhost';
 FLUSH PRIVILEGES;
 SET default_storage_engine=InnoDB;
 SET SESSION sql_mode = 'ANSI_QUOTES';

--- a/docs/Versioning-and-Upgrades.md
+++ b/docs/Versioning-and-Upgrades.md
@@ -34,7 +34,7 @@ Users who cannot migrate immediately to v7 should remain on the latest v6 mainte
 
 ## Choosing the Right Version
 
-- **New deployments**: Use **v6** until the first stabilized v7 released
+- **New deployments**: Use **v6** until the first stabilized v7 release
 - **Existing v6 deployments**:
     - May stay on v6 short-term
     - Plan migration to v7


### PR DESCRIPTION
Fix spelling and grammar issues across documentation files.

## Describe changes proposed in this pull request:

### CONTRIBUTING.md
- Fix spelling: `commmunity` → `community`
- Fix grammar: `your working on` → `you're working on`

### Versioning-and-Upgrades.md
- Fix grammar: `v7 released` → `v7 release`

### Architecture-Overview.md
- Fix spelling: `recommmend` → `recommend`

### Importer-Tool.md
- Fix grammar: `The page describes` → `This page describes`
- Fix grammar: `The follow assumptions` → `The following assumptions`
- Fix spelling: `clinicla` → `clinical`

### Testing.md
- Remove stray double-quote in SQL `GRANT` statement

### Migration-Guide.md
- Fix duplicate word: `be be public` → `be public`

## Checks
- [x] The commit log is comprehensible.
- [x] Has tests — N/A, documentation-only change.
- [x] Is this PR adding logic based on clinical attributes? No.
- [ ] Make sure your PR has one of the labels defined in release-drafter.yml

## Any screenshots or GIFs?
N/A — text-only documentation fix.

## Notify reviewers
Documentation-only change, no code logic affected. Fixes span 6 files across `CONTRIBUTING.md` and `docs/` directory.
