### PR TITLE
Apply study ACLs to projection=META count endpoints

### DIFF
--- a/src/main/java/org/cbioportal/legacy/web/ClinicalAttributeController.java
+++ b/src/main/java/org/cbioportal/legacy/web/ClinicalAttributeController.java
@@ -76,10 +76,20 @@ public class ClinicalAttributeController {
           Direction direction) {
 
     if (projection == Projection.META) {
+      // Count only the clinical attributes in studies the caller is authorized to see. Reusing the
+      // ACL-filtered (@PostFilter) row query keeps the META total consistent with the rows that
+      // would be returned and prevents the count from leaking private study contents.
+      int totalCount =
+          clinicalAttributeService
+              .getAllClinicalAttributes(
+                  Projection.SUMMARY.name(),
+                  PagingConstants.MAX_PAGE_SIZE,
+                  0,
+                  null,
+                  Direction.ASC.name())
+              .size();
       HttpHeaders responseHeaders = new HttpHeaders();
-      responseHeaders.add(
-          HeaderKeyConstants.TOTAL_COUNT,
-          clinicalAttributeService.getMetaClinicalAttributes().getTotalCount().toString());
+      responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, String.valueOf(totalCount));
       return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
     } else {
       return new ResponseEntity<>(

--- a/src/main/java/org/cbioportal/legacy/web/MolecularProfileController.java
+++ b/src/main/java/org/cbioportal/legacy/web/MolecularProfileController.java
@@ -79,10 +79,20 @@ public class MolecularProfileController {
           Direction direction) {
 
     if (projection == Projection.META) {
+      // Count only the molecular profiles in studies the caller is authorized to see. Reusing the
+      // ACL-filtered (@PostFilter) row query keeps the META total consistent with the rows that
+      // would be returned and prevents the count from leaking private study contents.
+      int totalCount =
+          molecularProfileService
+              .getAllMolecularProfiles(
+                  Projection.SUMMARY.name(),
+                  PagingConstants.MAX_PAGE_SIZE,
+                  0,
+                  null,
+                  Direction.ASC.name())
+              .size();
       HttpHeaders responseHeaders = new HttpHeaders();
-      responseHeaders.add(
-          HeaderKeyConstants.TOTAL_COUNT,
-          molecularProfileService.getMetaMolecularProfiles().getTotalCount().toString());
+      responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, String.valueOf(totalCount));
       return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
     } else {
       return new ResponseEntity<>(

--- a/src/main/java/org/cbioportal/legacy/web/PatientController.java
+++ b/src/main/java/org/cbioportal/legacy/web/PatientController.java
@@ -84,10 +84,21 @@ public class PatientController {
       throws StudyNotFoundException {
 
     if (projection == Projection.META) {
+      // Count only the patients in studies the caller is authorized to see. Reusing the
+      // ACL-filtered (@PostFilter) row query keeps the META total consistent with the rows that
+      // would be returned and prevents the count from leaking private study contents.
+      int totalCount =
+          patientService
+              .getAllPatients(
+                  keyword,
+                  Projection.SUMMARY.name(),
+                  PagingConstants.MAX_PAGE_SIZE,
+                  0,
+                  null,
+                  Direction.ASC.name())
+              .size();
       HttpHeaders responseHeaders = new HttpHeaders();
-      responseHeaders.add(
-          HeaderKeyConstants.TOTAL_COUNT,
-          patientService.getMetaPatients(keyword).getTotalCount().toString());
+      responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, String.valueOf(totalCount));
       return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
     } else {
       return new ResponseEntity<>(

--- a/src/main/java/org/cbioportal/legacy/web/SampleListController.java
+++ b/src/main/java/org/cbioportal/legacy/web/SampleListController.java
@@ -74,10 +74,20 @@ public class SampleListController {
           Direction direction) {
 
     if (projection == Projection.META) {
+      // Count only the sample lists in studies the caller is authorized to see. Reusing the
+      // ACL-filtered (@PostFilter) row query keeps the META total consistent with the rows that
+      // would be returned and prevents the count from leaking private study contents.
+      int totalCount =
+          sampleListService
+              .getAllSampleLists(
+                  Projection.SUMMARY.name(),
+                  PagingConstants.MAX_PAGE_SIZE,
+                  0,
+                  null,
+                  Direction.ASC.name())
+              .size();
       HttpHeaders responseHeaders = new HttpHeaders();
-      responseHeaders.add(
-          HeaderKeyConstants.TOTAL_COUNT,
-          sampleListService.getMetaSampleLists().getTotalCount().toString());
+      responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, String.valueOf(totalCount));
       return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
     } else {
       return new ResponseEntity<>(

--- a/src/main/java/org/cbioportal/legacy/web/StudyController.java
+++ b/src/main/java/org/cbioportal/legacy/web/StudyController.java
@@ -139,10 +139,23 @@ public class StudyController {
     } else authentication = SecurityContextHolder.getContext().getAuthentication();
 
     if (projection == Projection.META) {
+      // Count only the studies the caller is authorized to see. Reusing the ACL-filtered row query
+      // (rather than an unfiltered count) keeps the META total consistent with the rows that would
+      // be returned and prevents the count from leaking the existence of private studies.
+      int totalCount =
+          studyService
+              .getAllStudies(
+                  keyword,
+                  Projection.SUMMARY.name(),
+                  PagingConstants.MAX_PAGE_SIZE,
+                  0,
+                  null,
+                  Direction.ASC.name(),
+                  authentication,
+                  getAccessLevel())
+              .size();
       HttpHeaders responseHeaders = new HttpHeaders();
-      responseHeaders.add(
-          HeaderKeyConstants.TOTAL_COUNT,
-          studyService.getMetaStudies(keyword).getTotalCount().toString());
+      responseHeaders.add(HeaderKeyConstants.TOTAL_COUNT, String.valueOf(totalCount));
       return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
     } else {
       return new ResponseEntity<>(


### PR DESCRIPTION
## Summary

The row-returning paths of five legacy list endpoints filter results by study-level ACLs (`@PostFilter` in the service layer), but the `?projection=META` paths returned an **unfiltered total count**:

- `GET /api/studies?projection=META`
- `GET /api/patients?projection=META`
- `GET /api/sample-lists?projection=META`
- `GET /api/clinical-attributes?projection=META`
- `GET /api/molecular-profiles?projection=META`

Combined with the `keyword` parameter, the unfiltered count is a binary-search side channel for probing the existence and contents of private studies.

## Fix

Each META total is now derived from the **same ACL-filtered row query** the row path uses (counting the `@PostFilter`-ed result) instead of an unfiltered count, so the count matches exactly what the caller is authorized to see. `StudyController` keeps using its existing access level, so `skin.home_page.show_unauthorized_studies` behavior is preserved.

## Note

This trades a cheap `COUNT` for a fetch-then-count, consistent with what the row endpoints already do. Happy to push the authorized-study set into the repository query instead if reviewers prefer.

## Testing

`mvn test-compile` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
