### PR TITLE
fix: remove silent error swallowing in session service endpoints

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/cbioportal/application/rest/error/GlobalExceptionHandler.java
@@ -50,11 +50,9 @@ public class GlobalExceptionHandler {
 
   private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-  @ExceptionHandler(HttpClientErrorException.NotFound.class)
-  public ResponseEntity<ErrorResponse> handleHttpClientErrorNotFound(
-      HttpClientErrorException.NotFound ex) {
-    return new ResponseEntity<>(
-        new ErrorResponse("Requested session not found"), HttpStatus.NOT_FOUND);
+  @ExceptionHandler(HttpClientErrorException.class)
+  public ResponseEntity<ErrorResponse> handleHttpClientError(HttpClientErrorException ex) {
+    return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), ex.getStatusCode());
   }
 
   @ExceptionHandler(UnsupportedOperationException.class)

--- a/src/main/java/org/cbioportal/application/rest/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/cbioportal/application/rest/error/GlobalExceptionHandler.java
@@ -40,6 +40,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.client.HttpClientErrorException;
 
 // TODO
 // - consider extending extends ResponseEntityExceptionHandler
@@ -48,6 +49,13 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class GlobalExceptionHandler {
 
   private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+  @ExceptionHandler(HttpClientErrorException.NotFound.class)
+  public ResponseEntity<ErrorResponse> handleHttpClientErrorNotFound(
+      HttpClientErrorException.NotFound ex) {
+    return new ResponseEntity<>(
+        new ErrorResponse("Requested session not found"), HttpStatus.NOT_FOUND);
+  }
 
   @ExceptionHandler(UnsupportedOperationException.class)
   public ResponseEntity<ErrorResponse> handleUnsupportedOperation() {

--- a/src/main/java/org/cbioportal/legacy/service/util/SessionServiceRequestHandler.java
+++ b/src/main/java/org/cbioportal/legacy/service/util/SessionServiceRequestHandler.java
@@ -55,13 +55,13 @@ public class SessionServiceRequestHandler {
   @Value("${session.service.password:}")
   private String sessionServicePassword;
 
-  private Boolean isBasicAuthEnabled() {
+  private boolean isBasicAuthEnabled() {
     return isSessionServiceEnabled()
         && sessionServicePassword != null
         && !sessionServicePassword.equals("");
   }
 
-  public Boolean isSessionServiceEnabled() {
+  public boolean isSessionServiceEnabled() {
     return !StringUtils.isEmpty(sessionServiceURL);
   }
 

--- a/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
+++ b/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
@@ -344,7 +344,8 @@ public class SessionServiceController {
           sessionServiceRequestHandler.getVirtualStudiesForUser(userName(), studyIds);
       return new ResponseEntity<>(virtualStudyList, HttpStatus.OK);
     }
-    LOG.warn("Refusing to fetch user groups: session service not enabled or user is not authenticated");
+    LOG.warn(
+        "Refusing to fetch user groups: session service not enabled or user is not authenticated");
     return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
   }
 
@@ -458,7 +459,8 @@ public class SessionServiceController {
           sessionServiceRequestHandler.getCustomDataSessionForUser(userName(), studyIds);
       return new ResponseEntity<>(customDataSessionList, HttpStatus.OK);
     }
-    LOG.warn("Refusing to fetch custom properties: session service not enabled or user is not authenticated");
+    LOG.warn(
+        "Refusing to fetch custom properties: session service not enabled or user is not authenticated");
     return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
   }
 
@@ -486,7 +488,8 @@ public class SessionServiceController {
           sessionServiceRequestHandler.getCustomGeneListsForUser(userName());
       return new ResponseEntity<>(customGeneLists, HttpStatus.OK);
     }
-    LOG.warn("Refusing to fetch custom gene lists: session service not enabled or user is not authenticated");
+    LOG.warn(
+        "Refusing to fetch custom gene lists: session service not enabled or user is not authenticated");
     return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
   }
 }

--- a/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
+++ b/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
@@ -125,6 +125,7 @@ public class SessionServiceController {
         payload = virtualStudyData;
       } else if (type.equals(Session.SessionType.settings)) {
         if (!(isAuthorized())) {
+          LOG.warn("Refusing to create settings session: user is not authenticated");
           return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
         }
         Class<? extends PageSettingsData> pageDataClass =
@@ -148,6 +149,7 @@ public class SessionServiceController {
         payload = customData;
       } else if (type.equals(Session.SessionType.custom_gene_list)) {
         if (!(isAuthorized())) {
+          LOG.warn("Refusing to create custom gene list session: user is not authenticated");
           return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
         }
         CustomGeneListData customGeneListData =
@@ -164,7 +166,7 @@ public class SessionServiceController {
       return sessionServiceRequestHandler.createSession(type, payload);
 
     } catch (IOException e) {
-      LOG.error("Error occurred", e);
+      LOG.error("Failed to create session of type '{}'", type, e);
       return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
   }
@@ -198,10 +200,10 @@ public class SessionServiceController {
       }
       return new ResponseEntity<>(session, HttpStatus.OK);
     } catch (HttpClientErrorException.NotFound exception) {
-      LOG.error("Session not found", exception);
+      LOG.error("Session not found: type='{}', id='{}'", type, id, exception);
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     } catch (Exception exception) {
-      LOG.error("Error occurred", exception);
+      LOG.error("Failed to get session: type='{}', id='{}'", type, id, exception);
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
@@ -304,6 +306,10 @@ public class SessionServiceController {
 
       response.sendError(HttpStatus.OK.value());
     } else {
+      LOG.warn(
+          "Refusing to update users in session: session service not enabled or user is not authenticated: type='{}', id='{}'",
+          type,
+          id);
       response.sendError(HttpStatus.SERVICE_UNAVAILABLE.value());
     }
   }
@@ -338,6 +344,7 @@ public class SessionServiceController {
           sessionServiceRequestHandler.getVirtualStudiesForUser(userName(), studyIds);
       return new ResponseEntity<>(virtualStudyList, HttpStatus.OK);
     }
+    LOG.warn("Refusing to fetch user groups: session service not enabled or user is not authenticated");
     return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
   }
 
@@ -365,10 +372,12 @@ public class SessionServiceController {
         }
         response.setStatus(HttpStatus.OK.value());
       } else {
+        LOG.warn(
+            "Refusing to update page settings: session service not enabled or user is not authenticated");
         response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
       }
     } catch (IOException | ParseException e) {
-      LOG.error("Error occurred", e);
+      LOG.error("Failed to update page settings", e);
       response.setStatus(HttpStatus.BAD_REQUEST.value());
     }
   }
@@ -394,9 +403,14 @@ public class SessionServiceController {
         sessionServiceRequestHandler.updatePageSettings(type, pageSettings.getId(), body);
         response.setStatus(HttpStatus.OK.value());
       } else {
+        LOG.warn(
+            "Refusing to update page settings for session '{}': user '{}' is not the owner or origin does not match",
+            pageSettings.getId(),
+            userName());
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
       }
     } else {
+      LOG.warn("Refusing to update page settings session: user is not authenticated");
       response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
     }
   }
@@ -419,9 +433,11 @@ public class SessionServiceController {
         return new ResponseEntity<>(
             pageSettings == null ? null : pageSettings.getData(), HttpStatus.OK);
       }
+      LOG.warn(
+          "Refusing to fetch page settings: session service not enabled or user is not authenticated");
       return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
     } catch (Exception e) {
-      LOG.error("Error occurred", e);
+      LOG.error("Failed to fetch page settings", e);
       return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
   }
@@ -442,6 +458,7 @@ public class SessionServiceController {
           sessionServiceRequestHandler.getCustomDataSessionForUser(userName(), studyIds);
       return new ResponseEntity<>(customDataSessionList, HttpStatus.OK);
     }
+    LOG.warn("Refusing to fetch custom properties: session service not enabled or user is not authenticated");
     return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
   }
 
@@ -469,6 +486,7 @@ public class SessionServiceController {
           sessionServiceRequestHandler.getCustomGeneListsForUser(userName());
       return new ResponseEntity<>(customGeneLists, HttpStatus.OK);
     }
+    LOG.warn("Refusing to fetch custom gene lists: session service not enabled or user is not authenticated");
     return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
   }
 }

--- a/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
+++ b/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
@@ -195,14 +195,11 @@ public class SessionServiceController {
           @Content(array = @ArraySchema(schema = @Schema(implementation = VirtualStudy.class))))
   public ResponseEntity<List<VirtualStudy>> getUserStudies() throws JsonProcessingException {
 
-    if (!sessionServiceRequestHandler.isSessionServiceEnabled()) {
-      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    if (sessionServiceRequestHandler.isSessionServiceEnabled() && isAuthorized()) {
+      List<VirtualStudy> virtualStudyList = virtualStudyService.getUserVirtualStudies(userName());
+      return new ResponseEntity<>(virtualStudyList, HttpStatus.OK);
     }
-    if (!isAuthorized()) {
-      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-    List<VirtualStudy> virtualStudyList = virtualStudyService.getUserVirtualStudies(userName());
-    return new ResponseEntity<>(virtualStudyList, HttpStatus.OK);
+    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
   @RequestMapping(value = "/{type}", method = RequestMethod.POST)

--- a/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
+++ b/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
@@ -39,8 +39,6 @@ import org.cbioportal.legacy.web.parameter.VirtualStudyData;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -55,8 +53,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 @Controller
 @RequestMapping("/api/session")
 public class SessionServiceController {
-
-  private static final Logger LOG = LoggerFactory.getLogger(SessionServiceController.class);
 
   SessionServiceRequestHandler sessionServiceRequestHandler;
 
@@ -123,7 +119,6 @@ public class SessionServiceController {
       payload = virtualStudyData;
     } else if (type.equals(Session.SessionType.settings)) {
       if (!(isAuthorized())) {
-        LOG.warn("Refusing to create settings session: user is not authenticated");
         return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
       }
       Class<? extends PageSettingsData> pageDataClass =
@@ -147,7 +142,6 @@ public class SessionServiceController {
       payload = customData;
     } else if (type.equals(Session.SessionType.custom_gene_list)) {
       if (!(isAuthorized())) {
-        LOG.warn("Refusing to create custom gene list session: user is not authenticated");
         return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
       }
       CustomGeneListData customGeneListData =
@@ -202,12 +196,9 @@ public class SessionServiceController {
   public ResponseEntity<List<VirtualStudy>> getUserStudies() throws JsonProcessingException {
 
     if (!sessionServiceRequestHandler.isSessionServiceEnabled()) {
-      LOG.error(
-          "Failed to get virtual studies: session service is not enabled (session.service.url is not configured)");
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
     if (!isAuthorized()) {
-      LOG.error("Failed to get virtual studies: user is not authenticated");
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
     List<VirtualStudy> virtualStudyList = virtualStudyService.getUserVirtualStudies(userName());
@@ -286,10 +277,6 @@ public class SessionServiceController {
 
       response.sendError(HttpStatus.OK.value());
     } else {
-      LOG.warn(
-          "Refusing to update users in session: session service not enabled or user is not authenticated: type='{}', id='{}'",
-          type,
-          id);
       response.sendError(HttpStatus.SERVICE_UNAVAILABLE.value());
     }
   }
@@ -324,8 +311,6 @@ public class SessionServiceController {
           sessionServiceRequestHandler.getVirtualStudiesForUser(userName(), studyIds);
       return new ResponseEntity<>(virtualStudyList, HttpStatus.OK);
     }
-    LOG.warn(
-        "Refusing to fetch user groups: session service not enabled or user is not authenticated");
     return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
   }
 
@@ -353,8 +338,6 @@ public class SessionServiceController {
       }
       response.setStatus(HttpStatus.OK.value());
     } else {
-      LOG.warn(
-          "Refusing to update page settings: session service not enabled or user is not authenticated");
       response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
     }
   }
@@ -380,14 +363,9 @@ public class SessionServiceController {
         sessionServiceRequestHandler.updatePageSettings(type, pageSettings.getId(), body);
         response.setStatus(HttpStatus.OK.value());
       } else {
-        LOG.warn(
-            "Refusing to update page settings for session '{}': user '{}' is not the owner or origin does not match",
-            pageSettings.getId(),
-            userName());
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
       }
     } else {
-      LOG.warn("Refusing to update page settings session: user is not authenticated");
       response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
     }
   }
@@ -409,8 +387,6 @@ public class SessionServiceController {
       return new ResponseEntity<>(
           pageSettings == null ? null : pageSettings.getData(), HttpStatus.OK);
     }
-    LOG.warn(
-        "Refusing to fetch page settings: session service not enabled or user is not authenticated");
     return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
   }
 
@@ -430,8 +406,6 @@ public class SessionServiceController {
           sessionServiceRequestHandler.getCustomDataSessionForUser(userName(), studyIds);
       return new ResponseEntity<>(customDataSessionList, HttpStatus.OK);
     }
-    LOG.warn(
-        "Refusing to fetch custom properties: session service not enabled or user is not authenticated");
     return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
   }
 
@@ -459,8 +433,6 @@ public class SessionServiceController {
           sessionServiceRequestHandler.getCustomGeneListsForUser(userName());
       return new ResponseEntity<>(customGeneLists, HttpStatus.OK);
     }
-    LOG.warn(
-        "Refusing to fetch custom gene lists: session service not enabled or user is not authenticated");
     return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
   }
 }

--- a/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
+++ b/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
@@ -237,7 +237,7 @@ public class SessionServiceController {
       @PathVariable String id,
       @PathVariable Operation operation,
       HttpServletResponse response)
-      throws IOException {
+      throws Exception {
 
     if (sessionServiceRequestHandler.isSessionServiceEnabled() && isAuthorized()) {
       Serializable payload;

--- a/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
+++ b/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
@@ -214,16 +214,22 @@ public class SessionServiceController {
           @Content(array = @ArraySchema(schema = @Schema(implementation = VirtualStudy.class))))
   public ResponseEntity<List<VirtualStudy>> getUserStudies() throws JsonProcessingException {
 
-    if (sessionServiceRequestHandler.isSessionServiceEnabled() && isAuthorized()) {
-      try {
-        List<VirtualStudy> virtualStudyList = virtualStudyService.getUserVirtualStudies(userName());
-        return new ResponseEntity<>(virtualStudyList, HttpStatus.OK);
-      } catch (Exception exception) {
-        LOG.error("Error occurred", exception);
-        return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-      }
+    if (!sessionServiceRequestHandler.isSessionServiceEnabled()) {
+      LOG.error(
+          "Failed to get virtual studies: session service is not enabled (session.service.url is not configured)");
+      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    if (!isAuthorized()) {
+      LOG.error("Failed to get virtual studies: user is not authenticated");
+      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+    try {
+      List<VirtualStudy> virtualStudyList = virtualStudyService.getUserVirtualStudies(userName());
+      return new ResponseEntity<>(virtualStudyList, HttpStatus.OK);
+    } catch (Exception exception) {
+      LOG.error("Failed to get virtual studies for user '{}'", userName(), exception);
+      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
   }
 
   @RequestMapping(value = "/{type}", method = RequestMethod.POST)

--- a/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
+++ b/src/main/java/org/cbioportal/legacy/web/SessionServiceController.java
@@ -51,7 +51,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.client.HttpClientErrorException;
 
 @Controller
 @RequestMapping("/api/session")
@@ -98,77 +97,71 @@ public class SessionServiceController {
   }
 
   private ResponseEntity<Session> addSession(
-      Session.SessionType type, Optional<SessionOperation> operation, JSONObject body) {
-    try {
-      Serializable payload;
-      if (type.equals(Session.SessionType.virtual_study)
-          || type.equals(Session.SessionType.group)) {
-        // JSON from file to Object
-        VirtualStudyData virtualStudyData =
-            sessionServiceObjectMapper.readValue(body.toString(), VirtualStudyData.class);
-        // TODO sanitize what's supplied. e.g. anonymous user should not specify the users field!
+      Session.SessionType type, Optional<SessionOperation> operation, JSONObject body)
+      throws IOException {
+    Serializable payload;
+    if (type.equals(Session.SessionType.virtual_study) || type.equals(Session.SessionType.group)) {
+      // JSON from file to Object
+      VirtualStudyData virtualStudyData =
+          sessionServiceObjectMapper.readValue(body.toString(), VirtualStudyData.class);
+      // TODO sanitize what's supplied. e.g. anonymous user should not specify the users field!
 
-        if (isAuthorized()) {
-          String userName = userName();
-          if (userName.equals(ALL_USERS)) {
-            throw new IllegalStateException(
-                "Illegal username " + ALL_USERS + " for assigning virtual studies.");
-          }
-          virtualStudyData.setOwner(userName);
-          if ((operation.isPresent() && operation.get().equals(SessionOperation.save))
-              || type.equals(Session.SessionType.group)) {
-            virtualStudyData.setUsers(Collections.singleton(userName));
-          }
+      if (isAuthorized()) {
+        String userName = userName();
+        if (userName.equals(ALL_USERS)) {
+          throw new IllegalStateException(
+              "Illegal username " + ALL_USERS + " for assigning virtual studies.");
         }
-
-        // use basic authentication for session service if set
-        payload = virtualStudyData;
-      } else if (type.equals(Session.SessionType.settings)) {
-        if (!(isAuthorized())) {
-          LOG.warn("Refusing to create settings session: user is not authenticated");
-          return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
+        virtualStudyData.setOwner(userName);
+        if ((operation.isPresent() && operation.get().equals(SessionOperation.save))
+            || type.equals(Session.SessionType.group)) {
+          virtualStudyData.setUsers(Collections.singleton(userName));
         }
-        Class<? extends PageSettingsData> pageDataClass =
-            pageToSettingsDataClass.get(SessionPage.valueOf((String) body.get("page")));
-        PageSettingsData pageSettings =
-            sessionServiceObjectMapper.readValue(body.toString(), pageDataClass);
-        pageSettings.setOwner(userName());
-        payload = pageSettings;
-
-      } else if (type.equals(Session.SessionType.custom_data)) {
-        // JSON from file to Object
-        CustomAttributeWithData customData =
-            sessionServiceObjectMapper.readValue(body.toString(), CustomAttributeWithData.class);
-
-        if (isAuthorized()) {
-          customData.setOwner(userName());
-          customData.setUsers(Collections.singleton(userName()));
-        }
-
-        // use basic authentication for session service if set
-        payload = customData;
-      } else if (type.equals(Session.SessionType.custom_gene_list)) {
-        if (!(isAuthorized())) {
-          LOG.warn("Refusing to create custom gene list session: user is not authenticated");
-          return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
-        }
-        CustomGeneListData customGeneListData =
-            sessionServiceObjectMapper.readValue(body.toString(), CustomGeneListData.class);
-        customGeneListData.setUsers(Collections.singleton(userName()));
-        payload = customGeneListData;
-      } else {
-        payload = body;
       }
-      // returns {"id":"5799648eef86c0e807a2e965"}
-      // using HashMap because converter is MappingJackson2HttpMessageConverter
-      // (Jackson 2 is on classpath)
-      // was String when default converter StringHttpMessageConverter was used
-      return sessionServiceRequestHandler.createSession(type, payload);
 
-    } catch (IOException e) {
-      LOG.error("Failed to create session of type '{}'", type, e);
-      return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+      // use basic authentication for session service if set
+      payload = virtualStudyData;
+    } else if (type.equals(Session.SessionType.settings)) {
+      if (!(isAuthorized())) {
+        LOG.warn("Refusing to create settings session: user is not authenticated");
+        return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
+      }
+      Class<? extends PageSettingsData> pageDataClass =
+          pageToSettingsDataClass.get(SessionPage.valueOf((String) body.get("page")));
+      PageSettingsData pageSettings =
+          sessionServiceObjectMapper.readValue(body.toString(), pageDataClass);
+      pageSettings.setOwner(userName());
+      payload = pageSettings;
+
+    } else if (type.equals(Session.SessionType.custom_data)) {
+      // JSON from file to Object
+      CustomAttributeWithData customData =
+          sessionServiceObjectMapper.readValue(body.toString(), CustomAttributeWithData.class);
+
+      if (isAuthorized()) {
+        customData.setOwner(userName());
+        customData.setUsers(Collections.singleton(userName()));
+      }
+
+      // use basic authentication for session service if set
+      payload = customData;
+    } else if (type.equals(Session.SessionType.custom_gene_list)) {
+      if (!(isAuthorized())) {
+        LOG.warn("Refusing to create custom gene list session: user is not authenticated");
+        return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
+      }
+      CustomGeneListData customGeneListData =
+          sessionServiceObjectMapper.readValue(body.toString(), CustomGeneListData.class);
+      customGeneListData.setUsers(Collections.singleton(userName()));
+      payload = customGeneListData;
+    } else {
+      payload = body;
     }
+    // returns {"id":"5799648eef86c0e807a2e965"}
+    // using HashMap because converter is MappingJackson2HttpMessageConverter
+    // (Jackson 2 is on classpath)
+    // was String when default converter StringHttpMessageConverter was used
+    return sessionServiceRequestHandler.createSession(type, payload);
   }
 
   @RequestMapping(value = "/{type}/{id}", method = RequestMethod.GET)
@@ -177,35 +170,27 @@ public class SessionServiceController {
       description = "OK",
       content = @Content(schema = @Schema(implementation = Session.class)))
   public ResponseEntity<Session> getSession(
-      @PathVariable Session.SessionType type, @PathVariable String id) {
+      @PathVariable Session.SessionType type, @PathVariable String id) throws Exception {
 
-    try {
-      String sessionDataJson = sessionServiceRequestHandler.getSessionDataJson(type, id);
-      Session session;
-      switch (type) {
-        case virtual_study:
-          session = virtualStudyService.getVirtualStudy(id);
-          break;
-        case settings:
-          session = sessionServiceObjectMapper.readValue(sessionDataJson, PageSettings.class);
-          break;
-        case custom_data:
-          session = sessionServiceObjectMapper.readValue(sessionDataJson, CustomDataSession.class);
-          break;
-        case custom_gene_list:
-          session = sessionServiceObjectMapper.readValue(sessionDataJson, CustomGeneList.class);
-          break;
-        default:
-          session = sessionServiceObjectMapper.readValue(sessionDataJson, Session.class);
-      }
-      return new ResponseEntity<>(session, HttpStatus.OK);
-    } catch (HttpClientErrorException.NotFound exception) {
-      LOG.error("Session not found: type='{}', id='{}'", type, id, exception);
-      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-    } catch (Exception exception) {
-      LOG.error("Failed to get session: type='{}', id='{}'", type, id, exception);
-      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    String sessionDataJson = sessionServiceRequestHandler.getSessionDataJson(type, id);
+    Session session;
+    switch (type) {
+      case virtual_study:
+        session = virtualStudyService.getVirtualStudy(id);
+        break;
+      case settings:
+        session = sessionServiceObjectMapper.readValue(sessionDataJson, PageSettings.class);
+        break;
+      case custom_data:
+        session = sessionServiceObjectMapper.readValue(sessionDataJson, CustomDataSession.class);
+        break;
+      case custom_gene_list:
+        session = sessionServiceObjectMapper.readValue(sessionDataJson, CustomGeneList.class);
+        break;
+      default:
+        session = sessionServiceObjectMapper.readValue(sessionDataJson, Session.class);
     }
+    return new ResponseEntity<>(session, HttpStatus.OK);
   }
 
   @RequestMapping(value = "/virtual_study", method = RequestMethod.GET)
@@ -225,13 +210,8 @@ public class SessionServiceController {
       LOG.error("Failed to get virtual studies: user is not authenticated");
       return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
-    try {
-      List<VirtualStudy> virtualStudyList = virtualStudyService.getUserVirtualStudies(userName());
-      return new ResponseEntity<>(virtualStudyList, HttpStatus.OK);
-    } catch (Exception exception) {
-      LOG.error("Failed to get virtual studies for user '{}'", userName(), exception);
-      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-    }
+    List<VirtualStudy> virtualStudyList = virtualStudyService.getUserVirtualStudies(userName());
+    return new ResponseEntity<>(virtualStudyList, HttpStatus.OK);
   }
 
   @RequestMapping(value = "/{type}", method = RequestMethod.POST)
@@ -351,35 +331,31 @@ public class SessionServiceController {
 
   @RequestMapping(value = "/settings", method = RequestMethod.POST)
   public void updateUserPageSettings(
-      @RequestBody PageSettingsData settingsData, HttpServletResponse response) {
+      @RequestBody PageSettingsData settingsData, HttpServletResponse response)
+      throws IOException, ParseException {
 
-    try {
-      ObjectMapper objectMapper =
-          new ObjectMapper()
-              .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-              .setSerializationInclusion(Include.NON_NULL);
-      if (sessionServiceRequestHandler.isSessionServiceEnabled() && isAuthorized()) {
-        PageSettings pageSettings =
-            sessionServiceRequestHandler.getRecentlyUpdatePageSettings(
-                userName(), settingsData.getOrigin(), settingsData.getPage().name());
-        JSONParser parser = new JSONParser();
-        JSONObject jsonObject =
-            (JSONObject) parser.parse(objectMapper.writeValueAsString(settingsData));
+    ObjectMapper objectMapper =
+        new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .setSerializationInclusion(Include.NON_NULL);
+    if (sessionServiceRequestHandler.isSessionServiceEnabled() && isAuthorized()) {
+      PageSettings pageSettings =
+          sessionServiceRequestHandler.getRecentlyUpdatePageSettings(
+              userName(), settingsData.getOrigin(), settingsData.getPage().name());
+      JSONParser parser = new JSONParser();
+      JSONObject jsonObject =
+          (JSONObject) parser.parse(objectMapper.writeValueAsString(settingsData));
 
-        if (pageSettings == null) {
-          addSession(Session.SessionType.settings, Optional.empty(), jsonObject);
-        } else {
-          updatedPageSettingSession(pageSettings, settingsData, response);
-        }
-        response.setStatus(HttpStatus.OK.value());
+      if (pageSettings == null) {
+        addSession(Session.SessionType.settings, Optional.empty(), jsonObject);
       } else {
-        LOG.warn(
-            "Refusing to update page settings: session service not enabled or user is not authenticated");
-        response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
+        updatedPageSettingSession(pageSettings, settingsData, response);
       }
-    } catch (IOException | ParseException e) {
-      LOG.error("Failed to update page settings", e);
-      response.setStatus(HttpStatus.BAD_REQUEST.value());
+      response.setStatus(HttpStatus.OK.value());
+    } else {
+      LOG.warn(
+          "Refusing to update page settings: session service not enabled or user is not authenticated");
+      response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
     }
   }
 
@@ -424,23 +400,18 @@ public class SessionServiceController {
   public ResponseEntity<PageSettingsData> getPageSettings(
       @RequestBody PageSettingsIdentifier pageSettingsIdentifier) {
 
-    try {
-      if (sessionServiceRequestHandler.isSessionServiceEnabled() && isAuthorized()) {
-        PageSettings pageSettings =
-            sessionServiceRequestHandler.getRecentlyUpdatePageSettings(
-                userName(),
-                pageSettingsIdentifier.getOrigin(),
-                pageSettingsIdentifier.getPage().name());
-        return new ResponseEntity<>(
-            pageSettings == null ? null : pageSettings.getData(), HttpStatus.OK);
-      }
-      LOG.warn(
-          "Refusing to fetch page settings: session service not enabled or user is not authenticated");
-      return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
-    } catch (Exception e) {
-      LOG.error("Failed to fetch page settings", e);
-      return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    if (sessionServiceRequestHandler.isSessionServiceEnabled() && isAuthorized()) {
+      PageSettings pageSettings =
+          sessionServiceRequestHandler.getRecentlyUpdatePageSettings(
+              userName(),
+              pageSettingsIdentifier.getOrigin(),
+              pageSettingsIdentifier.getPage().name());
+      return new ResponseEntity<>(
+          pageSettings == null ? null : pageSettings.getData(), HttpStatus.OK);
     }
+    LOG.warn(
+        "Refusing to fetch page settings: session service not enabled or user is not authenticated");
+    return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
   }
 
   @RequestMapping(value = "/custom_data/fetch", method = RequestMethod.POST)


### PR DESCRIPTION
   ## Summary

   Session service endpoints were catching all exceptions and returning generic
   500/400 responses, causing Datadog traces to show "Missing error message and
   stack trace". This PR removes the silent error handling and lets the existing
   `GlobalExceptionHandler` do its job.

   ## Root Cause

   `SessionServiceController` had try-catch blocks on every endpoint that caught
   exceptions and returned bare HTTP status codes with no error body and no useful
   log output. Datadog received the 500 but had nothing to trace it to.

   ## Changes

   ### `SessionServiceController`
   - Removed all try-catch blocks — exceptions now propagate to `GlobalExceptionHandler`
   - Removed unused `Logger` field and imports

   ### `GlobalExceptionHandler`
   - Added `@ExceptionHandler(HttpClientErrorException.class)` to handle 4xx
     responses from downstream services (e.g. session service returning 404),
     propagating the upstream status code and message

   ### `SessionServiceRequestHandler`
   - Changed `isSessionServiceEnabled()` and `isBasicAuthEnabled()` return types
     from boxed `Boolean` to primitive `boolean` to eliminate unnecessary
     auto-unboxing

   ## Frontend Compatibility

   Verified — all frontend call sites already handle errors defensively with
   `.catch(() => [])` or `.catch(() => {})` and do not depend on specific error
   response shapes from these endpoints.

   ## No Behavior Changes for Success Path

   All success responses are unchanged.