### PR TITLE
docs: cBioPortalChat is live; clarify single bot uses two MCP servers

### DIFF
--- a/docs/ai-integrations/README.md
+++ b/docs/ai-integrations/README.md
@@ -1,8 +1,8 @@
 # AI Integrations
 
-The cBioPortal community is exploring the use of large language models (LLMs) to make cancer genomics data more accessible and easier to explore.
+The cBioPortal community uses large language models (LLMs) to make cancer genomics data more accessible and easier to explore. The **cBioPortalChat** interface is live and open to everyone.
 
 ## Contents
 
-- **[Chat Interface](chat-interface.md)** - Ask questions about cBioPortal data in plain English using our AI-powered chat interface
+- **[Chat Interface](chat-interface.md)** - Ask questions about cBioPortal data in plain English using our live AI-powered chat interface
 - **[Model Context Protocol (MCP)](mcp.md)** - Technical documentation about MCP servers and building AI integrations with cBioPortal

--- a/docs/ai-integrations/chat-interface.md
+++ b/docs/ai-integrations/chat-interface.md
@@ -1,12 +1,10 @@
 # Chat Interface
 
-We're developing an AI-powered chat interface that lets users explore cBioPortal data with natural language. We're looking for early test users to give us feedback and help guide future development. If that sounds like you, sign up [here](https://docs.google.com/forms/d/e/1FAIpQLSfQ53xWgzZRu5qMINOqZCfK_8StG7bjbtJ7WsQM9fZpe1bq3A/viewform).
-
-> **Note:** This is a prototype and work in progress. Features and functionality are actively being developed and improved.
+**cBioPortalChat** is an AI-powered chat interface that lets you explore cBioPortal data with natural language. It's live and open to everyone — just [open the chat](https://chat.cbioportal.org/) and start asking questions.
 
 ## What is the Chat Interface?
 
-The cBioPortal chat interface (**cBioPortalChat**) is an experimental platform that lets you ask cBioPortal questions in plain English. It uses [Claude](https://www.anthropic.com/claude) (Anthropic's LLM, provided via Amazon Bedrock) and combines two capabilities in a single agent:
+The cBioPortal chat interface (**cBioPortalChat**) lets you ask cBioPortal questions in plain English. It uses [Claude](https://www.anthropic.com/claude) (Anthropic's LLM, provided via Amazon Bedrock) and combines two capabilities in a single agent:
 
 - **Database queries** — answers about studies, patients, samples, mutations, copy-number changes, clinical attributes, and treatments by querying cBioPortal's underlying database.
 - **Web navigation** — generates direct links into cBioPortal views (study summaries, OncoPrint, patient view, group comparison) when you describe what you want to look at.
@@ -46,7 +44,7 @@ You don't need to pick which one you want — the agent decides which tools to c
 
 ## Getting Started
 
-1. Fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSfQ53xWgzZRu5qMINOqZCfK_8StG7bjbtJ7WsQM9fZpe1bq3A/viewform) to request access. We onboard new users in groups — we appreciate your patience until we get in touch.
+1. Open [cBioPortalChat](https://chat.cbioportal.org/).
 2. Type your question in the chat input.
 3. Review the AI-generated response.
 4. Ask follow-up questions to dive deeper.

--- a/docs/ai-integrations/mcp.md
+++ b/docs/ai-integrations/mcp.md
@@ -2,7 +2,7 @@
 
 This document provides technical information about the Model Context Protocol (MCP) servers and architecture that power AI integrations with cBioPortal.
 
-> **Note:** All these are prototypes and work in progress. Features and functionality are actively being developed and improved.
+> **Note:** The cBioPortal MCP servers power the live cBioPortalChat interface and remain in active development, so their interfaces may still change.
 
 ## What is MCP?
 
@@ -12,9 +12,14 @@ For details on how MCP powers the cBioPortal chat interface, see the [Chat Inter
 
 ## Available MCP Servers
 
-### cBioPortal MCP Servers in Development
+### cBioPortal MCP Servers
 
-These MCP servers are early prototypes developed by the cBioPortal team and are in active development.
+The live **cBioPortalChat** bot is a single agent that uses **both** of the cBioPortal MCP servers below at the same time — it is one bot with two MCP servers, not two separate bots:
+
+- **`cbioportal-mcp`** powers the database-query capability (referred to as the "database MCP" in the [Chat Interface documentation](chat-interface.md)).
+- **`cbioportal-navigator`** powers the link-generation capability (the "navigator MCP").
+
+The agent decides which of the two to call for each turn. Both servers are developed by the cBioPortal team and remain in active development.
 
 #### cbioportal-mcp
 

--- a/docs/ai-integrations/mcp.md
+++ b/docs/ai-integrations/mcp.md
@@ -14,7 +14,7 @@ For details on how MCP powers the cBioPortal chat interface, see the [Chat Inter
 
 ### cBioPortal MCP Servers
 
-The live **cBioPortalChat** bot is a single agent that uses **both** of the cBioPortal MCP servers below at the same time — it is one bot with two MCP servers, not two separate bots:
+The live **cBioPortalChat** bot is a single agent that uses **both** of the cBioPortal MCP servers below at the same time — it is one bot with two MCP servers:
 
 - **`cbioportal-mcp`** powers the database-query capability (referred to as the "database MCP" in the [Chat Interface documentation](chat-interface.md)).
 - **`cbioportal-navigator`** powers the link-generation capability (the "navigator MCP").


### PR DESCRIPTION
## What

Now that the Chat interface is live (the Chat tab is enabled for all MSK-portal users, and cBioPortalChat is open to everyone), this updates the AI-integrations docs:

- **`chat-interface.md`** — replaces the "we're developing / looking for early test users" framing and the access-request sign-up form with a direct link to the live chat. Drops "experimental platform" / "prototype" hedging.
- **`mcp.md`** — clarifies that **cBioPortalChat is a single agent that uses both cBioPortal MCP servers together** (`cbioportal-mcp` for database queries + `cbioportal-navigator` for link generation) — one bot with two MCP servers, not two separate bots. Softens the top prototype note.
- **`README.md`** — reflects that the chat interface is live.

The historical "earlier prototypes were two separate agents, now merged" note is kept, since it reinforces the single-agent point.

## Notes

- No structural/nav changes (`SUMMARY.md` untouched); wording only.
- Framing assumes public `chat.cbioportal.org` is open to all. If access is still gated, say so and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)