### PR TITLE
Fix SQL injection in ClickHouse getEntityToGenePanels mapper

### DIFF
--- a/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/alteration/ClickhouseAlterationMapper.java
+++ b/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/alteration/ClickhouseAlterationMapper.java
@@ -90,7 +90,7 @@ public interface ClickhouseAlterationMapper {
    * @return a list of EntityToPanel objects representing the entity-to-panel associations
    */
   List<EntityToPanel> getEntityToGenePanels(
-      String sampleStableIdsJoined, String profileIdsJoined, String field);
+      List<String> sampleStableIds, List<String> profileIds, String field);
 
   List<AlterationCountByGene> getAlterationCountByGeneGivenSamplesAndMolecularProfiles(
       String[] samples, String[] molecularProfiles, AlterationFilterHelper alterationFilterHelper);

--- a/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/alteration/ClickhouseAlterationRepository.java
+++ b/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/alteration/ClickhouseAlterationRepository.java
@@ -73,10 +73,7 @@ public class ClickhouseAlterationRepository implements AlterationRepository {
 
     var field = enrichmentType == EnrichmentType.SAMPLE ? "sample_unique_id" : "patient_unique_id";
 
-    return mapper.getEntityToGenePanels(
-        sampleStableIds.stream().map(s -> "'" + s + "'").collect(Collectors.joining(",")),
-        profileIds.stream().map(p -> "'" + p + "'").collect(Collectors.joining(",")),
-        field);
+    return mapper.getEntityToGenePanels(sampleStableIds, profileIds, field);
   }
 
   @Override

--- a/src/main/resources/mappers/clickhouse/alteration/ClickhouseAlterationMapper.xml
+++ b/src/main/resources/mappers/clickhouse/alteration/ClickhouseAlterationMapper.xml
@@ -176,13 +176,13 @@ totalProfiled Count per gene in java.
         FROM sample_to_gene_panel_derived sgpd
                  JOIN sample_derived sd ON sgpd.sample_unique_id=sd.sample_unique_id
         WHERE sd.${field} IN
-              (
-                  ${sampleStableIdsJoined}
-                  )
+              <foreach item="sampleStableId" collection="sampleStableIds" open="(" separator="," close=")">
+                  #{sampleStableId}
+              </foreach>
           AND sgpd.genetic_profile_id IN
-              (
-                  ${profileIdsJoined}
-                  )
+              <foreach item="profileId" collection="profileIds" open="(" separator="," close=")">
+                  #{profileId}
+              </foreach>
     </select>
 
     <sql id="getAlterationCountByGeneGiven">


### PR DESCRIPTION
## Summary

`getEntityToGenePanels` built `'studyId_caseId'` strings by raw string concatenation in `ClickhouseAlterationRepository` and substituted them into the mapper using MyBatis **`${...}`** (unescaped text substitution) in the `IN (...)` clauses. Sample and profile identifiers reached the query unescaped — a SQL injection sink.

## Fix

- Pass the identifier `List`s through to the mapper and bind them with `<foreach>` + parameterized `#{...}` placeholders.
- The remaining `${field}` is an internal column-name selector (`sample_unique_id` / `patient_unique_id`) derived from an enum, not user input, and cannot be parameterized with `#{}`.

## Mapper `${...}` audit

Per the report I swept every MyBatis mapper for `${...}` in `WHERE`/`IN`/`VALUES` clauses. The remaining occurrences are internal column/projection selectors (`${field}`, `${type}`, `${prefix}`, `${unique_id}`) or an `Integer` substitution (`${geneFilterQuery.getEntrezGeneId()}`) — not injectable. Separately, ORDER BY `${sortBy}`/`${direction}` in some mappers is identifier-position substitution that cannot use `#{}` and would need allowlist validation; that is a distinct issue from this finding and is left for follow-up.

## Testing

`mvn test-compile` green; existing alteration tests compile against the new `List` signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
