### PR TITLE
Change CORE_BRANCH from 'rfc100-rc' to 'main'

### DIFF
--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -11,7 +11,7 @@
 # NOTE: the .git folder is included in the build stage (the git-commit-id Maven
 # plugin needs it), but excluded from the final image. No confidential
 # information is exposed. (see: stackoverflow.com/questions/56278325)
-ARG CORE_BRANCH=rfc100-rc
+ARG CORE_BRANCH=main
 
 FROM maven:3-eclipse-temurin-21 AS build
 


### PR DESCRIPTION
`rfc100-rc` is outdated. As part of the upcoming `cbioportal-core` refactoring, we'll move the importers into this repository so they can be released together with the core project