### PR TITLE
perf(api): restore memory cut on gene-panel-data/fetch and generic_assay_meta/fetch

### DIFF
--- a/src/e2e/js/src/types.ts
+++ b/src/e2e/js/src/types.ts
@@ -287,6 +287,44 @@ export interface ClinicalDataCount {
 }
 
 /**
+ * GenePanelData - Gene panel profiling status for one (sample, molecular profile) pair.
+ * Source: https://www.cbioportal.org/api/v3/api-docs/public (GenePanelData schema)
+ * Required fields: molecularProfileId, sampleId, patientId, studyId, profiled
+ */
+export interface GenePanelData {
+  /** Molecular profile stable id (e.g. "acc_tcga_mutations") */
+  molecularProfileId: string;
+  /** Sample stable id */
+  sampleId: string;
+  /** Patient stable id */
+  patientId: string;
+  /** Study stable id */
+  studyId: string;
+  /** Whether the sample is profiled in this molecular profile */
+  profiled: boolean;
+  /** Gene panel stable id; absent/null when whole-genome profiled */
+  genePanelId?: string;
+  /** Base64(sampleId + studyId) */
+  uniqueSampleKey: string;
+  /** Base64(patientId + studyId) */
+  uniquePatientKey: string;
+}
+
+/**
+ * GenericAssayMeta - Metadata for a generic assay entity.
+ * Source: https://www.cbioportal.org/api/v3/api-docs/public (GenericAssayMeta schema)
+ * Required fields: stableId
+ */
+export interface GenericAssayMeta {
+  /** Generic assay entity stable id */
+  stableId: string;
+  /** Entity type (e.g. "GENERIC_ASSAY") */
+  entityType: string;
+  /** Arbitrary key->value annotation properties (e.g. NAME, DESCRIPTION, URL, GENE_SYMBOL) */
+  genericEntityMetaProperties: { [key: string]: string };
+}
+
+/**
  * ClinicalDataCountItem - Count breakdown for one clinical attribute across all values
  * Source: https://www.cbioportal.org/api/v3/api-docs/internal (ClinicalDataCountItem schema)
  * Required fields: attributeId, counts

--- a/src/e2e/js/test/GenePanelDataController/GenePanelDataController.spec.ts
+++ b/src/e2e/js/test/GenePanelDataController/GenePanelDataController.spec.ts
@@ -1,0 +1,102 @@
+import { expect } from 'chai';
+import _ from 'lodash';
+import axios from 'axios';
+import { GenePanelData } from '../../src/types';
+import { config } from '../../src/config';
+import { TestUtils } from '../../src/utils';
+
+describe('GenePanelDataController E2E Tests', () => {
+  /**
+   * Calls POST /api/gene-panel-data/fetch with a multi-study filter.
+   * This endpoint (the sampleMolecularIdentifiers path) was changed to push the
+   * (profile, sample) filter into SQL instead of fetching every sample of the profile and
+   * filtering in Java; these tests guard that it still returns the correct rows.
+   * @param testData - request body containing sampleMolecularIdentifiers
+   * @returns array of GenePanelData rows
+   */
+  async function callFetchGenePanelData(testData: any): Promise<GenePanelData[]> {
+    const url = `${config.serverUrl}/api/gene-panel-data/fetch`;
+
+    const response = await axios.post<GenePanelData[]>(url, testData, {
+      headers: { 'Content-Type': 'application/json' }
+    });
+
+    // Verify the response status is 200 OK
+    expect(response.status).to.equal(200, 'Response status should be 200 OK');
+
+    // Verify the response body is present
+    expect(response.data).to.not.be.null;
+    expect(response.data).to.not.be.undefined;
+
+    return response.data;
+  }
+
+  describe('testFetchGenePanelData_sampleMolecularIdentifiers', () => {
+    it('should return exactly one profiled row per requested (profile, sample) pair', async () => {
+      // The JSON requests three specific samples of the acc_tcga mutation profile.
+      // All three are sequenced/profiled in acc_tcga, so each yields a profiled row.
+      const testData = await TestUtils.loadTestData('gene_panel_data_filter.json');
+
+      // Call the gene-panel-data fetch endpoint
+      const genePanelData = await callFetchGenePanelData(testData);
+
+      // The SQL-filtered query must return exactly the three requested rows (no cross-product)
+      expect(genePanelData).to.be.an('array', 'Response should be an array');
+      expect(genePanelData.length).to.equal(
+        3,
+        'Should return exactly one row per requested (profile, sample) pair'
+      );
+
+      // Every row should belong to the requested profile and study
+      const allForRequestedProfile = _.every(genePanelData, {
+        molecularProfileId: 'acc_tcga_mutations',
+        studyId: 'acc_tcga'
+      });
+      expect(
+        allForRequestedProfile,
+        'All rows should be for acc_tcga_mutations / acc_tcga'
+      ).to.be.true;
+
+      // The returned sample ids should be exactly the three requested ones
+      const returnedSampleIds = _.sortBy(_.map(genePanelData, 'sampleId'));
+      expect(returnedSampleIds).to.deep.equal(
+        ['TCGA-OR-A5J1-01', 'TCGA-OR-A5J2-01', 'TCGA-OR-A5J3-01'],
+        'Returned sample ids should match exactly the requested sample ids'
+      );
+
+      // All three samples are sequenced in acc_tcga, so all should be profiled
+      const allProfiled = _.every(genePanelData, { profiled: true });
+      expect(allProfiled, 'All three acc_tcga samples should be profiled').to.be.true;
+
+      // The derived unique keys (added in the response) should be populated for every row
+      const allHaveKeys = _.every(
+        genePanelData,
+        row => !_.isEmpty(row.uniqueSampleKey) && !_.isEmpty(row.uniquePatientKey)
+      );
+      expect(allHaveKeys, 'Every row should have uniqueSampleKey/uniquePatientKey').to.be.true;
+    });
+
+    it('should not return rows for samples that were not requested', async () => {
+      // Request a single sample of the acc_tcga mutation profile
+      const testData = {
+        sampleMolecularIdentifiers: [
+          { molecularProfileId: 'acc_tcga_mutations', sampleId: 'TCGA-OR-A5J1-01' }
+        ]
+      };
+
+      // Call the endpoint
+      const genePanelData = await callFetchGenePanelData(testData);
+
+      // Because filtering happens in SQL, only the single requested sample comes back,
+      // even though acc_tcga has ~90 samples in this profile.
+      expect(genePanelData.length).to.equal(
+        1,
+        'Only the single requested (profile, sample) pair should be returned'
+      );
+      expect(genePanelData[0].sampleId).to.equal(
+        'TCGA-OR-A5J1-01',
+        'The returned row should be the requested sample'
+      );
+    });
+  });
+});

--- a/src/e2e/js/test/GenePanelDataController/gene_panel_data_filter.json
+++ b/src/e2e/js/test/GenePanelDataController/gene_panel_data_filter.json
@@ -1,0 +1,7 @@
+{
+  "sampleMolecularIdentifiers": [
+    { "molecularProfileId": "acc_tcga_mutations", "sampleId": "TCGA-OR-A5J1-01" },
+    { "molecularProfileId": "acc_tcga_mutations", "sampleId": "TCGA-OR-A5J2-01" },
+    { "molecularProfileId": "acc_tcga_mutations", "sampleId": "TCGA-OR-A5J3-01" }
+  ]
+}

--- a/src/e2e/js/test/GenericAssayMetaController/GenericAssayMetaController.spec.ts
+++ b/src/e2e/js/test/GenericAssayMetaController/GenericAssayMetaController.spec.ts
@@ -1,0 +1,125 @@
+import { expect } from 'chai';
+import _ from 'lodash';
+import axios from 'axios';
+import { GenericAssayMeta, ProjectionType } from '../../src/types';
+import { config } from '../../src/config';
+import { TestUtils } from '../../src/utils';
+
+describe('GenericAssayMetaController E2E Tests', () => {
+  /**
+   * Calls POST /api/legacy/generic_assay_meta/fetch for a given projection.
+   * For non-DETAILED projections the additional-properties query is now restricted to the
+   * property names the frontend consumes (NAME/DESCRIPTION/URL); DETAILED still returns the
+   * full property map. These tests guard both behaviors.
+   * @param testData - request body containing molecularProfileIds and/or genericAssayStableIds
+   * @param projection - ID | SUMMARY | DETAILED
+   * @returns array of GenericAssayMeta entities
+   */
+  async function callFetchGenericAssayMeta(
+    testData: any,
+    projection: ProjectionType
+  ): Promise<GenericAssayMeta[]> {
+    const url = `${config.serverUrl}/api/legacy/generic_assay_meta/fetch?projection=${projection}`;
+
+    const response = await axios.post<GenericAssayMeta[]>(url, testData, {
+      headers: { 'Content-Type': 'application/json' }
+    });
+
+    // Verify the response status is 200 OK
+    expect(response.status).to.equal(200, 'Response status should be 200 OK');
+
+    // Verify the response body is present
+    expect(response.data).to.not.be.null;
+    expect(response.data).to.not.be.undefined;
+
+    return response.data;
+  }
+
+  // This profile's entities carry two property names: NAME and GENE_SYMBOL. The frontend only
+  // consumes NAME/DESCRIPTION/URL, so SUMMARY should drop GENE_SYMBOL while DETAILED keeps it.
+  const PROFILE_ID = 'lusc_cptac_2021_circular_rna';
+  const EXPECTED_ENTITY_COUNT = 306;
+
+  describe('testFetchGenericAssayMeta_summaryRestrictsProperties', () => {
+    it('SUMMARY should return only the frontend-consumed property names', async () => {
+      // Load the filter targeting the circular-RNA generic-assay profile
+      const testData = await TestUtils.loadTestData('generic_assay_meta_filter.json');
+
+      // Fetch with SUMMARY projection (the default the frontend uses)
+      const summaryMeta = await callFetchGenericAssayMeta(testData, ProjectionType.SUMMARY);
+
+      // The set of entities is unchanged by the property restriction
+      expect(summaryMeta.length).to.equal(
+        EXPECTED_ENTITY_COUNT,
+        `SUMMARY should return all ${EXPECTED_ENTITY_COUNT} entities of the profile`
+      );
+
+      // Collect every distinct property key present across all entities
+      const summaryPropertyKeys = _.uniq(
+        _.flatMap(summaryMeta, entity => _.keys(entity.genericEntityMetaProperties))
+      ).sort();
+
+      // SUMMARY must expose only NAME here (GENE_SYMBOL is dropped; DESCRIPTION/URL are absent
+      // from this profile). It must never expose the non-consumed GENE_SYMBOL property.
+      expect(summaryPropertyKeys).to.deep.equal(
+        ['NAME'],
+        'SUMMARY should expose only NAME for this profile'
+      );
+      expect(summaryPropertyKeys).to.not.include(
+        'GENE_SYMBOL',
+        'SUMMARY must not include the unused GENE_SYMBOL property'
+      );
+
+      // Every entity should still carry its NAME value (the restriction drops keys, not entities)
+      const allHaveName = _.every(
+        summaryMeta,
+        entity => !_.isEmpty(_.get(entity, ['genericEntityMetaProperties', 'NAME']))
+      );
+      expect(allHaveName, 'Every entity should still have a NAME property').to.be.true;
+    });
+  });
+
+  describe('testFetchGenericAssayMeta_detailedReturnsFullMap', () => {
+    it('DETAILED should still return the full property map (including GENE_SYMBOL)', async () => {
+      const testData = await TestUtils.loadTestData('generic_assay_meta_filter.json');
+
+      // Fetch SUMMARY and DETAILED for the same profile to compare property coverage
+      const summaryMeta = await callFetchGenericAssayMeta(testData, ProjectionType.SUMMARY);
+      const detailedMeta = await callFetchGenericAssayMeta(testData, ProjectionType.DETAILED);
+
+      // Same entity set for both projections
+      expect(detailedMeta.length).to.equal(
+        summaryMeta.length,
+        'DETAILED and SUMMARY should return the same number of entities'
+      );
+
+      // DETAILED must expose the full property set for this profile: NAME and GENE_SYMBOL
+      const detailedPropertyKeys = _.uniq(
+        _.flatMap(detailedMeta, entity => _.keys(entity.genericEntityMetaProperties))
+      ).sort();
+      expect(detailedPropertyKeys).to.deep.equal(
+        ['GENE_SYMBOL', 'NAME'],
+        'DETAILED should expose the full property map (NAME and GENE_SYMBOL)'
+      );
+
+      // Concretely: DETAILED carries GENE_SYMBOL where SUMMARY does not, for the same entity
+      const sampleStableId = detailedMeta[0].stableId;
+      const detailedEntity = _.find(detailedMeta, { stableId: sampleStableId });
+      const summaryEntity = _.find(summaryMeta, { stableId: sampleStableId });
+      expect(
+        _.has(detailedEntity!.genericEntityMetaProperties, 'GENE_SYMBOL'),
+        'DETAILED entity should include GENE_SYMBOL'
+      ).to.be.true;
+      expect(
+        _.has(summaryEntity!.genericEntityMetaProperties, 'GENE_SYMBOL'),
+        'SUMMARY entity should not include GENE_SYMBOL'
+      ).to.be.false;
+
+      // The NAME value must be identical across projections (only the key set differs)
+      expect(summaryEntity!.genericEntityMetaProperties.NAME).to.equal(
+        detailedEntity!.genericEntityMetaProperties.NAME,
+        'NAME should be identical between SUMMARY and DETAILED'
+      );
+    });
+  });
+});

--- a/src/e2e/js/test/GenericAssayMetaController/generic_assay_meta_filter.json
+++ b/src/e2e/js/test/GenericAssayMetaController/generic_assay_meta_filter.json
@@ -1,0 +1,3 @@
+{
+  "molecularProfileIds": ["lusc_cptac_2021_circular_rna"]
+}

--- a/src/main/java/org/cbioportal/legacy/persistence/GenericAssayRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/GenericAssayRepository.java
@@ -15,7 +15,8 @@ public interface GenericAssayRepository {
   @Cacheable(
       cacheResolver = "generalRepositoryCacheResolver",
       condition = "@cacheEnabledConfig.getEnabled()")
-  List<GenericAssayAdditionalProperty> getGenericAssayAdditionalproperties(List<String> stableIds);
+  List<GenericAssayAdditionalProperty> getGenericAssayAdditionalproperties(
+      List<String> stableIds, List<String> propertyNames);
 
   @Cacheable(
       cacheResolver = "generalRepositoryCacheResolver",

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/GenericAssayMapper.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/GenericAssayMapper.java
@@ -1,6 +1,7 @@
 package org.cbioportal.legacy.persistence.mybatis;
 
 import java.util.List;
+import org.apache.ibatis.annotations.Param;
 import org.cbioportal.legacy.model.GenericAssayAdditionalProperty;
 import org.cbioportal.legacy.model.meta.GenericAssayMeta;
 
@@ -8,7 +9,13 @@ public interface GenericAssayMapper {
 
   List<GenericAssayMeta> getGenericAssayMeta(List<String> stableIds);
 
-  List<GenericAssayAdditionalProperty> getGenericAssayAdditionalproperties(List<String> stableIds);
+  /**
+   * @param propertyNames when non-null and non-empty, restricts the returned properties to these
+   *     names (pushed into SQL); when null, all properties for the entities are returned.
+   */
+  List<GenericAssayAdditionalProperty> getGenericAssayAdditionalproperties(
+      @Param("stableIds") List<String> stableIds,
+      @Param("propertyNames") List<String> propertyNames);
 
   List<Integer> getMolecularProfileInternalIdsByMolecularProfileIds(
       List<String> molecularProfileIds);

--- a/src/main/java/org/cbioportal/legacy/persistence/mybatis/GenericAssayMyBatisRepository.java
+++ b/src/main/java/org/cbioportal/legacy/persistence/mybatis/GenericAssayMyBatisRepository.java
@@ -32,8 +32,8 @@ public class GenericAssayMyBatisRepository implements GenericAssayRepository {
       cacheResolver = "staticRepositoryCacheOneResolver",
       condition = "@cacheEnabledConfig.getEnabled()")
   public List<GenericAssayAdditionalProperty> getGenericAssayAdditionalproperties(
-      List<String> stableIds) {
-    return genericAssayMapper.getGenericAssayAdditionalproperties(stableIds);
+      List<String> stableIds, List<String> propertyNames) {
+    return genericAssayMapper.getGenericAssayAdditionalproperties(stableIds, propertyNames);
   }
 
   @Override

--- a/src/main/java/org/cbioportal/legacy/service/impl/GenePanelServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/GenePanelServiceImpl.java
@@ -33,11 +33,6 @@ public class GenePanelServiceImpl implements GenePanelService {
 
   private final String SEQUENCED_LIST_SUFFIX = "_sequenced";
 
-  private final Function<GenePanelData, String> sampleIdentifierGenerator =
-      d -> d.getMolecularProfileId() + d.getSampleId();
-  private final Function<GenePanelData, String> patientIdentifierGenerator =
-      d -> d.getMolecularProfileId() + d.getPatientId();
-
   @Override
   public List<GenePanel> getAllGenePanels(
       String projection, Integer pageSize, Integer pageNumber, String sortBy, String direction) {
@@ -168,34 +163,49 @@ public class GenePanelServiceImpl implements GenePanelService {
   @Override
   public List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfiles(
       List<MolecularProfileCaseIdentifier> molecularProfileSampleIdentifiers) {
-    return getGenePanelData(molecularProfileSampleIdentifiers, sampleIdentifierGenerator);
+    return annotateBySequencedSampleLists(
+        genePanelRepository.fetchGenePanelDataInMultipleMolecularProfiles(
+            molecularProfileSampleIdentifiers));
   }
 
   @Override
   public List<GenePanelData> fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(
       List<MolecularProfileCaseIdentifier> molecularProfilePatientIdentifiers) {
-    return getGenePanelData(molecularProfilePatientIdentifiers, patientIdentifierGenerator);
+    return annotateBySequencedSampleLists(
+        genePanelRepository.fetchGenePanelDataInMultipleMolecularProfilesByPatientIds(
+            molecularProfilePatientIdentifiers));
   }
 
-  private List<GenePanelData> getGenePanelData(
-      List<MolecularProfileCaseIdentifier> molecularProfileCaseIdentifiers,
-      Function<GenePanelData, String> keyGenerator) {
+  /**
+   * Applies the sequenced-sample-list profiled annotation (needed for MUTATION profiles) to gene
+   * panel data that the repository has already filtered down to the requested (profile, case) pairs
+   * in SQL. Previously this path fetched gene panel data for every sample of each requested profile
+   * and filtered in Java, materializing the full samples x profiles cross-product on the heap.
+   */
+  private List<GenePanelData> annotateBySequencedSampleLists(List<GenePanelData> genePanelData) {
+    if (CollectionUtils.isEmpty(genePanelData)) {
+      return genePanelData;
+    }
+
     Set<String> molecularProfileIds =
-        molecularProfileCaseIdentifiers.stream()
-            .map(MolecularProfileCaseIdentifier::getMolecularProfileId)
-            .collect(toSet());
+        genePanelData.stream().map(GenePanelData::getMolecularProfileId).collect(toSet());
 
-    Map<String, Boolean> queriedMolecularProfileCaseIdentifierMap =
-        molecularProfileCaseIdentifiers.stream()
-            .collect(
-                Collectors.toMap(
-                    datum -> datum.getMolecularProfileId() + datum.getCaseId(), datum -> true));
+    Map<String, MolecularProfile> molecularProfileIdMap =
+        molecularProfileService.getMolecularProfiles(molecularProfileIds, "SUMMARY").stream()
+            .collect(Collectors.toMap(MolecularProfile::getStableId, Function.identity()));
 
-    return fetchGenePanelDataByMolecularProfileIds(molecularProfileIds).stream()
-        .filter(
-            datum ->
-                queriedMolecularProfileCaseIdentifierMap.containsKey(keyGenerator.apply(datum)))
-        .toList();
+    Map<String, List<GenePanelData>> genePanelDataByProfileId =
+        genePanelData.stream().collect(Collectors.groupingBy(GenePanelData::getMolecularProfileId));
+
+    genePanelDataByProfileId.forEach(
+        (profileId, profileData) -> {
+          MolecularProfile molecularProfile = molecularProfileIdMap.get(profileId);
+          if (molecularProfile != null) {
+            annotateDataFromSequencedSampleLists(profileData, molecularProfile);
+          }
+        });
+
+    return genePanelData;
   }
 
   /**

--- a/src/main/java/org/cbioportal/legacy/service/impl/GenericAssayServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/impl/GenericAssayServiceImpl.java
@@ -34,6 +34,13 @@ public class GenericAssayServiceImpl implements GenericAssayService {
 
   @Autowired private SampleListRepository sampleListRepository;
 
+  // The only generic-entity meta properties consumed by the frontend. For non-DETAILED
+  // projections we restrict the properties query to these names (pushed into SQL), avoiding
+  // loading and serializing large unused properties (e.g. TRANSCRIPT_ID, GENE_SYMBOL, PHOSPHOSITES)
+  // for every entity. DETAILED still returns the full property map.
+  private static final List<String> SUMMARY_META_PROPERTY_NAMES =
+      Arrays.asList("NAME", "DESCRIPTION", "URL");
+
   // TODO: When fully migrated to column-store, replace this method body with a delegation to
   //       GetGenericAssayMetaUseCase.execute(stableIds, molecularProfileIds, projection).
   @Override
@@ -79,8 +86,14 @@ public class GenericAssayServiceImpl implements GenericAssayService {
           metaResults.add(new GenericAssayMeta(meta.getStableId()));
         }
       } else {
+        // DETAILED returns the full property map; SUMMARY (the default and only projection the
+        // frontend uses) returns just the consumed property names, restricted in SQL.
+        List<String> propertyNames =
+            projection.equals("DETAILED") ? null : SUMMARY_META_PROPERTY_NAMES;
         Map<String, List<GenericAssayAdditionalProperty>> additionalPropertiesGroupedByStableId =
-            genericAssayRepository.getGenericAssayAdditionalproperties(distinctStableIds).stream()
+            genericAssayRepository
+                .getGenericAssayAdditionalproperties(distinctStableIds, propertyNames)
+                .stream()
                 .collect(Collectors.groupingBy(GenericAssayAdditionalProperty::getStableId));
         for (GenericAssayMeta meta : metaData) {
           String stableId = meta.getStableId();

--- a/src/main/resources/org/cbioportal/legacy/persistence/mybatis/GenericAssayMapper.xml
+++ b/src/main/resources/org/cbioportal/legacy/persistence/mybatis/GenericAssayMapper.xml
@@ -27,9 +27,13 @@
                 FROM genetic_entity
                     <where>
                         genetic_entity.stable_id IN
-                            <foreach item="item" collection="list" open="(" separator="," close=")">#{item}</foreach>
+                            <foreach item="item" collection="stableIds" open="(" separator="," close=")">#{item}</foreach>
                     </where>
             )
+            <if test="propertyNames != null and !propertyNames.isEmpty()">
+                AND generic_entity_properties.name IN
+                    <foreach item="name" collection="propertyNames" open="(" separator="," close=")">#{name}</foreach>
+            </if>
     </select>
 
     <select id="getMolecularProfileInternalIdsByMolecularProfileIds" resultType="int">

--- a/src/test/java/org/cbioportal/legacy/persistence/mybatis/GenericAssayMyBatisRepositoryTest.java
+++ b/src/test/java/org/cbioportal/legacy/persistence/mybatis/GenericAssayMyBatisRepositoryTest.java
@@ -38,7 +38,7 @@ public class GenericAssayMyBatisRepositoryTest {
   public void getGenericAssayAdditionalproperties() {
     List<String> stableIds = Arrays.asList("mean_1", "mean_2");
     List<GenericAssayAdditionalProperty> result =
-        genericAssayMyBatisRepository.getGenericAssayAdditionalproperties(stableIds);
+        genericAssayMyBatisRepository.getGenericAssayAdditionalproperties(stableIds, null);
     Assert.assertNotNull(result);
     Assert.assertEquals(4, result.size());
 
@@ -56,6 +56,21 @@ public class GenericAssayMyBatisRepositoryTest {
           Assert.assertEquals("description of mean_2", additionalProperty.getValue());
         }
       }
+    }
+  }
+
+  @Test
+  public void getGenericAssayAdditionalpropertiesRestrictedByName() {
+    List<String> stableIds = Arrays.asList("mean_1", "mean_2");
+    List<GenericAssayAdditionalProperty> result =
+        genericAssayMyBatisRepository.getGenericAssayAdditionalproperties(
+            stableIds, Arrays.asList("name"));
+    Assert.assertNotNull(result);
+    // Only the "name" property for each of the two entities is returned (the "description"
+    // properties are filtered out in SQL).
+    Assert.assertEquals(2, result.size());
+    for (GenericAssayAdditionalProperty additionalProperty : result) {
+      Assert.assertEquals("name", additionalProperty.getName());
     }
   }
 }

--- a/src/test/java/org/cbioportal/legacy/service/impl/GenePanelServiceImplTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/impl/GenePanelServiceImplTest.java
@@ -1,7 +1,6 @@
 package org.cbioportal.legacy.service.impl;
 
 import java.util.*;
-import java.util.stream.Collectors;
 import org.cbioportal.legacy.model.GenePanel;
 import org.cbioportal.legacy.model.GenePanelData;
 import org.cbioportal.legacy.model.GenePanelToGene;
@@ -215,8 +214,7 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
         .thenReturn(Arrays.asList(molecularProfile));
 
     Mockito.when(
-            genePanelRepository.fetchGenePanelDataByMolecularProfileIds(
-                Collections.singleton(MOLECULAR_PROFILE_ID)))
+            genePanelRepository.fetchGenePanelDataInMultipleMolecularProfiles(Mockito.anyList()))
         .thenReturn(genePanelDataList);
 
     List<GenePanelData> result =
@@ -270,14 +268,11 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
     profileCaseIdentifier3.setCaseId(SAMPLE_ID3);
     molecularProfileSampleIdentifiers.add(profileCaseIdentifier3);
 
+    // The repository now filters to the requested (profile, case) pairs in SQL, so it returns
+    // only the matching rows directly.
     Mockito.when(
-            genePanelRepository.fetchGenePanelDataByMolecularProfileIds(
-                Collections.singleton(MOLECULAR_PROFILE_ID)))
+            genePanelRepository.fetchGenePanelDataInMultipleMolecularProfiles(Mockito.anyList()))
         .thenReturn(genePanelDataList);
-    Set<String> molecularProfileIds =
-        molecularProfileSampleIdentifiers.stream()
-            .map(MolecularProfileCaseIdentifier::getMolecularProfileId)
-            .collect(Collectors.toSet());
 
     MolecularProfile molecularProfile = new MolecularProfile();
     molecularProfile.setStableId(MOLECULAR_PROFILE_ID);
@@ -285,9 +280,10 @@ public class GenePanelServiceImplTest extends BaseServiceImplTest {
     molecularProfile.setMolecularAlterationType(
         MolecularProfile.MolecularAlterationType.COPY_NUMBER_ALTERATION);
 
+    // Profile metadata is now looked up only for the profiles present in the returned rows.
     Mockito.when(
             molecularProfileService.getMolecularProfiles(
-                new HashSet<>(molecularProfileIds), "SUMMARY"))
+                Collections.singleton(MOLECULAR_PROFILE_ID), "SUMMARY"))
         .thenReturn(Arrays.asList(molecularProfile));
 
     List<GenePanelData> result =

--- a/src/test/java/org/cbioportal/legacy/service/impl/GenericAssayServiceImpTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/impl/GenericAssayServiceImpTest.java
@@ -277,7 +277,9 @@ public class GenericAssayServiceImpTest extends BaseServiceImplTest {
         .thenReturn(mockGenericAssayMetaList);
     Mockito.when(genericAssayRepository.getGenericAssayStableIdsByMolecularIds(PROFILE_ID_LIST))
         .thenReturn(idList);
-    Mockito.when(genericAssayRepository.getGenericAssayAdditionalproperties(idList))
+    Mockito.when(
+            genericAssayRepository.getGenericAssayAdditionalproperties(
+                Mockito.eq(idList), Mockito.anyList()))
         .thenReturn(mockGenericAssayAdditionalPropertyList);
 
     List<GenericAssayMeta> result =


### PR DESCRIPTION
## What

Restores the memory optimization from #12210 (commit `3b00a2688a`), which was reverted in #12225 (`30831bfb21`).

This is a clean cherry-pick of the original optimization onto current `master`. The only merge conflict — in `GenePanelServiceImpl.java` — came from a SonarCloud field-rename that the revert PR had bundled in; those fields are **deleted** by this optimization, so the rename was moot and resolved in favor of the optimized code.

## The optimization (unchanged from #12210)

- **`gene-panel-data/fetch` (sampleMolecularIdentifiers path):** use the SQL-filtered mapper (`fetchGenePanelDataInMultipleMolecularProfiles[ByPatientIds]`) instead of fetching gene panel data for every sample of each requested profile and filtering in Java. The sequenced-sample-list profiled annotation for MUTATION profiles is preserved via the new `annotateBySequencedSampleLists` helper.
- **`generic_assay_meta/fetch` (SUMMARY projection):** restrict the generic-entity properties query to the names the frontend consumes (NAME/DESCRIPTION/URL) via an optional `propertyNames` SQL filter, instead of loading every property for every entity. DETAILED still returns the full map.

Original benchmarks (ClickHouse Cloud clone, `-Xmx2g`, N=24):
- gene-panel (10 samples of a 54k-sample profile): heap alloc/req 118 → 44 MB (−63%), peak heap 570 → 285 MB (−50%), latency 0.49 → 0.34s; response byte-identical.

## Verification

- `mvn -o compile` succeeds against the current `master` base.
- Net diff vs `master`: +366 / −43 across 14 files — the exact inverse of the revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)