### PR TITLE
Fix SSRF and local file read in /api/getexternalpage.json

### DIFF
--- a/src/main/java/org/cbioportal/application/documentation/ExternalPageController.java
+++ b/src/main/java/org/cbioportal/application/documentation/ExternalPageController.java
@@ -3,22 +3,52 @@ package org.cbioportal.application.documentation;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.server.ResponseStatusException;
 
 // Retrieve the content of an external page
-// Make it auto-scannable
 @Controller
 public class ExternalPageController {
+
+  // Only these schemes may be fetched. file://, ftp://, gopher:// etc. are rejected so the
+  // endpoint cannot be used to read local files or reach non-HTTP internal services.
+  private static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https");
+
+  // Optional strict allowlist of hostnames that may be fetched (comma-separated). When empty, any
+  // public host is allowed but internal/private destinations are always blocked (see below).
+  private final Set<String> allowedHosts;
+
+  public ExternalPageController(
+      @Value("${external_page.allowed_hosts:}") String allowedHostsProperty) {
+    this.allowedHosts =
+        Arrays.stream(allowedHostsProperty.split(","))
+            .map(String::trim)
+            .filter(host -> !host.isEmpty())
+            .map(host -> host.toLowerCase(Locale.ROOT))
+            .collect(Collectors.toUnmodifiableSet());
+  }
 
   // service name: getexternalpage.json
   // available via GET method
@@ -29,24 +59,83 @@ public class ExternalPageController {
       method = {RequestMethod.GET})
   public @ResponseBody Map<String, String> getExternalPage(
       @RequestParam(required = true) String sourceURL) throws IOException {
-    String decodedString, pageText = "";
 
-    // decode the sourceURL and open a connection
-    sourceURL = URLDecoder.decode(sourceURL, "UTF-8");
-    URL url = new URL(sourceURL);
+    sourceURL = URLDecoder.decode(sourceURL, StandardCharsets.UTF_8);
+    URL url = validateAndParse(sourceURL);
+
     URLConnection connection = url.openConnection();
 
-    // create a reader
-    BufferedReader in =
-        new BufferedReader(new InputStreamReader(connection.getInputStream(), "UTF-8"));
-
-    // read
-    while ((decodedString = in.readLine()) != null) {
-      pageText += decodedString + "\n";
+    StringBuilder pageText = new StringBuilder();
+    try (BufferedReader in =
+        new BufferedReader(
+            new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = in.readLine()) != null) {
+        pageText.append(line).append("\n");
+      }
     }
-    in.close();
 
-    // turn the pageText into a singletonMap for json and return
-    return Collections.singletonMap("response", pageText);
+    return Collections.singletonMap("response", pageText.toString());
+  }
+
+  /**
+   * Validates that {@code sourceURL} is safe to fetch and returns the parsed {@link URL}. Rejects
+   * (with HTTP 400) any URL that uses a non-HTTP(S) scheme, is not on the configured host allowlist,
+   * or resolves to a loopback, link-local, private, or otherwise internal address. This prevents
+   * SSRF and local file disclosure (e.g. {@code file:///etc/passwd},
+   * {@code http://169.254.169.254/...}, {@code http://localhost:8080/...}).
+   */
+  private URL validateAndParse(String sourceURL) {
+    URI uri;
+    try {
+      uri = new URI(sourceURL);
+    } catch (URISyntaxException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Malformed sourceURL");
+    }
+
+    String scheme = uri.getScheme();
+    if (scheme == null || !ALLOWED_SCHEMES.contains(scheme.toLowerCase(Locale.ROOT))) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Only http and https URLs are allowed");
+    }
+
+    String host = uri.getHost();
+    if (host == null || host.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "sourceURL must specify a host");
+    }
+    String normalizedHost = host.toLowerCase(Locale.ROOT);
+
+    if (!allowedHosts.isEmpty() && !allowedHosts.contains(normalizedHost)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Host is not allowed");
+    }
+
+    InetAddress[] addresses;
+    try {
+      addresses = InetAddress.getAllByName(host);
+    } catch (UnknownHostException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Host could not be resolved");
+    }
+    // Reject if the host resolves to any internal address. Checking every resolved address
+    // (rather than only the first) closes off names that mix public and internal records.
+    for (InetAddress address : addresses) {
+      if (isInternalAddress(address)) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Host resolves to a disallowed address");
+      }
+    }
+
+    try {
+      return uri.toURL();
+    } catch (MalformedURLException | IllegalArgumentException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Malformed sourceURL");
+    }
+  }
+
+  private boolean isInternalAddress(InetAddress address) {
+    return address.isLoopbackAddress()
+        || address.isAnyLocalAddress()
+        || address.isLinkLocalAddress()
+        || address.isSiteLocalAddress()
+        || address.isMulticastAddress();
   }
 }

--- a/src/test/java/org/cbioportal/application/documentation/ExternalPageControllerTest.java
+++ b/src/test/java/org/cbioportal/application/documentation/ExternalPageControllerTest.java
@@ -1,0 +1,65 @@
+package org.cbioportal.application.documentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+class ExternalPageControllerTest {
+
+  private final ExternalPageController controller = new ExternalPageController("");
+
+  private void assertRejected(String sourceURL) throws Exception {
+    ResponseStatusException ex =
+        assertThrows(ResponseStatusException.class, () -> controller.getExternalPage(sourceURL));
+    assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+  }
+
+  @Test
+  void rejectsFileScheme() throws Exception {
+    assertRejected("file:///etc/passwd");
+  }
+
+  @Test
+  void rejectsNonHttpSchemes() throws Exception {
+    assertRejected("ftp://example.com/file");
+    assertRejected("gopher://example.com/");
+    assertRejected("jar:file:///etc/passwd!/");
+  }
+
+  @Test
+  void rejectsLoopback() throws Exception {
+    assertRejected("http://localhost:8080/api/health");
+    assertRejected("http://127.0.0.1/");
+    assertRejected("http://[::1]/");
+  }
+
+  @Test
+  void rejectsLinkLocalMetadataEndpoint() throws Exception {
+    assertRejected("http://169.254.169.254/latest/meta-data/iam/security-credentials/");
+  }
+
+  @Test
+  void rejectsPrivateNetwork() throws Exception {
+    assertRejected("http://10.0.0.5/");
+    assertRejected("http://192.168.1.1/");
+    assertRejected("http://172.16.0.1/");
+  }
+
+  @Test
+  void rejectsMissingHost() throws Exception {
+    assertRejected("http:///etc/passwd");
+  }
+
+  @Test
+  void rejectsHostNotOnAllowlistWhenConfigured() throws Exception {
+    ExternalPageController restricted = new ExternalPageController("docs.cbioportal.org");
+    ResponseStatusException ex =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> restricted.getExternalPage("http://attacker.example.com/"));
+    assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+  }
+}


### PR DESCRIPTION
## Summary

`ExternalPageController` (`/api/getexternalpage.json`) fetched any URL supplied in the `sourceURL` parameter with **no validation**, then returned the response body to the caller. This allows unauthenticated SSRF and local file disclosure.

This is the gap left behind when **CVE-2024-41668** was fixed only for the `/proxy` endpoint — this controller was missed.

## Impact

- `file:///etc/passwd`, `file:///.../application.properties` → read local files / exfiltrate DB credentials and secrets
- `http://169.254.169.254/latest/meta-data/...` → cloud instance metadata / IAM credential theft
- `http://localhost:8080/...`, private-network hosts → internal service probing

## Fix

- Restrict to `http`/`https` schemes (rejects `file://`, `ftp://`, `gopher://`, `jar:`…)
- Reject any URL whose host resolves to a loopback, any-local, link-local, site-local (private), or multicast address — **all** resolved addresses are checked, not just the first
- Optional strict hostname allowlist via `external_page.allowed_hosts` (comma-separated); when empty, public hosts are still allowed but internal destinations are always blocked

## Testing

`ExternalPageControllerTest` covers rejection of `file://`, non-HTTP schemes, loopback (IPv4/IPv6), the link-local metadata endpoint, RFC1918 ranges, missing host, and allowlist enforcement. `mvn test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
