### PR TITLE
Cap page size on study-wide clinical-events endpoint (prevent OOM)

### DIFF
--- a/src/main/java/org/cbioportal/legacy/web/ClinicalEventController.java
+++ b/src/main/java/org/cbioportal/legacy/web/ClinicalEventController.java
@@ -51,6 +51,13 @@ public class ClinicalEventController {
 
   @Autowired private ClinicalEventService clinicalEventService;
 
+  // Study-wide clinical events can number in the millions (e.g. large MSK cohorts).
+  // Cap paging below the shared 10M PagingConstants default so a single unpaginated
+  // request cannot materialize the whole table in heap and OOM the backend; callers
+  // needing everything must page through with pageSize/pageNumber.
+  public static final int CLINICAL_EVENT_MAX_PAGE_SIZE = 100000;
+  private static final String CLINICAL_EVENT_DEFAULT_PAGE_SIZE = "100000";
+
   @PreAuthorize(
       "hasPermission(#studyId, 'CancerStudyId', T(org.cbioportal.legacy.utils.security.AccessLevel).READ)")
   @RequestMapping(
@@ -129,9 +136,9 @@ public class ClinicalEventController {
           @RequestParam(defaultValue = "SUMMARY")
           Projection projection,
       @Parameter(description = "Page size of the result list")
-          @Max(PagingConstants.MAX_PAGE_SIZE)
+          @Max(CLINICAL_EVENT_MAX_PAGE_SIZE)
           @Min(PagingConstants.MIN_PAGE_SIZE)
-          @RequestParam(defaultValue = PagingConstants.DEFAULT_PAGE_SIZE)
+          @RequestParam(defaultValue = CLINICAL_EVENT_DEFAULT_PAGE_SIZE)
           Integer pageSize,
       @Parameter(description = "Page number of the result list")
           @Min(PagingConstants.MIN_PAGE_NUMBER)

--- a/src/test/java/org/cbioportal/legacy/web/ClinicalEventControllerTest.java
+++ b/src/test/java/org/cbioportal/legacy/web/ClinicalEventControllerTest.java
@@ -2,6 +2,7 @@ package org.cbioportal.legacy.web;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
@@ -186,6 +187,43 @@ public class ClinicalEventControllerTest {
         .andExpect(MockMvcResultMatchers.jsonPath("$[1].attributes[0].value").value(TEST_VALUE_3))
         .andExpect(MockMvcResultMatchers.jsonPath("$[1].attributes[1].key").value(TEST_KEY_4))
         .andExpect(MockMvcResultMatchers.jsonPath("$[1].attributes[1].value").value(TEST_VALUE_4));
+  }
+
+  @Test
+  @WithMockUser
+  public void getAllClinicalEventsInStudyDefaultsPageSizeToCap() throws Exception {
+    when(clinicalEventService.getAllClinicalEventsInStudy(any(), any(), any(), any(), any(), any()))
+        .thenReturn(createExampleClinicalEventList());
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/api/studies/test_study_id/clinical-events")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(MockMvcResultMatchers.status().isOk());
+
+    // When pageSize is omitted it must default to the endpoint cap, not the shared 10M default,
+    // so a single unpaginated request cannot pull an entire large study's events into heap.
+    Mockito.verify(clinicalEventService)
+        .getAllClinicalEventsInStudy(
+            any(),
+            any(),
+            eq(ClinicalEventController.CLINICAL_EVENT_MAX_PAGE_SIZE),
+            any(),
+            any(),
+            any());
+  }
+
+  @Test
+  @WithMockUser
+  public void getAllClinicalEventsInStudyRejectsPageSizeAboveCap() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/api/studies/test_study_id/clinical-events")
+                .param(
+                    "pageSize",
+                    String.valueOf(ClinicalEventController.CLINICAL_EVENT_MAX_PAGE_SIZE + 1))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
   }
 
   @Test


### PR DESCRIPTION
## Problem

`GET /api/studies/{studyId}/clinical-events` defaults `pageSize` to `PagingConstants.DEFAULT_PAGE_SIZE` (**10,000,000**) and allows up to `MAX_PAGE_SIZE` (10,000,000). When a client omits `pageSize`, the endpoint returns **every clinical event in the study in one response**.

For large cohorts this is enormous — e.g. `msk_chord_2024` has **~2.29M** clinical events (~600MB JSON; millions of `ClinicalEvent` objects in heap). This has been OOM-crash-looping the public backend (pods killed with `exitCode 137`/`OOMKilled`, ~150 restarts/pod/day) whenever bulk clients pull it.

## Fix

Follow the existing `SampleController` per-endpoint idiom: add controller-local `CLINICAL_EVENT_MAX_PAGE_SIZE` / `CLINICAL_EVENT_DEFAULT_PAGE_SIZE` (100000) and wire them into the `@Max` + `@RequestParam(defaultValue=...)` on `getAllClinicalEventsInStudy`, instead of the shared 10M `PagingConstants`. The per-patient endpoint is unchanged. The cap value is tunable.

- Normal studies (well under 100k events) are unaffected — they still return all events in one page.
- Only pathologically large studies are paged; bulk consumers page through with `pageSize`/`pageNumber` (or use datahub).

## Why not rely on the Redis cache instead?

The method is `@Cacheable`, so one might expect the full result to just be cached. But caching does **not** prevent the OOM: on a cache *hit*, Spring still deserializes the entire cached blob (all ~2.29M objects) back into heap to return it — the multi-GB spike happens on every request, hit or miss. Caching a 600MB+ result also thrashes an 8GB `volatile-ttl` Redis. Capping the page size bounds both the heap and the cache-entry size; it does not fragment the cache for consistent callers (the key still resolves to one entry per study).

## UI impact: none

The cBioPortal frontend does not call the study-wide endpoint (0 call sites for `getAllClinicalEventsInStudyUsingGET`); the patient timeline uses the per-patient route (`getAllClinicalEventsOfPatientInStudyUsingGET`), which is untouched. The study-wide endpoint is API/bulk-only.

## Companion

Interim infra mitigation (Traefik per-IP rate limit on this + `discrete-copy-number/fetch`): PR in `knowledgesystems/knowledgesystems-k8s-deployment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
