### PR TITLE
fix: deserialize GeneFilterQuery from legacy string format in virtual studies

### DIFF
--- a/src/main/java/org/cbioportal/legacy/model/GeneFilterQuery.java
+++ b/src/main/java/org/cbioportal/legacy/model/GeneFilterQuery.java
@@ -1,10 +1,17 @@
 package org.cbioportal.legacy.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.cbioportal.legacy.model.util.Select;
 
 public class GeneFilterQuery extends BaseAlterationFilter implements Serializable {
+
+  private static final String GENE_QUERY_PATTERN =
+      "^(\\w+)[\\s]*?(?:\\:(?:[\\s]*(?:(AMP)|(GAIN)|(DIPLOID)|(HETLOSS)|(HOMDEL))\\b)+)?$";
 
   private String hugoGeneSymbol;
   private Integer entrezGeneId;
@@ -36,6 +43,32 @@ public class GeneFilterQuery extends BaseAlterationFilter implements Serializabl
     this.hugoGeneSymbol = hugoGeneSymbol;
     this.entrezGeneId = entrezGeneId;
     this.alterations = alterations;
+  }
+
+  /**
+   * Deserializes a GeneFilterQuery from a legacy string format used in stored dynamic virtual
+   * studies (e.g. "BRAF" or "BRAF:AMP"). All alteration inclusion flags default to {@code true}
+   * (include everything), matching the behaviour of {@link
+   * BaseAlterationFilter#BaseAlterationFilter()}.
+   */
+  @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+  public static GeneFilterQuery fromString(String geneQueryString) {
+    Matcher matcher = Pattern.compile(GENE_QUERY_PATTERN).matcher(geneQueryString.trim());
+    if (!matcher.find()) {
+      throw new IllegalArgumentException(
+          "Cannot parse gene query string: '" + geneQueryString + "'");
+    }
+    String hugoGeneSymbol = matcher.group(1);
+    List<CNA> alterations = new ArrayList<>();
+    for (int i = 2; i <= matcher.groupCount(); i++) {
+      if (matcher.group(i) != null) {
+        alterations.add(CNA.valueOf(matcher.group(i)));
+      }
+    }
+    GeneFilterQuery query = new GeneFilterQuery();
+    query.setHugoGeneSymbol(hugoGeneSymbol);
+    query.setAlterations(alterations.isEmpty() ? null : alterations);
+    return query;
   }
 
   public String getHugoGeneSymbol() {

--- a/src/main/java/org/cbioportal/legacy/model/GeneFilterQuery.java
+++ b/src/main/java/org/cbioportal/legacy/model/GeneFilterQuery.java
@@ -4,14 +4,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.cbioportal.legacy.model.util.Select;
 
 public class GeneFilterQuery extends BaseAlterationFilter implements Serializable {
-
-  private static final String GENE_QUERY_PATTERN =
-      "^(\\w+)[\\s]*?(?:\\:(?:[\\s]*(?:(AMP)|(GAIN)|(DIPLOID)|(HETLOSS)|(HOMDEL))\\b)+)?$";
 
   private String hugoGeneSymbol;
   private Integer entrezGeneId;
@@ -53,16 +48,18 @@ public class GeneFilterQuery extends BaseAlterationFilter implements Serializabl
    */
   @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
   public static GeneFilterQuery fromString(String geneQueryString) {
-    Matcher matcher = Pattern.compile(GENE_QUERY_PATTERN).matcher(geneQueryString.trim());
-    if (!matcher.find()) {
+    String[] parts = geneQueryString.trim().split(":");
+    String hugoGeneSymbol = parts[0].trim();
+    if (hugoGeneSymbol.isEmpty()) {
       throw new IllegalArgumentException(
           "Cannot parse gene query string: '" + geneQueryString + "'");
     }
-    String hugoGeneSymbol = matcher.group(1);
     List<CNA> alterations = new ArrayList<>();
-    for (int i = 2; i <= matcher.groupCount(); i++) {
-      if (matcher.group(i) != null) {
-        alterations.add(CNA.valueOf(matcher.group(i)));
+    for (int i = 1; i < parts.length; i++) {
+      for (String token : parts[i].trim().split("\\s+")) {
+        if (!token.isEmpty()) {
+          alterations.add(CNA.valueOf(token.toUpperCase()));
+        }
       }
     }
     GeneFilterQuery query = new GeneFilterQuery();

--- a/src/main/java/org/cbioportal/legacy/web/parameter/VirtualStudy.java
+++ b/src/main/java/org/cbioportal/legacy/web/parameter/VirtualStudy.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import org.cbioportal.legacy.utils.removeme.Session;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -17,7 +18,7 @@ public class VirtualStudy extends Session {
     try {
       this.data = mapper.readValue(mapper.writeValueAsString(data), VirtualStudyData.class);
     } catch (IOException e) {
-      throw new RuntimeException("Failed to deserialize virtual study data", e);
+      throw new UncheckedIOException("Failed to deserialize virtual study data", e);
     }
   }
 

--- a/src/main/java/org/cbioportal/legacy/web/parameter/VirtualStudy.java
+++ b/src/main/java/org/cbioportal/legacy/web/parameter/VirtualStudy.java
@@ -5,13 +5,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import org.cbioportal.legacy.utils.removeme.Session;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VirtualStudy extends Session {
 
-  private final Logger LOG = LoggerFactory.getLogger(VirtualStudy.class);
   private VirtualStudyData data;
 
   @Override
@@ -20,7 +17,7 @@ public class VirtualStudy extends Session {
     try {
       this.data = mapper.readValue(mapper.writeValueAsString(data), VirtualStudyData.class);
     } catch (IOException e) {
-      LOG.error("Error occurred", e);
+      throw new RuntimeException("Failed to deserialize virtual study data", e);
     }
   }
 


### PR DESCRIPTION
## Problem

   Loading a dynamic virtual study that contains gene filters caused two cascading errors:

   1. `MismatchedInputException: Cannot construct instance of GeneFilterQuery ... no String-argument constructor/factory method to deserialize from String value ('BRAF')`
   2. `NullPointerException: Cannot invoke "VirtualStudyData.getDynamic()" because "virtualStudyData" is null`

   **Root cause:** Dynamic virtual studies saved before a backend model change stored gene queries as plain strings (e.g. `"BRAF"`, `"BRAF:AMP"`) in the session service. On read, `VirtualStudy.setData()` tried to deserialize those strings into
  `GeneFilterQuery` objects and failed with a `MismatchedInputException`. The exception was then silently swallowed, leaving `data = null`, which caused the NPE on the next call to `getData().getDynamic()`.

   ## Changes

   **`GeneFilterQuery.java`** — add a `@JsonCreator` factory method that parses the legacy `"GENE"` / `"GENE:CNA"` string format:
   - Splits on `:` (handles hyphenated gene symbols like `HLA-A` that a regex `\w+` would reject)
   - Correctly captures multiple CNA types (e.g. `"BRAF:AMP HOMDEL"`)
   - All `BaseAlterationFilter` inclusion flags default to `true` (include everything), matching the no-arg constructor behaviour

   **`VirtualStudy.java`** — replace the silent `catch (IOException e)` with `throw new UncheckedIOException(...)` so any future deserialization failure surfaces immediately with a clear message rather than a confusing NPE downstream.
