### PR TITLE
refactor: migrate 15 legacy web controllers from field injection to c…

### DIFF
--- a/src/main/java/org/cbioportal/legacy/web/AlterationDriverAnnotationController.java
+++ b/src/main/java/org/cbioportal/legacy/web/AlterationDriverAnnotationController.java
@@ -10,7 +10,6 @@ import java.util.List;
 import org.cbioportal.legacy.model.CustomDriverAnnotationReport;
 import org.cbioportal.legacy.service.AlterationDriverAnnotationService;
 import org.cbioportal.legacy.web.config.annotation.InternalApi;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +27,12 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Custom driver annotations", description = " ")
 public class AlterationDriverAnnotationController {
 
-  @Autowired private AlterationDriverAnnotationService alterationDriverAnnotationService;
+  private final AlterationDriverAnnotationService alterationDriverAnnotationService;
+
+  public AlterationDriverAnnotationController(
+      AlterationDriverAnnotationService alterationDriverAnnotationService) {
+    this.alterationDriverAnnotationService = alterationDriverAnnotationService;
+  }
 
   @PreAuthorize(
       "hasPermission(#molecularProfileIds, 'Collection<MolecularProfileId>', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")

--- a/src/main/java/org/cbioportal/legacy/web/AlterationEnrichmentController.java
+++ b/src/main/java/org/cbioportal/legacy/web/AlterationEnrichmentController.java
@@ -22,7 +22,6 @@ import org.cbioportal.legacy.service.exception.MolecularProfileNotFoundException
 import org.cbioportal.legacy.web.config.annotation.InternalApi;
 import org.cbioportal.legacy.web.parameter.MolecularProfileCasesGroupAndAlterationTypeFilter;
 import org.cbioportal.legacy.web.parameter.MolecularProfileCasesGroupFilter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -43,7 +42,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Alteration Enrichments", description = " ")
 public class AlterationEnrichmentController {
 
-  @Autowired private AlterationEnrichmentService alterationEnrichmentService;
+  private final AlterationEnrichmentService alterationEnrichmentService;
+
+  public AlterationEnrichmentController(AlterationEnrichmentService alterationEnrichmentService) {
+    this.alterationEnrichmentService = alterationEnrichmentService;
+  }
 
   @PreAuthorize(
       "hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")

--- a/src/main/java/org/cbioportal/legacy/web/CancerTypeController.java
+++ b/src/main/java/org/cbioportal/legacy/web/CancerTypeController.java
@@ -20,7 +20,6 @@ import org.cbioportal.legacy.web.parameter.HeaderKeyConstants;
 import org.cbioportal.legacy.web.parameter.PagingConstants;
 import org.cbioportal.legacy.web.parameter.Projection;
 import org.cbioportal.legacy.web.parameter.sort.CancerTypeSortBy;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -38,7 +37,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = PublicApiTags.CANCER_TYPES, description = " ")
 public class CancerTypeController {
 
-  @Autowired private CancerTypeService cancerTypeService;
+  private final CancerTypeService cancerTypeService;
+
+  public CancerTypeController(CancerTypeService cancerTypeService) {
+    this.cancerTypeService = cancerTypeService;
+  }
 
   @RequestMapping(
       value = "/api/cancer-types",

--- a/src/main/java/org/cbioportal/legacy/web/ClinicalAttributeController.java
+++ b/src/main/java/org/cbioportal/legacy/web/ClinicalAttributeController.java
@@ -22,7 +22,6 @@ import org.cbioportal.legacy.web.parameter.HeaderKeyConstants;
 import org.cbioportal.legacy.web.parameter.PagingConstants;
 import org.cbioportal.legacy.web.parameter.Projection;
 import org.cbioportal.legacy.web.parameter.sort.ClinicalAttributeSortBy;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -43,7 +42,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = PublicApiTags.CLINICAL_ATTRIBUTES, description = " ")
 public class ClinicalAttributeController {
 
-  @Autowired private ClinicalAttributeService clinicalAttributeService;
+  private final ClinicalAttributeService clinicalAttributeService;
+
+  public ClinicalAttributeController(ClinicalAttributeService clinicalAttributeService) {
+    this.clinicalAttributeService = clinicalAttributeService;
+  }
 
   @RequestMapping(
       value = "/clinical-attributes",

--- a/src/main/java/org/cbioportal/legacy/web/ClinicalAttributeCountController.java
+++ b/src/main/java/org/cbioportal/legacy/web/ClinicalAttributeCountController.java
@@ -17,7 +17,6 @@ import org.cbioportal.legacy.web.config.InternalApiTags;
 import org.cbioportal.legacy.web.config.annotation.InternalApi;
 import org.cbioportal.legacy.web.parameter.ClinicalAttributeCountFilter;
 import org.cbioportal.legacy.web.parameter.SampleIdentifier;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -36,7 +35,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = InternalApiTags.CLINICAL_ATTRIBUTES_COUNT, description = " ")
 public class ClinicalAttributeCountController {
 
-  @Autowired private ClinicalAttributeService clinicalAttributeService;
+  private final ClinicalAttributeService clinicalAttributeService;
+
+  public ClinicalAttributeCountController(ClinicalAttributeService clinicalAttributeService) {
+    this.clinicalAttributeService = clinicalAttributeService;
+  }
 
   @PreAuthorize(
       "hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")

--- a/src/main/java/org/cbioportal/legacy/web/ClinicalEventController.java
+++ b/src/main/java/org/cbioportal/legacy/web/ClinicalEventController.java
@@ -26,7 +26,6 @@ import org.cbioportal.legacy.web.parameter.PagingConstants;
 import org.cbioportal.legacy.web.parameter.PatientIdentifier;
 import org.cbioportal.legacy.web.parameter.Projection;
 import org.cbioportal.legacy.web.parameter.sort.ClinicalEventSortBy;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -49,7 +48,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = InternalApiTags.CLINICAL_EVENTS, description = " ")
 public class ClinicalEventController {
 
-  @Autowired private ClinicalEventService clinicalEventService;
+  private final ClinicalEventService clinicalEventService;
+
+  public ClinicalEventController(ClinicalEventService clinicalEventService) {
+    this.clinicalEventService = clinicalEventService;
+  }
 
   @PreAuthorize(
       "hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")

--- a/src/main/java/org/cbioportal/legacy/web/CoExpressionController.java
+++ b/src/main/java/org/cbioportal/legacy/web/CoExpressionController.java
@@ -16,7 +16,6 @@ import org.cbioportal.legacy.service.CoExpressionService;
 import org.cbioportal.legacy.utils.config.annotation.ConditionalOnProperty;
 import org.cbioportal.legacy.web.config.annotation.InternalApi;
 import org.cbioportal.legacy.web.parameter.CoExpressionFilter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -37,7 +36,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Co-Expressions", description = " ")
 public class CoExpressionController {
 
-  @Autowired private CoExpressionService coExpressionService;
+  private final CoExpressionService coExpressionService;
+
+  public CoExpressionController(CoExpressionService coExpressionService) {
+    this.coExpressionService = coExpressionService;
+  }
 
   // requires permission to access both molecularProfileIdA and molecularProfileIdB because service
   // layer does not enforce requirement that both profiles are in the same study

--- a/src/main/java/org/cbioportal/legacy/web/CopyNumberSegmentController.java
+++ b/src/main/java/org/cbioportal/legacy/web/CopyNumberSegmentController.java
@@ -25,7 +25,6 @@ import org.cbioportal.legacy.web.parameter.PagingConstants;
 import org.cbioportal.legacy.web.parameter.Projection;
 import org.cbioportal.legacy.web.parameter.SampleIdentifier;
 import org.cbioportal.legacy.web.parameter.sort.CopyNumberSegmentSortBy;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -50,7 +49,11 @@ public class CopyNumberSegmentController {
   private static final int COPY_NUMBER_SEGMENT_MAX_PAGE_SIZE = 20000;
   private static final String COPY_NUMBER_SEGMENT_DEFAULT_PAGE_SIZE = "20000";
 
-  @Autowired private CopyNumberSegmentService copyNumberSegmentService;
+  private final CopyNumberSegmentService copyNumberSegmentService;
+
+  public CopyNumberSegmentController(CopyNumberSegmentService copyNumberSegmentService) {
+    this.copyNumberSegmentService = copyNumberSegmentService;
+  }
 
   @PreAuthorize(
       "hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")

--- a/src/main/java/org/cbioportal/legacy/web/DiscreteCopyNumberController.java
+++ b/src/main/java/org/cbioportal/legacy/web/DiscreteCopyNumberController.java
@@ -19,7 +19,6 @@ import org.cbioportal.legacy.web.parameter.DiscreteCopyNumberEventType;
 import org.cbioportal.legacy.web.parameter.DiscreteCopyNumberFilter;
 import org.cbioportal.legacy.web.parameter.HeaderKeyConstants;
 import org.cbioportal.legacy.web.parameter.Projection;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -40,7 +39,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = PublicApiTags.DISCRETE_COPY_NUMBER_ALTERATIONS, description = " ")
 public class DiscreteCopyNumberController {
 
-  @Autowired private DiscreteCopyNumberService discreteCopyNumberService;
+  private final DiscreteCopyNumberService discreteCopyNumberService;
+
+  public DiscreteCopyNumberController(DiscreteCopyNumberService discreteCopyNumberService) {
+    this.discreteCopyNumberService = discreteCopyNumberService;
+  }
 
   @PreAuthorize(
       "hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")

--- a/src/main/java/org/cbioportal/legacy/web/DiscreteCopyNumberCountController.java
+++ b/src/main/java/org/cbioportal/legacy/web/DiscreteCopyNumberCountController.java
@@ -16,7 +16,6 @@ import org.cbioportal.legacy.service.exception.MolecularProfileNotFoundException
 import org.cbioportal.legacy.web.config.InternalApiTags;
 import org.cbioportal.legacy.web.config.annotation.InternalApi;
 import org.cbioportal.legacy.web.parameter.CopyNumberCountIdentifier;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -37,7 +36,11 @@ public class DiscreteCopyNumberCountController {
 
   private static final int COPY_NUMBER_COUNT_MAX_PAGE_SIZE = 50000;
 
-  @Autowired private DiscreteCopyNumberService discreteCopyNumberService;
+  private final DiscreteCopyNumberService discreteCopyNumberService;
+
+  public DiscreteCopyNumberCountController(DiscreteCopyNumberService discreteCopyNumberService) {
+    this.discreteCopyNumberService = discreteCopyNumberService;
+  }
 
   @PreAuthorize(
       "hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")

--- a/src/main/java/org/cbioportal/legacy/web/ExpressionEnrichmentController.java
+++ b/src/main/java/org/cbioportal/legacy/web/ExpressionEnrichmentController.java
@@ -23,7 +23,6 @@ import org.cbioportal.legacy.service.exception.GenericAssayNotFoundException;
 import org.cbioportal.legacy.service.exception.MolecularProfileNotFoundException;
 import org.cbioportal.legacy.web.config.annotation.InternalApi;
 import org.cbioportal.legacy.web.parameter.MolecularProfileCasesGroupFilter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -42,7 +41,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @Tag(name = "Enrichments", description = " ")
 public class ExpressionEnrichmentController {
-  @Autowired private ExpressionEnrichmentService expressionEnrichmentService;
+  private final ExpressionEnrichmentService expressionEnrichmentService;
+
+  public ExpressionEnrichmentController(ExpressionEnrichmentService expressionEnrichmentService) {
+    this.expressionEnrichmentService = expressionEnrichmentService;
+  }
 
   @PreAuthorize(
       "hasPermission(#involvedCancerStudies, 'Collection<CancerStudyId>', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")

--- a/src/main/java/org/cbioportal/legacy/web/GeneController.java
+++ b/src/main/java/org/cbioportal/legacy/web/GeneController.java
@@ -23,7 +23,6 @@ import org.cbioportal.legacy.web.parameter.HeaderKeyConstants;
 import org.cbioportal.legacy.web.parameter.PagingConstants;
 import org.cbioportal.legacy.web.parameter.Projection;
 import org.cbioportal.legacy.web.parameter.sort.GeneSortBy;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -42,7 +41,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = PublicApiTags.GENES, description = " ")
 public class GeneController {
 
-  @Autowired private GeneService geneService;
+  private final GeneService geneService;
+
+  public GeneController(GeneService geneService) {
+    this.geneService = geneService;
+  }
 
   @RequestMapping(
       value = "/api/genes",

--- a/src/main/java/org/cbioportal/legacy/web/GenePanelController.java
+++ b/src/main/java/org/cbioportal/legacy/web/GenePanelController.java
@@ -22,7 +22,6 @@ import org.cbioportal.legacy.web.parameter.HeaderKeyConstants;
 import org.cbioportal.legacy.web.parameter.PagingConstants;
 import org.cbioportal.legacy.web.parameter.Projection;
 import org.cbioportal.legacy.web.parameter.sort.GenePanelSortBy;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -42,7 +41,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = PublicApiTags.GENE_PANELS, description = " ")
 public class GenePanelController {
 
-  @Autowired private GenePanelService genePanelService;
+  private final GenePanelService genePanelService;
+
+  public GenePanelController(GenePanelService genePanelService) {
+    this.genePanelService = genePanelService;
+  }
 
   @Hidden
   @RequestMapping(

--- a/src/main/java/org/cbioportal/legacy/web/GenePanelDataController.java
+++ b/src/main/java/org/cbioportal/legacy/web/GenePanelDataController.java
@@ -21,7 +21,6 @@ import org.cbioportal.legacy.web.config.annotation.PublicApi;
 import org.cbioportal.legacy.web.parameter.GenePanelDataFilter;
 import org.cbioportal.legacy.web.parameter.GenePanelDataMultipleStudyFilter;
 import org.cbioportal.legacy.web.parameter.SampleMolecularIdentifier;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -42,7 +41,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = PublicApiTags.GENE_PANEL_DATA, description = " ")
 public class GenePanelDataController {
 
-  @Autowired private GenePanelService genePanelService;
+  private final GenePanelService genePanelService;
+
+  public GenePanelDataController(GenePanelService genePanelService) {
+    this.genePanelService = genePanelService;
+  }
 
   @PreAuthorize(
       "hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")

--- a/src/main/java/org/cbioportal/legacy/web/GenericAssayDataController.java
+++ b/src/main/java/org/cbioportal/legacy/web/GenericAssayDataController.java
@@ -24,7 +24,6 @@ import org.cbioportal.legacy.web.parameter.GenericAssayFilter;
 import org.cbioportal.legacy.web.parameter.HeaderKeyConstants;
 import org.cbioportal.legacy.web.parameter.Projection;
 import org.cbioportal.legacy.web.parameter.SampleMolecularIdentifier;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -47,7 +46,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = PublicApiTags.GENERIC_ASSAY_DATA, description = " ")
 public class GenericAssayDataController {
 
-  @Autowired private GenericAssayService genericAssayService;
+  private final GenericAssayService genericAssayService;
+
+  public GenericAssayDataController(GenericAssayService genericAssayService) {
+    this.genericAssayService = genericAssayService;
+  }
 
   @PreAuthorize(
       "hasPermission(#molecularProfileId, 'MolecularProfileId', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")


### PR DESCRIPTION
Follow-up to #12212 (constructor injection PoC, approved by @dippindots).

## Describe changes proposed in this pull request:
- Migrates the first batch of 15 legacy web controllers from `@Autowired` field injection to constructor injection
- Makes all injected dependencies `private final`, ensuring they cannot be null or reassigned
- Removes the now-unused `import org.springframework.beans.factory.annotation.Autowired` from each file
- No logic changes whatsoever — purely a mechanical find-and-replace style refactor as discussed in #12212

**Controllers migrated in this batch:**
`AlterationDriverAnnotationController`, `AlterationEnrichmentController`, `CancerTypeController`, `ClinicalAttributeController`, `ClinicalAttributeCountController`, `ClinicalEventController`, `CoExpressionController`, `CopyNumberSegmentController`, `DiscreteCopyNumberController`, `DiscreteCopyNumberCountController`, `ExpressionEnrichmentController`, `GeneController`, `GenePanelController`, `GenePanelDataController`, `GenericAssayDataController`

# Checks
- [x] The commit log is comprehensible and follows the 7 rules of great commit messages
- [x] No tests added — this is a pure mechanical refactor with no logic changes. Constructor injection is verified by the existing Spring context and the build passing successfully.
- [x] This PR does not add logic based on clinical attributes
- [x] Label: `refactoring`

# Any screenshots or GIFs?
N/A — no visual changes. Backend refactor only.

# Notify reviewers
Used `git blame` to identify authors. Tagging @dippindots as reviewer since he approved the PoC PR (#12212) and greenlit this batch migration.
