### PR TITLE
Adjust Docker image to run in ARM64

### DIFF
--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -13,7 +13,7 @@
 # information is exposed. (see: stackoverflow.com/questions/56278325)
 ARG CORE_BRANCH=main
 
-FROM maven:3-eclipse-temurin-21 AS build
+FROM --platform=$BUILDPLATFORM maven:3-eclipse-temurin-21 AS build
 
 WORKDIR /cbioportal
 
@@ -76,10 +76,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ARG CLICKHOUSE_VERSION=25.8.24.21
 RUN ARCH="$(dpkg --print-architecture)" \
     && curl -fsSL "https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-${CLICKHOUSE_VERSION}-${ARCH}.tgz" -o /tmp/clickhouse.tgz \
-    && tar -xzf /tmp/clickhouse.tgz -C /tmp \
-    && install -m 755 "/tmp/clickhouse-common-static-${CLICKHOUSE_VERSION}/usr/bin/clickhouse" /usr/bin/clickhouse \
-    && rm -rf /tmp/clickhouse.tgz "/tmp/clickhouse-common-static-${CLICKHOUSE_VERSION}"
-
+    && tar -xzf /tmp/clickhouse.tgz -C /usr/bin --strip-components=3 "clickhouse-common-static-${CLICKHOUSE_VERSION}/usr/bin/clickhouse" \
+    && chmod 755 /usr/bin/clickhouse \
+    && rm -f /tmp/clickhouse.tgz
+ 
 # copy over core files (scripts, requirements) built from cbioportal-core
 COPY --from=build-core /core/scripts /core/scripts
 COPY --from=build-core /core/core-*.jar /core/core-IMPORTER.jar


### PR DESCRIPTION
The current Docker images (v7) don't run in ARM64

With the adjustments in this PR you can build the image with: 
`docker buildx build   --platform linux/amd64,linux/arm64   -t image-name   -f docker/web-and-data/Dockerfile`

# Checks
- [ ] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [ ] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
If this is a new visual feature please add a before/after screenshot or gif
here with e.g. [Giphy CAPTURE](https://giphy.com/apps/giphycapture) or [Peek](https://github.com/phw/peek)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
