### PR TITLE
Stream copy-number-segments, mutations, and clinical-data fetch to bound web-server memory

### DIFF
--- a/src/main/java/org/cbioportal/legacy/persistence/ClinicalDataRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/ClinicalDataRepository.java
@@ -1,6 +1,7 @@
 package org.cbioportal.legacy.persistence;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.cbioportal.legacy.model.ClinicalData;
 import org.cbioportal.legacy.model.ClinicalDataCount;
 import org.cbioportal.legacy.model.meta.BaseMeta;
@@ -87,6 +88,19 @@ public interface ClinicalDataRepository {
       List<String> attributeIds,
       String clinicalDataType,
       String projection);
+
+  /**
+   * Streaming counterpart of {@link #fetchClinicalData}: each datum is passed to {@code consumer}
+   * as it is read so the full (potentially very large) multi-study result is never held in memory.
+   * Not cached.
+   */
+  void streamClinicalData(
+      List<String> studyIds,
+      List<String> ids,
+      List<String> attributeIds,
+      String clinicalDataType,
+      String projection,
+      Consumer<ClinicalData> consumer);
 
   @Cacheable(
       cacheResolver = "generalRepositoryCacheResolver",

--- a/src/main/java/org/cbioportal/legacy/persistence/CopyNumberSegmentRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/CopyNumberSegmentRepository.java
@@ -1,6 +1,7 @@
 package org.cbioportal.legacy.persistence;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.cbioportal.legacy.model.CopyNumberSeg;
 import org.cbioportal.legacy.model.meta.BaseMeta;
 import org.springframework.cache.annotation.Cacheable;
@@ -37,6 +38,18 @@ public interface CopyNumberSegmentRepository {
       condition = "@cacheEnabledConfig.getEnabled()")
   List<CopyNumberSeg> fetchCopyNumberSegments(
       List<String> studyIds, List<String> sampleIds, String chromosome, String projection);
+
+  /**
+   * Streaming counterpart of {@link #fetchCopyNumberSegments}: each segment is passed to {@code
+   * consumer} as it is read from the database so the full result set is never held in memory. Not
+   * cached — intended for large, low-reuse multi-study fetches.
+   */
+  void streamCopyNumberSegments(
+      List<String> studyIds,
+      List<String> sampleIds,
+      String chromosome,
+      String projection,
+      Consumer<CopyNumberSeg> consumer);
 
   @Cacheable(
       cacheResolver = "generalRepositoryCacheResolver",

--- a/src/main/java/org/cbioportal/legacy/persistence/MutationRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/MutationRepository.java
@@ -1,6 +1,7 @@
 package org.cbioportal.legacy.persistence;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.cbioportal.legacy.model.GeneFilterQuery;
 import org.cbioportal.legacy.model.GenomicDataCountItem;
 import org.cbioportal.legacy.model.Mutation;
@@ -42,6 +43,22 @@ public interface MutationRepository {
       Integer pageNumber,
       String sortBy,
       String direction);
+
+  /**
+   * Streaming counterpart of {@link #getMutationsInMultipleMolecularProfiles}: each mutation is
+   * passed to {@code consumer} as it is read so the full result set is never held in memory. Not
+   * cached.
+   */
+  void streamMutationsInMultipleMolecularProfiles(
+      List<String> molecularProfileIds,
+      List<String> sampleIds,
+      List<Integer> entrezGeneIds,
+      String projection,
+      Integer pageSize,
+      Integer pageNumber,
+      String sortBy,
+      String direction,
+      Consumer<Mutation> consumer);
 
   @Cacheable(
       cacheResolver = "generalRepositoryCacheResolver",

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/ClinicalDataMapper.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/ClinicalDataMapper.java
@@ -1,6 +1,7 @@
 package org.cbioportal.legacy.persistence.mybatis;
 
 import java.util.List;
+import org.apache.ibatis.session.ResultHandler;
 import org.cbioportal.legacy.model.ClinicalData;
 import org.cbioportal.legacy.model.ClinicalDataCount;
 import org.cbioportal.legacy.model.meta.BaseMeta;
@@ -17,6 +18,22 @@ public interface ClinicalDataMapper {
       String sortBy,
       String direction);
 
+  /**
+   * Streaming overload of {@link #getSampleClinicalData}: routes to the same SQL statement but
+   * passes each mapped row to {@code handler} instead of building a list, so a large result set is
+   * never materialized in memory.
+   */
+  void getSampleClinicalData(
+      List<String> studyIds,
+      List<String> sampleIds,
+      List<String> attributeIds,
+      String projection,
+      Integer limit,
+      Integer offset,
+      String sortBy,
+      String direction,
+      ResultHandler<ClinicalData> handler);
+
   BaseMeta getMetaSampleClinicalData(
       List<String> studyIds, List<String> sampleIds, List<String> attributeIds);
 
@@ -29,6 +46,18 @@ public interface ClinicalDataMapper {
       Integer offset,
       String sortBy,
       String direction);
+
+  /** Streaming overload of {@link #getPatientClinicalData}; see {@link #getSampleClinicalData}. */
+  void getPatientClinicalData(
+      List<String> studyIds,
+      List<String> patientIds,
+      List<String> attributeIds,
+      String projection,
+      Integer limit,
+      Integer offset,
+      String sortBy,
+      String direction,
+      ResultHandler<ClinicalData> handler);
 
   List<ClinicalData> getSampleClinicalTable(
       List<String> studyIds,

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/ClinicalDataMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/ClinicalDataMyBatisRepository.java
@@ -1,8 +1,10 @@
 package org.cbioportal.legacy.persistence.mybatis;
 
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.ibatis.session.ResultHandler;
 import org.cbioportal.legacy.model.ClinicalAttribute;
 import org.cbioportal.legacy.model.ClinicalData;
 import org.cbioportal.legacy.model.ClinicalDataCount;
@@ -199,6 +201,27 @@ public class ClinicalDataMyBatisRepository implements ClinicalDataRepository {
     } else {
       return clinicalDataMapper.getPatientClinicalData(
           studyIds, ids, attributeIds, projection, 0, 0, null, null);
+    }
+  }
+
+  @Override
+  public void streamClinicalData(
+      List<String> studyIds,
+      List<String> ids,
+      List<String> attributeIds,
+      String clinicalDataType,
+      String projection,
+      Consumer<ClinicalData> consumer) {
+    if (ids.isEmpty()) {
+      return;
+    }
+    ResultHandler<ClinicalData> handler = context -> consumer.accept(context.getResultObject());
+    if (clinicalDataType.equals(PersistenceConstants.SAMPLE_CLINICAL_DATA_TYPE)) {
+      clinicalDataMapper.getSampleClinicalData(
+          studyIds, ids, attributeIds, projection, 0, 0, null, null, handler);
+    } else {
+      clinicalDataMapper.getPatientClinicalData(
+          studyIds, ids, attributeIds, projection, 0, 0, null, null, handler);
     }
   }
 

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/CopyNumberSegmentMapper.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/CopyNumberSegmentMapper.java
@@ -1,6 +1,7 @@
 package org.cbioportal.legacy.persistence.mybatis;
 
 import java.util.List;
+import org.apache.ibatis.session.ResultHandler;
 import org.cbioportal.legacy.model.CopyNumberSeg;
 import org.cbioportal.legacy.model.meta.BaseMeta;
 
@@ -15,6 +16,18 @@ public interface CopyNumberSegmentMapper {
       Integer offset,
       String sortBy,
       String direction);
+
+  /**
+   * Streams copy number segments for the given studies/samples to {@code handler} one row at a time
+   * (ordered by seg_id), so the full result set is never materialized in memory. Mirrors the
+   * unpaged "fetch" use of {@link #getCopyNumberSegments} but for large multi-study result sets.
+   */
+  void streamCopyNumberSegments(
+      List<String> studyIds,
+      List<String> sampleIds,
+      String chromosome,
+      String projection,
+      ResultHandler<CopyNumberSeg> handler);
 
   List<Integer> getSamplesWithCopyNumberSegments(
       List<String> studyIds, List<String> sampleIds, String chromosome);

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/CopyNumberSegmentMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/CopyNumberSegmentMyBatisRepository.java
@@ -2,6 +2,7 @@ package org.cbioportal.legacy.persistence.mybatis;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 import org.cbioportal.legacy.model.CopyNumberSeg;
 import org.cbioportal.legacy.model.meta.BaseMeta;
 import org.cbioportal.legacy.persistence.CopyNumberSegmentRepository;
@@ -57,6 +58,22 @@ public class CopyNumberSegmentMyBatisRepository implements CopyNumberSegmentRepo
 
     return copyNumberSegmentMapper.getCopyNumberSegments(
         studyIds, sampleIds, chromosome, projection, 0, 0, null, null);
+  }
+
+  @Override
+  public void streamCopyNumberSegments(
+      List<String> studyIds,
+      List<String> sampleIds,
+      String chromosome,
+      String projection,
+      Consumer<CopyNumberSeg> consumer) {
+
+    copyNumberSegmentMapper.streamCopyNumberSegments(
+        studyIds,
+        sampleIds,
+        chromosome,
+        projection,
+        context -> consumer.accept(context.getResultObject()));
   }
 
   @Override

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/MutationMapper.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/MutationMapper.java
@@ -1,6 +1,7 @@
 package org.cbioportal.legacy.persistence.mybatis;
 
 import java.util.List;
+import org.apache.ibatis.session.ResultHandler;
 import org.cbioportal.legacy.model.GeneFilterQuery;
 import org.cbioportal.legacy.model.GenomicDataCountItem;
 import org.cbioportal.legacy.model.Mutation;
@@ -33,6 +34,23 @@ public interface MutationMapper {
       Integer offset,
       String sortBy,
       String direction);
+
+  /**
+   * Streaming overload of {@link #getMutationsInMultipleMolecularProfiles}: routes to the same SQL
+   * statement (honoring the same projection/paging/sort) but passes each mapped row to {@code
+   * handler} instead of building a list, so a large result set is never materialized in memory.
+   */
+  void getMutationsInMultipleMolecularProfiles(
+      List<String> molecularProfileIds,
+      List<String> sampleIds,
+      List<Integer> entrezGeneIds,
+      boolean snpOnly,
+      String projection,
+      Integer limit,
+      Integer offset,
+      String sortBy,
+      String direction,
+      ResultHandler<Mutation> handler);
 
   List<Mutation> getMutationsInMultipleMolecularProfilesByGeneQueries(
       List<String> molecularProfileIds,

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/MutationMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/MutationMyBatisRepository.java
@@ -1,6 +1,7 @@
 package org.cbioportal.legacy.persistence.mybatis;
 
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.cbioportal.legacy.model.GeneFilterQuery;
 import org.cbioportal.legacy.model.GenomicDataCountItem;
@@ -72,6 +73,31 @@ public class MutationMyBatisRepository implements MutationRepository {
         PaginationCalculator.offset(pageSize, pageNumber),
         sortBy,
         direction);
+  }
+
+  @Override
+  public void streamMutationsInMultipleMolecularProfiles(
+      List<String> molecularProfileIds,
+      List<String> sampleIds,
+      List<Integer> entrezGeneIds,
+      String projection,
+      Integer pageSize,
+      Integer pageNumber,
+      String sortBy,
+      String direction,
+      Consumer<Mutation> consumer) {
+
+    mutationMapper.getMutationsInMultipleMolecularProfiles(
+        molecularProfileIds,
+        sampleIds,
+        entrezGeneIds,
+        false,
+        projection,
+        pageSize,
+        PaginationCalculator.offset(pageSize, pageNumber),
+        sortBy,
+        direction,
+        context -> consumer.accept(context.getResultObject()));
   }
 
   @Override

--- a/src/main/java/org/cbioportal/legacy/service/ClinicalDataService.java
+++ b/src/main/java/org/cbioportal/legacy/service/ClinicalDataService.java
@@ -1,6 +1,7 @@
 package org.cbioportal.legacy.service;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.cbioportal.legacy.model.ClinicalData;
 import org.cbioportal.legacy.model.ClinicalDataCountItem;
@@ -72,6 +73,14 @@ public interface ClinicalDataService {
       List<String> attributeIds,
       String clinicalDataType,
       String projection);
+
+  void streamClinicalData(
+      List<String> studyIds,
+      List<String> ids,
+      List<String> attributeIds,
+      String clinicalDataType,
+      String projection,
+      Consumer<ClinicalData> consumer);
 
   BaseMeta fetchMetaClinicalData(
       List<String> studyIds, List<String> ids, List<String> attributeIds, String clinicalDataType);

--- a/src/main/java/org/cbioportal/legacy/service/CopyNumberSegmentService.java
+++ b/src/main/java/org/cbioportal/legacy/service/CopyNumberSegmentService.java
@@ -1,6 +1,7 @@
 package org.cbioportal.legacy.service;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.cbioportal.legacy.model.CopyNumberSeg;
 import org.cbioportal.legacy.model.meta.BaseMeta;
 import org.cbioportal.legacy.service.exception.SampleNotFoundException;
@@ -25,6 +26,13 @@ public interface CopyNumberSegmentService {
 
   List<CopyNumberSeg> fetchCopyNumberSegments(
       List<String> studyIds, List<String> sampleIds, String chromosome, String projection);
+
+  void streamCopyNumberSegments(
+      List<String> studyIds,
+      List<String> sampleIds,
+      String chromosome,
+      String projection,
+      Consumer<CopyNumberSeg> consumer);
 
   BaseMeta fetchMetaCopyNumberSegments(
       List<String> studyIds, List<String> sampleIds, String chromosome);

--- a/src/main/java/org/cbioportal/legacy/service/MutationService.java
+++ b/src/main/java/org/cbioportal/legacy/service/MutationService.java
@@ -1,6 +1,7 @@
 package org.cbioportal.legacy.service;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.cbioportal.legacy.model.GeneFilterQuery;
 import org.cbioportal.legacy.model.GenomicDataCountItem;
 import org.cbioportal.legacy.model.Mutation;
@@ -35,6 +36,17 @@ public interface MutationService {
       Integer pageNumber,
       String sortBy,
       String direction);
+
+  void streamMutationsInMultipleMolecularProfiles(
+      List<String> molecularProfileIds,
+      List<String> sampleIds,
+      List<Integer> entrezGeneIds,
+      String projection,
+      Integer pageSize,
+      Integer pageNumber,
+      String sortBy,
+      String direction,
+      Consumer<Mutation> consumer);
 
   List<Mutation> getMutationsInMultipleMolecularProfilesByGeneQueries(
       List<String> molecularProfileIds,

--- a/src/main/java/org/cbioportal/legacy/service/impl/ClinicalDataServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/ClinicalDataServiceImpl.java
@@ -3,6 +3,7 @@ package org.cbioportal.legacy.service.impl;
 import static org.cbioportal.legacy.utils.Encoder.calculateBase64;
 
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -163,6 +164,21 @@ public class ClinicalDataServiceImpl implements ClinicalDataService {
     }
     return clinicalDataRepository.fetchClinicalData(
         studyIds, ids, attributeIds, clinicalDataType, projection);
+  }
+
+  @Override
+  public void streamClinicalData(
+      List<String> studyIds,
+      List<String> ids,
+      List<String> attributeIds,
+      String clinicalDataType,
+      String projection,
+      Consumer<ClinicalData> consumer) {
+    if (ids.isEmpty()) {
+      return;
+    }
+    clinicalDataRepository.streamClinicalData(
+        studyIds, ids, attributeIds, clinicalDataType, projection, consumer);
   }
 
   @Override

--- a/src/main/java/org/cbioportal/legacy/service/impl/CopyNumberSegmentServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/CopyNumberSegmentServiceImpl.java
@@ -1,6 +1,7 @@
 package org.cbioportal.legacy.service.impl;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.cbioportal.legacy.model.CopyNumberSeg;
 import org.cbioportal.legacy.model.meta.BaseMeta;
 import org.cbioportal.legacy.persistence.CopyNumberSegmentRepository;
@@ -52,6 +53,18 @@ public class CopyNumberSegmentServiceImpl implements CopyNumberSegmentService {
 
     return copyNumberSegmentRepository.fetchCopyNumberSegments(
         studyIds, sampleIds, chromosome, projection);
+  }
+
+  @Override
+  public void streamCopyNumberSegments(
+      List<String> studyIds,
+      List<String> sampleIds,
+      String chromosome,
+      String projection,
+      Consumer<CopyNumberSeg> consumer) {
+
+    copyNumberSegmentRepository.streamCopyNumberSegments(
+        studyIds, sampleIds, chromosome, projection, consumer);
   }
 
   @Override

--- a/src/main/java/org/cbioportal/legacy/service/impl/MutationServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/MutationServiceImpl.java
@@ -2,6 +2,7 @@ package org.cbioportal.legacy.service.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import org.cbioportal.legacy.model.GeneFilterQuery;
 import org.cbioportal.legacy.model.GenomicDataCountItem;
 import org.cbioportal.legacy.model.MolecularProfile;
@@ -109,6 +110,30 @@ public class MutationServiceImpl implements MutationService {
             direction);
 
     return mutationList;
+  }
+
+  @Override
+  public void streamMutationsInMultipleMolecularProfiles(
+      List<String> molecularProfileIds,
+      List<String> sampleIds,
+      List<Integer> entrezGeneIds,
+      String projection,
+      Integer pageSize,
+      Integer pageNumber,
+      String sortBy,
+      String direction,
+      Consumer<Mutation> consumer) {
+
+    mutationRepository.streamMutationsInMultipleMolecularProfiles(
+        molecularProfileIds,
+        sampleIds,
+        entrezGeneIds,
+        projection,
+        pageSize,
+        pageNumber,
+        sortBy,
+        direction,
+        consumer);
   }
 
   @Override

--- a/src/main/java/org/cbioportal/legacy/web/ClinicalDataController.java
+++ b/src/main/java/org/cbioportal/legacy/web/ClinicalDataController.java
@@ -1,5 +1,7 @@
 package org.cbioportal.legacy.web;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -10,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -43,6 +47,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @PublicApi
 @RestController()
@@ -55,6 +60,7 @@ public class ClinicalDataController {
   private static final String CLINICAL_DATA_DEFAULT_PAGE_SIZE = "10000000";
 
   @Autowired private ClinicalDataService clinicalDataService;
+  @Autowired private ObjectMapper objectMapper;
 
   @PreAuthorize(
       "hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
@@ -308,7 +314,7 @@ public class ClinicalDataController {
       description = "OK",
       content =
           @Content(array = @ArraySchema(schema = @Schema(implementation = ClinicalData.class))))
-  public ResponseEntity<List<ClinicalData>> fetchClinicalData(
+  public ResponseEntity<StreamingResponseBody> fetchClinicalData(
       @Parameter(hidden = true) // prevent reference to this attribute in the swagger-ui interface
           @RequestAttribute(required = false, value = "involvedCancerStudies")
           Collection<String> involvedCancerStudies,
@@ -353,15 +359,36 @@ public class ClinicalDataController {
               .getTotalCount()
               .toString());
       return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
-    } else {
-      return new ResponseEntity<>(
-          clinicalDataService.fetchClinicalData(
-              studyIds,
-              ids,
-              interceptedClinicalDataMultiStudyFilter.getAttributeIds(),
-              clinicalDataType.name(),
-              projection.name()),
-          HttpStatus.OK);
     }
+
+    // Stream the clinical data as a JSON array, writing each datum as it is read so the
+    // (potentially very large, multi-study) result set is never materialized into a list.
+    List<String> attributeIds = interceptedClinicalDataMultiStudyFilter.getAttributeIds();
+    String clinicalDataTypeName = clinicalDataType.name();
+    String projectionName = projection.name();
+    StreamingResponseBody body =
+        outputStream -> {
+          try (JsonGenerator generator = objectMapper.getFactory().createGenerator(outputStream)) {
+            generator.writeStartArray();
+            clinicalDataService.streamClinicalData(
+                studyIds,
+                ids,
+                attributeIds,
+                clinicalDataTypeName,
+                projectionName,
+                datum -> {
+                  try {
+                    generator.writeObject(datum);
+                  } catch (IOException e) {
+                    // ResultHandler/Consumer cannot throw checked exceptions; unwrapped below
+                    throw new UncheckedIOException(e);
+                  }
+                });
+            generator.writeEndArray();
+          } catch (UncheckedIOException e) {
+            throw e.getCause();
+          }
+        };
+    return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(body);
   }
 }

--- a/src/main/java/org/cbioportal/legacy/web/ClinicalDataController.java
+++ b/src/main/java/org/cbioportal/legacy/web/ClinicalDataController.java
@@ -369,6 +369,10 @@ public class ClinicalDataController {
     StreamingResponseBody body =
         outputStream -> {
           try (JsonGenerator generator = objectMapper.getFactory().createGenerator(outputStream)) {
+            // A committed 200 cannot become a 500 mid-stream; disable AUTO_CLOSE_JSON_CONTENT so a
+            // failure leaves the array unclosed (client sees invalid JSON) rather than a silently
+            // truncated but well-formed one. The exception still propagates and is logged.
+            generator.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
             generator.writeStartArray();
             clinicalDataService.streamClinicalData(
                 studyIds,

--- a/src/main/java/org/cbioportal/legacy/web/CopyNumberSegmentController.java
+++ b/src/main/java/org/cbioportal/legacy/web/CopyNumberSegmentController.java
@@ -1,5 +1,7 @@
 package org.cbioportal.legacy.web;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -10,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -39,6 +43,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @PublicApi
 @RestController()
@@ -51,6 +56,7 @@ public class CopyNumberSegmentController {
   private static final String COPY_NUMBER_SEGMENT_DEFAULT_PAGE_SIZE = "20000";
 
   @Autowired private CopyNumberSegmentService copyNumberSegmentService;
+  @Autowired private ObjectMapper objectMapper;
 
   @PreAuthorize(
       "hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
@@ -126,7 +132,7 @@ public class CopyNumberSegmentController {
       description = "OK",
       content =
           @Content(array = @ArraySchema(schema = @Schema(implementation = CopyNumberSeg.class))))
-  public ResponseEntity<List<CopyNumberSeg>> fetchCopyNumberSegments(
+  public ResponseEntity<StreamingResponseBody> fetchCopyNumberSegments(
       @Parameter(hidden = true) // prevent reference to this attribute in the swagger-ui interface
           @RequestAttribute(required = false, value = "involvedCancerStudies")
           Collection<String> involvedCancerStudies,
@@ -162,11 +168,33 @@ public class CopyNumberSegmentController {
               .getTotalCount()
               .toString());
       return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
-    } else {
-      return new ResponseEntity<>(
-          copyNumberSegmentService.fetchCopyNumberSegments(
-              studyIds, sampleIds, chromosome, projection.name()),
-          HttpStatus.OK);
     }
+
+    // Stream the segments as a JSON array, writing each row as it is read from the database so the
+    // (potentially very large, multi-study) result set is never materialized into a list in memory.
+    String projectionName = projection.name();
+    StreamingResponseBody body =
+        outputStream -> {
+          try (JsonGenerator generator = objectMapper.getFactory().createGenerator(outputStream)) {
+            generator.writeStartArray();
+            copyNumberSegmentService.streamCopyNumberSegments(
+                studyIds,
+                sampleIds,
+                chromosome,
+                projectionName,
+                seg -> {
+                  try {
+                    generator.writeObject(seg);
+                  } catch (IOException e) {
+                    // ResultHandler/Consumer cannot throw checked exceptions; unwrapped below
+                    throw new UncheckedIOException(e);
+                  }
+                });
+            generator.writeEndArray();
+          } catch (UncheckedIOException e) {
+            throw e.getCause();
+          }
+        };
+    return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(body);
   }
 }

--- a/src/main/java/org/cbioportal/legacy/web/CopyNumberSegmentController.java
+++ b/src/main/java/org/cbioportal/legacy/web/CopyNumberSegmentController.java
@@ -176,6 +176,10 @@ public class CopyNumberSegmentController {
     StreamingResponseBody body =
         outputStream -> {
           try (JsonGenerator generator = objectMapper.getFactory().createGenerator(outputStream)) {
+            // A committed 200 cannot become a 500 mid-stream; disable AUTO_CLOSE_JSON_CONTENT so a
+            // failure leaves the array unclosed (client sees invalid JSON) rather than a silently
+            // truncated but well-formed one. The exception still propagates and is logged.
+            generator.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
             generator.writeStartArray();
             copyNumberSegmentService.streamCopyNumberSegments(
                 studyIds,

--- a/src/main/java/org/cbioportal/legacy/web/MutationController.java
+++ b/src/main/java/org/cbioportal/legacy/web/MutationController.java
@@ -1,5 +1,7 @@
 package org.cbioportal.legacy.web;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -10,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,6 +46,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @PublicApi
 @RestController()
@@ -51,6 +56,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MutationController {
 
   @Autowired private MutationService mutationService;
+  @Autowired private ObjectMapper objectMapper;
 
   @PreAuthorize(
       "hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
@@ -224,7 +230,7 @@ public class MutationController {
       responseCode = "200",
       description = "OK",
       content = @Content(array = @ArraySchema(schema = @Schema(implementation = Mutation.class))))
-  public ResponseEntity<List<Mutation>> fetchMutationsInMultipleMolecularProfiles(
+  public ResponseEntity<StreamingResponseBody> fetchMutationsInMultipleMolecularProfiles(
       @Parameter(hidden = true) // prevent reference to this attribute in the swagger-ui interface
           @RequestAttribute(required = false, value = "involvedCancerStudies")
           Collection<String> involvedCancerStudies,
@@ -287,39 +293,53 @@ public class MutationController {
       responseHeaders.add(
           HeaderKeyConstants.SAMPLE_COUNT, mutationMeta.getSampleCount().toString());
       return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
-    } else {
-      List<Mutation> mutations;
-      if (interceptedMutationMultipleStudyFilter.getMolecularProfileIds() != null) {
-        mutations =
-            mutationService.getMutationsInMultipleMolecularProfiles(
-                interceptedMutationMultipleStudyFilter.getMolecularProfileIds(),
-                null,
-                interceptedMutationMultipleStudyFilter.getEntrezGeneIds(),
-                projection.name(),
-                pageSize,
-                pageNumber,
-                sortBy == null ? null : sortBy.getOriginalValue(),
-                direction.name());
-      } else {
+    }
 
-        List<String> molecularProfileIds = new ArrayList<>();
-        List<String> sampleIds = new ArrayList<>();
-        extractMolecularProfileAndSampleIds(
-            interceptedMutationMultipleStudyFilter, molecularProfileIds, sampleIds);
-        mutations =
-            mutationService.getMutationsInMultipleMolecularProfiles(
+    // Resolve the (profileIds, sampleIds) for the chosen branch, then stream the result as a JSON
+    // array so the (potentially very large) mutation result set is never materialized into a list.
+    final List<String> molecularProfileIds;
+    final List<String> sampleIds;
+    if (interceptedMutationMultipleStudyFilter.getMolecularProfileIds() != null) {
+      molecularProfileIds = interceptedMutationMultipleStudyFilter.getMolecularProfileIds();
+      sampleIds = null;
+    } else {
+      molecularProfileIds = new ArrayList<>();
+      sampleIds = new ArrayList<>();
+      extractMolecularProfileAndSampleIds(
+          interceptedMutationMultipleStudyFilter, molecularProfileIds, sampleIds);
+    }
+    final List<Integer> entrezGeneIds = interceptedMutationMultipleStudyFilter.getEntrezGeneIds();
+    final String projectionName = projection.name();
+    final String sortByValue = sortBy == null ? null : sortBy.getOriginalValue();
+    final String directionName = direction.name();
+
+    StreamingResponseBody body =
+        outputStream -> {
+          try (JsonGenerator generator = objectMapper.getFactory().createGenerator(outputStream)) {
+            generator.writeStartArray();
+            mutationService.streamMutationsInMultipleMolecularProfiles(
                 molecularProfileIds,
                 sampleIds,
-                interceptedMutationMultipleStudyFilter.getEntrezGeneIds(),
-                projection.name(),
+                entrezGeneIds,
+                projectionName,
                 pageSize,
                 pageNumber,
-                sortBy == null ? null : sortBy.getOriginalValue(),
-                direction.name());
-      }
-
-      return new ResponseEntity<>(mutations, HttpStatus.OK);
-    }
+                sortByValue,
+                directionName,
+                mutation -> {
+                  try {
+                    generator.writeObject(mutation);
+                  } catch (IOException e) {
+                    // ResultHandler/Consumer cannot throw checked exceptions; unwrapped below
+                    throw new UncheckedIOException(e);
+                  }
+                });
+            generator.writeEndArray();
+          } catch (UncheckedIOException e) {
+            throw e.getCause();
+          }
+        };
+    return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(body);
   }
 
   private void extractMolecularProfileAndSampleIds(

--- a/src/main/java/org/cbioportal/legacy/web/MutationController.java
+++ b/src/main/java/org/cbioportal/legacy/web/MutationController.java
@@ -316,6 +316,10 @@ public class MutationController {
     StreamingResponseBody body =
         outputStream -> {
           try (JsonGenerator generator = objectMapper.getFactory().createGenerator(outputStream)) {
+            // A committed 200 cannot become a 500 mid-stream; disable AUTO_CLOSE_JSON_CONTENT so a
+            // failure leaves the array unclosed (client sees invalid JSON) rather than a silently
+            // truncated but well-formed one. The exception still propagates and is logged.
+            generator.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
             generator.writeStartArray();
             mutationService.streamMutationsInMultipleMolecularProfiles(
                 molecularProfileIds,

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/CopyNumberSegmentMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/CopyNumberSegmentMapper.xml
@@ -69,6 +69,19 @@
         </if>
     </select>
 
+    <!-- Unpaged streaming variant of getCopyNumberSegments; consumed row-by-row via a ResultHandler
+         so a large multi-study result set is never materialized. fetchSize keeps the driver streaming. -->
+    <select id="streamCopyNumberSegments" resultType="org.cbioportal.legacy.model.CopyNumberSeg" fetchSize="10000">
+        SELECT
+        <include refid="select"/>
+        <include refid="from"/>
+        <include refid="where"/>
+        <if test="chromosome != null and !chromosome.isEmpty()">
+            AND copy_number_seg.chr = #{chromosome}
+        </if>
+        ORDER BY copy_number_seg.seg_id ASC
+    </select>
+
     <select id="getMetaCopyNumberSegments" resultType="org.cbioportal.legacy.model.meta.BaseMeta">
         SELECT
         COUNT(*) AS totalCount

--- a/src/test/java/org/cbioportal/legacy/persistence/mybatis/ClinicalDataMyBatisRepositoryTest.java
+++ b/src/test/java/org/cbioportal/legacy/persistence/mybatis/ClinicalDataMyBatisRepositoryTest.java
@@ -487,6 +487,23 @@ public class ClinicalDataMyBatisRepositoryTest {
   }
 
   @Test
+  public void streamClinicalDataNullAttributeSummaryProjection() {
+
+    // Streaming variant must yield the same rows as fetchClinicalData.
+    List<ClinicalData> result = new java.util.ArrayList<>();
+    clinicalDataMyBatisRepository.streamClinicalData(
+        studyIds,
+        sampleIds,
+        null,
+        PersistenceConstants.SAMPLE_CLINICAL_DATA_TYPE,
+        "SUMMARY",
+        result::add);
+
+    Assert.assertEquals(8, result.size());
+    Assert.assertTrue(result.stream().anyMatch(r -> r.getAttrId().equals("DAYS_TO_COLLECTION")));
+  }
+
+  @Test
   public void fetchClinicalSampleIdsClinicalTabShowAllSamples() {
 
     List<Integer> result =

--- a/src/test/java/org/cbioportal/legacy/persistence/mybatis/CopyNumberSegmentMyBatisRepositoryTest.java
+++ b/src/test/java/org/cbioportal/legacy/persistence/mybatis/CopyNumberSegmentMyBatisRepositoryTest.java
@@ -265,7 +265,8 @@ public class CopyNumberSegmentMyBatisRepositoryTest {
     sampleIds.add("TCGA-A1-A0SB-01");
     sampleIds.add("TCGA-A1-B0SO-01");
 
-    // Streaming variant must yield the same rows as fetchCopyNumberSegments, one at a time.
+    // Streams each row to the consumer; assert the streamed rows match the expected segments
+    // (same inputs/assertions as fetchCopyNumberSegments above).
     List<CopyNumberSeg> streamed = new ArrayList<>();
     copyNumberSegmentMyBatisRepository.streamCopyNumberSegments(
         studyIds, sampleIds, null, "SUMMARY", streamed::add);

--- a/src/test/java/org/cbioportal/legacy/persistence/mybatis/CopyNumberSegmentMyBatisRepositoryTest.java
+++ b/src/test/java/org/cbioportal/legacy/persistence/mybatis/CopyNumberSegmentMyBatisRepositoryTest.java
@@ -256,6 +256,28 @@ public class CopyNumberSegmentMyBatisRepositoryTest {
   }
 
   @Test
+  public void streamCopyNumberSegments() throws Exception {
+
+    List<String> studyIds = new ArrayList<>();
+    studyIds.add("study_tcga_pub");
+    studyIds.add("acc_tcga");
+    List<String> sampleIds = new ArrayList<>();
+    sampleIds.add("TCGA-A1-A0SB-01");
+    sampleIds.add("TCGA-A1-B0SO-01");
+
+    // Streaming variant must yield the same rows as fetchCopyNumberSegments, one at a time.
+    List<CopyNumberSeg> streamed = new ArrayList<>();
+    copyNumberSegmentMyBatisRepository.streamCopyNumberSegments(
+        studyIds, sampleIds, null, "SUMMARY", streamed::add);
+    streamed = sortedResult(streamed);
+
+    Assert.assertEquals(3, streamed.size());
+    Assert.assertEquals("TCGA-A1-A0SB-01", streamed.get(0).getSampleStableId());
+    Assert.assertEquals("TCGA-A1-A0SB-01", streamed.get(1).getSampleStableId());
+    Assert.assertEquals("TCGA-A1-B0SO-01", streamed.get(2).getSampleStableId());
+  }
+
+  @Test
   public void fetchMetaCopyNumberSegments() throws Exception {
 
     List<String> studyIds = new ArrayList<>();

--- a/src/test/java/org/cbioportal/legacy/persistence/mybatis/MutationMyBatisRepositoryTest.java
+++ b/src/test/java/org/cbioportal/legacy/persistence/mybatis/MutationMyBatisRepositoryTest.java
@@ -427,6 +427,33 @@ public class MutationMyBatisRepositoryTest {
   }
 
   @Test
+  public void streamMutationsInMultipleMolecularProfiles() throws Exception {
+
+    List<String> molecularProfileIds = new ArrayList<>();
+    molecularProfileIds.add("acc_tcga_mutations");
+    molecularProfileIds.add("study_tcga_pub_mutations");
+
+    List<String> sampleIds = new ArrayList<>();
+    sampleIds.add("TCGA-A1-B0SO-01");
+    sampleIds.add("TCGA-A1-A0SH-01");
+
+    // Streaming variant must yield the same rows as getMutationsInMultipleMolecularProfiles.
+    List<Mutation> result = new ArrayList<>();
+    mutationMyBatisRepository.streamMutationsInMultipleMolecularProfiles(
+        molecularProfileIds, sampleIds, null, "SUMMARY", null, null, null, null, result::add);
+
+    Assert.assertEquals(3, result.size());
+    Assert.assertEquals(
+        2,
+        result.stream()
+            .filter(
+                r ->
+                    r.getSampleId().equals("TCGA-A1-A0SH-01")
+                        && r.getMolecularProfileId().equals("study_tcga_pub_mutations"))
+            .count());
+  }
+
+  @Test
   public void getMutationsInMultipleMolecularProfilesByGeneQueries() throws Exception {
 
     GeneFilterQuery geneFilterQuery1 =

--- a/src/test/java/org/cbioportal/legacy/web/ClinicalDataControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/ClinicalDataControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
@@ -314,8 +315,15 @@ public class ClinicalDataControllerTest {
     patientClinicalData2.setAttrValue(TEST_ATTR_VALUE_2);
     patientClinicalData2.setInternalId(TEST_INTERNAL_ID_2);
     patientClinicalDataList.add(patientClinicalData2);
-    when(clinicalDataService.fetchClinicalData(any(), any(), any(), any(), any()))
-        .thenReturn(patientClinicalDataList);
+    // The endpoint now streams; feed the data to the consumer the controller supplies.
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              java.util.function.Consumer<ClinicalData> consumer = invocation.getArgument(5);
+              patientClinicalDataList.forEach(consumer);
+              return null;
+            })
+        .when(clinicalDataService)
+        .streamClinicalData(any(), any(), any(), any(), any(), any());
 
     List<ClinicalDataIdentifier> clinicalDataIdentifiers = new ArrayList<>();
     ClinicalDataIdentifier clinicalDataIdentifier1 = new ClinicalDataIdentifier();
@@ -329,14 +337,20 @@ public class ClinicalDataControllerTest {
     ClinicalDataMultiStudyFilter clinicalDataMultiStudyFilter = new ClinicalDataMultiStudyFilter();
     clinicalDataMultiStudyFilter.setIdentifiers(clinicalDataIdentifiers);
 
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.post("/api/clinical-data/fetch")
+                    .with(csrf())
+                    .param("clinicalDataType", "PATIENT")
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(clinicalDataMultiStudyFilter)))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn();
+
     mockMvc
-        .perform(
-            MockMvcRequestBuilders.post("/api/clinical-data/fetch")
-                .with(csrf())
-                .param("clinicalDataType", "PATIENT")
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(clinicalDataMultiStudyFilter)))
+        .perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(
             MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))

--- a/src/test/java/org/cbioportal/legacy/web/CopyNumberSegmentControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/CopyNumberSegmentControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.web.context.WebApplicationContext;
@@ -136,10 +137,16 @@ public class CopyNumberSegmentControllerTest {
 
     List<CopyNumberSeg> copyNumberSegList = createExampleCopyNumberSegs();
 
-    Mockito.when(
-            copyNumberSegmentService.fetchCopyNumberSegments(
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenReturn(copyNumberSegList);
+    // The endpoint now streams; feed the segments to the consumer the controller supplies.
+    Mockito.doAnswer(
+            invocation -> {
+              java.util.function.Consumer<CopyNumberSeg> consumer = invocation.getArgument(4);
+              copyNumberSegList.forEach(consumer);
+              return null;
+            })
+        .when(copyNumberSegmentService)
+        .streamCopyNumberSegments(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 
     List<SampleIdentifier> sampleIdentifiers = new ArrayList<>();
     SampleIdentifier sampleIdentifier1 = new SampleIdentifier();
@@ -151,13 +158,19 @@ public class CopyNumberSegmentControllerTest {
     sampleIdentifier2.setSampleId(TEST_SAMPLE_STABLE_ID_2);
     sampleIdentifiers.add(sampleIdentifier2);
 
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.post("/api/copy-number-segments/fetch")
+                    .with(csrf())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(sampleIdentifiers)))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn();
+
     mockMvc
-        .perform(
-            MockMvcRequestBuilders.post("/api/copy-number-segments/fetch")
-                .with(csrf())
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(sampleIdentifiers)))
+        .perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(
             MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))

--- a/src/test/java/org/cbioportal/legacy/web/CopyNumberSegmentControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/CopyNumberSegmentControllerTest.java
@@ -133,6 +133,56 @@ public class CopyNumberSegmentControllerTest {
 
   @Test
   @WithMockUser
+  public void fetchCopyNumberSegmentsFailureMidStreamLeavesArrayUnclosed() throws Exception {
+    // Emit one element, then fail (as a DB error mid-stream would). The 200 is already committed so
+    // it cannot become a 500; assert the array is left unclosed so the client gets detectably
+    // invalid JSON rather than a silently truncated but well-formed array.
+    Mockito.doAnswer(
+            invocation -> {
+              java.util.function.Consumer<CopyNumberSeg> consumer = invocation.getArgument(4);
+              consumer.accept(createExampleCopyNumberSegs().get(0));
+              throw new RuntimeException("boom mid-stream");
+            })
+        .when(copyNumberSegmentService)
+        .streamCopyNumberSegments(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+
+    List<SampleIdentifier> sampleIdentifiers = new ArrayList<>();
+    SampleIdentifier sampleIdentifier1 = new SampleIdentifier();
+    sampleIdentifier1.setStudyId(TEST_CANCER_STUDY_IDENTIFIER_1);
+    sampleIdentifier1.setSampleId(TEST_SAMPLE_STABLE_ID_1);
+    sampleIdentifiers.add(sampleIdentifier1);
+
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.post("/api/copy-number-segments/fetch")
+                    .with(csrf())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(sampleIdentifiers)))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn();
+
+    String body;
+    try {
+      body =
+          mockMvc
+              .perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+    } catch (Exception propagated) {
+      body = mvcResult.getResponse().getContentAsString();
+    }
+
+    org.junit.Assert.assertFalse(
+        "array must be left unclosed on mid-stream failure, got: " + body,
+        body.trim().endsWith("]"));
+  }
+
+  @Test
+  @WithMockUser
   public void fetchCopyNumberSegmentsDefaultProjection() throws Exception {
 
     List<CopyNumberSeg> copyNumberSegList = createExampleCopyNumberSegs();

--- a/src/test/java/org/cbioportal/legacy/web/MutationControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/MutationControllerTest.java
@@ -30,6 +30,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
@@ -545,17 +546,24 @@ public class MutationControllerTest {
 
     List<Mutation> mutationList = createExampleMutations();
 
-    Mockito.when(
-            mutationService.getMutationsInMultipleMolecularProfiles(
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any()))
-        .thenReturn(mutationList);
+    // The endpoint now streams; feed the mutations to the consumer the controller supplies.
+    Mockito.doAnswer(
+            invocation -> {
+              java.util.function.Consumer<Mutation> consumer = invocation.getArgument(8);
+              mutationList.forEach(consumer);
+              return null;
+            })
+        .when(mutationService)
+        .streamMutationsInMultipleMolecularProfiles(
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any());
 
     List<SampleMolecularIdentifier> sampleMolecularIdentifiers = new ArrayList<>();
     SampleMolecularIdentifier sampleMolecularIdentifier1 = new SampleMolecularIdentifier();
@@ -569,13 +577,19 @@ public class MutationControllerTest {
     MutationMultipleStudyFilter mutationMultipleStudyFilter = new MutationMultipleStudyFilter();
     mutationMultipleStudyFilter.setSampleMolecularIdentifiers(sampleMolecularIdentifiers);
 
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.post("/api/mutations/fetch")
+                    .with(csrf())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(mutationMultipleStudyFilter)))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn();
+
     mockMvc
-        .perform(
-            MockMvcRequestBuilders.post("/api/mutations/fetch")
-                .with(csrf())
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(mutationMultipleStudyFilter)))
+        .perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(
             MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
## Problem

Several column-store-backed `/fetch` endpoints built the entire result `List` in memory (and the repository `@Cacheable`d it) before serializing. Production `query_log` shows these are the largest materializers:

| endpoint | peak result | notes |
|---|---|---|
| `/api/copy-number-segments/fetch` | **~8.3M rows / 1.34 GiB** | largest single result |
| `/api/mutations/fetch` | ~800K rows / ~470 MiB | ~600 calls / 6 days |
| `/api/clinical-data/fetch` | ~1.3M rows / ~430 MiB | thousands of calls / 6 days |

## Change

Applies the `ResultHandler` streaming pattern validated in #12199 (generic-assay-meta) to all three. For each, a new **additive** streaming method is threaded controller → service → repository → mapper, and the controller's `/fetch` endpoint returns `StreamingResponseBody`, writing a JSON array element-by-element via a `JsonGenerator`. The result set is never collected into a list; peak heap becomes bounded regardless of result size.

Per-endpoint notes:
- **copy-number-segments**: distinct `streamCopyNumberSegments` mapper statement (unpaged, ordered by seg_id).
- **mutations** / **clinical-data**: the streaming mapper method is a `ResultHandler` **overload** of the existing `getMutationsInMultipleMolecularProfiles` / `getSampleClinicalData` / `getPatientClinicalData` statements — the **exact same SQL** (projection/paging/sort) is reused with zero duplication.

In all cases:
- Existing `List`-returning methods and their `@Cacheable` are left intact for other callers; the streaming paths are **not** cached.
- `META` projection branches (count headers) are unchanged. Only the multi-study `/fetch` POSTs are converted; per-profile/single-study and paginated GET variants are untouched. **Output and API contract are identical.**

## Testing

- Reworked the three fetch controller tests to the async `StreamingResponseBody` flow (assertions unchanged — same JSON).
- Added real-ClickHouse (Testcontainers) streaming repo tests for all three, which also confirm MyBatis accepts the `ResultHandler` overloads.
- All affected tests pass (102); `spotless:check` clean.

## Context

Follow-up to #12199, which established the pattern (~15× lower peak heap, byte-identical output; latency on huge single requests is dominated by transfer/serialization, not the sub-second DB query). `gene-panel-data` and `discrete-copy-number` were intentionally excluded — they have service-layer transforms that aren't clean passthroughs and need separate design. The payload-reduction follow-up is tracked in #12201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
