### PR TITLE
Stream generic-assay-meta/fetch to bound web-server memory

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
@@ -128,6 +128,12 @@ public class ColumnStoreGenericAssayController {
     StreamingResponseBody body =
         outputStream -> {
           try (JsonGenerator generator = objectMapper.getFactory().createGenerator(outputStream)) {
+            // Once the 200 + first bytes are flushed the status can no longer change, so a
+            // mid-stream failure cannot become a 500 (inherent to streaming). Disable
+            // AUTO_CLOSE_JSON_CONTENT so that on failure the array is left unclosed: the client
+            // receives detectably-invalid JSON (parse error) rather than a silently-truncated but
+            // well-formed array, and the propagated exception is still logged server-side.
+            generator.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
             generator.writeStartArray();
             getGenericAssayMetaUseCase.execute(
                 stableIds,

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
@@ -1,5 +1,6 @@
 package org.cbioportal.application.rest.vcolumnstore;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -9,6 +10,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import org.cbioportal.domain.generic_assay.usecase.GetGenericAssayMetaUseCase;
@@ -70,12 +73,10 @@ public class ColumnStoreGenericAssayController {
       @Parameter(description = "Level of detail of the response")
           @RequestParam(defaultValue = "SUMMARY")
           Projection projection) {
-    List<GenericAssayMeta> result =
-        getGenericAssayMetaUseCase.execute(
-            genericAssayMetaFilter.getGenericAssayStableIds(),
-            genericAssayMetaFilter.getMolecularProfileIds(),
-            projection.name());
-    return streamJson(result);
+    return streamMeta(
+        genericAssayMetaFilter.getGenericAssayStableIds(),
+        genericAssayMetaFilter.getMolecularProfileIds(),
+        projection.name());
   }
 
   // PreAuthorize is removed for performance reason
@@ -95,9 +96,7 @@ public class ColumnStoreGenericAssayController {
       @Parameter(description = "Level of detail of the response")
           @RequestParam(defaultValue = "SUMMARY")
           Projection projection) {
-    return streamJson(
-        getGenericAssayMetaUseCase.execute(
-            null, Arrays.asList(molecularProfileId), projection.name()));
+    return streamMeta(null, Arrays.asList(molecularProfileId), projection.name());
   }
 
   @RequestMapping(
@@ -116,14 +115,37 @@ public class ColumnStoreGenericAssayController {
       @Parameter(description = "Level of detail of the response")
           @RequestParam(defaultValue = "SUMMARY")
           Projection projection) {
-    return streamJson(
-        getGenericAssayMetaUseCase.execute(
-            Arrays.asList(genericAssayStableId), null, projection.name()));
+    return streamMeta(Arrays.asList(genericAssayStableId), null, projection.name());
   }
 
-  private ResponseEntity<StreamingResponseBody> streamJson(List<GenericAssayMeta> data) {
-    return ResponseEntity.ok()
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(outputStream -> objectMapper.writeValue(outputStream, data));
+  /**
+   * Streams the matching {@link GenericAssayMeta} as a JSON array, writing each element to the
+   * response as it is read from the database. The result set is never collected into a list, so
+   * peak heap stays bounded regardless of how many entities the request resolves to.
+   */
+  private ResponseEntity<StreamingResponseBody> streamMeta(
+      List<String> stableIds, List<String> molecularProfileIds, String projection) {
+    StreamingResponseBody body =
+        outputStream -> {
+          try (JsonGenerator generator = objectMapper.getFactory().createGenerator(outputStream)) {
+            generator.writeStartArray();
+            getGenericAssayMetaUseCase.execute(
+                stableIds,
+                molecularProfileIds,
+                projection,
+                meta -> {
+                  try {
+                    generator.writeObject(meta);
+                  } catch (IOException e) {
+                    // ResultHandler/Consumer cannot throw checked exceptions; unwrapped below
+                    throw new UncheckedIOException(e);
+                  }
+                });
+            generator.writeEndArray();
+          } catch (UncheckedIOException e) {
+            throw e.getCause();
+          }
+        };
+    return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(body);
   }
 }

--- a/src/main/java/org/cbioportal/domain/generic_assay/repository/GenericAssayRepository.java
+++ b/src/main/java/org/cbioportal/domain/generic_assay/repository/GenericAssayRepository.java
@@ -1,6 +1,7 @@
 package org.cbioportal.domain.generic_assay.repository;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.cbioportal.domain.studyview.StudyViewFilterContext;
 import org.cbioportal.legacy.model.ClinicalDataCount;
 import org.cbioportal.legacy.model.GenericAssayDataCountItem;
@@ -64,24 +65,27 @@ public interface GenericAssayRepository {
   List<String> getGenericAssayStableIdsByProfileIds(List<String> molecularProfileIds);
 
   /**
-   * Retrieves generic assay meta data (with pre-aggregated properties) for the given entity stable
-   * IDs from the generic_assay_meta_derived table.
+   * Streams generic assay meta data (with pre-aggregated properties) for the given entity stable
+   * IDs from the generic_assay_meta_derived table. Each {@link GenericAssayMeta} is passed to
+   * {@code consumer} as it is read from the database, so the full result set is never held in
+   * memory.
    *
    * @param stableIds the list of entity stable IDs
-   * @return a list of {@link GenericAssayMeta} with properties pre-populated
+   * @param consumer invoked once per {@link GenericAssayMeta} with properties pre-populated
    */
-  List<GenericAssayMeta> getGenericAssayMetaByStableIds(List<String> stableIds);
+  void getGenericAssayMetaByStableIds(List<String> stableIds, Consumer<GenericAssayMeta> consumer);
 
   /**
-   * Retrieves generic assay meta data for entities belonging to the given molecular profile IDs in
-   * a single query. Resolves profile → entity via generic_assay_data_derived, then joins with
-   * generic_assay_meta_derived for pre-aggregated properties. When {@code stableIds} is non-null,
-   * results are further filtered to only those stable IDs.
+   * Streams generic assay meta data for entities belonging to the given molecular profile IDs in a
+   * single query. Resolves profile → entity via generic_assay_profile_entity_derived, then joins
+   * with generic_assay_meta_derived for pre-aggregated properties. When {@code stableIds} is
+   * non-null, results are further filtered to only those stable IDs. Each {@link GenericAssayMeta}
+   * is passed to {@code consumer} as it is read, so the full result set is never held in memory.
    *
    * @param profileIds the list of molecular profile stable IDs (must be non-empty)
    * @param stableIds optional additional filter; pass {@code null} to return all entities
-   * @return a list of {@link GenericAssayMeta} with properties pre-populated
+   * @param consumer invoked once per {@link GenericAssayMeta} with properties pre-populated
    */
-  List<GenericAssayMeta> getGenericAssayMetaByProfileIds(
-      List<String> profileIds, List<String> stableIds);
+  void getGenericAssayMetaByProfileIds(
+      List<String> profileIds, List<String> stableIds, Consumer<GenericAssayMeta> consumer);
 }

--- a/src/main/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCase.java
+++ b/src/main/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCase.java
@@ -3,6 +3,7 @@ package org.cbioportal.domain.generic_assay.usecase;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.cbioportal.domain.generic_assay.repository.GenericAssayRepository;
@@ -24,10 +25,13 @@ public class GetGenericAssayMetaUseCase {
 
   /**
    * Executes the use case, streaming each matching {@link GenericAssayMeta} to {@code consumer} as
-   * it is produced. Streaming keeps memory bounded: for large profile sets (e.g. methylation, which
-   * can resolve to hundreds of thousands of entities) the full result is never materialized into a
-   * list. This path is intentionally not cached — the cache key would be unique per study/profile
-   * combination (near-zero hit rate) while pinning the entire result on the heap.
+   * it is produced. For the meta-fetch projections (SUMMARY/DETAILED) the per-entity rows are
+   * streamed straight from the database and never collected into a list, which keeps memory bounded
+   * for large profile sets (e.g. methylation, which can resolve to hundreds of thousands of
+   * entities). The lightweight "ID" projection still resolves the matching stable IDs into a set in
+   * memory (it returns no per-entity properties and issues no meta query). This path is
+   * intentionally not cached — the cache key would be unique per study/profile combination
+   * (near-zero hit rate) while pinning the entire result on the heap.
    *
    * @param stableIds optional list of generic assay stable IDs to filter by
    * @param molecularProfileIds optional list of molecular profile IDs to filter by
@@ -41,7 +45,10 @@ public class GetGenericAssayMetaUseCase {
       Consumer<GenericAssayMeta> consumer) {
 
     if (molecularProfileIds != null) {
-      List<String> sortedProfileIds = molecularProfileIds.stream().distinct().sorted().toList();
+      // Filter nulls so a malformed request (a null element) can't NPE in sorted(); also lets the
+      // empty-check below short-circuit a request that contained only nulls.
+      List<String> sortedProfileIds =
+          molecularProfileIds.stream().filter(Objects::nonNull).distinct().sorted().toList();
       if (sortedProfileIds.isEmpty()) {
         return;
       }
@@ -66,7 +73,11 @@ public class GetGenericAssayMetaUseCase {
       return;
     }
 
-    List<String> distinctStableIds = stableIds.stream().distinct().toList();
+    List<String> distinctStableIds =
+        stableIds.stream().filter(Objects::nonNull).distinct().toList();
+    if (distinctStableIds.isEmpty()) {
+      return;
+    }
 
     if ("ID".equals(projection)) {
       distinctStableIds.forEach(id -> consumer.accept(new GenericAssayMeta(id)));

--- a/src/main/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCase.java
+++ b/src/main/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCase.java
@@ -1,13 +1,12 @@
 package org.cbioportal.domain.generic_assay.usecase;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 import org.cbioportal.domain.generic_assay.repository.GenericAssayRepository;
 import org.cbioportal.legacy.model.meta.GenericAssayMeta;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,30 +23,27 @@ public class GetGenericAssayMetaUseCase {
   }
 
   /**
-   * Executes the use case to retrieve generic assay meta data.
+   * Executes the use case, streaming each matching {@link GenericAssayMeta} to {@code consumer} as
+   * it is produced. Streaming keeps memory bounded: for large profile sets (e.g. methylation, which
+   * can resolve to hundreds of thousands of entities) the full result is never materialized into a
+   * list. This path is intentionally not cached — the cache key would be unique per study/profile
+   * combination (near-zero hit rate) while pinning the entire result on the heap.
    *
    * @param stableIds optional list of generic assay stable IDs to filter by
    * @param molecularProfileIds optional list of molecular profile IDs to filter by
    * @param projection projection level (e.g. "ID", "SUMMARY", "DETAILED")
-   * @return a list of {@link GenericAssayMeta}
+   * @param consumer invoked once per matching {@link GenericAssayMeta}
    */
-  // Cache key normalizes input lists into sorted TreeSets so that callers passing
-  // the same IDs in different order share the same cache entry. Null-safe: null
-  // lists produce null keys. Non-null entries are filtered to exclude nulls.
-  @Cacheable(
-      cacheResolver = "generalRepositoryCacheResolver",
-      condition = "@cacheEnabledConfig.getEnabled()",
-      key =
-          "{#stableIds == null ? null : new java.util.TreeSet(#stableIds.?[#this != null]),"
-              + " #molecularProfileIds == null ? null : new java.util.TreeSet(#molecularProfileIds.?[#this != null]),"
-              + " #projection}")
-  public List<GenericAssayMeta> execute(
-      List<String> stableIds, List<String> molecularProfileIds, String projection) {
+  public void execute(
+      List<String> stableIds,
+      List<String> molecularProfileIds,
+      String projection,
+      Consumer<GenericAssayMeta> consumer) {
 
     if (molecularProfileIds != null) {
       List<String> sortedProfileIds = molecularProfileIds.stream().distinct().sorted().toList();
       if (sortedProfileIds.isEmpty()) {
-        return Collections.emptyList();
+        return;
       }
 
       if ("ID".equals(projection)) {
@@ -57,23 +53,26 @@ public class GetGenericAssayMetaUseCase {
         if (stableIds != null) {
           resolvedIds.retainAll(new HashSet<>(stableIds));
         }
-        return resolvedIds.stream().map(GenericAssayMeta::new).toList();
+        resolvedIds.forEach(id -> consumer.accept(new GenericAssayMeta(id)));
+        return;
       }
 
       // Single merged query: profile → entity + meta join
-      return repository.getGenericAssayMetaByProfileIds(sortedProfileIds, stableIds);
+      repository.getGenericAssayMetaByProfileIds(sortedProfileIds, stableIds, consumer);
+      return;
     }
 
     if (stableIds == null || stableIds.isEmpty()) {
-      return Collections.emptyList();
+      return;
     }
 
     List<String> distinctStableIds = stableIds.stream().distinct().toList();
 
     if ("ID".equals(projection)) {
-      return distinctStableIds.stream().map(GenericAssayMeta::new).toList();
+      distinctStableIds.forEach(id -> consumer.accept(new GenericAssayMeta(id)));
+      return;
     }
 
-    return repository.getGenericAssayMetaByStableIds(distinctStableIds);
+    repository.getGenericAssayMetaByStableIds(distinctStableIds, consumer);
   }
 }

--- a/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayMapper.java
+++ b/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayMapper.java
@@ -2,6 +2,7 @@ package org.cbioportal.infrastructure.repository.clickhouse.generic_assay;
 
 import java.util.List;
 import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.session.ResultHandler;
 import org.cbioportal.domain.studyview.StudyViewFilterContext;
 import org.cbioportal.legacy.model.ClinicalDataCount;
 import org.cbioportal.legacy.model.GenericAssayDataCountItem;
@@ -69,22 +70,27 @@ public interface ClickhouseGenericAssayMapper {
   List<String> getGenericAssayStableIdsByProfileIds(List<String> molecularProfileIds);
 
   /**
-   * Retrieves generic assay meta data (with pre-aggregated properties) for the given entity stable
-   * IDs from the generic_assay_meta_derived table.
+   * Streams generic assay meta data (with pre-aggregated properties) for the given entity stable
+   * IDs from the generic_assay_meta_derived table. Each mapped row is passed to {@code handler} as
+   * it is read, so the full result set is never materialized in memory.
    *
    * @param stableIds the list of entity stable IDs
-   * @return a list of {@link GenericAssayMeta} with properties pre-populated
+   * @param handler invoked once per {@link GenericAssayMeta} row
    */
-  List<GenericAssayMeta> getGenericAssayMetaByStableIds(List<String> stableIds);
+  void getGenericAssayMetaByStableIds(
+      @Param("list") List<String> stableIds, ResultHandler<GenericAssayMeta> handler);
 
   /**
    * Resolves profile IDs → entity stable IDs via generic_assay_profile_entity_derived and joins
-   * with generic_assay_meta_derived in a single query.
+   * with generic_assay_meta_derived in a single query, streaming each mapped row to {@code handler}
+   * as it is read rather than materializing the full result set.
    *
    * @param profileIds the list of molecular profile stable IDs
    * @param stableIds optional additional stable ID filter; {@code null} means no filter
-   * @return a list of {@link GenericAssayMeta} with properties pre-populated
+   * @param handler invoked once per {@link GenericAssayMeta} row
    */
-  List<GenericAssayMeta> getGenericAssayMetaByProfileIds(
-      @Param("profileIds") List<String> profileIds, @Param("stableIds") List<String> stableIds);
+  void getGenericAssayMetaByProfileIds(
+      @Param("profileIds") List<String> profileIds,
+      @Param("stableIds") List<String> stableIds,
+      ResultHandler<GenericAssayMeta> handler);
 }

--- a/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayRepository.java
+++ b/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayRepository.java
@@ -1,6 +1,7 @@
 package org.cbioportal.infrastructure.repository.clickhouse.generic_assay;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.cbioportal.domain.generic_assay.repository.GenericAssayRepository;
 import org.cbioportal.domain.studyview.StudyViewFilterContext;
 import org.cbioportal.legacy.model.ClinicalDataCount;
@@ -52,13 +53,16 @@ public class ClickhouseGenericAssayRepository implements GenericAssayRepository 
   }
 
   @Override
-  public List<GenericAssayMeta> getGenericAssayMetaByStableIds(List<String> stableIds) {
-    return mapper.getGenericAssayMetaByStableIds(stableIds);
+  public void getGenericAssayMetaByStableIds(
+      List<String> stableIds, Consumer<GenericAssayMeta> consumer) {
+    mapper.getGenericAssayMetaByStableIds(
+        stableIds, context -> consumer.accept(context.getResultObject()));
   }
 
   @Override
-  public List<GenericAssayMeta> getGenericAssayMetaByProfileIds(
-      List<String> profileIds, List<String> stableIds) {
-    return mapper.getGenericAssayMetaByProfileIds(profileIds, stableIds);
+  public void getGenericAssayMetaByProfileIds(
+      List<String> profileIds, List<String> stableIds, Consumer<GenericAssayMeta> consumer) {
+    mapper.getGenericAssayMetaByProfileIds(
+        profileIds, stableIds, context -> consumer.accept(context.getResultObject()));
   }
 }

--- a/src/main/resources/mappers/clickhouse/generic_assay/GenericAssayMapper.xml
+++ b/src/main/resources/mappers/clickhouse/generic_assay/GenericAssayMapper.xml
@@ -171,7 +171,8 @@
                 typeHandler="org.cbioportal.infrastructure.repository.clickhouse.typehandlers.ClickhouseMapTypeHandler"/>
     </resultMap>
 
-    <select id="getGenericAssayMetaByStableIds" resultMap="GenericAssayMetaResultMap">
+    <!-- fetchSize keeps the JDBC driver streaming in batches; consumed row-by-row via a ResultHandler -->
+    <select id="getGenericAssayMetaByStableIds" resultMap="GenericAssayMetaResultMap" fetchSize="10000">
         SELECT
             entity_stable_id AS stableId,
             entity_type AS entityType,
@@ -183,7 +184,8 @@
         ORDER BY toUInt32OrZero(extract(entity_stable_id, '^[0-9]+')) ASC, entity_stable_id ASC
     </select>
 
-    <select id="getGenericAssayMetaByProfileIds" resultMap="GenericAssayMetaResultMap">
+    <!-- fetchSize keeps the JDBC driver streaming in batches; consumed row-by-row via a ResultHandler -->
+    <select id="getGenericAssayMetaByProfileIds" resultMap="GenericAssayMetaResultMap" fetchSize="10000">
         SELECT
             gam.entity_stable_id AS stableId,
             gam.entity_type AS entityType,

--- a/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
+++ b/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.function.Consumer;
 import org.cbioportal.domain.generic_assay.usecase.GetGenericAssayMetaUseCase;
 import org.cbioportal.legacy.model.meta.GenericAssayMeta;
 import org.cbioportal.legacy.web.config.TestConfig;
@@ -59,8 +60,7 @@ public class ColumnStoreGenericAssayControllerTest {
   public void testGetGenericAssayMetaByMolecularProfileId() throws Exception {
     List<GenericAssayMeta> genericAssayMetaItems = createGenericAssayMetaItemsList();
 
-    Mockito.when(getGenericAssayMetaUseCase.execute(Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenReturn(genericAssayMetaItems);
+    mockExecuteStreaming(genericAssayMetaItems);
 
     MvcResult mvcResult =
         mockMvc
@@ -93,8 +93,7 @@ public class ColumnStoreGenericAssayControllerTest {
   public void testGetGenericAssayMetaByStableId() throws Exception {
     List<GenericAssayMeta> genericAssayMetaSingleItem = createGenericAssayMetaSingleItem();
 
-    Mockito.when(getGenericAssayMetaUseCase.execute(Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenReturn(genericAssayMetaSingleItem);
+    mockExecuteStreaming(genericAssayMetaSingleItem);
 
     MvcResult mvcResult =
         mockMvc
@@ -130,8 +129,7 @@ public class ColumnStoreGenericAssayControllerTest {
     GenericAssayMetaFilter genericAssayMetaFilter = new GenericAssayMetaFilter();
     genericAssayMetaFilter.setGenericAssayStableIds(genericAssayStableIds);
 
-    Mockito.when(getGenericAssayMetaUseCase.execute(Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenReturn(genericAssayMetaItems);
+    mockExecuteStreaming(genericAssayMetaItems);
 
     MvcResult mvcResult =
         mockMvc
@@ -160,6 +158,21 @@ public class ColumnStoreGenericAssayControllerTest {
         .andExpect(
             MockMvcResultMatchers.jsonPath(
                 "$[1].genericEntityMetaProperties", Matchers.hasValue(TEST_NAME_VALUE)));
+  }
+
+  /**
+   * Stubs the streaming use case so that the given items are pushed to the {@link Consumer} the
+   * controller supplies, mirroring how rows are streamed from the database.
+   */
+  private void mockExecuteStreaming(List<GenericAssayMeta> items) {
+    Mockito.doAnswer(
+            invocation -> {
+              Consumer<GenericAssayMeta> consumer = invocation.getArgument(3);
+              items.forEach(consumer);
+              return null;
+            })
+        .when(getGenericAssayMetaUseCase)
+        .execute(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
   }
 
   private List<GenericAssayMeta> createGenericAssayMetaSingleItem() {

--- a/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
+++ b/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
@@ -160,6 +160,57 @@ public class ColumnStoreGenericAssayControllerTest {
                 "$[1].genericEntityMetaProperties", Matchers.hasValue(TEST_NAME_VALUE)));
   }
 
+  @Test
+  @WithMockUser
+  public void testFetchGenericAssayMeta_failureMidStreamLeavesArrayUnclosed() throws Exception {
+    // Emit one element, then fail (as a DB error mid-stream would). Because the 200 is already
+    // committed it cannot become a 500; we assert the array is NOT cleanly closed, so the client
+    // gets detectably-invalid JSON instead of a silently-truncated but well-formed array.
+    Mockito.doAnswer(
+            invocation -> {
+              Consumer<GenericAssayMeta> consumer = invocation.getArgument(3);
+              consumer.accept(new GenericAssayMeta(ENTITY_TYPE, GENERIC_ASSAY_STABLE_ID_1));
+              throw new RuntimeException("boom mid-stream");
+            })
+        .when(getGenericAssayMetaUseCase)
+        .execute(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+
+    GenericAssayMetaFilter filter = new GenericAssayMetaFilter();
+    filter.setGenericAssayStableIds(Arrays.asList(GENERIC_ASSAY_STABLE_ID_1));
+
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.post("/api/generic-assay-meta/fetch")
+                    .with(csrf())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(filter)))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn();
+
+    String body;
+    try {
+      body =
+          mockMvc
+              .perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+    } catch (Exception propagated) {
+      // The async dispatch may rethrow the mid-stream failure; the partial body is on the response.
+      body = mvcResult.getResponse().getContentAsString();
+    }
+
+    // One element was written but the array must not have been closed with ']'.
+    org.junit.Assert.assertTrue(
+        "expected a partial element to have been written",
+        body.contains(GENERIC_ASSAY_STABLE_ID_1));
+    org.junit.Assert.assertFalse(
+        "array must be left unclosed on mid-stream failure, got: " + body,
+        body.trim().endsWith("]"));
+  }
+
   /**
    * Stubs the streaming use case so that the given items are pushed to the {@link Consumer} the
    * controller supplies, mirroring how rows are streamed from the database.

--- a/src/test/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCaseTest.java
+++ b/src/test/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCaseTest.java
@@ -102,6 +102,16 @@ public class GetGenericAssayMetaUseCaseTest {
   }
 
   @Test
+  public void execute_profilesWithNullElement_filtersNullsWithoutThrowing() {
+    // A null element previously NPE'd in sorted() -> 500. It must now be filtered out.
+    streamProfileMeta(createMockMetaList());
+
+    collect(null, Arrays.asList(null, PROFILE_ID), PersistenceConstants.SUMMARY_PROJECTION);
+
+    verify(repository).getGenericAssayMetaByProfileIds(eq(PROFILE_ID_LIST), eq(null), any());
+  }
+
+  @Test
   public void execute_profilesOnly_summaryProjection() {
     List<GenericAssayMeta> mockList = createMockMetaList();
     streamProfileMeta(mockList);

--- a/src/test/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCaseTest.java
+++ b/src/test/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCaseTest.java
@@ -1,13 +1,18 @@
 package org.cbioportal.domain.generic_assay.usecase;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.function.Consumer;
 import org.cbioportal.domain.generic_assay.repository.GenericAssayRepository;
 import org.cbioportal.legacy.model.meta.GenericAssayMeta;
 import org.cbioportal.legacy.persistence.PersistenceConstants;
@@ -50,66 +55,98 @@ public class GetGenericAssayMetaUseCaseTest {
     return Arrays.asList(meta1, meta2);
   }
 
+  /** Collects everything the use case streams to its consumer. */
+  private List<GenericAssayMeta> collect(
+      List<String> stableIds, List<String> molecularProfileIds, String projection) {
+    List<GenericAssayMeta> collected = new ArrayList<>();
+    useCase.execute(stableIds, molecularProfileIds, projection, collected::add);
+    return collected;
+  }
+
+  /** Stubs the repository's profile-based streaming method to emit the given items. */
+  private void streamProfileMeta(List<GenericAssayMeta> items) {
+    doAnswer(
+            invocation -> {
+              Consumer<GenericAssayMeta> consumer = invocation.getArgument(2);
+              items.forEach(consumer);
+              return null;
+            })
+        .when(repository)
+        .getGenericAssayMetaByProfileIds(any(), any(), any());
+  }
+
+  /** Stubs the repository's stable-id-based streaming method to emit the given items. */
+  private void streamStableIdMeta(List<GenericAssayMeta> items) {
+    doAnswer(
+            invocation -> {
+              Consumer<GenericAssayMeta> consumer = invocation.getArgument(1);
+              items.forEach(consumer);
+              return null;
+            })
+        .when(repository)
+        .getGenericAssayMetaByStableIds(any(), any());
+  }
+
   @Test
   public void execute_profilesAndStableIds_summaryProjection() {
     List<GenericAssayMeta> mockList = createMockMetaList();
-    when(repository.getGenericAssayMetaByProfileIds(PROFILE_ID_LIST, ID_LIST)).thenReturn(mockList);
+    streamProfileMeta(mockList);
 
     List<GenericAssayMeta> result =
-        useCase.execute(ID_LIST, PROFILE_ID_LIST, PersistenceConstants.SUMMARY_PROJECTION);
+        collect(ID_LIST, PROFILE_ID_LIST, PersistenceConstants.SUMMARY_PROJECTION);
 
     Assert.assertEquals(2, result.size());
     Assert.assertEquals(mockList.get(0).getStableId(), result.get(0).getStableId());
     Assert.assertEquals(mockList.get(1).getStableId(), result.get(1).getStableId());
-    verify(repository).getGenericAssayMetaByProfileIds(PROFILE_ID_LIST, ID_LIST);
+    verify(repository).getGenericAssayMetaByProfileIds(eq(PROFILE_ID_LIST), eq(ID_LIST), any());
   }
 
   @Test
   public void execute_profilesOnly_summaryProjection() {
     List<GenericAssayMeta> mockList = createMockMetaList();
-    when(repository.getGenericAssayMetaByProfileIds(PROFILE_ID_LIST, null)).thenReturn(mockList);
+    streamProfileMeta(mockList);
 
     List<GenericAssayMeta> result =
-        useCase.execute(null, PROFILE_ID_LIST, PersistenceConstants.SUMMARY_PROJECTION);
+        collect(null, PROFILE_ID_LIST, PersistenceConstants.SUMMARY_PROJECTION);
 
     Assert.assertEquals(2, result.size());
     Assert.assertEquals(mockList.get(0).getStableId(), result.get(0).getStableId());
     Assert.assertEquals(mockList.get(1).getStableId(), result.get(1).getStableId());
+    verify(repository).getGenericAssayMetaByProfileIds(eq(PROFILE_ID_LIST), eq(null), any());
   }
 
   @Test
   public void execute_profilesOnly_idProjection() {
     when(repository.getGenericAssayStableIdsByProfileIds(PROFILE_ID_LIST)).thenReturn(ID_LIST);
 
-    List<GenericAssayMeta> result = useCase.execute(null, PROFILE_ID_LIST, "ID");
+    List<GenericAssayMeta> result = collect(null, PROFILE_ID_LIST, "ID");
 
     Assert.assertEquals(2, result.size());
     Assert.assertEquals(GENERIC_ASSAY_ID_1, result.get(0).getStableId());
     Assert.assertEquals(GENERIC_ASSAY_ID_2, result.get(1).getStableId());
     Assert.assertNull(result.get(0).getEntityType());
     verify(repository).getGenericAssayStableIdsByProfileIds(PROFILE_ID_LIST);
-    verify(repository, org.mockito.Mockito.never())
-        .getGenericAssayMetaByProfileIds(org.mockito.Mockito.any(), org.mockito.Mockito.any());
+    verify(repository, never()).getGenericAssayMetaByProfileIds(any(), any(), any());
   }
 
   @Test
   public void execute_stableIdsOnly_summaryProjection() {
     List<GenericAssayMeta> mockList = createMockMetaList();
-    when(repository.getGenericAssayMetaByStableIds(ID_LIST)).thenReturn(mockList);
+    streamStableIdMeta(mockList);
 
-    List<GenericAssayMeta> result =
-        useCase.execute(ID_LIST, null, PersistenceConstants.SUMMARY_PROJECTION);
+    List<GenericAssayMeta> result = collect(ID_LIST, null, PersistenceConstants.SUMMARY_PROJECTION);
 
     Assert.assertEquals(2, result.size());
     Assert.assertEquals(mockList.get(0).getStableId(), result.get(0).getStableId());
     Assert.assertEquals(
         mockList.get(0).getGenericEntityMetaProperties(),
         result.get(0).getGenericEntityMetaProperties());
+    verify(repository).getGenericAssayMetaByStableIds(eq(ID_LIST), any());
   }
 
   @Test
   public void execute_stableIdsOnly_idProjection() {
-    List<GenericAssayMeta> result = useCase.execute(ID_LIST, null, "ID");
+    List<GenericAssayMeta> result = collect(ID_LIST, null, "ID");
 
     Assert.assertEquals(2, result.size());
     Assert.assertEquals(GENERIC_ASSAY_ID_1, result.get(0).getStableId());
@@ -119,10 +156,9 @@ public class GetGenericAssayMetaUseCaseTest {
 
   @Test
   public void execute_bothNull_returnsEmpty() {
-    List<GenericAssayMeta> result =
-        useCase.execute(null, null, PersistenceConstants.SUMMARY_PROJECTION);
+    List<GenericAssayMeta> result = collect(null, null, PersistenceConstants.SUMMARY_PROJECTION);
 
-    Assert.assertEquals(Collections.emptyList(), result);
+    Assert.assertTrue(result.isEmpty());
     verifyNoInteractions(repository);
   }
 }

--- a/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayMapperTest.java
+++ b/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayMapperTest.java
@@ -2,7 +2,9 @@ package org.cbioportal.infrastructure.repository.clickhouse.generic_assay;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
 import java.util.List;
+import org.apache.ibatis.session.ResultHandler;
 import org.cbioportal.domain.studyview.StudyViewFilterFactory;
 import org.cbioportal.infrastructure.repository.clickhouse.AbstractTestcontainers;
 import org.cbioportal.infrastructure.repository.clickhouse.config.MyBatisConfig;
@@ -34,6 +36,24 @@ public class ClickhouseGenericAssayMapperTest {
   private static final String ACC_TCGA_ARMLEVEL_CNA_PROFILE = "acc_tcga_armlevel_cna";
 
   @Autowired private ClickhouseGenericAssayMapper mapper;
+
+  /** Collects the streamed rows from the stable-id meta query into a list for assertions. */
+  private List<GenericAssayMeta> metaByStableIds(List<String> stableIds) {
+    List<GenericAssayMeta> collected = new ArrayList<>();
+    mapper.getGenericAssayMetaByStableIds(stableIds, collect(collected));
+    return collected;
+  }
+
+  /** Collects the streamed rows from the profile-id meta query into a list for assertions. */
+  private List<GenericAssayMeta> metaByProfileIds(List<String> profileIds, List<String> stableIds) {
+    List<GenericAssayMeta> collected = new ArrayList<>();
+    mapper.getGenericAssayMetaByProfileIds(profileIds, stableIds, collect(collected));
+    return collected;
+  }
+
+  private static ResultHandler<GenericAssayMeta> collect(List<GenericAssayMeta> sink) {
+    return context -> sink.add(context.getResultObject());
+  }
 
   @Test
   public void getSampleCategoricalGenericAssayDataCounts() {
@@ -110,7 +130,7 @@ public class ClickhouseGenericAssayMapperTest {
 
   @Test
   public void getGenericAssayMetaByStableIds_returnsMetaWithProperties() {
-    List<GenericAssayMeta> result = mapper.getGenericAssayMetaByStableIds(List.of("1p_status"));
+    List<GenericAssayMeta> result = metaByStableIds(List.of("1p_status"));
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getStableId()).isEqualTo("1p_status");
@@ -124,8 +144,7 @@ public class ClickhouseGenericAssayMapperTest {
     // Lexicographic order would be: 10p_status, 1p_status, 2p_status, 9p_status
     // Numeric-aware order should be: 1p_status, 2p_status, 9p_status, 10p_status
     List<GenericAssayMeta> result =
-        mapper.getGenericAssayMetaByStableIds(
-            List.of("10p_status", "9p_status", "2p_status", "1p_status"));
+        metaByStableIds(List.of("10p_status", "9p_status", "2p_status", "1p_status"));
 
     assertThat(result)
         .extracting(GenericAssayMeta::getStableId)
@@ -134,8 +153,7 @@ public class ClickhouseGenericAssayMapperTest {
 
   @Test
   public void getGenericAssayMetaByProfileIds_noStableIdsFilter_returnsAllEntities() {
-    List<GenericAssayMeta> result =
-        mapper.getGenericAssayMetaByProfileIds(List.of(ACC_TCGA_ARMLEVEL_CNA_PROFILE), null);
+    List<GenericAssayMeta> result = metaByProfileIds(List.of(ACC_TCGA_ARMLEVEL_CNA_PROFILE), null);
 
     assertThat(result)
         .isNotEmpty()
@@ -149,8 +167,7 @@ public class ClickhouseGenericAssayMapperTest {
   public void getGenericAssayMetaByProfileIds_sortsNumerically() {
     // Lexicographic order would be: 10p_status, 1p_status, 2p_status, 9p_status
     // Numeric-aware order should be: 1p_status, 2p_status, 9p_status, 10p_status
-    List<GenericAssayMeta> result =
-        mapper.getGenericAssayMetaByProfileIds(List.of(ACC_TCGA_ARMLEVEL_CNA_PROFILE), null);
+    List<GenericAssayMeta> result = metaByProfileIds(List.of(ACC_TCGA_ARMLEVEL_CNA_PROFILE), null);
 
     assertThat(result)
         .extracting(GenericAssayMeta::getStableId)
@@ -160,8 +177,7 @@ public class ClickhouseGenericAssayMapperTest {
   @Test
   public void getGenericAssayMetaByProfileIds_withStableIdsFilter_returnsOnlyMatchingEntities() {
     List<GenericAssayMeta> result =
-        mapper.getGenericAssayMetaByProfileIds(
-            List.of(ACC_TCGA_ARMLEVEL_CNA_PROFILE), List.of("1p_status"));
+        metaByProfileIds(List.of(ACC_TCGA_ARMLEVEL_CNA_PROFILE), List.of("1p_status"));
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getStableId()).isEqualTo("1p_status");


### PR DESCRIPTION
## Problem

The column-store `/api/generic-assay-meta/fetch` endpoint (and the two `GET` variants) materialized the **entire** `List<GenericAssayMeta>` in memory — and cached it — before serializing the response.

Measured against a production-data ClickHouse clone, a methylation (`hm450`) request resolves to ~396K–835K entities, each an object holding a `HashMap` of properties — **hundreds of MB of heap** to produce a response that gzips to a few MB. The `@Cacheable` on the use case pinned a **second** full copy on the heap, keyed by the exact profile/stable-id set, so for the large, varied requests that caused the problem its hit rate was ~0 while the memory cost was full.

## Change

Switch the meta fetch to **MyBatis `ResultHandler` streaming**:

- The mapper methods stream each mapped row to a `ResultHandler` instead of returning a `List`.
- The domain `GenericAssayRepository` exposes a `Consumer<GenericAssayMeta>`; the ClickHouse impl bridges `ResultHandler` → `Consumer`.
- `GetGenericAssayMetaUseCase.execute(...)` pushes each entity to the consumer as it is read.
- The controller writes a JSON array element-by-element via a `JsonGenerator` inside the `StreamingResponseBody`, so the result set is **never collected into a list**.

The SQL and result maps are unchanged. The per-request `@Cacheable` is dropped on this path — it is incompatible with streaming (nothing is returned to cache) and provided little benefit for the large requests that motivated this work.

## Validation

Benchmarked old (master) vs new, both booted against a production-data ClickHouse clone, same 396,065-entity `hm450` request, 6 sequential runs each:

| | response | latency (median of 6) | peak old-gen heap growth |
|---|---|---|---|
| **OLD** (materialize + serialize) | 55 MB / 396,065 rows | ~6.0s | **+255 MB** |
| **NEW** (streaming) | 55 MB / 396,065 rows | ~13.5s | **+3–5 MB** |

- **~15× lower peak heap**, constant regardless of result size.
- Output is **byte-identical** to the old impl (`cmp` confirms; both 55,332,682 bytes).
- All **1,329 core tests pass** (0 failures/errors), including a real-ClickHouse Testcontainers mapper test exercising the `ResultHandler` path.

### Latency tradeoff (honest)

Streaming was ~2.2× slower wall-clock **in this benchmark** — but that number is inflated by the test setup, and the tradeoff is favorable:

- The ClickHouse query itself is **~0.7–0.9s** server-side (verified via `system.query_log`: 671/817/893 ms, ~175 MiB peak server memory). The rest of the measured latency is **transferring 55 MB from ClickHouse Cloud to the test box over the public internet + serialization** — not query execution. In production the app is co-located with ClickHouse (LAN), so absolute latencies are far lower and the gap shrinks.
- The slowdown is intrinsic to incremental consumption (per-row read cadence throttles network throughput vs. a tight drain-into-a-List loop). It is **not** fixable by `fetchSize` or output buffering — both were tested and made no difference.
- The gap only affects pathological large pulls, which are exactly the OOM-risk requests. Typical few-hundred-entity requests are sub-second either way.

If large-pull latency ever proves to matter in production, it can be recovered with a bounded read-ahead buffer (producer drains the cursor fast into a small bounded queue; consumer serializes) — deferred as out of scope here.

## Follow-up (the bigger lever): #12201

Benchmarking surfaced the real root cause: this endpoint returns **~396K entities / 55 MB regardless of how many studies are selected** (hm450 profiles share one probe set), and the frontend reads only `NAME`/`DESCRIPTION`/`URL` — ~80% of the property payload is keys it never reads. Reducing the payload (trim `SUMMARY` / have the frontend request less) would cut memory **and** latency more than streaming does. This PR bounds the memory; #12201 tracks shrinking the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
