### PR TITLE
Add ClickHouse HTTP request logging for endpoint QC

### DIFF
--- a/src/main/java/org/cbioportal/infrastructure/requestlog/HttpHeader.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/HttpHeader.java
@@ -4,7 +4,7 @@ package org.cbioportal.infrastructure.requestlog;
  * A single captured request header. The full set of headers for a request is serialized to JSON as
  * an array of these {@code {name, value}} objects and stored in a single column.
  *
- * <p>Headers are kept as a list of name/value pairs rather than a map so that duplicate header names
- * are preserved and attacker-supplied header names never need to become structural keys.
+ * <p>Headers are kept as a list of name/value pairs rather than a map so that duplicate header
+ * names are preserved and attacker-supplied header names never need to become structural keys.
  */
 public record HttpHeader(String name, String value) {}

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/HttpHeader.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/HttpHeader.java
@@ -1,10 +1,10 @@
 package org.cbioportal.infrastructure.requestlog;
 
 /**
- * A single captured request header, stored as a {@code {name, value}} sub-document.
+ * A single captured request header. The full set of headers for a request is serialized to JSON as
+ * an array of these {@code {name, value}} objects and stored in a single column.
  *
- * <p>Headers are kept as a list of these rather than a {@code Map} so that attacker-supplied header
- * names (which can legally contain characters such as {@code $} or {@code .}) never become MongoDB
- * field keys, where they would be rejected or interpreted as operators/paths.
+ * <p>Headers are kept as a list of name/value pairs rather than a map so that duplicate header names
+ * are preserved and attacker-supplied header names never need to become structural keys.
  */
 public record HttpHeader(String name, String value) {}

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/HttpHeader.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/HttpHeader.java
@@ -1,0 +1,10 @@
+package org.cbioportal.infrastructure.requestlog;
+
+/**
+ * A single captured request header, stored as a {@code {name, value}} sub-document.
+ *
+ * <p>Headers are kept as a list of these rather than a {@code Map} so that attacker-supplied header
+ * names (which can legally contain characters such as {@code $} or {@code .}) never become MongoDB
+ * field keys, where they would be rejected or interpreted as operators/paths.
+ */
+public record HttpHeader(String name, String value) {}

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/LoggedRequest.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/LoggedRequest.java
@@ -1,0 +1,168 @@
+package org.cbioportal.infrastructure.requestlog;
+
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * A single, unique HTTP request captured for QC purposes.
+ *
+ * <p>The {@link #id} is a deterministic hash of the request's method, path, query string and body,
+ * so re-issuing the same request simply increments {@link #count} and refreshes {@link #lastSeen}
+ * rather than creating a new document. This keeps the collection bounded by the number of
+ * <em>distinct</em> requests, not by traffic volume.
+ */
+@Document(collection = "logged_requests")
+public class LoggedRequest {
+
+  /** SHA-256 of {@code method\npath\nsortedQuery\nbody}; used as the Mongo {@code _id}. */
+  @Id private String id;
+
+  private String method;
+
+  /** Request path without the query string, e.g. {@code /api/studies/acc_tcga/clinical-data}. */
+  @Indexed private String path;
+
+  /**
+   * The matched controller route pattern, e.g. {@code /api/studies/{studyId}/clinical-data}. This
+   * is the primary field to search on when collecting all calls to a given endpoint.
+   */
+  @Indexed private String endpoint;
+
+  private String queryString;
+
+  /** Fully reconstructed request URL including scheme, host and query string. */
+  private String url;
+
+  private Map<String, String> headers;
+
+  private String contentType;
+
+  private String body;
+
+  private boolean bodyTruncated;
+
+  /** HTTP status returned the last time this request was seen. */
+  private int responseStatus;
+
+  /** Number of times this exact request has been observed. */
+  private long count;
+
+  private Instant firstSeen;
+
+  private Instant lastSeen;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getMethod() {
+    return method;
+  }
+
+  public void setMethod(String method) {
+    this.method = method;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public String getQueryString() {
+    return queryString;
+  }
+
+  public void setQueryString(String queryString) {
+    this.queryString = queryString;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public Map<String, String> getHeaders() {
+    return headers;
+  }
+
+  public void setHeaders(Map<String, String> headers) {
+    this.headers = headers;
+  }
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+
+  public String getBody() {
+    return body;
+  }
+
+  public void setBody(String body) {
+    this.body = body;
+  }
+
+  public boolean isBodyTruncated() {
+    return bodyTruncated;
+  }
+
+  public void setBodyTruncated(boolean bodyTruncated) {
+    this.bodyTruncated = bodyTruncated;
+  }
+
+  public int getResponseStatus() {
+    return responseStatus;
+  }
+
+  public void setResponseStatus(int responseStatus) {
+    this.responseStatus = responseStatus;
+  }
+
+  public long getCount() {
+    return count;
+  }
+
+  public void setCount(long count) {
+    this.count = count;
+  }
+
+  public Instant getFirstSeen() {
+    return firstSeen;
+  }
+
+  public void setFirstSeen(Instant firstSeen) {
+    this.firstSeen = firstSeen;
+  }
+
+  public Instant getLastSeen() {
+    return lastSeen;
+  }
+
+  public void setLastSeen(Instant lastSeen) {
+    this.lastSeen = lastSeen;
+  }
+}

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/LoggedRequest.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/LoggedRequest.java
@@ -2,38 +2,38 @@ package org.cbioportal.infrastructure.requestlog;
 
 import java.time.Instant;
 import java.util.List;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.index.Indexed;
-import org.springframework.data.mongodb.core.mapping.Document;
 
 /**
- * A single, unique HTTP request captured for QC purposes.
+ * A single observation of an HTTP request captured for QC purposes.
  *
- * <p>The {@link #id} is a deterministic hash of the request's method, path, query string and body,
- * so re-issuing the same request simply increments {@link #count} and refreshes {@link #lastSeen}
- * rather than creating a new document. This keeps the collection bounded by the number of
- * <em>distinct</em> requests, not by traffic volume.
+ * <p>The {@link #id} is a deterministic hash of the request's method, path, query string and body.
+ * Every observation is inserted as its own row; the backing ClickHouse table is a {@code
+ * ReplacingMergeTree} ordered by {@code id}, so background merges eventually collapse repeated
+ * observations of the same logical request to a single row. Per-request statistics such as how many
+ * times a request was seen, and the first/last time it was seen, are derived at query time
+ * ({@code count()}, {@code min(seen)}, {@code max(seen)} grouped by {@code id}) rather than being
+ * maintained on write.
  */
-@Document(collection = "logged_requests")
 public class LoggedRequest {
 
-  /**
-   * SHA-256 of {@code method\npath\nquery\nbody} (post-redaction); used as the Mongo {@code _id}.
-   */
-  @Id private String id;
+  /** SHA-256 of {@code method\npath\nquery\nbody} (post-redaction); the table's sort/dedup key. */
+  private String id;
 
   private String method;
 
   /** Request path without the query string, e.g. {@code /api/studies/acc_tcga/clinical-data}. */
-  @Indexed private String path;
+  private String path;
 
   /**
    * The matched controller route pattern, e.g. {@code /api/studies/{studyId}/clinical-data}. This
    * is the primary field to search on when collecting all calls to a given endpoint.
    */
-  @Indexed private String endpoint;
+  private String endpoint;
 
   private String queryString;
+
+  /** The server host the request was addressed to, e.g. {@code www.cbioportal.org}. */
+  private String serverName;
 
   /** Fully reconstructed request URL including scheme, host and query string. */
   private String url;
@@ -46,15 +46,11 @@ public class LoggedRequest {
 
   private boolean bodyTruncated;
 
-  /** HTTP status returned the last time this request was seen. */
+  /** HTTP status returned for this observation. */
   private int responseStatus;
 
-  /** Number of times this exact request has been observed. */
-  private long count;
-
-  private Instant firstSeen;
-
-  private Instant lastSeen;
+  /** When this observation was captured. */
+  private Instant seen;
 
   public String getId() {
     return id;
@@ -94,6 +90,14 @@ public class LoggedRequest {
 
   public void setQueryString(String queryString) {
     this.queryString = queryString;
+  }
+
+  public String getServerName() {
+    return serverName;
+  }
+
+  public void setServerName(String serverName) {
+    this.serverName = serverName;
   }
 
   public String getUrl() {
@@ -144,27 +148,11 @@ public class LoggedRequest {
     this.responseStatus = responseStatus;
   }
 
-  public long getCount() {
-    return count;
+  public Instant getSeen() {
+    return seen;
   }
 
-  public void setCount(long count) {
-    this.count = count;
-  }
-
-  public Instant getFirstSeen() {
-    return firstSeen;
-  }
-
-  public void setFirstSeen(Instant firstSeen) {
-    this.firstSeen = firstSeen;
-  }
-
-  public Instant getLastSeen() {
-    return lastSeen;
-  }
-
-  public void setLastSeen(Instant lastSeen) {
-    this.lastSeen = lastSeen;
+  public void setSeen(Instant seen) {
+    this.seen = seen;
   }
 }

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/LoggedRequest.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/LoggedRequest.java
@@ -10,8 +10,8 @@ import java.util.List;
  * Every observation is inserted as its own row; the backing ClickHouse table is a {@code
  * ReplacingMergeTree} ordered by {@code id}, so background merges eventually collapse repeated
  * observations of the same logical request to a single row. Per-request statistics such as how many
- * times a request was seen, and the first/last time it was seen, are derived at query time
- * ({@code count()}, {@code min(seen)}, {@code max(seen)} grouped by {@code id}) rather than being
+ * times a request was seen, and the first/last time it was seen, are derived at query time ({@code
+ * count()}, {@code min(seen)}, {@code max(seen)} grouped by {@code id}) rather than being
  * maintained on write.
  */
 public class LoggedRequest {

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/LoggedRequest.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/LoggedRequest.java
@@ -1,7 +1,7 @@
 package org.cbioportal.infrastructure.requestlog;
 
 import java.time.Instant;
-import java.util.Map;
+import java.util.List;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -17,7 +17,9 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "logged_requests")
 public class LoggedRequest {
 
-  /** SHA-256 of {@code method\npath\nsortedQuery\nbody}; used as the Mongo {@code _id}. */
+  /**
+   * SHA-256 of {@code method\npath\nquery\nbody} (post-redaction); used as the Mongo {@code _id}.
+   */
   @Id private String id;
 
   private String method;
@@ -36,7 +38,7 @@ public class LoggedRequest {
   /** Fully reconstructed request URL including scheme, host and query string. */
   private String url;
 
-  private Map<String, String> headers;
+  private List<HttpHeader> headers;
 
   private String contentType;
 
@@ -102,11 +104,11 @@ public class LoggedRequest {
     this.url = url;
   }
 
-  public Map<String, String> getHeaders() {
+  public List<HttpHeader> getHeaders() {
     return headers;
   }
 
-  public void setHeaders(Map<String, String> headers) {
+  public void setHeaders(List<HttpHeader> headers) {
     this.headers = headers;
   }
 

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLogService.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLogService.java
@@ -1,0 +1,103 @@
+package org.cbioportal.infrastructure.requestlog;
+
+import jakarta.annotation.PreDestroy;
+import java.time.Instant;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+/**
+ * Persists captured requests to MongoDB on a small background thread pool so request handling is
+ * never blocked by the database write. Writes are idempotent upserts keyed by {@link
+ * LoggedRequest#getId()}: the first time a distinct request is seen the full document is inserted;
+ * subsequent identical requests only bump {@code count}, {@code lastSeen} and {@code
+ * responseStatus}.
+ */
+public class RequestLogService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RequestLogService.class);
+
+  private final MongoOperations mongoOperations;
+  private final String collection;
+  private final ThreadPoolExecutor executor;
+
+  public RequestLogService(
+      MongoOperations mongoOperations, String collection, int writerThreads, int queueCapacity) {
+    this.mongoOperations = mongoOperations;
+    this.collection = collection;
+    this.executor =
+        new ThreadPoolExecutor(
+            writerThreads,
+            writerThreads,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(queueCapacity),
+            runnable -> {
+              Thread thread = new Thread(runnable, "request-log-writer");
+              thread.setDaemon(true);
+              return thread;
+            });
+  }
+
+  /** Hand a captured request off to be written asynchronously. Never blocks the caller. */
+  public void save(LoggedRequest request) {
+    try {
+      executor.execute(() -> upsert(request));
+    } catch (RejectedExecutionException ex) {
+      // Queue is full: drop the capture rather than slow down request handling.
+      LOG.debug("Request log queue full; dropping capture for {}", request.getPath());
+    }
+  }
+
+  private void upsert(LoggedRequest request) {
+    try {
+      Query query = new Query(Criteria.where("_id").is(request.getId()));
+      Update update =
+          new Update()
+              // Static, request-defining fields are only written on first insert.
+              .setOnInsert("method", request.getMethod())
+              .setOnInsert("path", request.getPath())
+              .setOnInsert("endpoint", request.getEndpoint())
+              .setOnInsert("queryString", request.getQueryString())
+              .setOnInsert("url", request.getUrl())
+              .setOnInsert("headers", request.getHeaders())
+              .setOnInsert("contentType", request.getContentType())
+              .setOnInsert("body", request.getBody())
+              .setOnInsert("bodyTruncated", request.isBodyTruncated())
+              .setOnInsert("firstSeen", request.getFirstSeen())
+              // Volatile fields are refreshed on every observation.
+              .set("lastSeen", request.getLastSeen())
+              .set("responseStatus", request.getResponseStatus())
+              .inc("count", 1);
+      mongoOperations.upsert(query, update, LoggedRequest.class, collection);
+    } catch (RuntimeException ex) {
+      LOG.warn("Failed to log request {} to MongoDB: {}", request.getPath(), ex.getMessage());
+      LOG.debug("Request logging failure", ex);
+    }
+  }
+
+  @PreDestroy
+  public void shutdown() {
+    executor.shutdown();
+    try {
+      if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+      }
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      executor.shutdownNow();
+    }
+  }
+
+  /** Exposed for tests. */
+  Instant now() {
+    return Instant.now();
+  }
+}

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLogService.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLogService.java
@@ -1,37 +1,48 @@
 package org.cbioportal.infrastructure.requestlog;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PreDestroy;
-import java.time.Instant;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.mongodb.core.MongoOperations;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.Update;
 
 /**
- * Persists captured requests to MongoDB on a small background thread pool so request handling is
- * never blocked by the database write. Writes are idempotent upserts keyed by {@link
- * LoggedRequest#getId()}: the first time a distinct request is seen the full document is inserted;
- * subsequent identical requests only bump {@code count}, {@code lastSeen} and {@code
- * responseStatus}.
+ * Persists captured requests to ClickHouse on a small background thread pool so request handling is
+ * never blocked by the database write. Each observation is appended as a single row; the table is a
+ * {@code ReplacingMergeTree} ordered by {@code id}, so duplicate observations of the same logical
+ * request are collapsed by background merges rather than at write time. With {@code async_insert}
+ * enabled (the default) ClickHouse buffers the many small per-request inserts server-side and
+ * flushes them in batches, which is what keeps the write impact of this columnar store low.
  */
 public class RequestLogService {
 
   private static final Logger LOG = LoggerFactory.getLogger(RequestLogService.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  private final MongoOperations mongoOperations;
-  private final String collection;
+  private final DataSource dataSource;
+  private final String insertSql;
+  private final String gitCommit;
   private final ThreadPoolExecutor executor;
 
   public RequestLogService(
-      MongoOperations mongoOperations, String collection, int writerThreads, int queueCapacity) {
-    this.mongoOperations = mongoOperations;
-    this.collection = collection;
+      DataSource dataSource,
+      String table,
+      boolean asyncInsert,
+      String gitCommit,
+      int writerThreads,
+      int queueCapacity) {
+    this.dataSource = dataSource;
+    this.insertSql = buildInsertSql(table, asyncInsert);
+    this.gitCommit = gitCommit;
     this.executor =
         new ThreadPoolExecutor(
             writerThreads,
@@ -46,41 +57,61 @@ public class RequestLogService {
             });
   }
 
+  private static String buildInsertSql(String table, boolean asyncInsert) {
+    // The SETTINGS clause sits between the column list and VALUES in ClickHouse's INSERT grammar.
+    String settings = asyncInsert ? " SETTINGS async_insert=1, wait_for_async_insert=0" : "";
+    return "INSERT INTO "
+        + table
+        + " (id, method, path, endpoint, query_string, server_name, url, headers, content_type,"
+        + " body, body_truncated, response_status, seen, git_commit)"
+        + settings
+        + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+  }
+
   /** Hand a captured request off to be written asynchronously. Never blocks the caller. */
   public void save(LoggedRequest request) {
     try {
-      executor.execute(() -> upsert(request));
+      executor.execute(() -> insert(request));
     } catch (RejectedExecutionException ex) {
       // Queue is full: drop the capture rather than slow down request handling.
       LOG.debug("Request log queue full; dropping capture for {}", request.getPath());
     }
   }
 
-  private void upsert(LoggedRequest request) {
-    try {
-      Query query = new Query(Criteria.where("_id").is(request.getId()));
-      Update update =
-          new Update()
-              // Static, request-defining fields are only written on first insert.
-              .setOnInsert("method", request.getMethod())
-              .setOnInsert("path", request.getPath())
-              .setOnInsert("endpoint", request.getEndpoint())
-              .setOnInsert("queryString", request.getQueryString())
-              .setOnInsert("url", request.getUrl())
-              .setOnInsert("headers", request.getHeaders())
-              .setOnInsert("contentType", request.getContentType())
-              .setOnInsert("body", request.getBody())
-              .setOnInsert("bodyTruncated", request.isBodyTruncated())
-              .setOnInsert("firstSeen", request.getFirstSeen())
-              // Volatile fields are refreshed on every observation.
-              .set("lastSeen", request.getLastSeen())
-              .set("responseStatus", request.getResponseStatus())
-              .inc("count", 1);
-      mongoOperations.upsert(query, update, LoggedRequest.class, collection);
-    } catch (RuntimeException ex) {
-      LOG.warn("Failed to log request {} to MongoDB: {}", request.getPath(), ex.getMessage());
+  private void insert(LoggedRequest request) {
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(insertSql)) {
+      statement.setString(1, request.getId());
+      statement.setString(2, request.getMethod());
+      statement.setString(3, request.getPath());
+      statement.setString(4, request.getEndpoint());
+      statement.setString(5, nullToEmpty(request.getQueryString()));
+      statement.setString(6, nullToEmpty(request.getServerName()));
+      statement.setString(7, nullToEmpty(request.getUrl()));
+      statement.setString(8, writeHeaders(request.getHeaders()));
+      statement.setString(9, nullToEmpty(request.getContentType()));
+      statement.setString(10, nullToEmpty(request.getBody()));
+      statement.setInt(11, request.isBodyTruncated() ? 1 : 0);
+      statement.setInt(12, request.getResponseStatus());
+      statement.setTimestamp(13, Timestamp.from(request.getSeen()));
+      statement.setString(14, gitCommit);
+      statement.executeUpdate();
+    } catch (SQLException | RuntimeException ex) {
+      LOG.warn("Failed to log request {} to ClickHouse: {}", request.getPath(), ex.getMessage());
       LOG.debug("Request logging failure", ex);
     }
+  }
+
+  private static String writeHeaders(List<HttpHeader> headers) {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(headers == null ? List.of() : headers);
+    } catch (RuntimeException | com.fasterxml.jackson.core.JsonProcessingException ex) {
+      return "[]";
+    }
+  }
+
+  private static String nullToEmpty(String value) {
+    return value == null ? "" : value;
   }
 
   @PreDestroy
@@ -94,10 +125,5 @@ public class RequestLogService {
       Thread.currentThread().interrupt();
       executor.shutdownNow();
     }
-  }
-
-  /** Exposed for tests. */
-  Instant now() {
-    return Instant.now();
   }
 }

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingConfig.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingConfig.java
@@ -1,8 +1,9 @@
 package org.cbioportal.infrastructure.requestlog;
 
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
-import java.time.Duration;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -11,18 +12,13 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
-import org.springframework.data.mongodb.core.index.Index;
 
 /**
- * Wires up the MongoDB HTTP request logger. Everything here is gated on {@code
- * request-logging.enabled=true}; when the feature is off no Mongo client is created and no filter
- * is registered, so the rest of the application is unaffected. This is needed because the
- * application deliberately excludes Spring Boot's Mongo auto-configuration (see {@code
- * PortalApplication}), so a dedicated, self-contained Mongo connection is provisioned just for
- * request logging.
+ * Wires up the ClickHouse HTTP request logger. Everything here is gated on {@code
+ * request-logging.enabled=true}; when the feature is off no filter is registered, so the rest of the
+ * application is unaffected. Captured requests are written through the application's primary
+ * datasource (the same ClickHouse the app already queries) into a dedicated table that is expected
+ * to already exist.
  */
 @Configuration
 @EnableConfigurationProperties(RequestLoggingProperties.class)
@@ -31,27 +27,45 @@ public class RequestLoggingConfig {
 
   private static final Logger LOG = LoggerFactory.getLogger(RequestLoggingConfig.class);
 
-  @Bean(destroyMethod = "close")
-  public MongoClient requestLogMongoClient(RequestLoggingProperties properties) {
-    return MongoClients.create(properties.getMongoUri());
-  }
-
-  @Bean
-  public MongoTemplate requestLogMongoTemplate(
-      MongoClient requestLogMongoClient, RequestLoggingProperties properties) {
-    return new MongoTemplate(
-        new SimpleMongoClientDatabaseFactory(requestLogMongoClient, properties.getDatabase()));
-  }
-
   @Bean
   public RequestLogService requestLogService(
-      MongoTemplate requestLogMongoTemplate, RequestLoggingProperties properties) {
-    ensureIndexes(requestLogMongoTemplate, properties);
+      DataSource dataSource, RequestLoggingProperties properties) {
     return new RequestLogService(
-        requestLogMongoTemplate,
-        properties.getCollection(),
+        dataSource,
+        properties.getTable(),
+        properties.isAsyncInsert(),
+        resolveGitCommit(),
         properties.getWriterThreads(),
         properties.getQueueCapacity());
+  }
+
+  /**
+   * The full commit the running backend was built from, suffixed with {@code -dirty} when the build
+   * had uncommitted changes (so QC can tell apart captures taken against a clean tag versus a local
+   * working tree). Read straight from the {@code git.properties} that the git-commit-id Maven plugin
+   * writes onto the classpath at build time, rather than the autoconfigured {@code GitProperties}
+   * bean (which doesn't expose the plugin's {@code git.commit.id.full} key in this build). Falls back
+   * to {@code "unknown"} when the file is absent (e.g. running from an IDE without the plugin).
+   */
+  private static String resolveGitCommit() {
+    Properties props = new Properties();
+    try (InputStream in = RequestLoggingConfig.class.getResourceAsStream("/git.properties")) {
+      if (in == null) {
+        return "unknown";
+      }
+      props.load(in);
+    } catch (IOException ex) {
+      LOG.warn("Could not read git.properties for request logging: {}", ex.getMessage());
+      return "unknown";
+    }
+    String commitId =
+        props.getProperty("git.commit.id.full", props.getProperty("git.commit.id", ""));
+    if (commitId.isEmpty()) {
+      return "unknown";
+    }
+    return Boolean.parseBoolean(props.getProperty("git.dirty", "false"))
+        ? commitId + "-dirty"
+        : commitId;
   }
 
   @Bean
@@ -65,33 +79,9 @@ public class RequestLoggingConfig {
     registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
     registration.setName("requestLoggingFilter");
     LOG.info(
-        "MongoDB request logging enabled; capturing {} into {}/{}",
+        "ClickHouse request logging enabled; capturing {} into {}",
         properties.getPathPatterns(),
-        properties.getDatabase(),
-        properties.getCollection());
+        properties.getTable());
     return registration;
-  }
-
-  /**
-   * Create the indexes that back endpoint/path search, plus an optional TTL index that bounds how
-   * long captured (potentially sensitive) requests are retained. Failures here must not prevent
-   * startup (e.g. Mongo temporarily unreachable), so they are logged and swallowed.
-   */
-  private void ensureIndexes(MongoTemplate template, RequestLoggingProperties properties) {
-    String collection = properties.getCollection();
-    try {
-      template.indexOps(collection).ensureIndex(new Index().on("endpoint", Sort.Direction.ASC));
-      template.indexOps(collection).ensureIndex(new Index().on("path", Sort.Direction.ASC));
-      if (properties.getTtlDays() > 0) {
-        template
-            .indexOps(collection)
-            .ensureIndex(
-                new Index()
-                    .on("lastSeen", Sort.Direction.ASC)
-                    .expire(Duration.ofDays(properties.getTtlDays())));
-      }
-    } catch (RuntimeException ex) {
-      LOG.warn("Could not create request-logging indexes: {}", ex.getMessage());
-    }
   }
 }

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingConfig.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingConfig.java
@@ -1,0 +1,91 @@
+package org.cbioportal.infrastructure.requestlog;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.data.mongodb.core.index.Index;
+
+/**
+ * Wires up the MongoDB HTTP request logger. Everything here is gated on {@code
+ * request-logging.enabled=true}; when the feature is off no Mongo client is created and no filter
+ * is registered, so the rest of the application is unaffected. This is needed because the
+ * application deliberately excludes Spring Boot's Mongo auto-configuration (see {@code
+ * PortalApplication}), so a dedicated, self-contained Mongo connection is provisioned just for
+ * request logging.
+ */
+@Configuration
+@EnableConfigurationProperties(RequestLoggingProperties.class)
+@ConditionalOnProperty(prefix = "request-logging", name = "enabled", havingValue = "true")
+public class RequestLoggingConfig {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RequestLoggingConfig.class);
+
+  @Bean(destroyMethod = "close")
+  public MongoClient requestLogMongoClient(RequestLoggingProperties properties) {
+    return MongoClients.create(properties.getMongoUri());
+  }
+
+  @Bean
+  public MongoTemplate requestLogMongoTemplate(
+      MongoClient requestLogMongoClient, RequestLoggingProperties properties) {
+    return new MongoTemplate(
+        new SimpleMongoClientDatabaseFactory(requestLogMongoClient, properties.getDatabase()));
+  }
+
+  @Bean
+  public RequestLogService requestLogService(
+      MongoTemplate requestLogMongoTemplate, RequestLoggingProperties properties) {
+    ensureIndexes(requestLogMongoTemplate, properties.getCollection());
+    return new RequestLogService(
+        requestLogMongoTemplate,
+        properties.getCollection(),
+        properties.getWriterThreads(),
+        properties.getQueueCapacity());
+  }
+
+  @Bean
+  public FilterRegistrationBean<RequestLoggingFilter> requestLoggingFilterRegistration(
+      RequestLogService requestLogService, RequestLoggingProperties properties) {
+    FilterRegistrationBean<RequestLoggingFilter> registration = new FilterRegistrationBean<>();
+    registration.setFilter(new RequestLoggingFilter(requestLogService, properties));
+    registration.addUrlPatterns("/*");
+    // Run first so the whole request lifecycle (including the controller's body read) happens
+    // inside this filter, guaranteeing the cached body is fully populated when we capture it.
+    registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    registration.setName("requestLoggingFilter");
+    LOG.info(
+        "MongoDB request logging enabled; capturing {} into {}/{}",
+        properties.getPathPatterns(),
+        properties.getDatabase(),
+        properties.getCollection());
+    return registration;
+  }
+
+  /**
+   * Create the indexes that back endpoint/path search. Failures here must not prevent startup (e.g.
+   * Mongo temporarily unreachable), so they are logged and swallowed; the indexes will be created
+   * on the next successful write attempt if missing.
+   */
+  private void ensureIndexes(MongoTemplate template, String collection) {
+    try {
+      template
+          .indexOps(collection)
+          .ensureIndex(
+              new Index().on("endpoint", org.springframework.data.domain.Sort.Direction.ASC));
+      template
+          .indexOps(collection)
+          .ensureIndex(new Index().on("path", org.springframework.data.domain.Sort.Direction.ASC));
+    } catch (RuntimeException ex) {
+      LOG.warn("Could not create request-logging indexes: {}", ex.getMessage());
+    }
+  }
+}

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingConfig.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingConfig.java
@@ -15,8 +15,8 @@ import org.springframework.core.Ordered;
 
 /**
  * Wires up the ClickHouse HTTP request logger. Everything here is gated on {@code
- * request-logging.enabled=true}; when the feature is off no filter is registered, so the rest of the
- * application is unaffected. Captured requests are written through the application's primary
+ * request-logging.enabled=true}; when the feature is off no filter is registered, so the rest of
+ * the application is unaffected. Captured requests are written through the application's primary
  * datasource (the same ClickHouse the app already queries) into a dedicated table that is expected
  * to already exist.
  */
@@ -42,10 +42,11 @@ public class RequestLoggingConfig {
   /**
    * The full commit the running backend was built from, suffixed with {@code -dirty} when the build
    * had uncommitted changes (so QC can tell apart captures taken against a clean tag versus a local
-   * working tree). Read straight from the {@code git.properties} that the git-commit-id Maven plugin
-   * writes onto the classpath at build time, rather than the autoconfigured {@code GitProperties}
-   * bean (which doesn't expose the plugin's {@code git.commit.id.full} key in this build). Falls back
-   * to {@code "unknown"} when the file is absent (e.g. running from an IDE without the plugin).
+   * working tree). Read straight from the {@code git.properties} that the git-commit-id Maven
+   * plugin writes onto the classpath at build time, rather than the autoconfigured {@code
+   * GitProperties} bean (which doesn't expose the plugin's {@code git.commit.id.full} key in this
+   * build). Falls back to {@code "unknown"} when the file is absent (e.g. running from an IDE
+   * without the plugin).
    */
   private static String resolveGitCommit() {
     Properties props = new Properties();

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingConfig.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingConfig.java
@@ -2,6 +2,7 @@ package org.cbioportal.infrastructure.requestlog;
 
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
+import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -10,6 +11,7 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.core.index.Index;
@@ -44,7 +46,7 @@ public class RequestLoggingConfig {
   @Bean
   public RequestLogService requestLogService(
       MongoTemplate requestLogMongoTemplate, RequestLoggingProperties properties) {
-    ensureIndexes(requestLogMongoTemplate, properties.getCollection());
+    ensureIndexes(requestLogMongoTemplate, properties);
     return new RequestLogService(
         requestLogMongoTemplate,
         properties.getCollection(),
@@ -71,19 +73,23 @@ public class RequestLoggingConfig {
   }
 
   /**
-   * Create the indexes that back endpoint/path search. Failures here must not prevent startup (e.g.
-   * Mongo temporarily unreachable), so they are logged and swallowed; the indexes will be created
-   * on the next successful write attempt if missing.
+   * Create the indexes that back endpoint/path search, plus an optional TTL index that bounds how
+   * long captured (potentially sensitive) requests are retained. Failures here must not prevent
+   * startup (e.g. Mongo temporarily unreachable), so they are logged and swallowed.
    */
-  private void ensureIndexes(MongoTemplate template, String collection) {
+  private void ensureIndexes(MongoTemplate template, RequestLoggingProperties properties) {
+    String collection = properties.getCollection();
     try {
-      template
-          .indexOps(collection)
-          .ensureIndex(
-              new Index().on("endpoint", org.springframework.data.domain.Sort.Direction.ASC));
-      template
-          .indexOps(collection)
-          .ensureIndex(new Index().on("path", org.springframework.data.domain.Sort.Direction.ASC));
+      template.indexOps(collection).ensureIndex(new Index().on("endpoint", Sort.Direction.ASC));
+      template.indexOps(collection).ensureIndex(new Index().on("path", Sort.Direction.ASC));
+      if (properties.getTtlDays() > 0) {
+        template
+            .indexOps(collection)
+            .ensureIndex(
+                new Index()
+                    .on("lastSeen", Sort.Direction.ASC)
+                    .expire(Duration.ofDays(properties.getTtlDays())));
+      }
     } catch (RuntimeException ex) {
       LOG.warn("Could not create request-logging indexes: {}", ex.getMessage());
     }

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingFilter.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingFilter.java
@@ -31,7 +31,7 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
 
 /**
  * Captures every matching HTTP request and hands it to {@link RequestLogService} to be stored in
- * MongoDB. The request body is read through a {@link ContentCachingRequestWrapper} so that
+ * ClickHouse. The request body is read through a {@link ContentCachingRequestWrapper} so that
  * capturing it does not interfere with the controller's own read of the body.
  *
  * <p>Capturing happens <em>after</em> the request has been handled, so the body has been fully read
@@ -118,16 +118,14 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
     logged.setPath(path);
     logged.setEndpoint(endpoint != null ? endpoint : path);
     logged.setQueryString(queryString);
+    logged.setServerName(request.getServerName());
     logged.setUrl(reconstructUrl(request, queryString));
     logged.setHeaders(extractHeaders(request));
     logged.setContentType(contentType);
     logged.setBody(body);
     logged.setBodyTruncated(truncated);
     logged.setResponseStatus(response.getStatus());
-    Instant now = Instant.now();
-    logged.setFirstSeen(now);
-    logged.setLastSeen(now);
-    logged.setCount(1);
+    logged.setSeen(Instant.now());
     return logged;
   }
 

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingFilter.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingFilter.java
@@ -20,6 +20,7 @@ import java.util.Enumeration;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -97,13 +98,17 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
     String contentType = request.getContentType();
 
     Charset charset =
-        request.getCharacterEncoding() != null
-            ? Charset.forName(request.getCharacterEncoding())
-            : StandardCharsets.UTF_8;
+        Optional.ofNullable(request.getCharacterEncoding())
+            .map(Charset::forName)
+            .orElse(StandardCharsets.UTF_8);
     byte[] bodyBytes = request.getContentAsByteArray();
+    // The cache filled to the cap. The body was truncated unless the declared content length proves
+    // it fit exactly; an unknown length (-1, e.g. chunked transfer) is treated as possibly
+    // truncated.
+    long contentLength = request.getContentLengthLong();
     boolean truncated =
         bodyBytes.length >= properties.getMaxBodyBytes()
-            && request.getContentLengthLong() > bodyBytes.length;
+            && (contentLength < 0 || contentLength > bodyBytes.length);
 
     // Redact before hashing/storing so secrets never reach the database and so requests that differ
     // only in a secret value still deduplicate to the same document.

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingFilter.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingFilter.java
@@ -1,0 +1,159 @@
+package org.cbioportal.infrastructure.requestlog;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+/**
+ * Captures every matching HTTP request and hands it to {@link RequestLogService} to be stored in
+ * MongoDB. The request body is read through a {@link ContentCachingRequestWrapper} so that
+ * capturing it does not interfere with the controller's own read of the body.
+ *
+ * <p>Capturing happens <em>after</em> the request has been handled, so the body has been fully read
+ * (and therefore cached) and the matched endpoint pattern and response status are available.
+ */
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RequestLoggingFilter.class);
+
+  private final RequestLogService requestLogService;
+  private final RequestLoggingProperties properties;
+  private final Set<String> redactHeaders;
+  private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+  public RequestLoggingFilter(
+      RequestLogService requestLogService, RequestLoggingProperties properties) {
+    this.requestLogService = requestLogService;
+    this.properties = properties;
+    this.redactHeaders =
+        properties.getRedactHeaders().stream()
+            .map(header -> header.toLowerCase(java.util.Locale.ROOT))
+            .collect(Collectors.toUnmodifiableSet());
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String path = request.getRequestURI();
+    return properties.getPathPatterns().stream()
+        .noneMatch(pattern -> pathMatcher.match(pattern, path));
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    ContentCachingRequestWrapper wrapped =
+        request instanceof ContentCachingRequestWrapper ccrw
+            ? ccrw
+            : new ContentCachingRequestWrapper(request, properties.getMaxBodyBytes());
+    try {
+      filterChain.doFilter(wrapped, response);
+    } finally {
+      try {
+        requestLogService.save(capture(wrapped, response));
+      } catch (RuntimeException ex) {
+        // Capturing must never break the response.
+        LOG.debug("Failed to capture request for logging", ex);
+      }
+    }
+  }
+
+  private LoggedRequest capture(
+      ContentCachingRequestWrapper request, HttpServletResponse response) {
+    String method = request.getMethod();
+    String path = request.getRequestURI();
+    String queryString = request.getQueryString();
+    String url = reconstructUrl(request);
+    Map<String, String> headers = extractHeaders(request);
+
+    Charset charset =
+        request.getCharacterEncoding() != null
+            ? Charset.forName(request.getCharacterEncoding())
+            : StandardCharsets.UTF_8;
+    byte[] bodyBytes = request.getContentAsByteArray();
+    String body = new String(bodyBytes, charset);
+    boolean truncated =
+        bodyBytes.length >= properties.getMaxBodyBytes()
+            && request.getContentLengthLong() > bodyBytes.length;
+
+    String endpoint = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+
+    LoggedRequest logged = new LoggedRequest();
+    logged.setId(computeId(method, path, queryString, body));
+    logged.setMethod(method);
+    logged.setPath(path);
+    logged.setEndpoint(endpoint != null ? endpoint : path);
+    logged.setQueryString(queryString);
+    logged.setUrl(url);
+    logged.setHeaders(headers);
+    logged.setContentType(request.getContentType());
+    logged.setBody(body);
+    logged.setBodyTruncated(truncated);
+    logged.setResponseStatus(response.getStatus());
+    Instant now = Instant.now();
+    logged.setFirstSeen(now);
+    logged.setLastSeen(now);
+    logged.setCount(1);
+    return logged;
+  }
+
+  private Map<String, String> extractHeaders(HttpServletRequest request) {
+    Map<String, String> headers = new LinkedHashMap<>();
+    Enumeration<String> names = request.getHeaderNames();
+    if (names == null) {
+      return headers;
+    }
+    for (String name : Collections.list(names)) {
+      String value =
+          redactHeaders.contains(name.toLowerCase(java.util.Locale.ROOT))
+              ? "REDACTED"
+              : String.join(", ", Collections.list(request.getHeaders(name)));
+      headers.put(name, value);
+    }
+    return headers;
+  }
+
+  private String reconstructUrl(HttpServletRequest request) {
+    StringBuffer url = request.getRequestURL();
+    if (request.getQueryString() != null) {
+      url.append('?').append(request.getQueryString());
+    }
+    return url.toString();
+  }
+
+  /**
+   * Deterministic id so the same logical request always maps to the same document. Hashing keeps
+   * the id short and bounded even for very large bodies.
+   */
+  private String computeId(String method, String path, String queryString, String body) {
+    String canonical =
+        method + '\n' + path + '\n' + (queryString == null ? "" : queryString) + '\n' + body;
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(canonical.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException ex) {
+      // SHA-256 is always available on a standard JVM.
+      throw new IllegalStateException(ex);
+    }
+  }
+}

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingFilter.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingFilter.java
@@ -1,5 +1,9 @@
 package org.cbioportal.infrastructure.requestlog;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,11 +14,12 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HexFormat;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -35,20 +40,27 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
 public class RequestLoggingFilter extends OncePerRequestFilter {
 
   private static final Logger LOG = LoggerFactory.getLogger(RequestLoggingFilter.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String REDACTED = "REDACTED";
 
   private final RequestLogService requestLogService;
   private final RequestLoggingProperties properties;
   private final Set<String> redactHeaders;
+  private final Set<String> redactParams;
   private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
   public RequestLoggingFilter(
       RequestLogService requestLogService, RequestLoggingProperties properties) {
     this.requestLogService = requestLogService;
     this.properties = properties;
-    this.redactHeaders =
-        properties.getRedactHeaders().stream()
-            .map(header -> header.toLowerCase(java.util.Locale.ROOT))
-            .collect(Collectors.toUnmodifiableSet());
+    this.redactHeaders = toLowerCaseSet(properties.getRedactHeaders());
+    this.redactParams = toLowerCaseSet(properties.getRedactParams());
+  }
+
+  private static Set<String> toLowerCaseSet(List<String> values) {
+    return values.stream()
+        .map(value -> value.toLowerCase(Locale.ROOT))
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   @Override
@@ -82,19 +94,21 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
       ContentCachingRequestWrapper request, HttpServletResponse response) {
     String method = request.getMethod();
     String path = request.getRequestURI();
-    String queryString = request.getQueryString();
-    String url = reconstructUrl(request);
-    Map<String, String> headers = extractHeaders(request);
+    String contentType = request.getContentType();
 
     Charset charset =
         request.getCharacterEncoding() != null
             ? Charset.forName(request.getCharacterEncoding())
             : StandardCharsets.UTF_8;
     byte[] bodyBytes = request.getContentAsByteArray();
-    String body = new String(bodyBytes, charset);
     boolean truncated =
         bodyBytes.length >= properties.getMaxBodyBytes()
             && request.getContentLengthLong() > bodyBytes.length;
+
+    // Redact before hashing/storing so secrets never reach the database and so requests that differ
+    // only in a secret value still deduplicate to the same document.
+    String queryString = redactQuery(request.getQueryString());
+    String body = redactBody(new String(bodyBytes, charset), contentType);
 
     String endpoint = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
 
@@ -104,9 +118,9 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
     logged.setPath(path);
     logged.setEndpoint(endpoint != null ? endpoint : path);
     logged.setQueryString(queryString);
-    logged.setUrl(url);
-    logged.setHeaders(headers);
-    logged.setContentType(request.getContentType());
+    logged.setUrl(reconstructUrl(request, queryString));
+    logged.setHeaders(extractHeaders(request));
+    logged.setContentType(contentType);
     logged.setBody(body);
     logged.setBodyTruncated(truncated);
     logged.setResponseStatus(response.getStatus());
@@ -117,28 +131,92 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
     return logged;
   }
 
-  private Map<String, String> extractHeaders(HttpServletRequest request) {
-    Map<String, String> headers = new LinkedHashMap<>();
+  private List<HttpHeader> extractHeaders(HttpServletRequest request) {
+    List<HttpHeader> headers = new ArrayList<>();
     Enumeration<String> names = request.getHeaderNames();
     if (names == null) {
       return headers;
     }
     for (String name : Collections.list(names)) {
       String value =
-          redactHeaders.contains(name.toLowerCase(java.util.Locale.ROOT))
-              ? "REDACTED"
+          redactHeaders.contains(name.toLowerCase(Locale.ROOT))
+              ? REDACTED
               : String.join(", ", Collections.list(request.getHeaders(name)));
-      headers.put(name, value);
+      headers.add(new HttpHeader(name, value));
     }
     return headers;
   }
 
-  private String reconstructUrl(HttpServletRequest request) {
+  private String reconstructUrl(HttpServletRequest request, String queryString) {
     StringBuffer url = request.getRequestURL();
-    if (request.getQueryString() != null) {
-      url.append('?').append(request.getQueryString());
+    if (queryString != null && !queryString.isEmpty()) {
+      url.append('?').append(queryString);
     }
     return url.toString();
+  }
+
+  /** Replace the values of configured parameter names in a {@code k=v&k2=v2} string. */
+  private String redactQuery(String query) {
+    if (query == null || query.isEmpty() || redactParams.isEmpty()) {
+      return query;
+    }
+    StringBuilder out = new StringBuilder();
+    String[] pairs = query.split("&");
+    for (int i = 0; i < pairs.length; i++) {
+      if (i > 0) {
+        out.append('&');
+      }
+      String pair = pairs[i];
+      int eq = pair.indexOf('=');
+      String key = eq >= 0 ? pair.substring(0, eq) : pair;
+      if (eq >= 0 && redactParams.contains(key.toLowerCase(Locale.ROOT))) {
+        out.append(key).append('=').append(REDACTED);
+      } else {
+        out.append(pair);
+      }
+    }
+    return out.toString();
+  }
+
+  private String redactBody(String body, String contentType) {
+    if (body == null || body.isEmpty() || redactParams.isEmpty()) {
+      return body;
+    }
+    String type = contentType == null ? "" : contentType.toLowerCase(Locale.ROOT);
+    if (type.contains("application/x-www-form-urlencoded")) {
+      return redactQuery(body);
+    }
+    if (type.contains("json")) {
+      return redactJson(body);
+    }
+    return body;
+  }
+
+  private String redactJson(String body) {
+    try {
+      JsonNode root = OBJECT_MAPPER.readTree(body);
+      redactJsonNode(root);
+      return OBJECT_MAPPER.writeValueAsString(root);
+    } catch (IOException ex) {
+      // Not parseable as JSON; leave it untouched rather than risk mangling it.
+      return body;
+    }
+  }
+
+  private void redactJsonNode(JsonNode node) {
+    if (node instanceof ObjectNode object) {
+      List<String> fieldNames = new ArrayList<>();
+      object.fieldNames().forEachRemaining(fieldNames::add);
+      for (String field : fieldNames) {
+        if (redactParams.contains(field.toLowerCase(Locale.ROOT))) {
+          object.put(field, REDACTED);
+        } else {
+          redactJsonNode(object.get(field));
+        }
+      }
+    } else if (node instanceof ArrayNode array) {
+      array.forEach(this::redactJsonNode);
+    }
   }
 
   /**

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingProperties.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingProperties.java
@@ -1,0 +1,127 @@
+package org.cbioportal.infrastructure.requestlog;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for the MongoDB HTTP request logger.
+ *
+ * <p>The feature is disabled by default. When {@code request-logging.enabled=true} every incoming
+ * HTTP request that matches {@link #getPathPatterns()} is captured (method, url, headers and body)
+ * and upserted into MongoDB, deduplicated by a hash of method + path + query + body so the
+ * collection stays bounded regardless of traffic. The stored documents contain everything needed to
+ * replay the request with {@code curl}, and can be searched by endpoint, making them a convenient
+ * corpus for QC of new endpoint implementations.
+ */
+@ConfigurationProperties(prefix = "request-logging")
+public class RequestLoggingProperties {
+
+  /** Master switch. When false (the default) no Mongo connection is opened and no filter is run. */
+  private boolean enabled = false;
+
+  /** MongoDB connection string for the database that stores the captured requests. */
+  private String mongoUri = "mongodb://localhost:27017";
+
+  /** Database name used to store captured requests. */
+  private String database = "cbioportal_qc";
+
+  /** Collection name used to store captured requests. */
+  private String collection = "logged_requests";
+
+  /** Ant-style path patterns to capture. Defaults to the REST API only. */
+  private List<String> pathPatterns = List.of("/api/**");
+
+  /**
+   * Maximum number of request body bytes to capture (and to keep buffered in memory per request).
+   * Bodies larger than this are truncated; the document is flagged with {@code bodyTruncated=true}.
+   */
+  private int maxBodyBytes = 5 * 1024 * 1024;
+
+  /**
+   * Header names (case-insensitive) whose values are replaced with {@code "REDACTED"} before being
+   * stored, so credentials don't land in the database. Set to an empty list to capture everything
+   * verbatim (e.g. when the captured requests need to be replayed with their original auth).
+   */
+  private List<String> redactHeaders = List.of("authorization", "cookie", "set-cookie");
+
+  /** Number of background threads used to write captured requests to MongoDB. */
+  private int writerThreads = 2;
+
+  /**
+   * Maximum number of captured requests queued for writing. When the queue is full new captures are
+   * dropped (and logged at debug level) so request handling is never blocked by Mongo.
+   */
+  private int queueCapacity = 10_000;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getMongoUri() {
+    return mongoUri;
+  }
+
+  public void setMongoUri(String mongoUri) {
+    this.mongoUri = mongoUri;
+  }
+
+  public String getDatabase() {
+    return database;
+  }
+
+  public void setDatabase(String database) {
+    this.database = database;
+  }
+
+  public String getCollection() {
+    return collection;
+  }
+
+  public void setCollection(String collection) {
+    this.collection = collection;
+  }
+
+  public List<String> getPathPatterns() {
+    return pathPatterns;
+  }
+
+  public void setPathPatterns(List<String> pathPatterns) {
+    this.pathPatterns = pathPatterns;
+  }
+
+  public int getMaxBodyBytes() {
+    return maxBodyBytes;
+  }
+
+  public void setMaxBodyBytes(int maxBodyBytes) {
+    this.maxBodyBytes = maxBodyBytes;
+  }
+
+  public List<String> getRedactHeaders() {
+    return redactHeaders;
+  }
+
+  public void setRedactHeaders(List<String> redactHeaders) {
+    this.redactHeaders = redactHeaders;
+  }
+
+  public int getWriterThreads() {
+    return writerThreads;
+  }
+
+  public void setWriterThreads(int writerThreads) {
+    this.writerThreads = writerThreads;
+  }
+
+  public int getQueueCapacity() {
+    return queueCapacity;
+  }
+
+  public void setQueueCapacity(int queueCapacity) {
+    this.queueCapacity = queueCapacity;
+  }
+}

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingProperties.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingProperties.java
@@ -44,6 +44,22 @@ public class RequestLoggingProperties {
    */
   private List<String> redactHeaders = List.of("authorization", "cookie", "set-cookie");
 
+  /**
+   * Query-string and body parameter/field names (case-insensitive) whose values are replaced with
+   * {@code "REDACTED"} before being stored, so secrets passed outside headers (e.g. {@code ?token=}
+   * or a JSON {@code "password"} field) don't land in the database. Applied to query strings,
+   * form-encoded bodies and JSON bodies. Empty by default; populating it adds a small parsing cost
+   * to capturing matching requests.
+   */
+  private List<String> redactParams = List.of();
+
+  /**
+   * Days after which a captured request that hasn't been seen again is automatically deleted (via a
+   * MongoDB TTL index on {@code lastSeen}). {@code 0} (the default) keeps documents forever; set a
+   * positive value to bound retention of potentially sensitive captured data.
+   */
+  private int ttlDays = 0;
+
   /** Number of background threads used to write captured requests to MongoDB. */
   private int writerThreads = 2;
 
@@ -107,6 +123,22 @@ public class RequestLoggingProperties {
 
   public void setRedactHeaders(List<String> redactHeaders) {
     this.redactHeaders = redactHeaders;
+  }
+
+  public List<String> getRedactParams() {
+    return redactParams;
+  }
+
+  public void setRedactParams(List<String> redactParams) {
+    this.redactParams = redactParams;
+  }
+
+  public int getTtlDays() {
+    return ttlDays;
+  }
+
+  public void setTtlDays(int ttlDays) {
+    this.ttlDays = ttlDays;
   }
 
   public int getWriterThreads() {

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingProperties.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingProperties.java
@@ -4,36 +4,43 @@ import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * Configuration for the MongoDB HTTP request logger.
+ * Configuration for the ClickHouse HTTP request logger.
  *
  * <p>The feature is disabled by default. When {@code request-logging.enabled=true} every incoming
  * HTTP request that matches {@link #getPathPatterns()} is captured (method, url, headers and body)
- * and upserted into MongoDB, deduplicated by a hash of method + path + query + body so the
- * collection stays bounded regardless of traffic. The stored documents contain everything needed to
- * replay the request with {@code curl}, and can be searched by endpoint, making them a convenient
- * corpus for QC of new endpoint implementations.
+ * and inserted into a dedicated ClickHouse table, reusing the application's primary datasource. The
+ * table is expected to be a {@code ReplacingMergeTree} ordered by {@code id} (a hash of method +
+ * path + query + body), so repeated observations of the same logical request eventually collapse to
+ * a single row during background merges. The stored rows contain everything needed to replay the
+ * request with {@code curl} and can be searched by endpoint, making them a convenient corpus for QC
+ * of new endpoint implementations.
  */
 @ConfigurationProperties(prefix = "request-logging")
 public class RequestLoggingProperties {
 
-  /** Master switch. When false (the default) no Mongo connection is opened and no filter is run. */
+  /** Master switch. When false (the default) no filter is registered and nothing is captured. */
   private boolean enabled = false;
 
-  /** MongoDB connection string for the database that stores the captured requests. */
-  private String mongoUri = "mongodb://localhost:27017";
+  /**
+   * Target table for captured requests. May be qualified with a database (e.g. {@code
+   * cbioportal_qc.logged_requests}); when unqualified it resolves against the database in the
+   * primary datasource URL. The table must already exist (see the project docs for the DDL).
+   */
+  private String table = "logged_requests";
 
-  /** Database name used to store captured requests. */
-  private String database = "cbioportal_qc";
-
-  /** Collection name used to store captured requests. */
-  private String collection = "logged_requests";
+  /**
+   * Use ClickHouse asynchronous inserts ({@code async_insert=1, wait_for_async_insert=0}) so the
+   * server batches the many small per-request inserts before flushing to disk, keeping write impact
+   * low. Leave enabled unless you specifically want synchronous inserts.
+   */
+  private boolean asyncInsert = true;
 
   /** Ant-style path patterns to capture. Defaults to the REST API only. */
   private List<String> pathPatterns = List.of("/api/**");
 
   /**
    * Maximum number of request body bytes to capture (and to keep buffered in memory per request).
-   * Bodies larger than this are truncated; the document is flagged with {@code bodyTruncated=true}.
+   * Bodies larger than this are truncated; the row is flagged with {@code bodyTruncated=true}.
    */
   private int maxBodyBytes = 5 * 1024 * 1024;
 
@@ -53,19 +60,12 @@ public class RequestLoggingProperties {
    */
   private List<String> redactParams = List.of();
 
-  /**
-   * Days after which a captured request that hasn't been seen again is automatically deleted (via a
-   * MongoDB TTL index on {@code lastSeen}). {@code 0} (the default) keeps documents forever; set a
-   * positive value to bound retention of potentially sensitive captured data.
-   */
-  private int ttlDays = 0;
-
-  /** Number of background threads used to write captured requests to MongoDB. */
+  /** Number of background threads used to write captured requests to ClickHouse. */
   private int writerThreads = 2;
 
   /**
    * Maximum number of captured requests queued for writing. When the queue is full new captures are
-   * dropped (and logged at debug level) so request handling is never blocked by Mongo.
+   * dropped (and logged at debug level) so request handling is never blocked by the database.
    */
   private int queueCapacity = 10_000;
 
@@ -77,28 +77,20 @@ public class RequestLoggingProperties {
     this.enabled = enabled;
   }
 
-  public String getMongoUri() {
-    return mongoUri;
+  public String getTable() {
+    return table;
   }
 
-  public void setMongoUri(String mongoUri) {
-    this.mongoUri = mongoUri;
+  public void setTable(String table) {
+    this.table = table;
   }
 
-  public String getDatabase() {
-    return database;
+  public boolean isAsyncInsert() {
+    return asyncInsert;
   }
 
-  public void setDatabase(String database) {
-    this.database = database;
-  }
-
-  public String getCollection() {
-    return collection;
-  }
-
-  public void setCollection(String collection) {
-    this.collection = collection;
+  public void setAsyncInsert(boolean asyncInsert) {
+    this.asyncInsert = asyncInsert;
   }
 
   public List<String> getPathPatterns() {
@@ -131,14 +123,6 @@ public class RequestLoggingProperties {
 
   public void setRedactParams(List<String> redactParams) {
     this.redactParams = redactParams;
-  }
-
-  public int getTtlDays() {
-    return ttlDays;
-  }
-
-  public void setTtlDays(int ttlDays) {
-    this.ttlDays = ttlDays;
   }
 
   public int getWriterThreads() {

--- a/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingProperties.java
+++ b/src/main/java/org/cbioportal/infrastructure/requestlog/RequestLoggingProperties.java
@@ -22,11 +22,12 @@ public class RequestLoggingProperties {
   private boolean enabled = false;
 
   /**
-   * Target table for captured requests. May be qualified with a database (e.g. {@code
-   * cbioportal_qc.logged_requests}); when unqualified it resolves against the database in the
-   * primary datasource URL. The table must already exist (see the project docs for the DDL).
+   * Target table for captured requests. Defaults to the database-qualified {@code
+   * cbioportal_qc.logged_requests} created by {@code db-scripts/clickhouse/request_log.sql}; an
+   * unqualified value resolves against the database in the primary datasource URL. The table must
+   * already exist (the application does not create it).
    */
-  private String table = "logged_requests";
+  private String table = "cbioportal_qc.logged_requests";
 
   /**
    * Use ClickHouse asynchronous inserts ({@code async_insert=1, wait_for_async_insert=0}) so the

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -457,11 +457,12 @@ feature.study.export.timeout_ms=600000
 # of the same request (same hash of method + path + query + body) are collapsed by the table's
 # ReplacingMergeTree merges, so the table converges on one row per distinct request. Each row holds
 # everything needed to replay the request with curl and can be searched by endpoint. Disabled by
-# default. The target table must already exist; create it with the ReplacingMergeTree DDL from the
-# project docs (ENGINE = ReplacingMergeTree(seen) ORDER BY id, optionally with a TTL on seen).
+# default. The target table must already exist; create it with the provisioning script
+# src/main/resources/db-scripts/clickhouse/request_log.sql (the application does not create it).
 # request-logging.enabled=false
-# Target table; may be database-qualified. Defaults to logged_requests in the datasource's database.
-# request-logging.table=logged_requests
+# Target table; may be database-qualified. Defaults to cbioportal_qc.logged_requests (as created by
+# request_log.sql); the runtime datasource user needs INSERT on it.
+# request-logging.table=cbioportal_qc.logged_requests
 # Use ClickHouse async inserts so small per-request inserts are batched server-side (recommended).
 # request-logging.async-insert=true
 # Ant-style paths to capture (comma separated); defaults to the REST API only.

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -451,5 +451,24 @@ spring.devtools.restart.enabled=false
 feature.study.export=false
 feature.study.export.timeout_ms=600000
 
+## MongoDB HTTP request logging (QC)
+# When enabled, every matching HTTP request (method, url, headers and body) is captured and
+# upserted into MongoDB, deduplicated by a hash of method + path + query + body so the collection
+# stays bounded regardless of traffic. Each document holds everything needed to replay the request
+# with curl and can be searched by endpoint. Disabled by default; turning it on opens a dedicated
+# Mongo connection used only for this purpose.
+# request-logging.enabled=false
+# request-logging.mongo-uri=mongodb://localhost:27017
+# request-logging.database=cbioportal_qc
+# request-logging.collection=logged_requests
+# Ant-style paths to capture (comma separated); defaults to the REST API only.
+# request-logging.path-patterns=/api/**
+# Max request body bytes to capture/buffer; larger bodies are truncated and flagged.
+# request-logging.max-body-bytes=5242880
+# Header names whose values are stored as REDACTED. Set empty to capture verbatim for replay.
+# request-logging.redact-headers=authorization,cookie,set-cookie
+# request-logging.writer-threads=2
+# request-logging.queue-capacity=10000
+
 # EOL - Do not delete the following lines
 

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -451,16 +451,19 @@ spring.devtools.restart.enabled=false
 feature.study.export=false
 feature.study.export.timeout_ms=600000
 
-## MongoDB HTTP request logging (QC)
-# When enabled, every matching HTTP request (method, url, headers and body) is captured and
-# upserted into MongoDB, deduplicated by a hash of method + path + query + body so the collection
-# stays bounded regardless of traffic. Each document holds everything needed to replay the request
-# with curl and can be searched by endpoint. Disabled by default; turning it on opens a dedicated
-# Mongo connection used only for this purpose.
+## ClickHouse HTTP request logging (QC)
+# When enabled, every matching HTTP request (method, url, headers and body) is captured and inserted
+# into a dedicated ClickHouse table using the application's primary datasource. Repeated observations
+# of the same request (same hash of method + path + query + body) are collapsed by the table's
+# ReplacingMergeTree merges, so the table converges on one row per distinct request. Each row holds
+# everything needed to replay the request with curl and can be searched by endpoint. Disabled by
+# default. The target table must already exist; create it with the ReplacingMergeTree DDL from the
+# project docs (ENGINE = ReplacingMergeTree(seen) ORDER BY id, optionally with a TTL on seen).
 # request-logging.enabled=false
-# request-logging.mongo-uri=mongodb://localhost:27017
-# request-logging.database=cbioportal_qc
-# request-logging.collection=logged_requests
+# Target table; may be database-qualified. Defaults to logged_requests in the datasource's database.
+# request-logging.table=logged_requests
+# Use ClickHouse async inserts so small per-request inserts are batched server-side (recommended).
+# request-logging.async-insert=true
 # Ant-style paths to capture (comma separated); defaults to the REST API only.
 # request-logging.path-patterns=/api/**
 # Max request body bytes to capture/buffer; larger bodies are truncated and flagged.
@@ -470,8 +473,6 @@ feature.study.export.timeout_ms=600000
 # Query-string/body (form or JSON) parameter names whose values are stored as REDACTED. Empty by
 # default; e.g. token,password,secret,access_token to scrub secrets passed outside headers.
 # request-logging.redact-params=
-# Auto-delete captures not seen for this many days (TTL index on lastSeen). 0 = keep forever.
-# request-logging.ttl-days=0
 # request-logging.writer-threads=2
 # request-logging.queue-capacity=10000
 

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -467,6 +467,11 @@ feature.study.export.timeout_ms=600000
 # request-logging.max-body-bytes=5242880
 # Header names whose values are stored as REDACTED. Set empty to capture verbatim for replay.
 # request-logging.redact-headers=authorization,cookie,set-cookie
+# Query-string/body (form or JSON) parameter names whose values are stored as REDACTED. Empty by
+# default; e.g. token,password,secret,access_token to scrub secrets passed outside headers.
+# request-logging.redact-params=
+# Auto-delete captures not seen for this many days (TTL index on lastSeen). 0 = keep forever.
+# request-logging.ttl-days=0
 # request-logging.writer-threads=2
 # request-logging.queue-capacity=10000
 

--- a/src/main/resources/db-scripts/clickhouse/request_log.sql
+++ b/src/main/resources/db-scripts/clickhouse/request_log.sql
@@ -1,0 +1,42 @@
+-- Schema for the optional HTTP request log used for endpoint QC.
+--
+-- This is independent of the main derived-table schema in clickhouse.sql: it is
+-- only needed when the backend is run with request-logging.enabled=true, in
+-- which case every matching HTTP request is captured and inserted here through
+-- the application's primary ClickHouse datasource (see
+-- org.cbioportal.infrastructure.requestlog.*). The table is NOT created by the
+-- application at startup; provision it out-of-band with this script.
+--
+-- The engine is a ReplacingMergeTree ordered by `id` (a SHA-256 of
+-- method + path + query + body), so repeated observations of the same logical
+-- request collapse to a single row during background merges. Read the
+-- deduplicated set with FINAL (or GROUP BY id). There is intentionally no TTL:
+-- rows persist until explicitly deleted.
+--
+-- The default target is cbioportal_qc.logged_requests; override with
+-- request-logging.table. The runtime datasource user needs INSERT on this
+-- table (plus SELECT/OPTIMIZE to query and compact it), e.g.:
+--   GRANT SELECT, INSERT, OPTIMIZE ON cbioportal_qc.* TO <app_user>;
+
+CREATE DATABASE IF NOT EXISTS cbioportal_qc;
+
+CREATE TABLE IF NOT EXISTS cbioportal_qc.logged_requests
+(
+    id String,                              -- SHA-256(method + path + query + body); dedup key
+    method LowCardinality(String),
+    path String,                            -- request path without the query string
+    endpoint String,                        -- matched controller route, e.g. /api/studies/{studyId}
+    query_string String,
+    server_name LowCardinality(String),     -- host the request was addressed to
+    url String,                             -- fully reconstructed URL incl. scheme, host, query
+    headers String,                         -- JSON array of {name, value}
+    content_type String,
+    body String,
+    body_truncated UInt8,                   -- 1 when the body exceeded the capture cap
+    response_status UInt16,
+    seen DateTime,                          -- when this observation was captured
+    git_commit LowCardinality(String),      -- backend build commit (suffixed -dirty if uncommitted)
+    INDEX idx_endpoint endpoint TYPE bloom_filter GRANULARITY 4
+)
+ENGINE = ReplacingMergeTree(seen)
+ORDER BY id;

--- a/src/test/java/org/cbioportal/infrastructure/requestlog/RequestLoggingFilterTest.java
+++ b/src/test/java/org/cbioportal/infrastructure/requestlog/RequestLoggingFilterTest.java
@@ -1,0 +1,114 @@
+package org.cbioportal.infrastructure.requestlog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.servlet.HandlerMapping;
+
+class RequestLoggingFilterTest {
+
+  private RequestLogService service;
+  private RequestLoggingFilter filter;
+
+  /** A chain that reads the body the way a controller would, so the cached body is populated. */
+  private final FilterChain bodyReadingChain =
+      (request, response) -> {
+        StreamUtils.copyToByteArray(request.getInputStream());
+        ((HttpServletResponse) response).setStatus(200);
+      };
+
+  @BeforeEach
+  void setUp() {
+    service = mock(RequestLogService.class);
+    filter = new RequestLoggingFilter(service, new RequestLoggingProperties());
+  }
+
+  private MockHttpServletRequest postRequest(String body) {
+    MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/studies/acc_tcga/x");
+    request.setServerName("cbioportal.org");
+    request.setQueryString("projection=SUMMARY");
+    request.setContentType("application/json");
+    request.setContent(body.getBytes());
+    request.setAttribute(
+        HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, "/api/studies/{studyId}/x");
+    return request;
+  }
+
+  private LoggedRequest runAndCapture(HttpServletRequest request)
+      throws ServletException, IOException {
+    filter.doFilter(request, new MockHttpServletResponse(), bodyReadingChain);
+    ArgumentCaptor<LoggedRequest> captor = ArgumentCaptor.forClass(LoggedRequest.class);
+    verify(service).save(captor.capture());
+    return captor.getValue();
+  }
+
+  @Test
+  void capturesMethodPathBodyAndEndpoint() throws Exception {
+    LoggedRequest logged = runAndCapture(postRequest("{\"ids\":[1,2,3]}"));
+
+    assertEquals("POST", logged.getMethod());
+    assertEquals("/api/studies/acc_tcga/x", logged.getPath());
+    assertEquals("/api/studies/{studyId}/x", logged.getEndpoint());
+    assertEquals("projection=SUMMARY", logged.getQueryString());
+    assertEquals("{\"ids\":[1,2,3]}", logged.getBody());
+    assertEquals(200, logged.getResponseStatus());
+    assertFalse(logged.isBodyTruncated());
+    assertTrue(logged.getUrl().endsWith("/api/studies/acc_tcga/x?projection=SUMMARY"));
+  }
+
+  @Test
+  void identicalRequestsProduceSameIdDifferentBodiesDiffer() throws Exception {
+    String idA1 = runAndCapture(postRequest("{\"ids\":[1]}")).getId();
+    // Fresh mock so the second verify() sees exactly one save.
+    service = mock(RequestLogService.class);
+    filter = new RequestLoggingFilter(service, new RequestLoggingProperties());
+    String idA2 = runAndCapture(postRequest("{\"ids\":[1]}")).getId();
+
+    service = mock(RequestLogService.class);
+    filter = new RequestLoggingFilter(service, new RequestLoggingProperties());
+    String idB = runAndCapture(postRequest("{\"ids\":[2]}")).getId();
+
+    assertEquals(idA1, idA2, "same method+path+query+body must hash to the same id");
+    assertFalse(idA1.equals(idB), "different bodies must hash to different ids");
+  }
+
+  @Test
+  void redactsSensitiveHeaders() throws Exception {
+    MockHttpServletRequest request = postRequest("{\"ids\":[1]}");
+    request.addHeader("Authorization", "Bearer secret-token");
+    request.addHeader("X-Custom", "keep-me");
+
+    LoggedRequest logged = runAndCapture(request);
+
+    assertEquals("REDACTED", logged.getHeaders().get("Authorization"));
+    assertEquals("keep-me", logged.getHeaders().get("X-Custom"));
+    assertFalse(
+        logged.getHeaders().values().contains("Bearer secret-token"),
+        "redacted secret must not be stored");
+  }
+
+  @Test
+  void skipsRequestsOutsideConfiguredPaths() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/images/logo.png");
+
+    filter.doFilter(request, new MockHttpServletResponse(), bodyReadingChain);
+
+    verify(service, never()).save(any());
+  }
+}

--- a/src/test/java/org/cbioportal/infrastructure/requestlog/RequestLoggingFilterTest.java
+++ b/src/test/java/org/cbioportal/infrastructure/requestlog/RequestLoggingFilterTest.java
@@ -13,6 +13,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -96,11 +97,40 @@ class RequestLoggingFilterTest {
 
     LoggedRequest logged = runAndCapture(request);
 
-    assertEquals("REDACTED", logged.getHeaders().get("Authorization"));
-    assertEquals("keep-me", logged.getHeaders().get("X-Custom"));
-    assertFalse(
-        logged.getHeaders().values().contains("Bearer secret-token"),
+    assertEquals("REDACTED", header(logged, "Authorization"));
+    assertEquals("keep-me", header(logged, "X-Custom"));
+    assertTrue(
+        logged.getHeaders().stream().noneMatch(h -> h.value().contains("secret-token")),
         "redacted secret must not be stored");
+  }
+
+  @Test
+  void redactsConfiguredQueryAndBodyParams() throws Exception {
+    RequestLoggingProperties props = new RequestLoggingProperties();
+    props.setRedactParams(List.of("token", "password"));
+    filter = new RequestLoggingFilter(service, props);
+
+    MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/studies/acc_tcga/x");
+    request.setServerName("cbioportal.org");
+    request.setQueryString("projection=SUMMARY&token=abc123");
+    request.setContentType("application/json");
+    request.setContent("{\"password\":\"hunter2\",\"ids\":[1]}".getBytes());
+
+    LoggedRequest logged = runAndCapture(request);
+
+    assertEquals("projection=SUMMARY&token=REDACTED", logged.getQueryString());
+    assertTrue(logged.getUrl().endsWith("token=REDACTED"));
+    assertFalse(logged.getBody().contains("hunter2"), "secret body value must be redacted");
+    assertTrue(logged.getBody().contains("REDACTED"));
+    assertTrue(logged.getBody().contains("\"ids\""), "non-secret fields must be preserved");
+  }
+
+  private static String header(LoggedRequest logged, String name) {
+    return logged.getHeaders().stream()
+        .filter(h -> h.name().equals(name))
+        .map(HttpHeader::value)
+        .findFirst()
+        .orElse(null);
   }
 
   @Test


### PR DESCRIPTION
## What

Adds an optional HTTP request logger that captures every matching `/api/**` request (method, path, query, headers, body, response status) and writes it to ClickHouse for QC of endpoint implementations. Each distinct request is captured once and can be replayed (e.g. as curl) and searched by matched route.

The earlier iterations of this branch targeted MongoDB; this changes the sink to **ClickHouse**, reusing the application's primary datasource instead of standing up a separate database with its own connection and credentials.

## How it works

- **Append-only + eventual dedup.** Every observation is one row in a `ReplacingMergeTree` ordered by `id` (a SHA-256 of method + path + query + body). Duplicate observations of the same logical request collapse during background merges; read the deduplicated set with `FINAL` / `GROUP BY id`.
- **Low write impact.** Inserts use ClickHouse `async_insert` so the many small per-request writes are batched server-side. Writes run on a bounded background thread pool with drop-on-full, so request handling is never blocked.
- **No auto-DDL / retention.** The table is provisioned out-of-band (`src/main/resources/db-scripts/clickhouse/request_log.sql`) and targeted via `request-logging.table`. No TTL — rows persist until explicitly deleted.
- **QC traceability columns:**
  - `git_commit` — the full commit the backend was built from (suffixed `-dirty` when the build had uncommitted changes), read straight from the classpath `git.properties`.
  - `server_name` — the host the request was addressed to, for deployments serving the API on multiple domains.
- **Redaction.** Sensitive headers (`authorization`/`cookie`/`set-cookie`) are redacted by default; configurable query/body param redaction is available via `request-logging.redact-params`.

## Off by default

The whole unit is gated on `@ConditionalOnProperty(request-logging.enabled=true)` with no `matchIfMissing`. With no config nothing is wired — no filter, no service, no writes, zero overhead. MongoDB remains wired for its other (legacy) uses; only the request-logging unit is migrated.

## Provisioning

Run `db-scripts/clickhouse/request_log.sql` (admin) to create `cbioportal_qc.logged_requests`, then grant the runtime datasource user `INSERT` (plus `SELECT`/`OPTIMIZE`) on it, and set `request-logging.enabled=true` + `request-logging.table=...`.

## Testing

- Unit tests for the capture/redaction filter pass.
- Verified end-to-end against a live ClickHouse Cloud instance: API requests captured with correct endpoint patterns, bodies, headers (as JSON), `server_name`, and `git_commit`; non-`/api` requests excluded; dedup behavior confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)