### PR TITLE
ci: update Retype action from v3.9.0 (expired) to v4.6.0

### DIFF
--- a/.github/workflows/retype-action.yml
+++ b/.github/workflows/retype-action.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 10.x
           
-      - uses: retypeapp/action-build@ddc4449f15ae65b75e13198b88200bfd64aef168 # before v3.10.0, which breaks the news on homepage
+      - uses: retypeapp/action-build@511f266c5de1ef96182ff88847e6169b906f50a2 # v4.6.0
 
       - uses: retypeapp/action-github-pages@latest
         with:


### PR DESCRIPTION
   ## Summary

   Retype v3.9.0 has expired, causing the documentation build CI job to fail with:

   > ERROR: This release of Retype has expired. Please update to the latest release.

   ## Changes

   - Bump `retypeapp/action-build` to v4.6.0 (pinned SHA: `511f266c5d`)
   - Update `actions/setup-dotnet` from v1 (dotnet 7.x) to v4 (dotnet 10.x)
   - Update `actions/checkout` from v2 to v4

   ## Notes

   The previous pin to v3.9.0 was intentional (avoiding v3.10.0 which reportedly broke the news/RFC section on the homepage). Please verify the homepage renders correctly after this merges