### PR TITLE
Add dev/qc-harness: replay real traffic to QC a PR (parity/memory/latency)

### DIFF
--- a/.claude/skills/qc-pr/SKILL.md
+++ b/.claude/skills/qc-pr/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: qc-pr
+description: QC a cBioPortal optimization PR by replaying real captured traffic (cbioportal_qc) against OLD vs NEW builds to verify response parity and measure memory/latency. Use when asked to QC, verify, benchmark, or "confirm the same result / faster / lighter" for a performance or optimization PR.
+---
+
+# QC a cBioPortal optimization PR
+
+Replays real production requests against two builds (OLD = baseline, NEW = the PR) and
+reports **parity** (identical responses?), **memory**, and **latency**. The tools live in
+`dev/qc-harness/` (see its `README.md` for full detail and the gotcha list); this skill is
+the playbook for driving them.
+
+## Requires: the ClickHouse MCP
+
+Corpus building and every bit of data exploration — discovering which endpoints have
+traffic, finding the pathological request shape for a memory test, checking study/value
+coverage, investigating a suspected regression — read the `cbioportal_qc` request-log
+database and the data clone. **The read-only replay credential (`apitests`) cannot read
+`cbioportal_qc`**, so do those queries through the ClickHouse MCP (`mcp-clickhouse`), whose
+user has the needed grants.
+
+Configure it as a project MCP server in `.mcp.json` at the repo root (an example is shipped
+at `dev/qc-harness/.mcp.json.example`):
+
+```json
+{
+  "mcpServers": {
+    "mcp-clickhouse": {
+      "command": "uv",
+      "args": ["run", "--with", "mcp-clickhouse", "--python", "3.13", "mcp-clickhouse"],
+      "env": {
+        "CLICKHOUSE_HOST": "dl96orhu96.us-east-1.aws.clickhouse.cloud",
+        "CLICKHOUSE_PORT": "8443",
+        "CLICKHOUSE_SECURE": "true",
+        "CLICKHOUSE_VERIFY": "true",
+        "CLICKHOUSE_USER": "<user-with-SELECT-on-cbioportal_qc-and-the-clone>",
+        "CLICKHOUSE_PASSWORD": "<password>",
+        "CLICKHOUSE_DATABASE": "cbioportal_qc"
+      }
+    }
+  }
+}
+```
+
+The MCP user needs `SELECT` on `cbioportal_qc` **and** the clone DB (e.g.
+`cbioportal_public_clone_*`). Never commit real credentials — keep `.mcp.json` out of git.
+It exposes `list_databases`, `list_tables`, and `run_query`.
+
+## Choose the approach first
+
+- **Pure SQL / mapper change** (e.g. a `*Mapper.xml` rewrite): skip the app. Render both query
+  versions with real params and measure straight from the ClickHouse HTTP
+  `X-ClickHouse-Summary` header (`read_rows` / `read_bytes` / `elapsed`). Pattern:
+  `dev/qc-harness/examples/coexp_sql_ab.py`. `read_rows`/`read_bytes` are cache-independent and
+  are exactly any "N× fewer rows read" claim; parity = identical sorted result rows.
+- **App behavior change** (controllers/services/serialization): full end-to-end via `qc.sh`.
+- **Any memory claim**: a broad corpus often shows *zero* benefit — see traps below.
+
+## Steps (end-to-end)
+
+1. `cp dev/qc-harness/config.env.example dev/qc-harness/config.env` and fill in creds.
+2. Find the PR's changed endpoint(s) and confirm there's traffic (MCP):
+   `SELECT endpoint, count(), uniqExact(body) FROM cbioportal_qc.logged_requests
+    WHERE endpoint LIKE '%...%' GROUP BY endpoint`.
+3. Run it:
+   `dev/qc-harness/qc.sh <old-ref> <new-ref> '<endpoint-LIKE>' <label> [count] [random|size]`
+   (`random` = representative mix; `size` = heaviest requests).
+4. Read the output: **parity is the gate**; latency as the OLD→NEW *delta*; peak heap / alloc.
+
+## Interpreting + traps (the parts that bite)
+
+- **Parity is the gate.** A single mismatch is a blocker — dump bodies with `--save-bodies`
+  and investigate before trusting any speed/memory number.
+- **Coverage trap (most important).** A passing parity run only covers what you *sampled*.
+  For changes that **narrow** behavior (filters, projections, `IN`-lists, case-sensitive
+  matches), the regression hides in the rows you didn't replay. Before declaring parity:
+  query the clone for the values the change could drop and confirm they still appear. (A
+  case-sensitive property-name `IN` filter regression sat behind a green broad run exactly
+  this way — caught only by querying the clone for lower/mixed-case values.)
+- **Memory is request-shape-dependent.** "Heavy by request-body size" ≠ "heap-stressing."
+  The win usually needs a specific shape — a few rows of a huge entity, or one large response
+  multiplied by concurrency (`replay.py --workers N`). Construct that shape (often from the DB
+  via MCP) rather than assuming a big corpus exercises it.
+- **Boot the A/B sequentially** — one `-Xmx2g` JVM fits this box; two do not.
+- **Other gotchas** (the runnable jar is `cbioportal-exec.jar`; `-Dmaven.gitcommitid.skip=true`
+  in worktrees; gzip request bodies are byte-corrupted in the log and unreplayable; preserve
+  query strings): documented in `dev/qc-harness/README.md`.
+
+## Reporting
+
+Lead with the parity verdict, then memory and latency as OLD→NEW deltas. State the corpus
+(endpoint, count, random/size) and call out coverage limits explicitly — what shapes were and
+were not exercised.

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ docs/.obsidian/
 .hermes/
 docker-test-checklist.md
 command-audit.md
+
+# Local MCP server config (may hold credentials)
+.mcp.json

--- a/dev/qc-harness/.gitignore
+++ b/dev/qc-harness/.gitignore
@@ -1,0 +1,8 @@
+# Local secrets and run artifacts — never commit.
+config.env
+*.jar
+*.log
+results-*.jsonl
+corpus*.tsv
+work/
+__pycache__/

--- a/dev/qc-harness/.mcp.json.example
+++ b/dev/qc-harness/.mcp.json.example
@@ -1,0 +1,20 @@
+{
+  "_comment": "Copy to .mcp.json at the repo root and fill in credentials. The qc-pr skill / corpus extraction reads cbioportal_qc and the data clone through this server. The user needs SELECT on cbioportal_qc AND the clone DB. Do NOT commit real credentials.",
+  "mcpServers": {
+    "mcp-clickhouse": {
+      "command": "uv",
+      "args": ["run", "--with", "mcp-clickhouse", "--python", "3.13", "mcp-clickhouse"],
+      "env": {
+        "CLICKHOUSE_HOST": "dl96orhu96.us-east-1.aws.clickhouse.cloud",
+        "CLICKHOUSE_PORT": "8443",
+        "CLICKHOUSE_SECURE": "true",
+        "CLICKHOUSE_VERIFY": "true",
+        "CLICKHOUSE_CONNECT_TIMEOUT": "30",
+        "CLICKHOUSE_SEND_RECEIVE_TIMEOUT": "300",
+        "CLICKHOUSE_USER": "REPLACE_ME",
+        "CLICKHOUSE_PASSWORD": "REPLACE_ME",
+        "CLICKHOUSE_DATABASE": "cbioportal_qc"
+      }
+    }
+  }
+}

--- a/dev/qc-harness/README.md
+++ b/dev/qc-harness/README.md
@@ -1,0 +1,117 @@
+# QC harness — replay real traffic to verify a PR
+
+Tools to **replay real captured production traffic against two builds of cBioPortal**
+and check that a change is correct (identical responses), and what it does to memory
+and latency. Built for performance/optimization PRs where "does it still return the
+same thing, and is it actually faster / lighter?" needs a quantitative answer.
+
+It has been used to QC several PRs (gene-panel / generic-assay memory cut; the
+copy-number-segments/mutations/clinical-data streaming change; the co-expression
+single-scan rewrite).
+
+## How it works
+
+Real requests are captured in `cbioportal_qc.logged_requests` (method, path, query
+string, headers, body, response status). The harness:
+
+1. **builds two jars** from two git refs (OLD = baseline, NEW = the PR),
+2. **extracts a corpus** of real requests for the endpoint(s) the PR touches,
+3. **replays the corpus** against each backend (pointed at the public ClickHouse
+   clone), recording status, latency, and a content hash of each response,
+4. **compares** OLD vs NEW: parity (responses identical?), latency distribution, and
+   peak heap / allocation from GC logs.
+
+Backends are booted **one at a time** (`-Xmx2g`) — see gotchas.
+
+## Setup
+
+```bash
+cp config.env.example config.env      # then set CH_PASSWORD (read-only staging cred)
+```
+
+`config.env` is gitignored. The defaults point at the same read-only public-staging
+ClickHouse clone used by `.circleci/config.yml`.
+
+## Quick start — full end-to-end A/B
+
+```bash
+# qc.sh <old-ref> <new-ref> <endpoint-LIKE> <label> [count] [order]
+./qc.sh master my-pr-branch '%co-expression%' coexp 80 random
+```
+
+Prints a parity verdict, latency percentiles (OLD vs NEW), and peak heap / alloc.
+
+## Quick start — pure-SQL change (no app build)
+
+If the PR is only a mapper/SQL change, you can measure it directly against ClickHouse
+via the HTTP `X-ClickHouse-Summary` header (read_rows / read_bytes / elapsed) without
+building the app — see `examples/coexp_sql_ab.py`.
+
+```bash
+set -a; source config.env; set +a
+python3 examples/coexp_sql_ab.py
+```
+
+## Pieces
+
+| Path | What |
+|---|---|
+| `qc.sh` | orchestrator: build → extract → replay OLD → replay NEW → compare |
+| `bin/build-ab.sh` | build OLD/NEW `cbioportal-exec.jar` from two refs (throwaway worktrees) |
+| `bin/extract-corpus.sh` | pull a replay corpus for an endpoint from `cbioportal_qc` |
+| `bin/run-backend.sh` | boot one jar vs the clone, clickhouse mode, GC-logged |
+| `lib/replay.py` | replay a corpus, record status/latency/raw+canonical response hash; `--workers N` for concurrency |
+| `lib/compare.py` | parity (raw or order-tolerant canonical) + latency diff of two result files |
+| `lib/gcstats.py` | parse a `-Xlog:gc*` log → peak heap + allocated-bytes/request |
+| `examples/coexp_sql_ab.py` | SQL-level A/B via X-ClickHouse-Summary (template) |
+
+## Reading the results
+
+- **Parity** is the gate. `compare.py` treats two responses as identical if the raw
+  bytes match **or** their canonical forms match (arrays sorted) — endpoints without
+  an `ORDER BY` legitimately return rows in different orders between builds.
+- **Latency** is end-to-end HTTP. Absolute numbers are network/cache-sensitive
+  (the clone is remote ClickHouse Cloud); the OLD-vs-NEW *delta* is the signal. The
+  harness warms each backend before measuring.
+- **Memory** = peak post-GC heap and allocated-bytes/request from the GC log.
+
+## Gotchas (learned the hard way — don't rediscover these)
+
+- **The runnable jar is `target/cbioportal-exec.jar`**, not `cbioportal.jar` (the
+  latter is the thin, non-bootable jar).
+- **`-Dmaven.gitcommitid.skip=true`** is required when building inside a git worktree
+  (the git-commit-id plugin can't read a worktree's `.git` file and aborts the build).
+- **`application.properties` is gitignored** — `build-ab.sh` seeds it so the build's
+  resource-filtering step succeeds; the runtime datasource is overridden anyway.
+- **Logged request bodies: the gzipped ones are byte-corrupted** in the table (a
+  lossy-UTF-8 capture turned the gzip magic into U+FFFD). They are *not* replayable —
+  `extract-corpus.sh` filters to clean JSON only. The corrupted bodies are usually the
+  *largest* requests, so a clean corpus under-samples big responses (see next point).
+- **Preserve query strings.** `projection`, `threshold`, `clinicalDataType`, etc. live
+  in the query string and change the response. `replay.py` replays them; the corpus
+  stores them.
+- **Boot A/B sequentially.** One `-Xmx2g` JVM fits comfortably; two concurrently do
+  not (~5 GB). `qc.sh` boots OLD, measures, shuts it down, then NEW.
+- **Memory wins are request-shape-dependent.** "Heavy by request-body size" is *not*
+  the same as "heap-stressing." Several optimizations only help a specific shape (e.g.
+  a few samples from a 54k-sample profile, or a single very large response). A broad
+  corpus can show *zero* memory benefit while the targeted shape shows a large one.
+  When verifying a memory claim, **construct the pathological shape** (often from the
+  DB, e.g. N samples of the biggest profile) and use **`--workers N` concurrency** to
+  surface peak-heap differences — materializing 24 large responses at once is what
+  pushes the heap, not one at a time.
+- **For pure-SQL changes, skip the app.** Render both query versions and read
+  `X-ClickHouse-Summary` — `read_rows`/`read_bytes` are cache-independent and are
+  exactly the "N× fewer rows read" claim; latency there is cache-sensitive, so
+  alternate runs and take medians.
+
+## Corpus tips
+
+`extract-corpus.sh <endpoint-LIKE> <label> <count> <out.tsv> [size|random]`
+
+- `size` order → the largest requests (stress/heavy). `random` → representative mix.
+- Corpus is TSV with every field base64-encoded (binary/quotes survive):
+  `label  path  ct_b64  qs_b64  headers_b64  body_b64`.
+- To find an endpoint's traffic volume / shape first:
+  `SELECT endpoint, count(), uniqExact(body) FROM cbioportal_qc.logged_requests
+   WHERE endpoint LIKE '%...%' GROUP BY endpoint`.

--- a/dev/qc-harness/bin/build-ab.sh
+++ b/dev/qc-harness/bin/build-ab.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Build two cbioportal "exec" jars from two git refs for an A/B comparison.
+# Uses throwaway worktrees so your main checkout is untouched.
+#
+# Usage: build-ab.sh <old-ref> <new-ref>
+#   e.g. build-ab.sh master my-pr-branch
+#
+# Output: <WORK_DIR>/cbioportal-OLD.jar and <WORK_DIR>/cbioportal-NEW.jar
+#
+# Gotchas baked in:
+#  - the runnable artifact is target/cbioportal-EXEC.jar, not cbioportal.jar
+#  - -Dmaven.gitcommitid.skip=true is required when building inside a git worktree
+#  - application.properties is gitignored, so we seed it from the source checkout
+#    (or .EXAMPLE) — runtime datasource is overridden by run-backend.sh anyway
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${HERE}/config.env"
+REPO="$(git -C "$HERE" rev-parse --show-toplevel)"
+mkdir -p "$WORK_DIR"
+
+seed_props() {  # $1 = worktree dir
+  local p="$1/src/main/resources/application.properties"
+  [ -f "$p" ] && return 0
+  if [ -f "$REPO/src/main/resources/application.properties" ]; then
+    cp "$REPO/src/main/resources/application.properties" "$p"
+  else
+    cp "$1/src/main/resources/application.properties.EXAMPLE" "$p"
+  fi
+}
+
+build_ref() {  # $1 = git ref, $2 = OLD|NEW
+  local ref="$1" label="$2" wt="$WORK_DIR/wt-$2"
+  echo ">>> building $label from '$ref'"
+  git -C "$REPO" worktree remove --force "$wt" 2>/dev/null || true
+  git -C "$REPO" worktree add -f "$wt" "$ref" >/dev/null
+  seed_props "$wt"
+  ( cd "$wt" && mvn -q -o package -DskipTests \
+      -Dspotless.check.skip=true -Dmaven.gitcommitid.skip=true )
+  cp "$wt/target/cbioportal-exec.jar" "$WORK_DIR/cbioportal-$label.jar"
+  git -C "$REPO" worktree remove --force "$wt" 2>/dev/null || true
+  echo "    -> $WORK_DIR/cbioportal-$label.jar"
+}
+
+build_ref "$1" OLD
+build_ref "$2" NEW
+echo "md5:"; md5sum "$WORK_DIR"/cbioportal-OLD.jar "$WORK_DIR"/cbioportal-NEW.jar

--- a/dev/qc-harness/bin/extract-corpus.sh
+++ b/dev/qc-harness/bin/extract-corpus.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Build a replay corpus from real captured traffic (cbioportal_qc.logged_requests)
+# for one endpoint pattern. Emits TSV lines: ep<TAB>path<TAB>ct_b64<TAB>qs_b64<TAB>
+# headers_b64<TAB>body_b64  (everything base64 so binary/quotes survive).
+#
+# Usage: extract-corpus.sh <endpoint-LIKE> <label> <count> <out.tsv> [size|random]
+#   e.g. extract-corpus.sh '%co-expression%' coexp 80 corpus.tsv random
+#        extract-corpus.sh '/api/gene-panel-data/fetch' gpd 150 corpus.tsv size
+#
+# Filters applied (learned the hard way):
+#  - response_status=200 only
+#  - clean JSON bodies only: starts {/[ and ends }/], and NO U+FFFD replacement char
+#    (the largest logged bodies are gzipped and were byte-corrupted on capture —
+#     they are NOT replayable, so we exclude them)
+#  - dedup by (query_string, body) — query strings carry projection/threshold/etc.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${HERE}/config.env"
+
+LIKE="$1"; LABEL="$2"; COUNT="$3"; OUT="$4"; ORDER="${5:-size}"
+case "$ORDER" in
+  size)   ORD="length(body) DESC" ;;
+  random) ORD="cityHash64(query_string, body)" ;;
+  *) echo "order must be size|random" >&2; exit 1 ;;
+esac
+
+SQL="
+WITH ranked AS (
+  SELECT path, query_string, content_type, headers, body,
+         row_number() OVER (ORDER BY ${ORD}) AS rn
+  FROM (
+    SELECT DISTINCT path, query_string, content_type, headers, body
+    FROM ${QC_DB}.${QC_TABLE}
+    WHERE method='POST' AND response_status=200 AND endpoint LIKE '${LIKE}'
+      AND ((startsWith(body,'{') AND endsWith(body,'}'))
+        OR (startsWith(body,'[') AND endsWith(body,']')))
+      AND position(body, unhex('EFBFBD'))=0 AND length(body) > 2
+  )
+)
+SELECT arrayStringConcat(groupArray(
+  concat('${LABEL}','\t', path, '\t', base64Encode(content_type), '\t',
+         base64Encode(query_string), '\t', base64Encode(headers), '\t',
+         base64Encode(body))), '\n')
+FROM ranked WHERE rn <= ${COUNT}
+FORMAT TSVRaw"
+
+# Uses the QC-log cred (SELECT on cbioportal_qc), which is distinct from the
+# clone-replay cred (CH_USER). See config.env.
+curl -s -u "${QC_CH_USER}:${QC_CH_PASSWORD}" "${QC_CH_HTTP_URL}/?database=${QC_DB}" \
+  --data-binary "$SQL" > "$OUT"
+if head -c 40 "$OUT" | grep -q 'DB::Exception'; then
+  echo "ERROR from ClickHouse:" >&2; head -c 300 "$OUT" >&2; echo >&2; exit 1
+fi
+echo "wrote $(wc -l < "$OUT") requests -> $OUT"
+awk -F'\t' 'NF!=6{bad++} END{if(bad) print "WARNING: "bad" malformed lines"}' "$OUT"

--- a/dev/qc-harness/bin/run-backend.sh
+++ b/dev/qc-harness/bin/run-backend.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Boot one cbioportal jar against the configured ClickHouse clone, in clickhouse
+# (column-store) mode, with GC logging for the memory measurement.
+#
+# Usage: run-backend.sh <jar> <label> <port>
+# Writes <WORK_DIR>/{app,gc}-<label>.log and <WORK_DIR>/backend-<label>.pid
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${HERE}/config.env"
+
+JAR="$1"; LABEL="$2"; PORT="${3:-8080}"
+mkdir -p "$WORK_DIR"
+GCLOG="$WORK_DIR/gc-$LABEL.log"; APPLOG="$WORK_DIR/app-$LABEL.log"
+rm -f "$GCLOG"
+
+# shellcheck disable=SC2086
+java $JVM_OPTS \
+  -Xlog:gc*:file="$GCLOG":time,uptime,level,tags \
+  -jar "$JAR" \
+  --server.port="$PORT" \
+  --authenticate=false \
+  --clickhouse_mode=true \
+  --spring.profiles.active=clickhouse \
+  --spring.datasource.driver-class-name=com.clickhouse.jdbc.ClickHouseDriver \
+  --spring.datasource.url="$CH_JDBC_URL" \
+  --spring.datasource.username="$CH_USER" \
+  --spring.datasource.password="$CH_PASSWORD" \
+  --spring.datasource.clickhouse.driver-class-name=com.clickhouse.jdbc.ClickHouseDriver \
+  --spring.datasource.clickhouse.url="$CH_JDBC_URL" \
+  --spring.datasource.clickhouse.username="$CH_USER" \
+  --spring.datasource.clickhouse.password="$CH_PASSWORD" \
+  > "$APPLOG" 2>&1 &
+echo $! > "$WORK_DIR/backend-$LABEL.pid"
+echo "started $LABEL pid=$(cat "$WORK_DIR/backend-$LABEL.pid") port=$PORT"
+
+# Wait for readiness (cancer-types is cheap and always present)
+for _ in $(seq 1 60); do
+  code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:$PORT/api/cancer-types?pageSize=1" 2>/dev/null || echo 000)
+  [ "$code" = "200" ] && { echo "$LABEL ready on $PORT"; exit 0; }
+  sleep 5
+done
+echo "ERROR: $LABEL did not become ready — see $APPLOG" >&2; exit 1

--- a/dev/qc-harness/config.env.example
+++ b/dev/qc-harness/config.env.example
@@ -1,0 +1,30 @@
+# Copy to config.env (gitignored) and fill in. Sourced by bin/* and examples/*.
+#
+# The defaults below point at the public read-only ClickHouse staging clone — the
+# same instance and credentials already hardcoded in .circleci/config.yml. Treat the
+# password as low-sensitivity (read-only, public data) but keep it out of git anyway.
+
+# --- ClickHouse (the clone the backend is pointed at) ---
+CH_HTTP_URL="https://dl96orhu96.us-east-1.aws.clickhouse.cloud:8443"
+CH_DB="cbioportal_public_clone_2026_05_27"
+CH_USER="apitests"
+CH_PASSWORD="REPLACE_ME"
+# JDBC form the backend uses (must reference the same DB as CH_DB)
+CH_JDBC_URL="jdbc:ch:${CH_HTTP_URL}/${CH_DB}?zeroDateTimeBehavior=convertToNull&socket_timeout=300000"
+
+# --- QC request log (real captured production traffic) ---
+# NOTE: cbioportal_qc is a SEPARATE database — the read-only CH_USER above (apitests)
+# does NOT have SELECT on it. extract-corpus.sh needs a cred granted on cbioportal_qc;
+# set it here. (If you only have it via another channel/MCP, extract a corpus.tsv that
+# way and feed it straight to lib/replay.py — the rest of the harness needs only CH_*.)
+QC_CH_HTTP_URL="${CH_HTTP_URL}"
+QC_CH_USER="REPLACE_ME"
+QC_CH_PASSWORD="REPLACE_ME"
+QC_DB="cbioportal_qc"
+QC_TABLE="logged_requests"
+
+# --- Backend JVM (matches the PR-benchmark memory method) ---
+JVM_OPTS="-Xms2g -Xmx2g -XX:+UseParallelGC"
+
+# --- Where build-ab.sh / run-backend.sh write jars, logs, results ---
+WORK_DIR="${HOME}/qc-work"

--- a/dev/qc-harness/examples/coexp_sql_ab.py
+++ b/dev/qc-harness/examples/coexp_sql_ab.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""SQL-level A/B example (PR #12187 co-expression rewrite).
+
+Run with config.env in the environment:
+  set -a; source ../config.env; set +a; python3 coexp_sql_ab.py
+
+Measures a pure-SQL change directly via the ClickHouse HTTP X-ClickHouse-Summary
+header (read_rows / read_bytes / elapsed) — no app build needed, since the
+endpoint just serializes the query result.
+
+QC for PR #12187 — co-expression single-scan SQL rewrite.
+
+For each scenario, render the OLD (3-scan, master) and NEW (1-scan, PR) query,
+run each several times against the ClickHouse clone, and capture:
+  - parity: sorted result rows must be identical (PR claims byte-identical)
+  - cost:   read_rows / read_bytes / elapsed from X-ClickHouse-Summary (the PR's claim)
+
+The optional MyBatis sampleUniqueIds filter is omitted: real traffic uses *_all
+sample lists (the whole profile), matching the PR's own full-dataset verification.
+"""
+import json, subprocess, statistics, sys
+
+import os
+CH = os.environ["CH_HTTP_URL"]
+U, P = os.environ["CH_USER"], os.environ["CH_PASSWORD"]
+DB = os.environ["CH_DB"]
+
+OLD = """
+WITH ref_values AS (
+  SELECT sample_unique_id, toFloat64OrNull(alteration_value) AS ref_val
+  FROM genetic_alteration_derived
+  WHERE cancer_study_identifier = '{sa}' AND profile_type = '{pa}'
+    AND hugo_gene_symbol = '{gene}'
+    AND alteration_value != '' AND alteration_value != 'NA'
+    AND toFloat64OrNull(alteration_value) IS NOT NULL
+),
+non_constant_genes AS (
+  SELECT hugo_gene_symbol FROM genetic_alteration_derived
+  WHERE cancer_study_identifier = '{sb}' AND profile_type = '{pb}'
+    AND hugo_gene_symbol != '{gene}'
+    AND alteration_value != '' AND alteration_value != 'NA'
+    AND toFloat64OrNull(alteration_value) IS NOT NULL
+  GROUP BY hugo_gene_symbol HAVING uniqExact(toFloat64OrNull(alteration_value)) > 1
+)
+SELECT g.entrez_gene_id AS entrezGeneId,
+  rankCorr(r.ref_val, toFloat64OrNull(d.alteration_value)) AS spearmansCorrelation,
+  count(*) AS numSamples
+FROM genetic_alteration_derived d
+INNER JOIN ref_values r ON d.sample_unique_id = r.sample_unique_id
+INNER JOIN gene g ON d.hugo_gene_symbol = g.hugo_gene_symbol
+WHERE d.cancer_study_identifier = '{sb}' AND d.profile_type = '{pb}'
+  AND d.hugo_gene_symbol IN (SELECT hugo_gene_symbol FROM non_constant_genes)
+  AND d.alteration_value != '' AND d.alteration_value != 'NA'
+  AND toFloat64OrNull(d.alteration_value) IS NOT NULL
+GROUP BY g.entrez_gene_id
+HAVING count(*) >= 3 AND uniq(toFloat64OrNull(d.alteration_value)) > count(*) / 2
+   AND isFinite(spearmansCorrelation) AND abs(spearmansCorrelation) >= {thr}
+UNION ALL
+SELECT g.entrez_gene_id AS entrezGeneId, NULL AS spearmansCorrelation, count(*) AS numSamples
+FROM genetic_alteration_derived d
+INNER JOIN ref_values r ON d.sample_unique_id = r.sample_unique_id
+INNER JOIN gene g ON d.hugo_gene_symbol = g.hugo_gene_symbol
+WHERE d.cancer_study_identifier = '{sb}' AND d.profile_type = '{pb}'
+  AND d.hugo_gene_symbol != '{gene}'
+  AND d.alteration_value != '' AND d.alteration_value != 'NA'
+  AND toFloat64OrNull(d.alteration_value) IS NOT NULL
+GROUP BY g.entrez_gene_id
+HAVING count(*) < 3 OR uniqExact(toFloat64OrNull(d.alteration_value)) = 1
+    OR uniq(toFloat64OrNull(d.alteration_value)) <= count(*) / 2
+SETTINGS max_bytes_before_external_group_by = 2000000000
+"""
+
+NEW = """
+WITH ref_values AS (
+  SELECT sample_unique_id, toFloat64OrNull(alteration_value) AS ref_val
+  FROM genetic_alteration_derived
+  WHERE cancer_study_identifier = '{sa}' AND profile_type = '{pa}'
+    AND hugo_gene_symbol = '{gene}'
+    AND alteration_value != '' AND alteration_value != 'NA'
+    AND toFloat64OrNull(alteration_value) IS NOT NULL
+),
+per_gene AS (
+  SELECT g.entrez_gene_id AS entrezGeneId, count(*) AS numSamples,
+    uniqExact(toFloat64OrNull(d.alteration_value)) AS exactDistinct,
+    uniq(toFloat64OrNull(d.alteration_value)) AS approxDistinct,
+    groupArray(r.ref_val) AS refValues,
+    groupArray(toFloat64OrNull(d.alteration_value)) AS geneValues
+  FROM genetic_alteration_derived d
+  INNER JOIN ref_values r ON d.sample_unique_id = r.sample_unique_id
+  INNER JOIN gene g ON d.hugo_gene_symbol = g.hugo_gene_symbol
+  WHERE d.cancer_study_identifier = '{sb}' AND d.profile_type = '{pb}'
+    AND d.hugo_gene_symbol != '{gene}'
+    AND d.alteration_value != '' AND d.alteration_value != 'NA'
+    AND toFloat64OrNull(d.alteration_value) IS NOT NULL
+  GROUP BY g.entrez_gene_id
+),
+scored AS (
+  SELECT entrezGeneId, numSamples,
+    (numSamples >= 3 AND exactDistinct > 1 AND approxDistinct > numSamples / 2) AS validNumeric,
+    arrayReduce('rankCorr',
+      if(exactDistinct > 1, refValues, [0., 1.]),
+      if(exactDistinct > 1, geneValues, [0., 1.])) AS corr
+  FROM per_gene
+)
+SELECT entrezGeneId,
+  if(validNumeric AND isFinite(corr), corr, NULL) AS spearmansCorrelation, numSamples
+FROM scored
+WHERE (validNumeric AND isFinite(corr) AND abs(corr) >= {thr}) OR (NOT validNumeric)
+SETTINGS max_bytes_before_external_group_by = 2000000000
+"""
+
+SCEN = [
+  dict(name="skcm_TNFRSF8_thr0.3(PR)", sa="skcm_tcga_pan_can_atlas_2018", pa="rna_seq_v2_mrna",
+       sb="skcm_tcga_pan_can_atlas_2018", pb="rna_seq_v2_mrna", gene="TNFRSF8", thr=0.3),
+  dict(name="ov_AHR_thr0", sa="ov_tcga", pa="rna_seq_v2_mrna", sb="ov_tcga", pb="rna_seq_v2_mrna",
+       gene="AHR", thr=0.0),
+  dict(name="ov_TP53_thr0.3", sa="ov_tcga", pa="rna_seq_v2_mrna", sb="ov_tcga", pb="rna_seq_v2_mrna",
+       gene="TP53", thr=0.3),
+  dict(name="ccle_EGFR_thr0", sa="ccle_broad_2025", pa="rna_seq_mrna", sb="ccle_broad_2025",
+       pb="rna_seq_mrna", gene="EGFR", thr=0.0),
+  dict(name="ov_mrnaU133_TP53_thr0.3", sa="ov_tcga", pa="mrna_U133", sb="ov_tcga", pb="mrna_U133",
+       gene="TP53", thr=0.3),
+]
+
+def run(sql):
+    """Return (sorted_result_text, read_rows, read_bytes, elapsed_s)."""
+    r = subprocess.run(["curl","-s","-u",f"{U}:{P}","-D","/tmp/chh.txt",
+                        f"{CH}/?database={DB}&default_format=TSV","--data-binary",sql],
+                       capture_output=True, text=True, timeout=600)
+    body = r.stdout
+    if "DB::Exception" in body:
+        return ("ERROR: "+body[:200], None, None, None)
+    summ = {}
+    for line in open("/tmp/chh.txt"):
+        if line.lower().startswith("x-clickhouse-summary"):
+            summ = json.loads(line.split(":",1)[1].strip())
+    rows = sorted(body.strip().split("\n")) if body.strip() else []
+    return ("\n".join(rows), int(summ.get("read_rows",0)), int(summ.get("read_bytes",0)),
+            int(summ.get("elapsed_ns",0))/1e9)
+
+ROUNDS = 3
+print(f"{'scenario':<28}{'parity':<10}{'rows OLD→NEW':<26}{'bytesGB O→N':<18}{'med s O→N':<16}{'speedup'}")
+allpass = True
+for s in SCEN:
+    old_sql = OLD.format(**s); new_sql = NEW.format(**s)
+    res_o = res_n = None; to=[]; tn=[]; ro=rn=bo=bn=None
+    for i in range(ROUNDS):  # alternate to share cache fairly; drop round 0
+        o = run(old_sql); n = run(new_sql)
+        if i == 0: res_o, res_n = o[0], n[0]; ro,bo = o[1],o[2]; rn,bn = n[1],n[2]
+        else: to.append(o[3]); tn.append(n[3])
+    if (res_o or "").startswith("ERROR") or (res_n or "").startswith("ERROR"):
+        print(f"{s['name']:<28}ERROR     {(res_o or res_n)[:80]}"); allpass=False; continue
+    parity = "IDENT" if res_o == res_n else "DIFFER"
+    if parity=="DIFFER": allpass=False
+    mo, mn = statistics.median(to), statistics.median(tn)
+    spd = f"{mo/mn:.2f}x" if mn else "n/a"
+    nrows = len(res_o.split("\n")) if res_o else 0
+    print(f"{s['name']:<28}{parity:<10}{ro/1e6:.1f}M→{rn/1e6:.1f}M{'':<6}"
+          f"{bo/1e9:.2f}→{bn/1e9:.2f}{'':<8}{mo:.2f}→{mn:.2f}{'':<7}{spd}  ({nrows} rows)")
+print("\nPARITY VERDICT:", "PASS — all scenarios identical" if allpass else "FAIL — see DIFFER above")

--- a/dev/qc-harness/lib/compare.py
+++ b/dev/qc-harness/lib/compare.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Compare two replay result files (OLD vs NEW) for parity + latency."""
+import json, sys, statistics
+
+def load(p):
+    return {r["idx"]: r for r in (json.loads(l) for l in open(p))}
+
+old = load(sys.argv[1]); new = load(sys.argv[2])
+idxs = sorted(set(old) & set(new))
+
+status_mismatch=[]; parity_mismatch=[]; errors=[]
+lat_old=[]; lat_new=[]
+by_ep = {}
+for i in idxs:
+    o, n = old[i], new[i]
+    ep = o["ep"]; by_ep.setdefault(ep, {"n":0,"parity_ok":0})
+    by_ep[ep]["n"] += 1
+    if o["err"] or n["err"]:
+        errors.append((i, ep, o["err"], n["err"]))
+    if o["status"] != n["status"]:
+        status_mismatch.append((i, ep, o["status"], n["status"]))
+    # identical if raw bytes match, OR (ordering-tolerant) canonical forms match
+    raw_eq = o.get("resp_raw","") == n.get("resp_raw","")
+    canon_eq = (o["resp_canon"] == n["resp_canon"]) and o["resp_canon"] not in ("", "skipped")
+    if raw_eq or canon_eq:
+        by_ep[ep]["parity_ok"] += 1
+    else:
+        parity_mismatch.append((i, ep, o["path"], o.get("resp_raw","")[:18]+"/"+o["resp_canon"][:14],
+                                n.get("resp_raw","")[:18]+"/"+n["resp_canon"][:14]))
+    if o["status"]==200: lat_old.append(o["latency_ms"])
+    if n["status"]==200: lat_new.append(n["latency_ms"])
+
+def pct(v,q):
+    return round(statistics.quantiles(v, n=100)[q-1],1) if len(v)>=2 else (v[0] if v else 0)
+
+print("="*64)
+print(f"PARITY  (n={len(idxs)} requests compared)")
+for ep,d in sorted(by_ep.items()):
+    print(f"  {ep}: {d['parity_ok']}/{d['n']} identical")
+print(f"  status mismatches : {len(status_mismatch)}")
+print(f"  parity mismatches : {len(parity_mismatch)}")
+print(f"  errors            : {len(errors)}")
+if status_mismatch[:10]:
+    print("  -- status mismatches --")
+    for i,ep,a,b in status_mismatch[:10]: print(f"    idx{i} {ep}: OLD={a} NEW={b}")
+if parity_mismatch[:10]:
+    print("  -- response mismatches (idx, ep, path) --")
+    for i,ep,path,a,b in parity_mismatch[:10]: print(f"    idx{i} {ep} {path}\n       OLD {a}\n       NEW {b}")
+if errors[:10]:
+    print("  -- errors --")
+    for i,ep,oe,ne in errors[:10]: print(f"    idx{i} {ep}: OLD={oe!r} NEW={ne!r}")
+print("="*64)
+print("LATENCY (200-OK requests, ms)")
+print(f"            {'OLD':>10} {'NEW':>10}   delta")
+for label,q in [("p50",50),("p90",90),("p95",95),("p99",99)]:
+    o=pct(lat_old,q); n=pct(lat_new,q)
+    d = f"{(n-o)/o*100:+.1f}%" if o else "n/a"
+    print(f"  {label:>5}    {o:>10} {n:>10}   {d}")
+print(f"  mean     {round(statistics.mean(lat_old),1):>10} {round(statistics.mean(lat_new),1):>10}")
+print(f"  sum(s)   {round(sum(lat_old)/1000,1):>10} {round(sum(lat_new)/1000,1):>10}")
+print("="*64)
+verdict = "PASS" if not status_mismatch and not parity_mismatch and not errors else "FAIL"
+print(f"PARITY VERDICT: {verdict}")

--- a/dev/qc-harness/lib/gcstats.py
+++ b/dev/qc-harness/lib/gcstats.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Parse an -Xlog:gc* ParallelGC log: peak heap + total allocated (freed) bytes.
+Allocation proxy = sum over collections of (used_before - used_after); for a
+workload returning to baseline this approximates total bytes allocated."""
+import re, sys
+
+unit = {'B':1,'K':1024,'M':1024**2,'G':1024**3}
+def tobytes(v,u): return float(v)*unit[u]
+
+# matches e.g. "1234M->567M(2048M)"
+pat = re.compile(r'(\d+(?:\.\d+)?)([BKMG])->(\d+(?:\.\d+)?)([BKMG])\((\d+(?:\.\d+)?)([BKMG])\)')
+peak=0.0; freed=0.0; n=0
+for line in open(sys.argv[1]):
+    m = pat.search(line)
+    if not m: continue
+    before = tobytes(m.group(1),m.group(2))
+    after  = tobytes(m.group(3),m.group(4))
+    peak = max(peak, before)
+    if before>after: freed += (before-after)
+    n+=1
+reqs = int(sys.argv[2]) if len(sys.argv)>2 else 0
+print(f"collections      : {n}")
+print(f"peak heap used   : {peak/1024**2:.0f} MB")
+print(f"total allocated  : {freed/1024**2:.0f} MB  (~{freed/1024**3:.2f} GB)")
+if reqs:
+    print(f"alloc per request: {freed/reqs/1024**2:.2f} MB/req  (over {reqs} reqs)")

--- a/dev/qc-harness/lib/replay.py
+++ b/dev/qc-harness/lib/replay.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Replay the heavy QC corpus against one running backend.
+
+For each request: POST the decoded JSON body to base_url+path, record HTTP status,
+latency, response length, and a canonical SHA-256 of the response (arrays/objects
+sorted so incidental ordering differences don't register as mismatches). The raw
+response is also saved so any parity mismatch can be inspected.
+
+Output: one JSONL line per request to --out.
+"""
+import argparse, base64, hashlib, json, sys, time, urllib.request, urllib.error
+from concurrent.futures import ThreadPoolExecutor
+
+def canonical(obj):
+    """Stable serialization: sort object keys, and sort arrays by their own
+    canonical form so element ordering is normalized."""
+    if isinstance(obj, dict):
+        return {k: canonical(obj[k]) for k in sorted(obj)}
+    if isinstance(obj, list):
+        norm = [canonical(x) for x in obj]
+        try:
+            return sorted(norm, key=lambda x: json.dumps(x, sort_keys=True))
+        except Exception:
+            return norm
+    return obj
+
+def canon_sha(text):
+    try:
+        obj = json.loads(text)
+    except Exception:
+        # non-JSON (error page etc) -> hash raw bytes
+        return "raw:" + hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()
+    blob = json.dumps(canonical(obj), sort_keys=True, separators=(",", ":"))
+    return "json:" + hashlib.sha256(blob.encode()).hexdigest()
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", required=True)
+    ap.add_argument("--base-url", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--save-bodies", help="dir to dump raw responses (optional)")
+    ap.add_argument("--workers", type=int, default=1, help="concurrent requests")
+    args = ap.parse_args()
+
+    rows = [l.rstrip("\n").split("\t") for l in open(args.corpus) if l.strip()]
+    out = open(args.out, "w")
+    n_ok = n_err = 0
+
+    def do_one(i, f):
+        ep, path = f[0], f[1]
+        qs = base64.b64decode(f[3]).decode() if len(f) > 3 and f[3] else ""
+        body = base64.b64decode(f[5])  # raw JSON bytes
+        url = args.base_url.rstrip("/") + path + (("?" + qs) if qs else "")
+        req = urllib.request.Request(url, data=body, method="POST",
+                                     headers={"Content-Type": "application/json",
+                                              "Accept": "application/json"})
+        t0 = time.perf_counter()
+        status = 0; resp_text = ""; err = ""
+        try:
+            with urllib.request.urlopen(req, timeout=300) as r:
+                status = r.status
+                resp_text = r.read().decode("utf-8", "replace")
+        except urllib.error.HTTPError as e:
+            status = e.code
+            resp_text = e.read().decode("utf-8", "replace")
+            err = f"HTTP {e.code}"
+        except Exception as e:
+            err = repr(e)
+        dt = (time.perf_counter() - t0) * 1000.0
+        raw_sha = "raw:" + hashlib.sha256(resp_text.encode("utf-8", "replace")).hexdigest() if resp_text else ""
+        # canonicalization reorders arrays (defends against benign ordering); skip for very
+        # large bodies where the raw sha already settles parity cheaply.
+        canon = canon_sha(resp_text) if (resp_text and len(resp_text) < 20_000_000) else "skipped"
+        return {"idx": i, "ep": ep, "path": path, "req_sha": hashlib.sha256(body).hexdigest()[:16],
+                "status": status, "latency_ms": round(dt, 1), "resp_len": len(resp_text),
+                "resp_raw": raw_sha, "resp_canon": canon, "err": err}
+
+    done = 0
+    if args.workers <= 1:
+        results = (do_one(i, f) for i, f in enumerate(rows))
+    else:
+        ex = ThreadPoolExecutor(max_workers=args.workers)
+        results = ex.map(lambda p: do_one(*p), list(enumerate(rows)))
+    for rec in results:
+        out.write(json.dumps(rec) + "\n")
+        done += 1
+        if rec["err"]: n_err += 1
+        else: n_ok += 1
+        if done % 50 == 0:
+            print(f"  {done}/{len(rows)} ok={n_ok} err={n_err}", file=sys.stderr, flush=True)
+    out.close()
+    print(f"DONE {args.base_url} (workers={args.workers}): {n_ok} ok, {n_err} err -> {args.out}", file=sys.stderr)
+
+if __name__ == "__main__":
+    main()

--- a/dev/qc-harness/lib/replay.py
+++ b/dev/qc-harness/lib/replay.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """Replay the heavy QC corpus against one running backend.
 
-For each request: POST the decoded JSON body to base_url+path, record HTTP status,
-latency, response length, and a canonical SHA-256 of the response (arrays/objects
-sorted so incidental ordering differences don't register as mismatches). The raw
-response is also saved so any parity mismatch can be inspected.
+For each request: POST the decoded JSON body to base_url+path (query string included),
+record HTTP status, latency, response length, a raw SHA-256, and a canonical SHA-256
+of the response (arrays/objects sorted so incidental ordering differences don't
+register as mismatches).
 
-Output: one JSONL line per request to --out.
+Output: one JSONL line per request to --out. Pass --save-bodies <dir> to also dump
+each raw response to <dir>/<idx>.json so a parity mismatch can be inspected.
 """
 import argparse, base64, hashlib, json, sys, time, urllib.request, urllib.error
 from concurrent.futures import ThreadPoolExecutor
@@ -45,6 +46,9 @@ def main():
     rows = [l.rstrip("\n").split("\t") for l in open(args.corpus) if l.strip()]
     out = open(args.out, "w")
     n_ok = n_err = 0
+    if args.save_bodies:
+        import os
+        os.makedirs(args.save_bodies, exist_ok=True)
 
     def do_one(i, f):
         ep, path = f[0], f[1]
@@ -71,6 +75,9 @@ def main():
         # canonicalization reorders arrays (defends against benign ordering); skip for very
         # large bodies where the raw sha already settles parity cheaply.
         canon = canon_sha(resp_text) if (resp_text and len(resp_text) < 20_000_000) else "skipped"
+        if args.save_bodies:
+            with open(f"{args.save_bodies}/{i:05d}.json", "w") as bf:
+                bf.write(resp_text)
         return {"idx": i, "ep": ep, "path": path, "req_sha": hashlib.sha256(body).hexdigest()[:16],
                 "status": status, "latency_ms": round(dt, 1), "resp_len": len(resp_text),
                 "resp_raw": raw_sha, "resp_canon": canon, "err": err}

--- a/dev/qc-harness/qc.sh
+++ b/dev/qc-harness/qc.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# End-to-end A/B QC for a cbioportal PR: build two jars, replay real captured
+# traffic for an endpoint against each (sequentially — one -Xmx2g JVM at a time),
+# and report parity + latency + peak heap.
+#
+# Usage: qc.sh <old-ref> <new-ref> <endpoint-LIKE> <label> [count] [order]
+#   e.g. qc.sh master coexpression-single-scan-query '%co-expression%' coexp 80 random
+#
+# Prereqs: cp config.env.example config.env  (and fill in CH_PASSWORD)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${HERE}/config.env"
+OLD_REF="$1"; NEW_REF="$2"; LIKE="$3"; LABEL="$4"; COUNT="${5:-80}"; ORDER="${6:-random}"
+mkdir -p "$WORK_DIR"; cd "$WORK_DIR"
+
+echo "== 1/5 build jars =="
+"$HERE/bin/build-ab.sh" "$OLD_REF" "$NEW_REF"
+
+echo "== 2/5 extract corpus =="
+"$HERE/bin/extract-corpus.sh" "$LIKE" "$LABEL" "$COUNT" "$WORK_DIR/corpus.tsv" "$ORDER"
+
+replay_side() {  # $1=OLD|NEW  $2=jar  $3=port
+  "$HERE/bin/run-backend.sh" "$2" "$1" "$3"
+  # warmup pass (warms JIT + ClickHouse cache), then the measured pass
+  python3 "$HERE/lib/replay.py" --corpus "$WORK_DIR/corpus.tsv" \
+      --base-url "http://localhost:$3" --out /tmp/warm-$1.jsonl 2>/dev/null || true
+  python3 "$HERE/lib/replay.py" --corpus "$WORK_DIR/corpus.tsv" \
+      --base-url "http://localhost:$3" --out "$WORK_DIR/results-$1.jsonl"
+  python3 "$HERE/lib/gcstats.py" "$WORK_DIR/gc-$1.log" "$((COUNT*2))" > "$WORK_DIR/mem-$1.txt" || true
+  kill "$(cat "$WORK_DIR/backend-$1.pid")" 2>/dev/null || true
+  while kill -0 "$(cat "$WORK_DIR/backend-$1.pid")" 2>/dev/null; do sleep 1; done
+}
+
+echo "== 3/5 replay OLD =="; replay_side OLD "$WORK_DIR/cbioportal-OLD.jar" 8111
+echo "== 4/5 replay NEW =="; replay_side NEW "$WORK_DIR/cbioportal-NEW.jar" 8112
+
+echo "== 5/5 compare =="
+python3 "$HERE/lib/compare.py" "$WORK_DIR/results-OLD.jsonl" "$WORK_DIR/results-NEW.jsonl"
+echo; echo "--- peak heap / alloc (OLD) ---"; cat "$WORK_DIR/mem-OLD.txt"
+echo "--- peak heap / alloc (NEW) ---"; cat "$WORK_DIR/mem-NEW.txt"
+echo; echo "artifacts in $WORK_DIR"

--- a/dev/qc-harness/qc.sh
+++ b/dev/qc-harness/qc.sh
@@ -26,7 +26,10 @@ replay_side() {  # $1=OLD|NEW  $2=jar  $3=port
       --base-url "http://localhost:$3" --out /tmp/warm-$1.jsonl 2>/dev/null || true
   python3 "$HERE/lib/replay.py" --corpus "$WORK_DIR/corpus.tsv" \
       --base-url "http://localhost:$3" --out "$WORK_DIR/results-$1.jsonl"
-  python3 "$HERE/lib/gcstats.py" "$WORK_DIR/gc-$1.log" "$((COUNT*2))" > "$WORK_DIR/mem-$1.txt" || true
+  # GC log covers warmup + measured = 2x the ACTUAL corpus size (DISTINCT+filtering
+  # can yield fewer than COUNT rows), so derive the denominator from the corpus.
+  local n_req; n_req=$(( $(wc -l < "$WORK_DIR/corpus.tsv") * 2 ))
+  python3 "$HERE/lib/gcstats.py" "$WORK_DIR/gc-$1.log" "$n_req" > "$WORK_DIR/mem-$1.txt" || true
   kill "$(cat "$WORK_DIR/backend-$1.pid")" 2>/dev/null || true
   while kill -0 "$(cat "$WORK_DIR/backend-$1.pid")" 2>/dev/null; do sleep 1; done
 }


### PR DESCRIPTION
## What

A reusable harness for **replaying real captured traffic (`cbioportal_qc.logged_requests`) against two builds of cBioPortal** to verify a change returns identical responses, and to measure its effect on memory and latency.

I built this while QC'ing three optimization PRs and it kept paying off, so this packages it up (generalized, secrets externalized, documented) for the next one.

## Layout

```
dev/qc-harness/
├── README.md            # methodology + gotchas
├── config.env.example   # DB URLs/creds/ports — real config gitignored
├── qc.sh                # build → extract corpus → replay OLD/NEW → compare
├── bin/  build-ab.sh · run-backend.sh · extract-corpus.sh
├── lib/  replay.py · compare.py · gcstats.py
└── examples/coexp_sql_ab.py   # SQL-level A/B via X-ClickHouse-Summary
```

## Usage

```bash
cp dev/qc-harness/config.env.example dev/qc-harness/config.env   # set creds
# end-to-end A/B for an endpoint:
dev/qc-harness/qc.sh master <pr-branch> '%co-expression%' coexp 80 random
```

Prints a parity verdict (raw or order-tolerant canonical), OLD-vs-NEW latency percentiles, and peak heap / allocation per request.

For pure-SQL/mapper changes there's a no-app-build path (`examples/coexp_sql_ab.py`) that measures `read_rows`/`read_bytes`/`elapsed` straight from the ClickHouse HTTP `X-ClickHouse-Summary` header.

## Notes

- **No secrets committed** — everything sensitive lives in a gitignored `config.env`; `config.env.example` is shipped. (The default clone + read-only cred are the same ones already in `.circleci/config.yml`.)
- Reading `cbioportal_qc` needs a cred with `SELECT` on that database (separate from the clone-replay cred) — documented in the config and README.
- The README captures the gotchas worth not rediscovering: the runnable artifact is `cbioportal-exec.jar`; `-Dmaven.gitcommitid.skip=true` is needed in worktrees; the largest logged request bodies are gzip-corrupted (unreplayable); query strings carry `projection`/`threshold`/`clinicalDataType`; boot the A/B sequentially; and memory wins are request-shape-dependent (a broad corpus can show none while the targeted shape shows a lot).

No production code touched — additive tooling under `dev/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)