### PR TITLE
Generic assay display text backend support

### DIFF
--- a/src/main/java/org/cbioportal/legacy/service/FrontendPropertiesServiceImpl.java
+++ b/src/main/java/org/cbioportal/legacy/service/FrontendPropertiesServiceImpl.java
@@ -155,6 +155,7 @@ public class FrontendPropertiesServiceImpl implements FrontendPropertiesService 
     skin_citation_rule_text("skin.citation_rule_text", null),
     skin_geneset_hierarchy_default_p_value("skin.geneset_hierarchy.default_p_value", null),
     skin_geneset_hierarchy_default_gsva_score("skin.geneset_hierarchy.default_gsva_score", null),
+    generic_assay_display_text("generic_assay_display_text", null),
     app_version("app.version", null),
     frontendSentryEndpoint("sentryjs.frontend_project_endpoint", null),
 

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -146,6 +146,11 @@ enable_cross_study_expression=(studies)=>studies.filter(s=>/pan_can_atlas/.test(
 # Any Number | Disabled when not set
 # studyview.max_samples_selected=
 
+## Optional Generic Assay display-title overrides exposed to the frontend.
+## Format: GENERIC_ASSAY_TYPE:Display Text pairs separated by commas.
+## Example:
+## generic_assay_display_text=TREATMENT_RESPONSE:Treatment Response,MUTATIONAL_SIGNATURE:Mutational Signature,LOH_HLA:HLA LOH
+
 # multithreading configuration
 multithread.core_pool_size=16
 
@@ -478,4 +483,3 @@ feature.study.export.timeout_ms=600000
 # request-logging.queue-capacity=10000
 
 # EOL - Do not delete the following lines
-

--- a/src/test/java/org/cbioportal/legacy/service/FrontendPropertiesServiceImplTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/FrontendPropertiesServiceImplTest.java
@@ -1,8 +1,6 @@
 package org.cbioportal.legacy.service;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -67,28 +65,5 @@ public class FrontendPropertiesServiceImplTest {
     } finally {
       Files.deleteIfExists(runtimeFile);
     }
-  }
-
-  @Test
-  public void initShouldExposeGenericAssayDisplayTextToFrontendConfig() {
-    FrontendPropertiesServiceImpl service = new FrontendPropertiesServiceImpl();
-    ReflectionTestUtils.setField(service, "env", env);
-    when(env.getProperty(anyString(), nullable(String.class)))
-        .thenAnswer(
-            invocation -> {
-              String key = invocation.getArgument(0);
-              String defaultValue = invocation.getArgument(1);
-              if ("generic_assay_display_text".equals(key)) {
-                return "LOH_HLA:HLA LOH,MUTATIONAL_SIGNATURE:Mutational Signature";
-              }
-              return defaultValue;
-            });
-
-    service.init();
-
-    assertEquals(
-        "LOH_HLA:HLA LOH,MUTATIONAL_SIGNATURE:Mutational Signature",
-        service.getFrontendProperty(
-            FrontendPropertiesServiceImpl.FrontendProperty.generic_assay_display_text));
   }
 }

--- a/src/test/java/org/cbioportal/legacy/service/FrontendPropertiesServiceImplTest.java
+++ b/src/test/java/org/cbioportal/legacy/service/FrontendPropertiesServiceImplTest.java
@@ -1,6 +1,8 @@
 package org.cbioportal.legacy.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -65,5 +67,28 @@ public class FrontendPropertiesServiceImplTest {
     } finally {
       Files.deleteIfExists(runtimeFile);
     }
+  }
+
+  @Test
+  public void initShouldExposeGenericAssayDisplayTextToFrontendConfig() {
+    FrontendPropertiesServiceImpl service = new FrontendPropertiesServiceImpl();
+    ReflectionTestUtils.setField(service, "env", env);
+    when(env.getProperty(anyString(), nullable(String.class)))
+        .thenAnswer(
+            invocation -> {
+              String key = invocation.getArgument(0);
+              String defaultValue = invocation.getArgument(1);
+              if ("generic_assay_display_text".equals(key)) {
+                return "LOH_HLA:HLA LOH,MUTATIONAL_SIGNATURE:Mutational Signature";
+              }
+              return defaultValue;
+            });
+
+    service.init();
+
+    assertEquals(
+        "LOH_HLA:HLA LOH,MUTATIONAL_SIGNATURE:Mutational Signature",
+        service.getFrontendProperty(
+            FrontendPropertiesServiceImpl.FrontendProperty.generic_assay_display_text));
   }
 }


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/12208

## Summary

   Restore backend support for `generic_assay_display_text` so values set in `application.properties` are exposed to the frontend again.

   ## What changed

   - Re-added `generic_assay_display_text` to `FrontendPropertiesServiceImpl.FrontendProperty`
   - Documented the supported property in `src/main/resources/application.properties.EXAMPLE`
   - Included an example showing how to override Generic Assay display titles, including `LOH_HLA:HLA LOH`

   ## Why

   The frontend still supports `generic_assay_display_text`, but the backend was no longer exporting that property through the frontend config allowlist. As a result, setting `generic_assay_display_text` in backend `application.properties` had no effect.

   This change restores the existing frontend contract without changing frontend behavior.

   ## Example

   ```properties
   generic_assay_display_text=TREATMENT_RESPONSE:Treatment Response,MUTATIONAL_SIGNATURE:Mutational Signature,LOH_HLA:HLA LOH