### PR TITLE
Improve release-drafter: update action, fix cl-skip-changelog check, add breaking API label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,6 +23,9 @@ categories:
     labels:
       - 'style tweak'
       - 'cl-style-tweak'
+  - title: '💥 Breaking API Changes'
+    labels:
+      - 'breaking-api'
   - title: '⚙️ REST API Changes'
     labels:
       - 'api'

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -26,8 +26,7 @@ jobs:
       - name: Get Labels from release-drafter.yml
         id: get_labels
         run: |
-          curl -s "https://raw.githubusercontent.com/cBioPortal/cbioportal/master/.github/release-drafter.yml" | \
-            yq -r '.categories[].labels[]' > labels.txt
+          yq -r '.categories[].labels[]' .github/release-drafter.yml > labels.txt
       - name: Check Labels
         id: check_labels
         run: |

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -39,8 +39,8 @@ jobs:
           pr_label_index=0
           while [ $pr_label_index -lt ${#PR_LABELS[@]} ] ; do
             pr_label="${PR_LABELS[$pr_label_index]}"
-            if [[ "$pr_label" == "skip-changelog" ]] ; then
-              echo "PR contains a valid label: skip-changelog"
+            if [[ "$pr_label" == "skip-changelog" || "$pr_label" == "cl-skip-changelog" ]] ; then
+              echo "PR contains a valid label: $pr_label"
               exit 0  # Valid label found, exit successfully
             fi
             available_label_index=0

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: toolmantim/release-drafter@v5.2.0
+      - uses: release-drafter/release-drafter@v7.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- **`release-management.yml`**: Updates action from `toolmantim/release-drafter@v5.2.0` to `release-drafter/release-drafter@v7.4.0`. The project migrated orgs over 3 years ago; the old `toolmantim` reference still redirects but pins a version from 2021 and misses all maintenance and security updates since then.
- **`label-check.yml`**: Three fixes:
  - Reads `release-drafter.yml` from the checked-out PR branch instead of fetching from the hardcoded `master` URL — previously any label added to a category in `release-drafter.yml` would not be recognized by the check until after its PR merged.
  - Adds `cl-skip-changelog` as a valid skip label alongside the existing `skip-changelog`, matching the `exclude-labels` list in `release-drafter.yml`.
- **`release-drafter.yml`**: Adds a `💥 Breaking API Changes` category (label: `breaking-api`) above the existing `⚙️ REST API Changes` category. This lets downstream users immediately see whether a release requires code changes on their end, as opposed to purely additive API updates.

## Test plan

- [ ] Confirm the Release Management workflow runs successfully on next merge to master
- [ ] Open a test PR, apply `cl-skip-changelog` label only, verify label-check passes
- [ ] Apply `breaking-api` label to a PR and confirm label-check passes and it appears under the new category in the draft release

🤖 Generated with [Claude Code](https://claude.com/claude-code)