### PR TITLE
feat: paginate generic assay meta fetch

### DIFF
--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
@@ -9,6 +9,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.Arrays;
 import java.util.List;
 import org.cbioportal.domain.generic_assay.usecase.GetGenericAssayMetaUseCase;
@@ -16,7 +18,10 @@ import org.cbioportal.legacy.model.meta.GenericAssayMeta;
 import org.cbioportal.legacy.web.config.PublicApiTags;
 import org.cbioportal.legacy.web.config.annotation.PublicApi;
 import org.cbioportal.legacy.web.parameter.GenericAssayMetaFilter;
+import org.cbioportal.legacy.web.parameter.HeaderKeyConstants;
+import org.cbioportal.legacy.web.parameter.PagingConstants;
 import org.cbioportal.legacy.web.parameter.Projection;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -67,15 +72,35 @@ public class ColumnStoreGenericAssayController {
           @Valid
           @RequestBody
           GenericAssayMetaFilter genericAssayMetaFilter,
+      @Parameter(description = "Search keyword that applies to stable ID, name, and description")
+          @RequestParam(required = false)
+          String searchTerm,
+      @Parameter(description = "Page size of the result list")
+          @Max(PagingConstants.MAX_PAGE_SIZE)
+          @Min(PagingConstants.MIN_PAGE_SIZE)
+          @RequestParam(required = false)
+          Integer pageSize,
+      @Parameter(description = "Page number of the result list")
+          @Min(PagingConstants.MIN_PAGE_NUMBER)
+          @RequestParam(required = false)
+          Integer pageNumber,
       @Parameter(description = "Level of detail of the response")
           @RequestParam(defaultValue = "SUMMARY")
           Projection projection) {
+    Integer totalCount =
+        getGenericAssayMetaUseCase.count(
+            genericAssayMetaFilter.getGenericAssayStableIds(),
+            genericAssayMetaFilter.getMolecularProfileIds(),
+            searchTerm);
     List<GenericAssayMeta> result =
         getGenericAssayMetaUseCase.execute(
             genericAssayMetaFilter.getGenericAssayStableIds(),
             genericAssayMetaFilter.getMolecularProfileIds(),
-            projection.name());
-    return streamJson(result);
+            projection.name(),
+            searchTerm,
+            pageSize,
+            pageNumber);
+    return streamJson(result, totalCount);
   }
 
   // PreAuthorize is removed for performance reason
@@ -97,7 +122,8 @@ public class ColumnStoreGenericAssayController {
           Projection projection) {
     return streamJson(
         getGenericAssayMetaUseCase.execute(
-            null, Arrays.asList(molecularProfileId), projection.name()));
+            null, Arrays.asList(molecularProfileId), projection.name()),
+        null);
   }
 
   @RequestMapping(
@@ -118,11 +144,18 @@ public class ColumnStoreGenericAssayController {
           Projection projection) {
     return streamJson(
         getGenericAssayMetaUseCase.execute(
-            Arrays.asList(genericAssayStableId), null, projection.name()));
+            Arrays.asList(genericAssayStableId), null, projection.name()),
+        null);
   }
 
-  private ResponseEntity<StreamingResponseBody> streamJson(List<GenericAssayMeta> data) {
+  private ResponseEntity<StreamingResponseBody> streamJson(
+      List<GenericAssayMeta> data, Integer totalCount) {
+    HttpHeaders headers = new HttpHeaders();
+    if (totalCount != null) {
+      headers.add(HeaderKeyConstants.TOTAL_COUNT, totalCount.toString());
+    }
     return ResponseEntity.ok()
+        .headers(headers)
         .contentType(MediaType.APPLICATION_JSON)
         .body(outputStream -> objectMapper.writeValue(outputStream, data));
   }

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
@@ -87,11 +87,16 @@ public class ColumnStoreGenericAssayController {
       @Parameter(description = "Level of detail of the response")
           @RequestParam(defaultValue = "SUMMARY")
           Projection projection) {
+    // Only compute a total count when the caller is actually paging; legacy callers that
+    // just want the full list (e.g. patient view) shouldn't pay for an extra count query.
     Integer totalCount =
-        getGenericAssayMetaUseCase.count(
-            genericAssayMetaFilter.getGenericAssayStableIds(),
-            genericAssayMetaFilter.getMolecularProfileIds(),
-            searchTerm);
+        pageSize != null && pageNumber != null
+            ? getGenericAssayMetaUseCase.count(
+                genericAssayMetaFilter.getGenericAssayStableIds(),
+                genericAssayMetaFilter.getMolecularProfileIds(),
+                projection.name(),
+                searchTerm)
+            : null;
     List<GenericAssayMeta> result =
         getGenericAssayMetaUseCase.execute(
             genericAssayMetaFilter.getGenericAssayStableIds(),

--- a/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
+++ b/src/main/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayController.java
@@ -22,6 +22,7 @@ import org.cbioportal.legacy.web.parameter.HeaderKeyConstants;
 import org.cbioportal.legacy.web.parameter.PagingConstants;
 import org.cbioportal.legacy.web.parameter.Projection;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 /**
@@ -87,6 +89,10 @@ public class ColumnStoreGenericAssayController {
       @Parameter(description = "Level of detail of the response")
           @RequestParam(defaultValue = "SUMMARY")
           Projection projection) {
+    if ((pageSize == null) != (pageNumber == null)) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "pageSize and pageNumber must both be supplied together");
+    }
     // Only compute a total count when the caller is actually paging; legacy callers that
     // just want the full list (e.g. patient view) shouldn't pay for an extra count query.
     Integer totalCount =

--- a/src/main/java/org/cbioportal/domain/generic_assay/repository/GenericAssayRepository.java
+++ b/src/main/java/org/cbioportal/domain/generic_assay/repository/GenericAssayRepository.java
@@ -81,7 +81,14 @@ public interface GenericAssayRepository {
    * @param stableIds the list of entity stable IDs
    * @return a list of {@link GenericAssayMeta} with properties pre-populated
    */
-  List<GenericAssayMeta> getGenericAssayMetaByStableIds(List<String> stableIds);
+  default List<GenericAssayMeta> getGenericAssayMetaByStableIds(List<String> stableIds) {
+    return getGenericAssayMetaByStableIds(stableIds, null, null, null);
+  }
+
+  List<GenericAssayMeta> getGenericAssayMetaByStableIds(
+      List<String> stableIds, String searchTerm, Integer pageSize, Integer offset);
+
+  Integer countGenericAssayMetaByStableIds(List<String> stableIds, String searchTerm);
 
   /**
    * Retrieves generic assay meta data for entities belonging to the given molecular profile IDs in
@@ -93,6 +100,18 @@ public interface GenericAssayRepository {
    * @param stableIds optional additional filter; pass {@code null} to return all entities
    * @return a list of {@link GenericAssayMeta} with properties pre-populated
    */
+  default List<GenericAssayMeta> getGenericAssayMetaByProfileIds(
+      List<String> profileIds, List<String> stableIds) {
+    return getGenericAssayMetaByProfileIds(profileIds, stableIds, null, null, null);
+  }
+
   List<GenericAssayMeta> getGenericAssayMetaByProfileIds(
-      List<String> profileIds, List<String> stableIds);
+      List<String> profileIds,
+      List<String> stableIds,
+      String searchTerm,
+      Integer pageSize,
+      Integer offset);
+
+  Integer countGenericAssayMetaByProfileIds(
+      List<String> profileIds, List<String> stableIds, String searchTerm);
 }

--- a/src/main/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCase.java
+++ b/src/main/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCase.java
@@ -43,6 +43,25 @@ public class GetGenericAssayMetaUseCase {
               + " #projection}")
   public List<GenericAssayMeta> execute(
       List<String> stableIds, List<String> molecularProfileIds, String projection) {
+    return execute(stableIds, molecularProfileIds, projection, null, null, null);
+  }
+
+  @Cacheable(
+      cacheResolver = "generalRepositoryCacheResolver",
+      condition = "@cacheEnabledConfig.getEnabled()",
+      key =
+          "{#stableIds == null ? null : new java.util.TreeSet(#stableIds.?[#this != null]),"
+              + " #molecularProfileIds == null ? null : new java.util.TreeSet(#molecularProfileIds.?[#this != null]),"
+              + " #projection, #searchTerm, #pageSize, #pageNumber}")
+  public List<GenericAssayMeta> execute(
+      List<String> stableIds,
+      List<String> molecularProfileIds,
+      String projection,
+      String searchTerm,
+      Integer pageSize,
+      Integer pageNumber) {
+    String normalizedSearchTerm = normalizeSearchTerm(searchTerm);
+    Integer offset = pageSize == null || pageNumber == null ? null : pageSize * pageNumber;
 
     if (molecularProfileIds != null) {
       List<String> sortedProfileIds = molecularProfileIds.stream().distinct().sorted().toList();
@@ -57,11 +76,18 @@ public class GetGenericAssayMetaUseCase {
         if (stableIds != null) {
           resolvedIds.retainAll(new HashSet<>(stableIds));
         }
-        return resolvedIds.stream().map(GenericAssayMeta::new).toList();
+        var filteredIds =
+            resolvedIds.stream()
+                .filter(id -> containsSearchText(id, normalizedSearchTerm))
+                .toList();
+        return pageIds(filteredIds, pageSize, pageNumber).stream()
+            .map(GenericAssayMeta::new)
+            .toList();
       }
 
       // Single merged query: profile → entity + meta join
-      return repository.getGenericAssayMetaByProfileIds(sortedProfileIds, stableIds);
+      return repository.getGenericAssayMetaByProfileIds(
+          sortedProfileIds, stableIds, normalizedSearchTerm, pageSize, offset);
     }
 
     if (stableIds == null || stableIds.isEmpty()) {
@@ -71,9 +97,67 @@ public class GetGenericAssayMetaUseCase {
     List<String> distinctStableIds = stableIds.stream().distinct().toList();
 
     if ("ID".equals(projection)) {
-      return distinctStableIds.stream().map(GenericAssayMeta::new).toList();
+      return pageIds(
+              distinctStableIds.stream()
+                  .filter(id -> containsSearchText(id, normalizedSearchTerm))
+                  .toList(),
+              pageSize,
+              pageNumber)
+          .stream()
+          .map(GenericAssayMeta::new)
+          .toList();
     }
 
-    return repository.getGenericAssayMetaByStableIds(distinctStableIds);
+    return repository.getGenericAssayMetaByStableIds(
+        distinctStableIds, normalizedSearchTerm, pageSize, offset);
+  }
+
+  @Cacheable(
+      cacheResolver = "generalRepositoryCacheResolver",
+      condition = "@cacheEnabledConfig.getEnabled()",
+      key =
+          "{#stableIds == null ? null : new java.util.TreeSet(#stableIds.?[#this != null]),"
+              + " #molecularProfileIds == null ? null : new java.util.TreeSet(#molecularProfileIds.?[#this != null]),"
+              + " #searchTerm, 'count'}")
+  public Integer count(
+      List<String> stableIds, List<String> molecularProfileIds, String searchTerm) {
+    String normalizedSearchTerm = normalizeSearchTerm(searchTerm);
+    if (molecularProfileIds != null) {
+      List<String> sortedProfileIds = molecularProfileIds.stream().distinct().sorted().toList();
+      if (sortedProfileIds.isEmpty()) {
+        return 0;
+      }
+      return repository.countGenericAssayMetaByProfileIds(
+          sortedProfileIds, stableIds, normalizedSearchTerm);
+    }
+
+    if (stableIds == null || stableIds.isEmpty()) {
+      return 0;
+    }
+
+    return repository.countGenericAssayMetaByStableIds(
+        stableIds.stream().distinct().toList(), normalizedSearchTerm);
+  }
+
+  private String normalizeSearchTerm(String searchTerm) {
+    if (searchTerm == null || searchTerm.isBlank()) {
+      return null;
+    }
+    return searchTerm.trim();
+  }
+
+  private boolean containsSearchText(String value, String searchTerm) {
+    return searchTerm == null || value.toLowerCase().contains(searchTerm.toLowerCase());
+  }
+
+  private List<String> pageIds(List<String> ids, Integer pageSize, Integer pageNumber) {
+    if (pageSize == null || pageNumber == null) {
+      return ids;
+    }
+    int offset = pageSize * pageNumber;
+    if (offset >= ids.size()) {
+      return Collections.emptyList();
+    }
+    return ids.subList(offset, Math.min(offset + pageSize, ids.size()));
   }
 }

--- a/src/main/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCase.java
+++ b/src/main/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCase.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import org.cbioportal.domain.generic_assay.repository.GenericAssayRepository;
 import org.cbioportal.legacy.model.meta.GenericAssayMeta;
@@ -53,7 +54,9 @@ public class GetGenericAssayMetaUseCase {
       key =
           "{#stableIds == null ? null : new java.util.TreeSet(#stableIds.?[#this != null]),"
               + " #molecularProfileIds == null ? null : new java.util.TreeSet(#molecularProfileIds.?[#this != null]),"
-              + " #projection, #searchTerm, #pageSize, #pageNumber}")
+              + " #projection,"
+              + " (#searchTerm == null or #searchTerm.trim().isEmpty() ? null : #searchTerm.trim()),"
+              + " #pageSize, #pageNumber}")
   public List<GenericAssayMeta> execute(
       List<String> stableIds,
       List<String> molecularProfileIds,
@@ -111,7 +114,9 @@ public class GetGenericAssayMetaUseCase {
       key =
           "{#stableIds == null ? null : new java.util.TreeSet(#stableIds.?[#this != null]),"
               + " #molecularProfileIds == null ? null : new java.util.TreeSet(#molecularProfileIds.?[#this != null]),"
-              + " #projection, #searchTerm, 'count'}")
+              + " #projection,"
+              + " (#searchTerm == null or #searchTerm.trim().isEmpty() ? null : #searchTerm.trim()),"
+              + " 'count'}")
   public Integer count(
       List<String> stableIds,
       List<String> molecularProfileIds,
@@ -152,7 +157,9 @@ public class GetGenericAssayMetaUseCase {
   }
 
   private boolean containsSearchText(String value, String searchTerm) {
-    return searchTerm == null || value.toLowerCase().contains(searchTerm.toLowerCase());
+    return searchTerm == null
+        || (value != null
+            && value.toLowerCase(Locale.ROOT).contains(searchTerm.toLowerCase(Locale.ROOT)));
   }
 
   private List<String> filterIdsBySearchTerm(Collection<String> ids, String normalizedSearchTerm) {

--- a/src/main/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCase.java
+++ b/src/main/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCase.java
@@ -1,5 +1,6 @@
 package org.cbioportal.domain.generic_assay.usecase;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -71,15 +72,8 @@ public class GetGenericAssayMetaUseCase {
 
       if ("ID".equals(projection)) {
         // Lightweight path: resolve IDs only, skip meta fetch
-        Set<String> resolvedIds =
-            new LinkedHashSet<>(repository.getGenericAssayStableIdsByProfileIds(sortedProfileIds));
-        if (stableIds != null) {
-          resolvedIds.retainAll(new HashSet<>(stableIds));
-        }
         var filteredIds =
-            resolvedIds.stream()
-                .filter(id -> containsSearchText(id, normalizedSearchTerm))
-                .toList();
+            resolveFilteredIdsByProfileIds(sortedProfileIds, stableIds, normalizedSearchTerm);
         return pageIds(filteredIds, pageSize, pageNumber).stream()
             .map(GenericAssayMeta::new)
             .toList();
@@ -98,11 +92,7 @@ public class GetGenericAssayMetaUseCase {
 
     if ("ID".equals(projection)) {
       return pageIds(
-              distinctStableIds.stream()
-                  .filter(id -> containsSearchText(id, normalizedSearchTerm))
-                  .toList(),
-              pageSize,
-              pageNumber)
+              filterIdsBySearchTerm(distinctStableIds, normalizedSearchTerm), pageSize, pageNumber)
           .stream()
           .map(GenericAssayMeta::new)
           .toList();
@@ -112,20 +102,31 @@ public class GetGenericAssayMetaUseCase {
         distinctStableIds, normalizedSearchTerm, pageSize, offset);
   }
 
+  // Mirrors the ID-projection branches in execute(): count must use the same match
+  // criteria (stable ID only, no name/description) as the data it's counting, or the
+  // reported total-count won't line up with what's actually paginable for that projection.
   @Cacheable(
       cacheResolver = "generalRepositoryCacheResolver",
       condition = "@cacheEnabledConfig.getEnabled()",
       key =
           "{#stableIds == null ? null : new java.util.TreeSet(#stableIds.?[#this != null]),"
               + " #molecularProfileIds == null ? null : new java.util.TreeSet(#molecularProfileIds.?[#this != null]),"
-              + " #searchTerm, 'count'}")
+              + " #projection, #searchTerm, 'count'}")
   public Integer count(
-      List<String> stableIds, List<String> molecularProfileIds, String searchTerm) {
+      List<String> stableIds,
+      List<String> molecularProfileIds,
+      String projection,
+      String searchTerm) {
     String normalizedSearchTerm = normalizeSearchTerm(searchTerm);
+
     if (molecularProfileIds != null) {
       List<String> sortedProfileIds = molecularProfileIds.stream().distinct().sorted().toList();
       if (sortedProfileIds.isEmpty()) {
         return 0;
+      }
+      if ("ID".equals(projection)) {
+        return resolveFilteredIdsByProfileIds(sortedProfileIds, stableIds, normalizedSearchTerm)
+            .size();
       }
       return repository.countGenericAssayMetaByProfileIds(
           sortedProfileIds, stableIds, normalizedSearchTerm);
@@ -135,8 +136,12 @@ public class GetGenericAssayMetaUseCase {
       return 0;
     }
 
-    return repository.countGenericAssayMetaByStableIds(
-        stableIds.stream().distinct().toList(), normalizedSearchTerm);
+    List<String> distinctStableIds = stableIds.stream().distinct().toList();
+    if ("ID".equals(projection)) {
+      return filterIdsBySearchTerm(distinctStableIds, normalizedSearchTerm).size();
+    }
+
+    return repository.countGenericAssayMetaByStableIds(distinctStableIds, normalizedSearchTerm);
   }
 
   private String normalizeSearchTerm(String searchTerm) {
@@ -148,6 +153,20 @@ public class GetGenericAssayMetaUseCase {
 
   private boolean containsSearchText(String value, String searchTerm) {
     return searchTerm == null || value.toLowerCase().contains(searchTerm.toLowerCase());
+  }
+
+  private List<String> filterIdsBySearchTerm(Collection<String> ids, String normalizedSearchTerm) {
+    return ids.stream().filter(id -> containsSearchText(id, normalizedSearchTerm)).toList();
+  }
+
+  private List<String> resolveFilteredIdsByProfileIds(
+      List<String> sortedProfileIds, List<String> stableIds, String normalizedSearchTerm) {
+    Set<String> resolvedIds =
+        new LinkedHashSet<>(repository.getGenericAssayStableIdsByProfileIds(sortedProfileIds));
+    if (stableIds != null) {
+      resolvedIds.retainAll(new HashSet<>(stableIds));
+    }
+    return filterIdsBySearchTerm(resolvedIds, normalizedSearchTerm);
   }
 
   private List<String> pageIds(List<String> ids, Integer pageSize, Integer pageNumber) {

--- a/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayMapper.java
+++ b/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayMapper.java
@@ -79,7 +79,18 @@ public interface ClickhouseGenericAssayMapper {
    * @param stableIds the list of entity stable IDs
    * @return a list of {@link GenericAssayMeta} with properties pre-populated
    */
-  List<GenericAssayMeta> getGenericAssayMetaByStableIds(List<String> stableIds);
+  default List<GenericAssayMeta> getGenericAssayMetaByStableIds(List<String> stableIds) {
+    return getGenericAssayMetaByStableIds(stableIds, null, null, null);
+  }
+
+  List<GenericAssayMeta> getGenericAssayMetaByStableIds(
+      @Param("stableIds") List<String> stableIds,
+      @Param("searchTerm") String searchTerm,
+      @Param("pageSize") Integer pageSize,
+      @Param("offset") Integer offset);
+
+  Integer countGenericAssayMetaByStableIds(
+      @Param("stableIds") List<String> stableIds, @Param("searchTerm") String searchTerm);
 
   /**
    * Resolves profile IDs → entity stable IDs via generic_assay_profile_entity_derived and joins
@@ -89,6 +100,20 @@ public interface ClickhouseGenericAssayMapper {
    * @param stableIds optional additional stable ID filter; {@code null} means no filter
    * @return a list of {@link GenericAssayMeta} with properties pre-populated
    */
+  default List<GenericAssayMeta> getGenericAssayMetaByProfileIds(
+      List<String> profileIds, List<String> stableIds) {
+    return getGenericAssayMetaByProfileIds(profileIds, stableIds, null, null, null);
+  }
+
   List<GenericAssayMeta> getGenericAssayMetaByProfileIds(
-      @Param("profileIds") List<String> profileIds, @Param("stableIds") List<String> stableIds);
+      @Param("profileIds") List<String> profileIds,
+      @Param("stableIds") List<String> stableIds,
+      @Param("searchTerm") String searchTerm,
+      @Param("pageSize") Integer pageSize,
+      @Param("offset") Integer offset);
+
+  Integer countGenericAssayMetaByProfileIds(
+      @Param("profileIds") List<String> profileIds,
+      @Param("stableIds") List<String> stableIds,
+      @Param("searchTerm") String searchTerm);
 }

--- a/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayRepository.java
+++ b/src/main/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayRepository.java
@@ -58,13 +58,30 @@ public class ClickhouseGenericAssayRepository implements GenericAssayRepository 
   }
 
   @Override
-  public List<GenericAssayMeta> getGenericAssayMetaByStableIds(List<String> stableIds) {
-    return mapper.getGenericAssayMetaByStableIds(stableIds);
+  public List<GenericAssayMeta> getGenericAssayMetaByStableIds(
+      List<String> stableIds, String searchTerm, Integer pageSize, Integer offset) {
+    return mapper.getGenericAssayMetaByStableIds(stableIds, searchTerm, pageSize, offset);
+  }
+
+  @Override
+  public Integer countGenericAssayMetaByStableIds(List<String> stableIds, String searchTerm) {
+    return mapper.countGenericAssayMetaByStableIds(stableIds, searchTerm);
   }
 
   @Override
   public List<GenericAssayMeta> getGenericAssayMetaByProfileIds(
-      List<String> profileIds, List<String> stableIds) {
-    return mapper.getGenericAssayMetaByProfileIds(profileIds, stableIds);
+      List<String> profileIds,
+      List<String> stableIds,
+      String searchTerm,
+      Integer pageSize,
+      Integer offset) {
+    return mapper.getGenericAssayMetaByProfileIds(
+        profileIds, stableIds, searchTerm, pageSize, offset);
+  }
+
+  @Override
+  public Integer countGenericAssayMetaByProfileIds(
+      List<String> profileIds, List<String> stableIds, String searchTerm) {
+    return mapper.countGenericAssayMetaByProfileIds(profileIds, stableIds, searchTerm);
   }
 }

--- a/src/main/resources/mappers/clickhouse/generic_assay/GenericAssayMapper.xml
+++ b/src/main/resources/mappers/clickhouse/generic_assay/GenericAssayMapper.xml
@@ -301,6 +301,16 @@
                 typeHandler="org.cbioportal.infrastructure.repository.clickhouse.typehandlers.ClickhouseMapTypeHandler"/>
     </resultMap>
 
+    <sql id="GenericAssayMetaSearchPredicate">
+        <if test="searchTerm != null and searchTerm != ''">
+            AND (
+                entity_stable_id ILIKE concat('%', #{searchTerm}, '%')
+                OR properties['NAME'] ILIKE concat('%', #{searchTerm}, '%')
+                OR properties['DESCRIPTION'] ILIKE concat('%', #{searchTerm}, '%')
+            )
+        </if>
+    </sql>
+
     <select id="getGenericAssayMetaByStableIds" resultMap="GenericAssayMetaResultMap">
         SELECT
             entity_stable_id AS stableId,
@@ -308,9 +318,21 @@
             properties
         FROM generic_assay_meta_derived
         WHERE entity_stable_id IN
-            <foreach item="item" collection="list" open="(" separator="," close=")">#{item}</foreach>
+            <foreach item="item" collection="stableIds" open="(" separator="," close=")">#{item}</foreach>
+        <include refid="GenericAssayMetaSearchPredicate"/>
         <!-- Sort numerically by leading digits, then lexicographically (e.g. 1p, 2p, ... 10p, not 10p, 1p, 2p) -->
         ORDER BY toUInt32OrZero(extract(entity_stable_id, '^[0-9]+')) ASC, entity_stable_id ASC
+        <if test="pageSize != null and offset != null">
+            LIMIT #{pageSize} OFFSET #{offset}
+        </if>
+    </select>
+
+    <select id="countGenericAssayMetaByStableIds" resultType="int">
+        SELECT count()
+        FROM generic_assay_meta_derived
+        WHERE entity_stable_id IN
+            <foreach item="item" collection="stableIds" open="(" separator="," close=")">#{item}</foreach>
+        <include refid="GenericAssayMetaSearchPredicate"/>
     </select>
 
     <select id="getGenericAssayMetaByProfileIds" resultMap="GenericAssayMetaResultMap">
@@ -329,8 +351,40 @@
             AND gam.entity_stable_id IN
                 <foreach item="item" collection="stableIds" open="(" separator="," close=")">#{item}</foreach>
         </if>
+        <if test="searchTerm != null and searchTerm != ''">
+            AND (
+                gam.entity_stable_id ILIKE concat('%', #{searchTerm}, '%')
+                OR gam.properties['NAME'] ILIKE concat('%', #{searchTerm}, '%')
+                OR gam.properties['DESCRIPTION'] ILIKE concat('%', #{searchTerm}, '%')
+            )
+        </if>
         <!-- Sort numerically by leading digits, then lexicographically (e.g. 1p, 2p, ... 10p, not 10p, 1p, 2p) -->
         ORDER BY toUInt32OrZero(extract(gam.entity_stable_id, '^[0-9]+')) ASC, gam.entity_stable_id ASC
+        <if test="pageSize != null and offset != null">
+            LIMIT #{pageSize} OFFSET #{offset}
+        </if>
+    </select>
+
+    <select id="countGenericAssayMetaByProfileIds" resultType="int">
+        SELECT count()
+        FROM generic_assay_meta_derived gam
+        WHERE gam.entity_stable_id IN (
+            SELECT DISTINCT entity_stable_id
+            FROM generic_assay_profile_entity_derived
+            WHERE profile_stable_id IN
+                <foreach item="item" collection="profileIds" open="(" separator="," close=")">#{item}</foreach>
+        )
+        <if test="stableIds != null and !stableIds.isEmpty()">
+            AND gam.entity_stable_id IN
+                <foreach item="item" collection="stableIds" open="(" separator="," close=")">#{item}</foreach>
+        </if>
+        <if test="searchTerm != null and searchTerm != ''">
+            AND (
+                gam.entity_stable_id ILIKE concat('%', #{searchTerm}, '%')
+                OR gam.properties['NAME'] ILIKE concat('%', #{searchTerm}, '%')
+                OR gam.properties['DESCRIPTION'] ILIKE concat('%', #{searchTerm}, '%')
+            )
+        </if>
     </select>
 
 </mapper>

--- a/src/main/resources/mappers/clickhouse/generic_assay/GenericAssayMapper.xml
+++ b/src/main/resources/mappers/clickhouse/generic_assay/GenericAssayMapper.xml
@@ -305,8 +305,8 @@
         <if test="searchTerm != null and searchTerm != ''">
             AND (
                 entity_stable_id ILIKE concat('%', #{searchTerm}, '%')
-                OR properties['NAME'] ILIKE concat('%', #{searchTerm}, '%')
-                OR properties['DESCRIPTION'] ILIKE concat('%', #{searchTerm}, '%')
+                OR ifNull(properties['NAME'], '') ILIKE concat('%', #{searchTerm}, '%')
+                OR ifNull(properties['DESCRIPTION'], '') ILIKE concat('%', #{searchTerm}, '%')
             )
         </if>
     </sql>
@@ -354,8 +354,8 @@
         <if test="searchTerm != null and searchTerm != ''">
             AND (
                 gam.entity_stable_id ILIKE concat('%', #{searchTerm}, '%')
-                OR gam.properties['NAME'] ILIKE concat('%', #{searchTerm}, '%')
-                OR gam.properties['DESCRIPTION'] ILIKE concat('%', #{searchTerm}, '%')
+                OR ifNull(gam.properties['NAME'], '') ILIKE concat('%', #{searchTerm}, '%')
+                OR ifNull(gam.properties['DESCRIPTION'], '') ILIKE concat('%', #{searchTerm}, '%')
             )
         </if>
         <!-- Sort numerically by leading digits, then lexicographically (e.g. 1p, 2p, ... 10p, not 10p, 1p, 2p) -->
@@ -381,8 +381,8 @@
         <if test="searchTerm != null and searchTerm != ''">
             AND (
                 gam.entity_stable_id ILIKE concat('%', #{searchTerm}, '%')
-                OR gam.properties['NAME'] ILIKE concat('%', #{searchTerm}, '%')
-                OR gam.properties['DESCRIPTION'] ILIKE concat('%', #{searchTerm}, '%')
+                OR ifNull(gam.properties['NAME'], '') ILIKE concat('%', #{searchTerm}, '%')
+                OR ifNull(gam.properties['DESCRIPTION'], '') ILIKE concat('%', #{searchTerm}, '%')
             )
         </if>
     </select>

--- a/src/main/resources/mappers/clickhouse/generic_assay/GenericAssayMapper.xml
+++ b/src/main/resources/mappers/clickhouse/generic_assay/GenericAssayMapper.xml
@@ -301,13 +301,30 @@
                 typeHandler="org.cbioportal.infrastructure.repository.clickhouse.typehandlers.ClickhouseMapTypeHandler"/>
     </resultMap>
 
+    <!-- alias is the (optionally empty) table-alias-plus-dot prefix, e.g. "gam." or "" -->
     <sql id="GenericAssayMetaSearchPredicate">
         <if test="searchTerm != null and searchTerm != ''">
             AND (
-                entity_stable_id ILIKE concat('%', #{searchTerm}, '%')
-                OR ifNull(properties['NAME'], '') ILIKE concat('%', #{searchTerm}, '%')
-                OR ifNull(properties['DESCRIPTION'], '') ILIKE concat('%', #{searchTerm}, '%')
+                ${alias}entity_stable_id ILIKE concat('%', #{searchTerm}, '%')
+                OR ifNull(${alias}properties['NAME'], '') ILIKE concat('%', #{searchTerm}, '%')
+                OR ifNull(${alias}properties['DESCRIPTION'], '') ILIKE concat('%', #{searchTerm}, '%')
             )
+        </if>
+    </sql>
+
+    <!-- resolves gam.entity_stable_id to those in the given profiles, optionally further
+         restricted to the given stableIds; shared by the get/count profile-id queries below
+         so their entity-resolution logic can't drift apart -->
+    <sql id="GenericAssayEntityIdsForProfileIds">
+        gam.entity_stable_id IN (
+            SELECT DISTINCT entity_stable_id
+            FROM generic_assay_profile_entity_derived
+            WHERE profile_stable_id IN
+                <foreach item="item" collection="profileIds" open="(" separator="," close=")">#{item}</foreach>
+        )
+        <if test="stableIds != null and !stableIds.isEmpty()">
+            AND gam.entity_stable_id IN
+                <foreach item="item" collection="stableIds" open="(" separator="," close=")">#{item}</foreach>
         </if>
     </sql>
 
@@ -319,7 +336,9 @@
         FROM generic_assay_meta_derived
         WHERE entity_stable_id IN
             <foreach item="item" collection="stableIds" open="(" separator="," close=")">#{item}</foreach>
-        <include refid="GenericAssayMetaSearchPredicate"/>
+        <include refid="GenericAssayMetaSearchPredicate">
+            <property name="alias" value=""/>
+        </include>
         <!-- Sort numerically by leading digits, then lexicographically (e.g. 1p, 2p, ... 10p, not 10p, 1p, 2p) -->
         ORDER BY toUInt32OrZero(extract(entity_stable_id, '^[0-9]+')) ASC, entity_stable_id ASC
         <if test="pageSize != null and offset != null">
@@ -332,7 +351,9 @@
         FROM generic_assay_meta_derived
         WHERE entity_stable_id IN
             <foreach item="item" collection="stableIds" open="(" separator="," close=")">#{item}</foreach>
-        <include refid="GenericAssayMetaSearchPredicate"/>
+        <include refid="GenericAssayMetaSearchPredicate">
+            <property name="alias" value=""/>
+        </include>
     </select>
 
     <select id="getGenericAssayMetaByProfileIds" resultMap="GenericAssayMetaResultMap">
@@ -341,23 +362,10 @@
             gam.entity_type AS entityType,
             gam.properties
         FROM generic_assay_meta_derived gam
-        WHERE gam.entity_stable_id IN (
-            SELECT DISTINCT entity_stable_id
-            FROM generic_assay_profile_entity_derived
-            WHERE profile_stable_id IN
-                <foreach item="item" collection="profileIds" open="(" separator="," close=")">#{item}</foreach>
-        )
-        <if test="stableIds != null and !stableIds.isEmpty()">
-            AND gam.entity_stable_id IN
-                <foreach item="item" collection="stableIds" open="(" separator="," close=")">#{item}</foreach>
-        </if>
-        <if test="searchTerm != null and searchTerm != ''">
-            AND (
-                gam.entity_stable_id ILIKE concat('%', #{searchTerm}, '%')
-                OR ifNull(gam.properties['NAME'], '') ILIKE concat('%', #{searchTerm}, '%')
-                OR ifNull(gam.properties['DESCRIPTION'], '') ILIKE concat('%', #{searchTerm}, '%')
-            )
-        </if>
+        WHERE <include refid="GenericAssayEntityIdsForProfileIds"/>
+        <include refid="GenericAssayMetaSearchPredicate">
+            <property name="alias" value="gam."/>
+        </include>
         <!-- Sort numerically by leading digits, then lexicographically (e.g. 1p, 2p, ... 10p, not 10p, 1p, 2p) -->
         ORDER BY toUInt32OrZero(extract(gam.entity_stable_id, '^[0-9]+')) ASC, gam.entity_stable_id ASC
         <if test="pageSize != null and offset != null">
@@ -368,23 +376,10 @@
     <select id="countGenericAssayMetaByProfileIds" resultType="int">
         SELECT count()
         FROM generic_assay_meta_derived gam
-        WHERE gam.entity_stable_id IN (
-            SELECT DISTINCT entity_stable_id
-            FROM generic_assay_profile_entity_derived
-            WHERE profile_stable_id IN
-                <foreach item="item" collection="profileIds" open="(" separator="," close=")">#{item}</foreach>
-        )
-        <if test="stableIds != null and !stableIds.isEmpty()">
-            AND gam.entity_stable_id IN
-                <foreach item="item" collection="stableIds" open="(" separator="," close=")">#{item}</foreach>
-        </if>
-        <if test="searchTerm != null and searchTerm != ''">
-            AND (
-                gam.entity_stable_id ILIKE concat('%', #{searchTerm}, '%')
-                OR ifNull(gam.properties['NAME'], '') ILIKE concat('%', #{searchTerm}, '%')
-                OR ifNull(gam.properties['DESCRIPTION'], '') ILIKE concat('%', #{searchTerm}, '%')
-            )
-        </if>
+        WHERE <include refid="GenericAssayEntityIdsForProfileIds"/>
+        <include refid="GenericAssayMetaSearchPredicate">
+            <property name="alias" value="gam."/>
+        </include>
     </select>
 
 </mapper>

--- a/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
+++ b/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
@@ -130,25 +130,29 @@ public class ColumnStoreGenericAssayControllerTest {
     GenericAssayMetaFilter genericAssayMetaFilter = new GenericAssayMetaFilter();
     genericAssayMetaFilter.setGenericAssayStableIds(genericAssayStableIds);
 
-    Mockito.when(getGenericAssayMetaUseCase.execute(Mockito.any(), Mockito.any(), Mockito.any()))
+    Mockito.when(getGenericAssayMetaUseCase.count(Mockito.any(), Mockito.any(), Mockito.any()))
+        .thenReturn(2);
+    Mockito.when(
+            getGenericAssayMetaUseCase.execute(
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()))
         .thenReturn(genericAssayMetaItems);
 
-    MvcResult mvcResult =
-        mockMvc
-            .perform(
-                MockMvcRequestBuilders.post("/api/generic-assay-meta/fetch")
-                    .with(csrf())
-                    .accept(MediaType.APPLICATION_JSON)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(genericAssayMetaFilter)))
-            .andExpect(MockMvcResultMatchers.request().asyncStarted())
-            .andReturn();
-
     mockMvc
-        .perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+        .perform(
+            MockMvcRequestBuilders.post("/api/generic-assay-meta/fetch")
+                .with(csrf())
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(genericAssayMetaFilter)))
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(
             MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(MockMvcResultMatchers.header().string("total-count", "2"))
         .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].entityType").value(ENTITY_TYPE))
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].stableId").value(GENERIC_ASSAY_STABLE_ID_1))
@@ -160,6 +164,56 @@ public class ColumnStoreGenericAssayControllerTest {
         .andExpect(
             MockMvcResultMatchers.jsonPath(
                 "$[1].genericEntityMetaProperties", Matchers.hasValue(TEST_NAME_VALUE)));
+
+    Mockito.verify(getGenericAssayMetaUseCase).count(genericAssayStableIds, null, null);
+    Mockito.verify(getGenericAssayMetaUseCase)
+        .execute(genericAssayStableIds, null, "SUMMARY", null, null, null);
+  }
+
+  @Test
+  @WithMockUser
+  public void testFetchGenericAssayMeta_withPagingAndSearch() throws Exception {
+    List<GenericAssayMeta> genericAssayMetaItems = createGenericAssayMetaSingleItem();
+    GenericAssayMetaFilter genericAssayMetaFilter = new GenericAssayMetaFilter();
+    genericAssayMetaFilter.setMolecularProfileIds(List.of(PROF_ID));
+
+    Mockito.when(getGenericAssayMetaUseCase.count(Mockito.any(), Mockito.any(), Mockito.any()))
+        .thenReturn(250);
+    Mockito.when(
+            getGenericAssayMetaUseCase.execute(
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()))
+        .thenReturn(genericAssayMetaItems);
+
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.post("/api/generic-assay-meta/fetch")
+                    .queryParam("searchTerm", "tp53")
+                    .queryParam("pageSize", "100")
+                    .queryParam("pageNumber", "1")
+                    .with(csrf())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(genericAssayMetaFilter)))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn();
+
+    mockMvc
+        .perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andExpect(MockMvcResultMatchers.header().string("total-count", "250"))
+        .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(1)))
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$[0].stableId").value(GENERIC_ASSAY_STABLE_ID_2));
+
+    Mockito.verify(getGenericAssayMetaUseCase).count(null, List.of(PROF_ID), "tp53");
+    Mockito.verify(getGenericAssayMetaUseCase)
+        .execute(null, List.of(PROF_ID), "SUMMARY", "tp53", 100, 1);
   }
 
   private List<GenericAssayMeta> createGenericAssayMetaSingleItem() {

--- a/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
+++ b/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
@@ -130,8 +130,6 @@ public class ColumnStoreGenericAssayControllerTest {
     GenericAssayMetaFilter genericAssayMetaFilter = new GenericAssayMetaFilter();
     genericAssayMetaFilter.setGenericAssayStableIds(genericAssayStableIds);
 
-    Mockito.when(getGenericAssayMetaUseCase.count(Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenReturn(2);
     Mockito.when(
             getGenericAssayMetaUseCase.execute(
                 Mockito.any(),
@@ -152,7 +150,7 @@ public class ColumnStoreGenericAssayControllerTest {
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(
             MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-        .andExpect(MockMvcResultMatchers.header().string("total-count", "2"))
+        .andExpect(MockMvcResultMatchers.header().doesNotExist("total-count"))
         .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.hasSize(2)))
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].entityType").value(ENTITY_TYPE))
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].stableId").value(GENERIC_ASSAY_STABLE_ID_1))
@@ -165,9 +163,10 @@ public class ColumnStoreGenericAssayControllerTest {
             MockMvcResultMatchers.jsonPath(
                 "$[1].genericEntityMetaProperties", Matchers.hasValue(TEST_NAME_VALUE)));
 
-    Mockito.verify(getGenericAssayMetaUseCase).count(genericAssayStableIds, null, null);
     Mockito.verify(getGenericAssayMetaUseCase)
         .execute(genericAssayStableIds, null, "SUMMARY", null, null, null);
+    Mockito.verify(getGenericAssayMetaUseCase, Mockito.never())
+        .count(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
   }
 
   @Test
@@ -177,7 +176,9 @@ public class ColumnStoreGenericAssayControllerTest {
     GenericAssayMetaFilter genericAssayMetaFilter = new GenericAssayMetaFilter();
     genericAssayMetaFilter.setMolecularProfileIds(List.of(PROF_ID));
 
-    Mockito.when(getGenericAssayMetaUseCase.count(Mockito.any(), Mockito.any(), Mockito.any()))
+    Mockito.when(
+            getGenericAssayMetaUseCase.count(
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
         .thenReturn(250);
     Mockito.when(
             getGenericAssayMetaUseCase.execute(
@@ -211,9 +212,56 @@ public class ColumnStoreGenericAssayControllerTest {
         .andExpect(
             MockMvcResultMatchers.jsonPath("$[0].stableId").value(GENERIC_ASSAY_STABLE_ID_2));
 
-    Mockito.verify(getGenericAssayMetaUseCase).count(null, List.of(PROF_ID), "tp53");
+    Mockito.verify(getGenericAssayMetaUseCase).count(null, List.of(PROF_ID), "SUMMARY", "tp53");
     Mockito.verify(getGenericAssayMetaUseCase)
         .execute(null, List.of(PROF_ID), "SUMMARY", "tp53", 100, 1);
+  }
+
+  @Test
+  @WithMockUser
+  public void testFetchGenericAssayMeta_idProjectionWithPaging_countUsesIdProjection()
+      throws Exception {
+    List<GenericAssayMeta> genericAssayMetaItems = createGenericAssayMetaSingleItem();
+    GenericAssayMetaFilter genericAssayMetaFilter = new GenericAssayMetaFilter();
+    genericAssayMetaFilter.setMolecularProfileIds(List.of(PROF_ID));
+
+    Mockito.when(
+            getGenericAssayMetaUseCase.count(
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        .thenReturn(5);
+    Mockito.when(
+            getGenericAssayMetaUseCase.execute(
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any(),
+                Mockito.any()))
+        .thenReturn(genericAssayMetaItems);
+
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.post("/api/generic-assay-meta/fetch")
+                    .queryParam("searchTerm", "tp53")
+                    .queryParam("pageSize", "100")
+                    .queryParam("pageNumber", "0")
+                    .queryParam("projection", "ID")
+                    .with(csrf())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(genericAssayMetaFilter)))
+            .andExpect(MockMvcResultMatchers.request().asyncStarted())
+            .andReturn();
+
+    mockMvc
+        .perform(MockMvcRequestBuilders.asyncDispatch(mvcResult))
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andExpect(MockMvcResultMatchers.header().string("total-count", "5"));
+
+    Mockito.verify(getGenericAssayMetaUseCase).count(null, List.of(PROF_ID), "ID", "tp53");
+    Mockito.verify(getGenericAssayMetaUseCase)
+        .execute(null, List.of(PROF_ID), "ID", "tp53", 100, 0);
   }
 
   private List<GenericAssayMeta> createGenericAssayMetaSingleItem() {

--- a/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
+++ b/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
@@ -264,6 +264,46 @@ public class ColumnStoreGenericAssayControllerTest {
         .execute(null, List.of(PROF_ID), "ID", "tp53", 100, 0);
   }
 
+  @Test
+  @WithMockUser
+  public void testFetchGenericAssayMeta_pageSizeWithoutPageNumber_returnsBadRequest()
+      throws Exception {
+    GenericAssayMetaFilter genericAssayMetaFilter = new GenericAssayMetaFilter();
+    genericAssayMetaFilter.setMolecularProfileIds(List.of(PROF_ID));
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/generic-assay-meta/fetch")
+                .queryParam("pageSize", "100")
+                .with(csrf())
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(genericAssayMetaFilter)))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+
+    Mockito.verifyNoInteractions(getGenericAssayMetaUseCase);
+  }
+
+  @Test
+  @WithMockUser
+  public void testFetchGenericAssayMeta_pageNumberWithoutPageSize_returnsBadRequest()
+      throws Exception {
+    GenericAssayMetaFilter genericAssayMetaFilter = new GenericAssayMetaFilter();
+    genericAssayMetaFilter.setMolecularProfileIds(List.of(PROF_ID));
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/generic-assay-meta/fetch")
+                .queryParam("pageNumber", "0")
+                .with(csrf())
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(genericAssayMetaFilter)))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+
+    Mockito.verifyNoInteractions(getGenericAssayMetaUseCase);
+  }
+
   private List<GenericAssayMeta> createGenericAssayMetaSingleItem() {
     List<GenericAssayMeta> items = new ArrayList<>();
     items.add(

--- a/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
+++ b/src/test/java/org/cbioportal/application/rest/vcolumnstore/ColumnStoreGenericAssayControllerTest.java
@@ -1,5 +1,10 @@
 package org.cbioportal.application.rest.vcolumnstore;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,7 +19,6 @@ import org.cbioportal.legacy.web.parameter.GenericAssayMetaFilter;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -59,8 +63,7 @@ public class ColumnStoreGenericAssayControllerTest {
   public void testGetGenericAssayMetaByMolecularProfileId() throws Exception {
     List<GenericAssayMeta> genericAssayMetaItems = createGenericAssayMetaItemsList();
 
-    Mockito.when(getGenericAssayMetaUseCase.execute(Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenReturn(genericAssayMetaItems);
+    when(getGenericAssayMetaUseCase.execute(any(), any(), any())).thenReturn(genericAssayMetaItems);
 
     MvcResult mvcResult =
         mockMvc
@@ -93,7 +96,7 @@ public class ColumnStoreGenericAssayControllerTest {
   public void testGetGenericAssayMetaByStableId() throws Exception {
     List<GenericAssayMeta> genericAssayMetaSingleItem = createGenericAssayMetaSingleItem();
 
-    Mockito.when(getGenericAssayMetaUseCase.execute(Mockito.any(), Mockito.any(), Mockito.any()))
+    when(getGenericAssayMetaUseCase.execute(any(), any(), any()))
         .thenReturn(genericAssayMetaSingleItem);
 
     MvcResult mvcResult =
@@ -130,14 +133,7 @@ public class ColumnStoreGenericAssayControllerTest {
     GenericAssayMetaFilter genericAssayMetaFilter = new GenericAssayMetaFilter();
     genericAssayMetaFilter.setGenericAssayStableIds(genericAssayStableIds);
 
-    Mockito.when(
-            getGenericAssayMetaUseCase.execute(
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any()))
+    when(getGenericAssayMetaUseCase.execute(any(), any(), any(), any(), any(), any()))
         .thenReturn(genericAssayMetaItems);
 
     mockMvc
@@ -163,10 +159,9 @@ public class ColumnStoreGenericAssayControllerTest {
             MockMvcResultMatchers.jsonPath(
                 "$[1].genericEntityMetaProperties", Matchers.hasValue(TEST_NAME_VALUE)));
 
-    Mockito.verify(getGenericAssayMetaUseCase)
+    verify(getGenericAssayMetaUseCase)
         .execute(genericAssayStableIds, null, "SUMMARY", null, null, null);
-    Mockito.verify(getGenericAssayMetaUseCase, Mockito.never())
-        .count(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+    verify(getGenericAssayMetaUseCase, never()).count(any(), any(), any(), any());
   }
 
   @Test
@@ -176,18 +171,8 @@ public class ColumnStoreGenericAssayControllerTest {
     GenericAssayMetaFilter genericAssayMetaFilter = new GenericAssayMetaFilter();
     genericAssayMetaFilter.setMolecularProfileIds(List.of(PROF_ID));
 
-    Mockito.when(
-            getGenericAssayMetaUseCase.count(
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenReturn(250);
-    Mockito.when(
-            getGenericAssayMetaUseCase.execute(
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any()))
+    when(getGenericAssayMetaUseCase.count(any(), any(), any(), any())).thenReturn(250);
+    when(getGenericAssayMetaUseCase.execute(any(), any(), any(), any(), any(), any()))
         .thenReturn(genericAssayMetaItems);
 
     MvcResult mvcResult =
@@ -212,9 +197,8 @@ public class ColumnStoreGenericAssayControllerTest {
         .andExpect(
             MockMvcResultMatchers.jsonPath("$[0].stableId").value(GENERIC_ASSAY_STABLE_ID_2));
 
-    Mockito.verify(getGenericAssayMetaUseCase).count(null, List.of(PROF_ID), "SUMMARY", "tp53");
-    Mockito.verify(getGenericAssayMetaUseCase)
-        .execute(null, List.of(PROF_ID), "SUMMARY", "tp53", 100, 1);
+    verify(getGenericAssayMetaUseCase).count(null, List.of(PROF_ID), "SUMMARY", "tp53");
+    verify(getGenericAssayMetaUseCase).execute(null, List.of(PROF_ID), "SUMMARY", "tp53", 100, 1);
   }
 
   @Test
@@ -225,18 +209,8 @@ public class ColumnStoreGenericAssayControllerTest {
     GenericAssayMetaFilter genericAssayMetaFilter = new GenericAssayMetaFilter();
     genericAssayMetaFilter.setMolecularProfileIds(List.of(PROF_ID));
 
-    Mockito.when(
-            getGenericAssayMetaUseCase.count(
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenReturn(5);
-    Mockito.when(
-            getGenericAssayMetaUseCase.execute(
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any(),
-                Mockito.any()))
+    when(getGenericAssayMetaUseCase.count(any(), any(), any(), any())).thenReturn(5);
+    when(getGenericAssayMetaUseCase.execute(any(), any(), any(), any(), any(), any()))
         .thenReturn(genericAssayMetaItems);
 
     MvcResult mvcResult =
@@ -259,9 +233,8 @@ public class ColumnStoreGenericAssayControllerTest {
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(MockMvcResultMatchers.header().string("total-count", "5"));
 
-    Mockito.verify(getGenericAssayMetaUseCase).count(null, List.of(PROF_ID), "ID", "tp53");
-    Mockito.verify(getGenericAssayMetaUseCase)
-        .execute(null, List.of(PROF_ID), "ID", "tp53", 100, 0);
+    verify(getGenericAssayMetaUseCase).count(null, List.of(PROF_ID), "ID", "tp53");
+    verify(getGenericAssayMetaUseCase).execute(null, List.of(PROF_ID), "ID", "tp53", 100, 0);
   }
 
   @Test
@@ -281,7 +254,7 @@ public class ColumnStoreGenericAssayControllerTest {
                 .content(objectMapper.writeValueAsString(genericAssayMetaFilter)))
         .andExpect(MockMvcResultMatchers.status().isBadRequest());
 
-    Mockito.verifyNoInteractions(getGenericAssayMetaUseCase);
+    verifyNoInteractions(getGenericAssayMetaUseCase);
   }
 
   @Test
@@ -301,7 +274,7 @@ public class ColumnStoreGenericAssayControllerTest {
                 .content(objectMapper.writeValueAsString(genericAssayMetaFilter)))
         .andExpect(MockMvcResultMatchers.status().isBadRequest());
 
-    Mockito.verifyNoInteractions(getGenericAssayMetaUseCase);
+    verifyNoInteractions(getGenericAssayMetaUseCase);
   }
 
   private List<GenericAssayMeta> createGenericAssayMetaSingleItem() {

--- a/src/test/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCaseTest.java
+++ b/src/test/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCaseTest.java
@@ -53,7 +53,8 @@ public class GetGenericAssayMetaUseCaseTest {
   @Test
   public void execute_profilesAndStableIds_summaryProjection() {
     List<GenericAssayMeta> mockList = createMockMetaList();
-    when(repository.getGenericAssayMetaByProfileIds(PROFILE_ID_LIST, ID_LIST)).thenReturn(mockList);
+    when(repository.getGenericAssayMetaByProfileIds(PROFILE_ID_LIST, ID_LIST, null, null, null))
+        .thenReturn(mockList);
 
     List<GenericAssayMeta> result =
         useCase.execute(ID_LIST, PROFILE_ID_LIST, PersistenceConstants.SUMMARY_PROJECTION);
@@ -61,13 +62,14 @@ public class GetGenericAssayMetaUseCaseTest {
     Assert.assertEquals(2, result.size());
     Assert.assertEquals(mockList.get(0).getStableId(), result.get(0).getStableId());
     Assert.assertEquals(mockList.get(1).getStableId(), result.get(1).getStableId());
-    verify(repository).getGenericAssayMetaByProfileIds(PROFILE_ID_LIST, ID_LIST);
+    verify(repository).getGenericAssayMetaByProfileIds(PROFILE_ID_LIST, ID_LIST, null, null, null);
   }
 
   @Test
   public void execute_profilesOnly_summaryProjection() {
     List<GenericAssayMeta> mockList = createMockMetaList();
-    when(repository.getGenericAssayMetaByProfileIds(PROFILE_ID_LIST, null)).thenReturn(mockList);
+    when(repository.getGenericAssayMetaByProfileIds(PROFILE_ID_LIST, null, null, null, null))
+        .thenReturn(mockList);
 
     List<GenericAssayMeta> result =
         useCase.execute(null, PROFILE_ID_LIST, PersistenceConstants.SUMMARY_PROJECTION);
@@ -95,7 +97,7 @@ public class GetGenericAssayMetaUseCaseTest {
   @Test
   public void execute_stableIdsOnly_summaryProjection() {
     List<GenericAssayMeta> mockList = createMockMetaList();
-    when(repository.getGenericAssayMetaByStableIds(ID_LIST)).thenReturn(mockList);
+    when(repository.getGenericAssayMetaByStableIds(ID_LIST, null, null, null)).thenReturn(mockList);
 
     List<GenericAssayMeta> result =
         useCase.execute(ID_LIST, null, PersistenceConstants.SUMMARY_PROJECTION);
@@ -124,5 +126,30 @@ public class GetGenericAssayMetaUseCaseTest {
 
     Assert.assertEquals(Collections.emptyList(), result);
     verifyNoInteractions(repository);
+  }
+
+  @Test
+  public void execute_profilesOnly_summaryProjection_withSearchAndPaging() {
+    List<GenericAssayMeta> mockList = createMockMetaList();
+    when(repository.getGenericAssayMetaByProfileIds(PROFILE_ID_LIST, null, "tp53", 100, 100))
+        .thenReturn(mockList);
+
+    List<GenericAssayMeta> result =
+        useCase.execute(
+            null, PROFILE_ID_LIST, PersistenceConstants.SUMMARY_PROJECTION, "tp53", 100, 1);
+
+    Assert.assertEquals(2, result.size());
+    verify(repository).getGenericAssayMetaByProfileIds(PROFILE_ID_LIST, null, "tp53", 100, 100);
+  }
+
+  @Test
+  public void count_profilesOnly_usesRepositoryCount() {
+    when(repository.countGenericAssayMetaByProfileIds(PROFILE_ID_LIST, null, "tp53"))
+        .thenReturn(42);
+
+    Integer result = useCase.count(null, PROFILE_ID_LIST, "tp53");
+
+    Assert.assertEquals(Integer.valueOf(42), result);
+    verify(repository).countGenericAssayMetaByProfileIds(PROFILE_ID_LIST, null, "tp53");
   }
 }

--- a/src/test/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCaseTest.java
+++ b/src/test/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCaseTest.java
@@ -176,4 +176,26 @@ public class GetGenericAssayMetaUseCaseTest {
     Assert.assertEquals(Integer.valueOf(1), result);
     verifyNoInteractions(repository);
   }
+
+  @Test
+  public void execute_stableIdsOnly_idProjection_withSearchTerm_ignoresNullStableId() {
+    // a malformed request can legally contain a null entry in genericAssayStableIds
+    // (GenericAssayMetaFilter only validates list size, not element nullability); it
+    // must be filtered out rather than throwing when a searchTerm is also supplied
+    List<String> idsWithNull = Arrays.asList(GENERIC_ASSAY_ID_1, null, GENERIC_ASSAY_ID_2);
+
+    List<GenericAssayMeta> result = useCase.execute(idsWithNull, null, "ID", "id_1", null, null);
+
+    Assert.assertEquals(1, result.size());
+    Assert.assertEquals(GENERIC_ASSAY_ID_1, result.get(0).getStableId());
+  }
+
+  @Test
+  public void count_stableIdsOnly_idProjection_withSearchTerm_ignoresNullStableId() {
+    List<String> idsWithNull = Arrays.asList(GENERIC_ASSAY_ID_1, null, GENERIC_ASSAY_ID_2);
+
+    Integer result = useCase.count(idsWithNull, null, "ID", "generic_assay_id");
+
+    Assert.assertEquals(Integer.valueOf(2), result);
+  }
 }

--- a/src/test/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCaseTest.java
+++ b/src/test/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCaseTest.java
@@ -1,5 +1,7 @@
 package org.cbioportal.domain.generic_assay.usecase;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -90,8 +92,7 @@ public class GetGenericAssayMetaUseCaseTest {
     Assert.assertEquals(GENERIC_ASSAY_ID_2, result.get(1).getStableId());
     Assert.assertNull(result.get(0).getEntityType());
     verify(repository).getGenericAssayStableIdsByProfileIds(PROFILE_ID_LIST);
-    verify(repository, org.mockito.Mockito.never())
-        .getGenericAssayMetaByProfileIds(org.mockito.Mockito.any(), org.mockito.Mockito.any());
+    verify(repository, never()).getGenericAssayMetaByProfileIds(any(), any());
   }
 
   @Test
@@ -164,9 +165,7 @@ public class GetGenericAssayMetaUseCaseTest {
     Integer result = useCase.count(null, PROFILE_ID_LIST, "ID", GENERIC_ASSAY_ID_1);
 
     Assert.assertEquals(Integer.valueOf(1), result);
-    verify(repository, org.mockito.Mockito.never())
-        .countGenericAssayMetaByProfileIds(
-            org.mockito.Mockito.any(), org.mockito.Mockito.any(), org.mockito.Mockito.any());
+    verify(repository, never()).countGenericAssayMetaByProfileIds(any(), any(), any());
   }
 
   @Test

--- a/src/test/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCaseTest.java
+++ b/src/test/java/org/cbioportal/domain/generic_assay/usecase/GetGenericAssayMetaUseCaseTest.java
@@ -143,13 +143,37 @@ public class GetGenericAssayMetaUseCaseTest {
   }
 
   @Test
-  public void count_profilesOnly_usesRepositoryCount() {
+  public void count_profilesOnly_summaryProjection_usesRepositoryCount() {
     when(repository.countGenericAssayMetaByProfileIds(PROFILE_ID_LIST, null, "tp53"))
         .thenReturn(42);
 
-    Integer result = useCase.count(null, PROFILE_ID_LIST, "tp53");
+    Integer result =
+        useCase.count(null, PROFILE_ID_LIST, PersistenceConstants.SUMMARY_PROJECTION, "tp53");
 
     Assert.assertEquals(Integer.valueOf(42), result);
     verify(repository).countGenericAssayMetaByProfileIds(PROFILE_ID_LIST, null, "tp53");
+  }
+
+  @Test
+  public void count_profilesOnly_idProjection_matchesStableIdOnly() {
+    // GENERIC_ASSAY_ID_2 does not contain "generic_assay_id_1", so only ID_1 should match;
+    // if this incorrectly delegated to the repository's name/description-aware count, this
+    // distinction would be lost.
+    when(repository.getGenericAssayStableIdsByProfileIds(PROFILE_ID_LIST)).thenReturn(ID_LIST);
+
+    Integer result = useCase.count(null, PROFILE_ID_LIST, "ID", GENERIC_ASSAY_ID_1);
+
+    Assert.assertEquals(Integer.valueOf(1), result);
+    verify(repository, org.mockito.Mockito.never())
+        .countGenericAssayMetaByProfileIds(
+            org.mockito.Mockito.any(), org.mockito.Mockito.any(), org.mockito.Mockito.any());
+  }
+
+  @Test
+  public void count_stableIdsOnly_idProjection_matchesStableIdOnly() {
+    Integer result = useCase.count(ID_LIST, null, "ID", GENERIC_ASSAY_ID_2);
+
+    Assert.assertEquals(Integer.valueOf(1), result);
+    verifyNoInteractions(repository);
   }
 }

--- a/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayMapperTest.java
+++ b/src/test/java/org/cbioportal/infrastructure/repository/clickhouse/generic_assay/ClickhouseGenericAssayMapperTest.java
@@ -403,4 +403,24 @@ public class ClickhouseGenericAssayMapperTest {
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getStableId()).isEqualTo("1p_status");
   }
+
+  @Test
+  public void getGenericAssayMetaByProfileIds_withSearchTermAndPaging_returnsMatchingPage() {
+    List<GenericAssayMeta> result =
+        mapper.getGenericAssayMetaByProfileIds(
+            List.of(ACC_TCGA_ARMLEVEL_CNA_PROFILE), null, "status", 2, 1);
+
+    assertThat(result)
+        .extracting(GenericAssayMeta::getStableId)
+        .containsExactly("2p_status", "9p_status");
+  }
+
+  @Test
+  public void countGenericAssayMetaByProfileIds_withSearchTerm_returnsTotalMatches() {
+    Integer result =
+        mapper.countGenericAssayMetaByProfileIds(
+            List.of(ACC_TCGA_ARMLEVEL_CNA_PROFILE), null, "status");
+
+    assertThat(result).isEqualTo(4);
+  }
 }


### PR DESCRIPTION
## Summary

Adds server-side pagination and search to the Generic Assay meta `fetch` endpoint so that selectors backed by this endpoint (e.g. the Plots tab axis picker) no longer have to load every generic assay entity for a profile into memory up front. The endpoint stays fully backward compatible: all new parameters are optional, and existing repository/mapper method signatures are preserved as defaults delegating to the new paged versions.

## Changes

### API
- `/api/generic-assay-meta/fetch` now accepts optional `searchTerm`, `pageSize`, and `pageNumber` query parameters.
- Responses include a `total-count` header when paging is requested, so callers can render "showing X of Y" without a second round trip.
- `pageSize` and `pageNumber` must be supplied together — requesting only one now returns `400 Bad Request` instead of silently falling back to inconsistent partial paging.

### Domain / data layer
- `GetGenericAssayMetaUseCase` gained paged `execute()`/`count()` overloads that apply search (`stableId`/name/description) and offset-based paging, alongside the original unpaged methods.
- `GenericAssayRepository` and the ClickHouse mapper/repository implementation were extended with paged retrieval and counting queries; the search predicate and profile→entity resolution subquery were consolidated into shared MyBatis `<sql>` fragments (previously duplicated three times).
- Fixed `count()` under `projection=ID` to match on stable ID only, consistent with what `execute()` actually returns for that projection — previously it silently fell back to a broader name/description-aware count, so the reported total-count could disagree with the paginable result set.
- Legacy (non-paged) callers no longer pay for an extra `count()` query — it now only runs when both `pageSize` and `pageNumber` are supplied.
- `@Cacheable` cache keys for the paged `execute()`/`count()` methods now normalize `searchTerm` (trim + blank→null) the same way the method body does, so equivalent search terms (e.g. `"tp53"` vs `" tp53 "`) share one cache entry instead of fragmenting the cache.

### Bug fixes
- Fixed a ClickHouse `NULL` Map-column issue: `generic_entity_properties` rows don't exist for every entity, so the aggregated `properties` map can be `NULL` rather than just missing a key — property lookups now wrap with `ifNull(...)`.
- `containsSearchText()` is now null-safe against malformed requests where `genericAssayStableIds` legally contains a `null` element (the filter's `@Size` validation doesn't guarantee non-null elements) combined with a `searchTerm`, which previously threw an NPE.

### Tests
- Unit tests covering paged/search `execute()` and `count()`, ID-projection count matching, null-stableId handling, and the pageSize/pageNumber both-or-neither validation.
- Integration tests on the controller for pagination, search, `total-count` header behavior, and the new 400 validation path.
- Cleaned up test style to use static Mockito imports (`verify`/`when`/`never`/`any`) consistently.

## Test plan
- [x] `mvn compile` — clean build
- [x] `mvn test -Dtest=GetGenericAssayMetaUseCaseTest,ColumnStoreGenericAssayControllerTest` — all passing
- [x] `ClickhouseGenericAssayMapperTest` (real ClickHouse-backed) — passing
- [x] Verified request/response contract stays backward compatible for existing non-paged callers (e.g. `PatientViewPageStore.ts`)