### PR TITLE
refactor: replace System.out.println and e.printStackTrace with SLF4J…

### DIFF
--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/util/LimitedPermissionArrayList.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/util/LimitedPermissionArrayList.java
@@ -2,68 +2,54 @@ package org.cbioportal.legacy.persistence.mybatis.util;
 
 import java.util.*;
 import java.util.function.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LimitedPermissionArrayList<T> extends ArrayList<T> {
 
+  private static final Logger log = LoggerFactory.getLogger(LimitedPermissionArrayList.class);
+
   public boolean addAll(Collection<? extends T> c) {
-    System.out.println("addAll called");
     throw new UnsupportedOperationException();
   }
 
   public boolean addAll(int index, Collection<? extends T> c) {
-    System.out.println("addAll called");
     throw new UnsupportedOperationException();
   }
 
   public void clear() {
-    System.out.println("clear called");
     throw new UnsupportedOperationException();
   }
 
   public T remove(int index) {
-    System.out.println("remove called");
     throw new UnsupportedOperationException();
   }
 
   public boolean remove(Object o) {
-    System.out.println(
-        "LimitedPermissionArrayList:remove() called, throwing UnsupportedOperationException()");
     throw new UnsupportedOperationException();
   }
 
   public boolean removeAll(Collection<?> c) {
-    System.out.println(
-        "LimitedPermissionArrayList:removeAll() called, throwing UnsupportedOperationException()");
     throw new UnsupportedOperationException();
   }
 
   public boolean removeIf(Predicate<? super T> filter) {
-    System.out.println(
-        "LimitedPermissionArrayList:removeIF() called, throwing UnsupportedOperationException()");
     throw new UnsupportedOperationException();
   }
 
   protected void removeRange(int fromIndex, int toIndex) {
-    System.out.println(
-        "LimitedPermissionArrayList:removeRange() called, throwing UnsupportedOperationException()");
     throw new UnsupportedOperationException();
   }
 
   public void replaceAll(UnaryOperator<T> operator) {
-    System.out.println(
-        "LimitedPermissionArrayList:replaceAll() called, throwing UnsupportedOperationException()");
     throw new UnsupportedOperationException();
   }
 
   public boolean retainAll(Collection<?> c) {
-    System.out.println(
-        "LimitedPermissionArrayList:retainAlll() called, throwing UnsupportedOperationException()");
     throw new UnsupportedOperationException();
   }
 
   public T set(int index, T element) {
-    System.out.println(
-        "LimitedPermissionArrayList:set() called, throwing UnsupportedOperationException()");
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/util/LimitedPermissionArrayList.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/util/LimitedPermissionArrayList.java
@@ -2,12 +2,8 @@ package org.cbioportal.legacy.persistence.mybatis.util;
 
 import java.util.*;
 import java.util.function.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class LimitedPermissionArrayList<T> extends ArrayList<T> {
-
-  private static final Logger log = LoggerFactory.getLogger(LimitedPermissionArrayList.class);
 
   public boolean addAll(Collection<? extends T> c) {
     throw new UnsupportedOperationException();

--- a/src/main/java/org/cbioportal/legacy/persistence/util/EhcacheStatistics.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/util/EhcacheStatistics.java
@@ -38,6 +38,8 @@ import org.cbioportal.legacy.utils.config.annotation.ConditionalOnProperty;
 import org.ehcache.config.ResourceType;
 import org.ehcache.core.statistics.*;
 import org.ehcache.impl.internal.statistics.DefaultStatisticsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -46,6 +48,8 @@ import org.springframework.stereotype.Component;
     name = "persistence.cache_type",
     havingValue = {"ehcache-heap", "ehcache-disk", "ehcache-hybrid"})
 public class EhcacheStatistics {
+
+  private static final Logger log = LoggerFactory.getLogger(EhcacheStatistics.class);
 
   private static String TIER_NOT_IN_USE = "Tier not in use";
 
@@ -68,7 +72,7 @@ public class EhcacheStatistics {
         statisticsService.cacheAdded(cacheName, ehcache);
       }
     } catch (Exception e) {
-      e.printStackTrace();
+      log.error("Error initializing Ehcache statistics service", e);
     }
   }
 

--- a/src/main/java/org/cbioportal/legacy/service/impl/CacheServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/CacheServiceImpl.java
@@ -82,8 +82,7 @@ public class CacheServiceImpl implements CacheService {
                 });
       }
     } catch (RuntimeException e) {
-      e.printStackTrace();
-      LOG.error("Error while evicting cache." + e.getMessage());
+      LOG.error("Error while evicting cache.", e);
       throw new CacheOperationException("Error while evicting cache.", e);
     }
   }

--- a/src/main/java/org/cbioportal/legacy/web/config/WebServletContextListener.java
+++ b/src/main/java/org/cbioportal/legacy/web/config/WebServletContextListener.java
@@ -4,11 +4,16 @@ import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 import java.io.*;
 import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.ObjectUtils;
 
 /** Created by Hongxin Zhang on 11/15/19. */
 public class WebServletContextListener implements ServletContextListener, InitializingBean {
+
+  private static final Logger log = LoggerFactory.getLogger(WebServletContextListener.class);
+
   private Boolean showOncokb;
 
   private String oncokbToken;
@@ -21,7 +26,7 @@ public class WebServletContextListener implements ServletContextListener, Initia
 
   @Override
   public void contextDestroyed(ServletContextEvent arg0) {
-    System.out.println("ServletContextListener destroyed");
+    log.info("ServletContextListener destroyed");
   }
 
   // Run this before web application is started
@@ -45,15 +50,15 @@ public class WebServletContextListener implements ServletContextListener, Initia
     if (ObjectUtils.isEmpty(this.oncokbToken)
         && (ObjectUtils.isEmpty(this.oncokbURL)
             || this.oncokbURL.equalsIgnoreCase(DEFAULT_ONCOKB_URL))) {
-      System.out.println(
+      log.warn(
           "----------------------------------------------------------------------------------------------------------------");
       // oncokb.org is deprecated, www.oncokb.org should be used
-      System.out.println(
+      log.warn(
           "-- You are connecting to the OncoKB public instance which does not include any therapeutic information.");
-      System.out.println(
+      log.warn(
           "-- Please consider obtaining a license to support future OncoKB development by following https://docs.cbioportal.org/2.4-integration-with-other-webservices/oncokb-data-access.");
-      System.out.println("-- Thank you.");
-      System.out.println(
+      log.warn("-- Thank you.");
+      log.warn(
           "----------------------------------------------------------------------------------------------------------------");
     }
   }
@@ -90,7 +95,7 @@ public class WebServletContextListener implements ServletContextListener, Initia
       properties.load(resourceInputStream);
       resourceInputStream.close();
     } catch (IOException e) {
-      System.out.println("Error loading properties file: " + e.getMessage());
+      log.error("Error loading properties file: {}", e.getMessage(), e);
     }
 
     return properties;

--- a/src/main/java/org/cbioportal/legacy/web/util/GoogleAnalyticsInterceptor.java
+++ b/src/main/java/org/cbioportal/legacy/web/util/GoogleAnalyticsInterceptor.java
@@ -101,7 +101,7 @@ public class GoogleAnalyticsInterceptor implements HandlerInterceptor {
               }
             }
           } catch (RestClientException e) {
-            e.printStackTrace();
+            LOG.error("Error sending POST request to Google Analytics", e);
           }
         });
   }


### PR DESCRIPTION
Replace raw `System.out.println()` and `e.printStackTrace()` calls with proper SLF4J logger calls across 5 legacy files. No logic changes....only logging hygiene.

## Describe changes proposed in this pull request:

### WebServletContextListener.java
->Replace 7 `System.out.println` calls with `log.info()`, `log.warn()`, and `log.error()`
->OncoKB license warnings now use `log.warn()` for appropriate severity
-> Properties loading error now includes exception stack trace via `log.error()`

### LimitedPermissionArrayList.java
-> Remove 11 leftover debug `System.out.println` statements 
-> Every method immediately throws `UnsupportedOperationException`, so the prints served no purpose

### GoogleAnalyticsInterceptor.java
-> Replace `e.printStackTrace()` with `LOG.error()` (class already had a logger field)

### CacheServiceImpl.java
-> Replace `e.printStackTrace()` with `LOG.error()` and consolidate duplicate error log

### EhcacheStatistics.java
-> Replace `e.printStackTrace()` with `log.error()` for cache statistics initialization errors

## Checks
- [x] The commit log is comprehensible.
- [x] Has tests — N/A, no logic changes. Only logging output destinations changed.
- [x] Is this PR adding logic based on clinical attributes? No.
- [ ] Make sure your PR has one of the labels defined in release-drafter.yml

## Any screenshots or GIFs?
N/A   no UI changes, text-only refactor.

## Notify reviewers
No logic changes only replaces raw stdout/stderr output with structured SLF4J logging to match the rest of the codebase.
