### PR TITLE
Fail closed on unsupported filter types in CancerStudyPermissionEvaluator

### DIFF
--- a/src/main/java/org/cbioportal/application/security/CancerStudyPermissionEvaluator.java
+++ b/src/main/java/org/cbioportal/application/security/CancerStudyPermissionEvaluator.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -50,11 +51,16 @@ import org.cbioportal.legacy.model.SampleList;
 import org.cbioportal.legacy.persistence.cachemaputil.CacheMapUtil;
 import org.cbioportal.legacy.utils.security.AccessLevel;
 import org.cbioportal.legacy.web.parameter.ClinicalDataCountFilter;
+import org.cbioportal.legacy.web.parameter.ClinicalDataIdentifier;
+import org.cbioportal.legacy.web.parameter.ClinicalDataMultiStudyFilter;
 import org.cbioportal.legacy.web.parameter.DataBinCountFilter;
 import org.cbioportal.legacy.web.parameter.GenericAssayDataCountFilter;
 import org.cbioportal.legacy.web.parameter.GenomicDataCountFilter;
+import org.cbioportal.legacy.web.parameter.Group;
+import org.cbioportal.legacy.web.parameter.GroupFilter;
 import org.cbioportal.legacy.web.parameter.MolecularProfileCasesGroupAndAlterationTypeFilter;
 import org.cbioportal.legacy.web.parameter.SampleFilter;
+import org.cbioportal.legacy.web.parameter.SampleIdentifier;
 import org.cbioportal.legacy.web.parameter.StudyViewFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -398,11 +404,42 @@ public class CancerStudyPermissionEvaluator implements PermissionEvaluator {
             .map(m -> m.getCancerStudyIdentifier())
             .collect(Collectors.toSet());
       }
-      default -> {
-        log.debug("hasPermission(), unknown filter type: " + filter.getClass().getName());
-        yield new HashSet<>();
+      case ClinicalDataMultiStudyFilter clinicalDataMultiStudyFilter -> {
+        List<ClinicalDataIdentifier> identifiers = clinicalDataMultiStudyFilter.getIdentifiers();
+        yield identifiers == null
+            ? new HashSet<>()
+            : identifiers.stream()
+                .map(ClinicalDataIdentifier::getStudyId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
       }
+      case GroupFilter groupFilter -> {
+        List<Group> groups = groupFilter.getGroups();
+        yield groups == null
+            ? new HashSet<>()
+            : groups.stream()
+                .filter(Objects::nonNull)
+                .map(Group::getSampleIdentifiers)
+                .filter(Objects::nonNull)
+                .flatMap(List::stream)
+                .map(SampleIdentifier::getStudyId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+      }
+      // Fail closed: an unrecognized filter type must never resolve to an empty study set, which
+      // would make the caller's permission check pass vacuously. Throwing denies access (the
+      // exception is caught by hasPermission and turned into false).
+      default ->
+          throw new UnsupportedFilterTypeException(
+              "Refusing to authorize unsupported filter type: " + filter.getClass().getName());
     };
+  }
+
+  /** Thrown when a filter type is not explicitly handled, so authorization fails closed. */
+  private static class UnsupportedFilterTypeException extends RuntimeException {
+    UnsupportedFilterTypeException(String message) {
+      super(message);
+    }
   }
 
   /**

--- a/src/test/java/org/cbioportal/application/security/CancerStudyPermissionEvaluatorTest.java
+++ b/src/test/java/org/cbioportal/application/security/CancerStudyPermissionEvaluatorTest.java
@@ -1,0 +1,97 @@
+package org.cbioportal.application.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import org.cbioportal.legacy.model.CancerStudy;
+import org.cbioportal.legacy.persistence.cachemaputil.CacheMapUtil;
+import org.cbioportal.legacy.utils.security.AccessLevel;
+import org.cbioportal.legacy.web.parameter.ClinicalDataIdentifier;
+import org.cbioportal.legacy.web.parameter.ClinicalDataMultiStudyFilter;
+import org.cbioportal.legacy.web.parameter.Group;
+import org.cbioportal.legacy.web.parameter.GroupFilter;
+import org.cbioportal.legacy.web.parameter.SampleIdentifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class CancerStudyPermissionEvaluatorTest {
+
+  @Mock private CacheMapUtil cacheMapUtil;
+
+  private CancerStudyPermissionEvaluator evaluator;
+
+  @BeforeEach
+  void setUp() {
+    evaluator = new CancerStudyPermissionEvaluator(null, null, null, cacheMapUtil);
+  }
+
+  /** A user with no granted authorities has access to no non-public study. */
+  private Authentication userWithoutAccess() {
+    return new TestingAuthenticationToken("user", "credentials");
+  }
+
+  private void stubPrivateStudy() {
+    CancerStudy study = new CancerStudy();
+    study.setCancerStudyIdentifier("private_study");
+    study.setGroups("");
+    when(cacheMapUtil.getCancerStudyMap()).thenReturn(Map.of("private_study", study));
+  }
+
+  @Test
+  void clinicalDataMultiStudyFilter_deniesAccessToPrivateStudy() {
+    stubPrivateStudy();
+
+    ClinicalDataIdentifier identifier = new ClinicalDataIdentifier();
+    identifier.setStudyId("private_study");
+    identifier.setEntityId("any_sample");
+    ClinicalDataMultiStudyFilter filter = new ClinicalDataMultiStudyFilter();
+    filter.setIdentifiers(List.of(identifier));
+
+    boolean result =
+        evaluator.hasPermission(
+            userWithoutAccess(), filter, "ClinicalDataMultiStudyFilter", AccessLevel.READ);
+
+    assertFalse(result);
+  }
+
+  @Test
+  void groupFilter_deniesAccessToPrivateStudy() {
+    stubPrivateStudy();
+
+    SampleIdentifier sampleIdentifier = new SampleIdentifier();
+    sampleIdentifier.setStudyId("private_study");
+    sampleIdentifier.setSampleId("any_sample");
+    Group group = new Group();
+    group.setSampleIdentifiers(List.of(sampleIdentifier));
+    GroupFilter filter = new GroupFilter();
+    filter.setGroups(List.of(group));
+
+    boolean result =
+        evaluator.hasPermission(userWithoutAccess(), filter, "GroupFilter", AccessLevel.READ);
+
+    assertFalse(result);
+  }
+
+  @Test
+  void unsupportedFilterType_failsClosed() {
+    Serializable unsupportedFilter = new UnsupportedFilter();
+
+    boolean result =
+        evaluator.hasPermission(
+            userWithoutAccess(), unsupportedFilter, "SomeUnsupportedFilter", AccessLevel.READ);
+
+    assertFalse(result);
+  }
+
+  /** A filter type the evaluator does not explicitly handle. Authorization must fail closed. */
+  private static class UnsupportedFilter implements Serializable {}
+}


### PR DESCRIPTION
## Summary

`CancerStudyPermissionEvaluator.extractStudyIdsFromFilter` returned an **empty study set** for any filter type it did not explicitly handle. The caller in `hasPermission` then iterates that empty collection and returns `true` vacuously — granting access.

Two filter types used by column-store endpoints were not handled, so these endpoints bypassed study-level ACLs entirely:

- `POST /api/column-store/clinical-data/fetch` (`ClinicalDataMultiStudyFilter`)
- `POST /api/column-store/clinical-data-enrichments/fetch` (`GroupFilter`)

## Fix

1. **Fail closed:** the default branch now throws, so any unhandled filter type denies access (the exception is caught by `hasPermission` and turned into `false`) instead of passing vacuously. This prevents recurrence as new filter types are added.
2. **Add the missing types:** study-id extraction for `ClinicalDataMultiStudyFilter` (from its identifiers) and `GroupFilter` (from each group's sample identifiers).

## Testing

`CancerStudyPermissionEvaluatorTest` verifies a user without access is denied for both `ClinicalDataMultiStudyFilter` and `GroupFilter` referencing a private study, and that an unsupported filter type fails closed. `mvn test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
