### PR TITLE
refactor: replace field injection with constructor injection in non-l…

### DIFF
--- a/src/main/java/org/cbioportal/application/proxy/ProxyController.java
+++ b/src/main/java/org/cbioportal/application/proxy/ProxyController.java
@@ -6,7 +6,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -29,7 +28,7 @@ import org.springframework.web.client.RestTemplate;
 public class ProxyController {
   private static final String DEFAULT_ONCOKB_URL = "https://public.api.oncokb.org/api/v1";
 
-  @Autowired private Monkifier monkifier;
+  private final Monkifier monkifier;
 
   @Value("${oncokb.token:}")
   private String oncokbToken;
@@ -39,6 +38,10 @@ public class ProxyController {
 
   @Value("${show.oncokb:false}")
   private Boolean showOncokb;
+
+  public ProxyController(Monkifier monkifier) {
+    this.monkifier = monkifier;
+  }
 
   /**
    * This dev endpoint can be used (with a personal access token) instead of the production

--- a/src/main/java/org/cbioportal/infrastructure/service/BasicDataBinner.java
+++ b/src/main/java/org/cbioportal/infrastructure/service/BasicDataBinner.java
@@ -36,7 +36,6 @@ import org.cbioportal.legacy.web.parameter.SampleIdentifier;
 import org.cbioportal.legacy.web.parameter.StudyViewFilter;
 import org.cbioportal.legacy.web.util.DataBinner;
 import org.cbioportal.legacy.web.util.StudyViewFilterUtil;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
@@ -54,7 +53,6 @@ public class BasicDataBinner {
   private final CustomDataService customDataService;
   private final StudyViewFilterUtil studyViewFilterUtil;
 
-  @Autowired
   public BasicDataBinner(
       StudyViewService studyViewService,
       DataBinner dataBinner,

--- a/src/main/java/org/cbioportal/infrastructure/service/ClinicalDataBinner.java
+++ b/src/main/java/org/cbioportal/infrastructure/service/ClinicalDataBinner.java
@@ -18,7 +18,6 @@ import org.cbioportal.legacy.web.parameter.ClinicalDataType;
 import org.cbioportal.legacy.web.parameter.DataBinMethod;
 import org.cbioportal.legacy.web.parameter.StudyViewFilter;
 import org.cbioportal.legacy.web.util.DataBinner;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
@@ -28,7 +27,6 @@ public class ClinicalDataBinner {
   private final StudyViewService studyViewService;
   private final DataBinner dataBinner;
 
-  @Autowired
   public ClinicalDataBinner(StudyViewService studyViewService, DataBinner dataBinner) {
     this.studyViewService = studyViewService;
     this.dataBinner = dataBinner;


### PR DESCRIPTION
Fix # N/A — proactive refactor, no linked issue

Describe changes proposed in this pull request:
- Audited all non-legacy Java classes for @Autowired field injection (7 files found; 4 are OAuth2/Security configs intentionally left untouched)
- ProxyController: converted @Autowired field injection of Monkifier to constructor injection; field is now final for immutability
- BasicDataBinner: removed redundant @Autowired on single constructor — Spring 4.3+ auto-detects injection when there is exactly one constructor
- ClinicalDataBinner: same redundant @Autowired removal as BasicDataBinner
- No logic changes; compile verified clean

# Checks
- [x] The commit log is comprehensible. It follows 7 rules of great commit messages.
- [x] No tests needed — pure structural refactor with zero logic change. Spring constructor injection is a framework guarantee, not application logic.
- [x] This PR does not add logic based on clinical attributes — not applicable.
- [x] Label added: refactoring

# Any screenshots or GIFs?
N/A — no visual changes.

# Notify reviewers
Assigned @dippindots as reviewer (confirmed on Slack he will review).
