### PR TITLE
Support dash-separated numeric ranges in ClinicalDataIntervalFilter

### DIFF
--- a/src/main/java/org/cbioportal/legacy/web/columnar/util/CustomDataFilterUtil.java
+++ b/src/main/java/org/cbioportal/legacy/web/columnar/util/CustomDataFilterUtil.java
@@ -27,6 +27,11 @@ import org.springframework.stereotype.Component;
 @Deprecated(forRemoval = true)
 @Component
 public class CustomDataFilterUtil {
+  private static final String LTE = "<=";
+  private static final String LT = "<";
+  private static final String GTE = ">=";
+  private static final String GT = ">";
+
   private final StudyViewFilterUtil studyViewFilterUtil;
   private final CustomDataService customDataService;
   private final PatientService patientService;
@@ -358,24 +363,19 @@ public class CustomDataFilterUtil {
 
     String value = attrValue.trim();
 
-    String lte = "<=";
-    String lt = "<";
-    String gte = ">=";
-    String gt = ">";
-
     boolean startInclusive = true;
     boolean endInclusive = true;
 
     try {
-      if (value.startsWith(lte)) {
-        max = new BigDecimal(value.substring(lte.length()));
-      } else if (value.startsWith(lt)) {
-        max = new BigDecimal(value.substring(lt.length()));
+      if (value.startsWith(LTE)) {
+        max = new BigDecimal(value.substring(LTE.length()));
+      } else if (value.startsWith(LT)) {
+        max = new BigDecimal(value.substring(LT.length()));
         endInclusive = false;
-      } else if (value.startsWith(gte)) {
-        min = new BigDecimal(value.substring(gte.length()));
-      } else if (value.startsWith(gt)) {
-        min = new BigDecimal(value.substring(gt.length()));
+      } else if (value.startsWith(GTE)) {
+        min = new BigDecimal(value.substring(GTE.length()));
+      } else if (value.startsWith(GT)) {
+        min = new BigDecimal(value.substring(GT.length()));
         startInclusive = false;
       } else {
         int dashIndex = value.indexOf('-', 1); // skip the first character to allow negative numbers
@@ -390,7 +390,7 @@ public class CustomDataFilterUtil {
           min = max = new BigDecimal(value);
         }
       }
-    } catch (Exception e) {
+    } catch (NumberFormatException e) {
       // invalid range
       return null;
     }

--- a/src/main/java/org/cbioportal/legacy/web/columnar/util/CustomDataFilterUtil.java
+++ b/src/main/java/org/cbioportal/legacy/web/columnar/util/CustomDataFilterUtil.java
@@ -378,10 +378,20 @@ public class CustomDataFilterUtil {
         min = new BigDecimal(value.substring(gt.length()));
         startInclusive = false;
       } else {
-        min = max = new BigDecimal(attrValue);
+        int dashIndex = value.indexOf('-', 1); // skip the first character to allow negative numbers
+        if (dashIndex > 0) {
+          try {
+            min = new BigDecimal(value.substring(0, dashIndex).trim());
+            max = new BigDecimal(value.substring(dashIndex + 1).trim());
+          } catch (NumberFormatException nfe) {
+            min = max = new BigDecimal(value);
+          }
+        } else {
+          min = max = new BigDecimal(value);
+        }
       }
     } catch (Exception e) {
-      // invalid range -- TODO: also support ranges like 20-30?
+      // invalid range
       return null;
     }
 

--- a/src/main/java/org/cbioportal/legacy/web/util/ClinicalDataIntervalFilterApplier.java
+++ b/src/main/java/org/cbioportal/legacy/web/util/ClinicalDataIntervalFilterApplier.java
@@ -98,10 +98,21 @@ public class ClinicalDataIntervalFilterApplier extends ClinicalDataFilterApplier
         min = new BigDecimal(value.substring(gt.length()));
         startInclusive = false;
       } else {
-        min = max = new BigDecimal(attrValue);
+        int dashIndex = value.indexOf('-', 1); // skip the first character to allow negative numbers
+        if (dashIndex > 0) {
+          try {
+            min = new BigDecimal(value.substring(0, dashIndex).trim());
+            max = new BigDecimal(value.substring(dashIndex + 1).trim());
+          } catch (NumberFormatException nfe) {
+            min = max = new BigDecimal(value);
+          }
+        } else {
+          min = max = new BigDecimal(value);
+        }
       }
     } catch (Exception e) {
-      // invalid range -- TODO: also support ranges like 20-30?
+      // invalid range
+
       return null;
     }
 

--- a/src/main/java/org/cbioportal/legacy/web/util/ClinicalDataIntervalFilterApplier.java
+++ b/src/main/java/org/cbioportal/legacy/web/util/ClinicalDataIntervalFilterApplier.java
@@ -17,6 +17,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class ClinicalDataIntervalFilterApplier extends ClinicalDataFilterApplier {
 
+  private static final String LTE = "<=";
+  private static final String LT = "<";
+  private static final String GTE = ">=";
+  private static final String GT = ">";
+
   @Autowired
   public ClinicalDataIntervalFilterApplier(
       PatientService patientService,
@@ -78,24 +83,19 @@ public class ClinicalDataIntervalFilterApplier extends ClinicalDataFilterApplier
 
     String value = attrValue.trim();
 
-    String lte = "<=";
-    String lt = "<";
-    String gte = ">=";
-    String gt = ">";
-
     boolean startInclusive = true;
     boolean endInclusive = true;
 
     try {
-      if (value.startsWith(lte)) {
-        max = new BigDecimal(value.substring(lte.length()));
-      } else if (value.startsWith(lt)) {
-        max = new BigDecimal(value.substring(lt.length()));
+      if (value.startsWith(LTE)) {
+        max = new BigDecimal(value.substring(LTE.length()));
+      } else if (value.startsWith(LT)) {
+        max = new BigDecimal(value.substring(LT.length()));
         endInclusive = false;
-      } else if (value.startsWith(gte)) {
-        min = new BigDecimal(value.substring(gte.length()));
-      } else if (value.startsWith(gt)) {
-        min = new BigDecimal(value.substring(gt.length()));
+      } else if (value.startsWith(GTE)) {
+        min = new BigDecimal(value.substring(GTE.length()));
+      } else if (value.startsWith(GT)) {
+        min = new BigDecimal(value.substring(GT.length()));
         startInclusive = false;
       } else {
         int dashIndex = value.indexOf('-', 1); // skip the first character to allow negative numbers
@@ -110,7 +110,7 @@ public class ClinicalDataIntervalFilterApplier extends ClinicalDataFilterApplier
           min = max = new BigDecimal(value);
         }
       }
-    } catch (Exception e) {
+    } catch (NumberFormatException e) {
       // invalid range
 
       return null;


### PR DESCRIPTION
fixes #12250

## Summary

This PR fixes the handling of clinical attribute values stored as dash-separated numeric ranges (e.g. `20-30` or `4.5 - 10.5`) in the backend interval parsing logic.

Previously, when a clinical attribute contained a range, the parser attempted to convert the entire string directly into a `BigDecimal`, causing a `NumberFormatException`. As a result, these values were treated as invalid and excluded from interval-based filtering.

This PR updates the parsing logic to correctly recognize and interpret dash-separated numeric ranges while preserving the existing behavior for single numeric values.

## Changes

* Updated `ClinicalDataIntervalFilterApplier` to detect and parse dash-separated numeric ranges.
* Updated `CustomDataFilterUtil` with the same parsing logic to keep interval handling consistent.
* Safely parses both bounds of a numeric range after trimming whitespace.
* Preserves support for single numeric values and negative numbers.
* Gracefully handles malformed ranges by falling back to the existing behavior.
* Removed the outdated TODO comments after implementing the missing functionality.

## Example

### Before

Clinical attribute value:

```text
20-30
```

Result:

* Parsing attempted to convert `"20-30"` directly into a `BigDecimal`.
* A `NumberFormatException` occurred.
* The value was treated as invalid and excluded from interval-based filtering.

### After

Clinical attribute value:

```text
20-30
```

Result:

* Parsed as the interval `[20, 30]`.
* Interval comparisons are performed correctly during filtering.

## Testing

Verified that:

* Single numeric values continue to behave as before.
* Dash-separated numeric ranges are parsed successfully.
* Negative numbers are not incorrectly interpreted as ranges.
* Invalid range values continue to be handled gracefully.
* Existing tests pass (`StudyViewFilterApplierTest`).

## Impact

This change ensures that patients with clinical attributes recorded as numeric ranges are no longer silently excluded from interval-based filtering. Researchers querying studies containing imprecise clinical measurements (for example, `20-30` or `4.5 - 10.5`) will now obtain results that correctly reflect the stored data.
