### PR TITLE
Fix Docker build by replacing stale cbioportal-core branch reference

### DIFF
--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -11,7 +11,7 @@
 # NOTE: the .git folder is included in the build stage (the git-commit-id Maven
 # plugin needs it), but excluded from the final image. No confidential
 # information is exposed. (see: stackoverflow.com/questions/56278325)
-ARG CORE_BRANCH=rfc100-rc
+ARG CORE_BRANCH=main
 
 FROM maven:3-eclipse-temurin-21 AS build
 

--- a/docs/deployment/clickhouse/README.md
+++ b/docs/deployment/clickhouse/README.md
@@ -257,7 +257,7 @@ This adds a delay between `OPTIMIZE TABLE .. FINAL` operations, reducing peak me
 
 ## 10. Verifying Database Integrity
 
-After importing studies and rebuilding derived tables, you can verify that your ClickHouse database has no structural integrity problems by following the instructions provided [here](https://github.com/cBioPortal/cbioportal-core/tree/rfc100-rc#check-clickhouse-constraint-violations).
+After importing studies and rebuilding derived tables, you can verify that your ClickHouse database has no structural integrity problems by following the instructions provided [here](https://github.com/cBioPortal/cbioportal-core/tree/main#check-clickhouse-constraint-violations).
 
 ---
 


### PR DESCRIPTION
fixes #12246
## Summary

This PR fixes a Docker build failure caused by a stale branch reference in `docker/web-and-data/Dockerfile`.

The Dockerfile uses the GitHub API to invalidate Docker's cache whenever the referenced `cbioportal-core` branch changes. It was still configured to use the `rfc100-rc` branch, which no longer exists in the `cBioPortal/cbioportal-core` repository. As a result, Docker receives an HTTP `422 Unprocessable Entity` response and the image build fails.

## Changes

* Update `ARG CORE_BRANCH` in `docker/web-and-data/Dockerfile`

  * `rfc100-rc` → `main`
* Update the outdated `rfc100-rc` reference in `docs/deployment/clickhouse/README.md`

## Testing

Verified by rebuilding the Docker image using:

```bash
docker build -t cbioportal/cbioportal:my-dev-cbioportal-image \
    -f docker/web-and-data/Dockerfile .
```
<img width="1121" height="341" alt="image" src="https://github.com/user-attachments/assets/98c2b601-e63d-4274-a0eb-d71c64e51d8d" />

Before this change, the build failed with:

<img width="1085" height="910" alt="image" src="https://github.com/user-attachments/assets/cb8bb55e-ff47-4d59-8af2-f9cba72ce89a" />

```text
failed to solve: failed to load cache key:
invalid response status 422
```

After this change, the build successfully proceeds past the `build-core` stage and continues with the remaining build steps.

