### PR TITLE
Add AI chat sidebar endpoint backed by Claude on Vertex AI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,27 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
+    <!-- AI chat sidebar prototype: Claude via Vertex AI, MCP tool clients, Langfuse-hosted system prompt -->
+    <dependency>
+      <groupId>com.anthropic</groupId>
+      <artifactId>anthropic-java</artifactId>
+      <version>2.52.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.anthropic</groupId>
+      <artifactId>anthropic-java-vertex</artifactId>
+      <version>2.52.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.modelcontextprotocol.sdk</groupId>
+      <artifactId>mcp</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.langfuse</groupId>
+      <artifactId>langfuse-java</artifactId>
+      <version>0.2.0</version>
+    </dependency>
     <dependency>
       <groupId>org.mybatis.spring.boot</groupId>
       <artifactId>mybatis-spring-boot-starter</artifactId>

--- a/src/main/java/org/cbioportal/application/chat/AnthropicChatConfig.java
+++ b/src/main/java/org/cbioportal/application/chat/AnthropicChatConfig.java
@@ -1,0 +1,43 @@
+package org.cbioportal.application.chat;
+
+import com.anthropic.backends.Backend;
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.client.okhttp.AnthropicOkHttpClient;
+import com.anthropic.vertex.backends.VertexBackend;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.FileInputStream;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AnthropicChatConfig {
+
+  @Value("${chat.vertex.project}")
+  private String vertexProject;
+
+  @Value("${chat.vertex.region:global}")
+  private String vertexRegion;
+
+  @Value("${chat.vertex.credentials-file}")
+  private String credentialsFile;
+
+  @Bean
+  public AnthropicClient anthropicClient() throws IOException {
+    GoogleCredentials credentials;
+    try (FileInputStream credentialsStream = new FileInputStream(credentialsFile)) {
+      // Service-account credentials carry no scopes; without this the token request 400s.
+      credentials =
+          GoogleCredentials.fromStream(credentialsStream)
+              .createScoped("https://www.googleapis.com/auth/cloud-platform");
+    }
+    Backend backend =
+        VertexBackend.builder()
+            .googleCredentials(credentials)
+            .project(vertexProject)
+            .region(vertexRegion)
+            .build();
+    return AnthropicOkHttpClient.builder().backend(backend).build();
+  }
+}

--- a/src/main/java/org/cbioportal/application/chat/ChatAgentService.java
+++ b/src/main/java/org/cbioportal/application/chat/ChatAgentService.java
@@ -1,0 +1,325 @@
+package org.cbioportal.application.chat;
+
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.core.JsonValue;
+import com.anthropic.models.messages.ContentBlock;
+import com.anthropic.models.messages.ContentBlockParam;
+import com.anthropic.models.messages.Message;
+import com.anthropic.models.messages.MessageCreateParams;
+import com.anthropic.models.messages.MessageParam;
+import com.anthropic.models.messages.Model;
+import com.anthropic.models.messages.TextBlock;
+import com.anthropic.models.messages.TextBlockParam;
+import com.anthropic.models.messages.Tool;
+import com.anthropic.models.messages.ToolResultBlockParam;
+import com.anthropic.models.messages.ToolUseBlock;
+import com.anthropic.models.messages.ToolUseBlockParam;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.cbioportal.application.chat.dto.ChatMessageDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * Multi-step tool-calling loop. Only the final, tool-free step's text is streamed — earlier steps'
+ * text is scratch commentary, not the answer.
+ */
+@Service
+public class ChatAgentService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ChatAgentService.class);
+
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+  private static final Set<String> NAVIGATE_TOOL_NAMES =
+      Set.of(
+          "navigate_to_study_view",
+          "navigate_to_patient_view",
+          "navigate_to_results_view",
+          "navigate_to_group_comparison");
+
+  private final AnthropicClient anthropicClient;
+  private final McpToolBridge mcpToolBridge;
+  private final SystemPromptService systemPromptService;
+  private final ObjectMapper objectMapper;
+
+  @Value("${chat.model:claude-sonnet-5}")
+  private String modelName;
+
+  @Value("${chat.max-steps:15}")
+  private int maxSteps;
+
+  public ChatAgentService(
+      AnthropicClient anthropicClient,
+      McpToolBridge mcpToolBridge,
+      SystemPromptService systemPromptService,
+      ObjectMapper objectMapper) {
+    this.anthropicClient = anthropicClient;
+    this.mcpToolBridge = mcpToolBridge;
+    this.systemPromptService = systemPromptService;
+    this.objectMapper = objectMapper;
+  }
+
+  @Async
+  public void runTurn(List<ChatMessageDto> incomingMessages, SseEmitter emitter) {
+    try {
+      if (incomingMessages == null || incomingMessages.isEmpty()) {
+        throw new IllegalArgumentException("messages must not be empty");
+      }
+      List<MessageParam> history = toMessageParams(incomingMessages);
+      List<ChatMessageDto> newMessages = new ArrayList<>();
+      String navigateUrl = null;
+      List<String> toolsCalled = new ArrayList<>();
+      int stepsUsed = 0;
+      boolean answered = false;
+
+      for (int step = 0; step < maxSteps; step++) {
+        stepsUsed = step + 1;
+        MessageCreateParams.Builder paramsBuilder =
+            MessageCreateParams.builder()
+                .model(Model.of(modelName))
+                .maxTokens(4096L)
+                .system(systemPromptService.getSystemPrompt())
+                .messages(history);
+        for (Tool tool : mcpToolBridge.tools()) {
+          paramsBuilder.addTool(tool);
+        }
+
+        Message response = anthropicClient.messages().create(paramsBuilder.build());
+
+        // Built once as JSON — both the SDK-bound history entry and the client-facing DTO are
+        // derived from this same node tree, instead of walking response.content() twice.
+        ArrayNode assistantContentJson = toContentJson(response.content());
+        history.add(
+            MessageParam.builder()
+                .role(MessageParam.Role.ASSISTANT)
+                .contentOfBlockParams(toContentBlockParams(assistantContentJson))
+                .build());
+        newMessages.add(toDto("assistant", assistantContentJson));
+
+        List<ToolUseBlock> toolUses =
+            response.content().stream().flatMap(block -> block.toolUse().stream()).toList();
+
+        if (toolUses.isEmpty()) {
+          String finalText =
+              response.content().stream()
+                  .flatMap(block -> block.text().stream())
+                  .map(TextBlock::text)
+                  .collect(Collectors.joining());
+          if (!finalText.isEmpty()) {
+            sendEvent(emitter, "text_delta", Map.of("text", finalText));
+          }
+          LOG.info(
+              "chat turn done: steps={} stopReason={} tools={} answerChars={} navigate={}",
+              stepsUsed,
+              response.stopReason().map(Object::toString).orElse("none"),
+              toolsCalled,
+              finalText.length(),
+              navigateUrl != null ? navigateUrl : "-");
+          answered = true;
+          break;
+        }
+
+        ArrayNode toolResultContentJson = objectMapper.createArrayNode();
+        for (ToolUseBlock toolUse : toolUses) {
+          Map<String, Object> input = asMap(toolUse._input());
+          long startedAt = System.currentTimeMillis();
+          String resultText = mcpToolBridge.callTool(toolUse.name(), input);
+          toolsCalled.add(toolUse.name());
+          LOG.info(
+              "  step {} tool {} -> {} chars in {} ms",
+              stepsUsed,
+              toolUse.name(),
+              resultText.length(),
+              System.currentTimeMillis() - startedAt);
+          if (NAVIGATE_TOOL_NAMES.contains(toolUse.name())) {
+            String url = extractUrl(resultText);
+            if (url != null) {
+              navigateUrl = url;
+            }
+          }
+
+          ObjectNode toolResultNode = objectMapper.createObjectNode();
+          toolResultNode.put("type", "tool_result");
+          toolResultNode.put("tool_use_id", toolUse.id());
+          toolResultNode.put("content", resultText);
+          toolResultContentJson.add(toolResultNode);
+        }
+        history.add(
+            MessageParam.builder()
+                .role(MessageParam.Role.USER)
+                .contentOfBlockParams(toContentBlockParams(toolResultContentJson))
+                .build());
+        newMessages.add(toDto("tool", toolResultContentJson));
+      }
+
+      if (!answered) {
+        LOG.warn(
+            "chat turn hit the {}-step cap without a final answer, tools={} — raise chat.max-steps"
+                + " if this recurs",
+            maxSteps,
+            toolsCalled);
+        String cappedMessage =
+            "I wasn't able to finish answering within the allotted number of steps. Please try"
+                + " rephrasing or narrowing your question.";
+        sendEvent(emitter, "text_delta", Map.of("text", cappedMessage));
+        ArrayNode cappedContentJson = objectMapper.createArrayNode();
+        ObjectNode cappedTextNode = objectMapper.createObjectNode();
+        cappedTextNode.put("type", "text");
+        cappedTextNode.put("text", cappedMessage);
+        cappedContentJson.add(cappedTextNode);
+        newMessages.add(toDto("assistant", cappedContentJson));
+      }
+
+      if (navigateUrl != null) {
+        sendEvent(emitter, "navigate", Map.of("url", navigateUrl));
+      }
+      sendEvent(emitter, "done", Map.of("messages", newMessages));
+      emitter.complete();
+    } catch (Exception e) {
+      LOG.error("chat turn failed", e);
+      try {
+        sendEvent(
+            emitter,
+            "error",
+            Map.of("message", e.getMessage() != null ? e.getMessage() : "Unknown error"));
+      } catch (Exception sendFailure) {
+        // emitter is already broken; fall through to completeWithError below
+      }
+      emitter.completeWithError(e);
+    }
+  }
+
+  private void sendEvent(SseEmitter emitter, String eventName, Object data) throws Exception {
+    emitter.send(SseEmitter.event().name(eventName).data(data, MediaType.APPLICATION_JSON));
+  }
+
+  /**
+   * The single source of truth for a step's assistant content: the SDK history entry and the
+   * client-facing DTO are both derived from this JSON, instead of walking response.content()
+   * separately for each.
+   */
+  private ArrayNode toContentJson(List<ContentBlock> blocks) {
+    ArrayNode contentArray = objectMapper.createArrayNode();
+    for (ContentBlock block : blocks) {
+      block
+          .text()
+          .ifPresent(
+              t -> {
+                ObjectNode node = objectMapper.createObjectNode();
+                node.put("type", "text");
+                node.put("text", t.text());
+                contentArray.add(node);
+              });
+      block
+          .toolUse()
+          .ifPresent(
+              t -> {
+                ObjectNode node = objectMapper.createObjectNode();
+                node.put("type", "tool_use");
+                node.put("id", t.id());
+                node.put("name", t.name());
+                node.set("input", objectMapper.valueToTree(asMap(t._input())));
+                contentArray.add(node);
+              });
+    }
+    return contentArray;
+  }
+
+  private ChatMessageDto toDto(String role, ArrayNode content) {
+    ChatMessageDto dto = new ChatMessageDto();
+    dto.setRole(role);
+    dto.setContent(content);
+    return dto;
+  }
+
+  private List<MessageParam> toMessageParams(List<ChatMessageDto> incoming) {
+    List<MessageParam> result = new ArrayList<>();
+    for (ChatMessageDto dto : incoming) {
+      if ("system".equals(dto.getRole())) {
+        continue;
+      }
+      MessageParam.Role role =
+          "tool".equals(dto.getRole())
+              ? MessageParam.Role.USER
+              : MessageParam.Role.of(dto.getRole());
+      JsonNode content = dto.getContent();
+      MessageParam.Builder builder = MessageParam.builder().role(role);
+      if (content.isTextual()) {
+        builder.content(content.asText());
+      } else if (content.isArray()) {
+        builder.contentOfBlockParams(toContentBlockParams(content));
+      }
+      result.add(builder.build());
+    }
+    return result;
+  }
+
+  private List<ContentBlockParam> toContentBlockParams(JsonNode blocksArray) {
+    List<ContentBlockParam> result = new ArrayList<>();
+    for (JsonNode block : blocksArray) {
+      String type = block.path("type").asText();
+      switch (type) {
+        case "text":
+          result.add(
+              ContentBlockParam.ofText(
+                  TextBlockParam.builder().text(block.path("text").asText()).build()));
+          break;
+        case "tool_use":
+          result.add(
+              ContentBlockParam.ofToolUse(
+                  ToolUseBlockParam.builder()
+                      .id(block.path("id").asText())
+                      .name(block.path("name").asText())
+                      .input(toToolInput(block.path("input")))
+                      .build()));
+          break;
+        case "tool_result":
+          result.add(
+              ContentBlockParam.ofToolResult(
+                  ToolResultBlockParam.builder()
+                      .toolUseId(block.path("tool_use_id").asText())
+                      .content(block.path("content").asText())
+                      .build()));
+          break;
+        default:
+          break;
+      }
+    }
+    return result;
+  }
+
+  private ToolUseBlockParam.Input toToolInput(JsonNode inputNode) {
+    ToolUseBlockParam.Input.Builder builder = ToolUseBlockParam.Input.builder();
+    Map<String, Object> rawMap = objectMapper.convertValue(inputNode, MAP_TYPE);
+    rawMap.forEach((key, value) -> builder.putAdditionalProperty(key, JsonValue.from(value)));
+    return builder.build();
+  }
+
+  private String extractUrl(String toolResultJson) {
+    try {
+      JsonNode node = objectMapper.readTree(toolResultJson);
+      JsonNode urlNode = node.path("url");
+      return urlNode.isTextual() ? urlNode.asText() : null;
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private static Map<String, Object> asMap(JsonValue value) {
+    return value.convert(MAP_TYPE);
+  }
+}

--- a/src/main/java/org/cbioportal/application/chat/ChatController.java
+++ b/src/main/java/org/cbioportal/application/chat/ChatController.java
@@ -1,0 +1,28 @@
+package org.cbioportal.application.chat;
+
+import org.cbioportal.application.chat.dto.ChatRequest;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/chat")
+public class ChatController {
+
+  private final ChatAgentService chatAgentService;
+
+  public ChatController(ChatAgentService chatAgentService) {
+    this.chatAgentService = chatAgentService;
+  }
+
+  @PostMapping(value = "/stream", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public SseEmitter stream(@RequestBody ChatRequest request) {
+    // No timeout: a multi-step tool-calling turn can take well over a minute.
+    SseEmitter emitter = new SseEmitter(0L);
+    chatAgentService.runTurn(request.getMessages(), emitter);
+    return emitter;
+  }
+}

--- a/src/main/java/org/cbioportal/application/chat/McpToolBridge.java
+++ b/src/main/java/org/cbioportal/application/chat/McpToolBridge.java
@@ -1,0 +1,115 @@
+package org.cbioportal.application.chat;
+
+import com.anthropic.core.JsonValue;
+import com.anthropic.models.messages.Tool;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import jakarta.annotation.PreDestroy;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/** Exposes both MCP servers' tools as Anthropic Tool definitions and dispatches calls to them. */
+@Component
+public class McpToolBridge {
+
+  private final McpSyncClient navigatorClient;
+  private final McpSyncClient dataQueryClient;
+  private final Map<String, McpSyncClient> toolOwners = new HashMap<>();
+  private final List<Tool> tools = new ArrayList<>();
+
+  public McpToolBridge(
+      @Value("${chat.mcp.navigator-url}") String navigatorUrl,
+      @Value("${chat.mcp.data-query-url}") String dataQueryUrl) {
+    this.navigatorClient = connect(navigatorUrl);
+    this.dataQueryClient = connect(dataQueryUrl);
+    registerTools(navigatorClient);
+    registerTools(dataQueryClient);
+  }
+
+  private McpSyncClient connect(String url) {
+    // Transport takes origin and path separately. Keep the path exact: FastMCP serves "/mcp/" and
+    // 307-redirects "/mcp", which the JDK HTTP client won't follow.
+    URI uri = URI.create(url);
+    String baseUri = uri.getScheme() + "://" + uri.getAuthority();
+    String endpoint = uri.getRawPath();
+    HttpClientStreamableHttpTransport transport =
+        HttpClientStreamableHttpTransport.builder(baseUri).endpoint(endpoint).build();
+    McpSyncClient client =
+        McpClient.sync(transport)
+            .requestTimeout(Duration.ofSeconds(120))
+            .clientInfo(McpSchema.Implementation.builder("cbioportal-chat-agent", "0.1.0").build())
+            .build();
+    client.initialize();
+    return client;
+  }
+
+  private void registerTools(McpSyncClient client) {
+    for (McpSchema.Tool mcpTool : client.listTools().tools()) {
+      toolOwners.put(mcpTool.name(), client);
+      tools.add(toAnthropicTool(mcpTool));
+    }
+  }
+
+  private Tool toAnthropicTool(McpSchema.Tool mcpTool) {
+    Map<String, Object> schema = mcpTool.inputSchema();
+    Tool.InputSchema.Builder inputSchema = Tool.InputSchema.builder();
+
+    Object type = schema.get("type");
+    inputSchema.type(JsonValue.from(type != null ? type : "object"));
+
+    Object propertiesValue = schema.get("properties");
+    if (propertiesValue instanceof Map<?, ?> properties) {
+      Tool.InputSchema.Properties.Builder propertiesBuilder = Tool.InputSchema.Properties.builder();
+      properties.forEach(
+          (key, value) ->
+              propertiesBuilder.putAdditionalProperty(String.valueOf(key), JsonValue.from(value)));
+      inputSchema.properties(propertiesBuilder.build());
+    }
+
+    Object requiredValue = schema.get("required");
+    if (requiredValue instanceof List<?> required) {
+      List<String> requiredNames = new ArrayList<>();
+      required.forEach(name -> requiredNames.add(String.valueOf(name)));
+      inputSchema.required(requiredNames);
+    }
+
+    return Tool.builder()
+        .name(mcpTool.name())
+        .description(mcpTool.description() != null ? mcpTool.description() : "")
+        .inputSchema(inputSchema.build())
+        .build();
+  }
+
+  public List<Tool> tools() {
+    return tools;
+  }
+
+  public String callTool(String name, Map<String, Object> input) {
+    McpSyncClient client = toolOwners.get(name);
+    if (client == null) {
+      return "Error: no MCP server registered the tool \"" + name + "\"";
+    }
+    McpSchema.CallToolResult result = client.callTool(new McpSchema.CallToolRequest(name, input));
+    StringBuilder text = new StringBuilder();
+    for (McpSchema.Content content : result.content()) {
+      if (content instanceof McpSchema.TextContent textContent) {
+        text.append(textContent.text());
+      }
+    }
+    return text.toString();
+  }
+
+  @PreDestroy
+  public void shutdown() {
+    navigatorClient.closeGracefully();
+    dataQueryClient.closeGracefully();
+  }
+}

--- a/src/main/java/org/cbioportal/application/chat/SystemPromptService.java
+++ b/src/main/java/org/cbioportal/application/chat/SystemPromptService.java
@@ -1,0 +1,63 @@
+package org.cbioportal.application.chat;
+
+import com.langfuse.client.LangfuseClient;
+import com.langfuse.client.resources.prompts.requests.GetPromptRequest;
+import com.langfuse.client.resources.prompts.types.Prompt;
+import java.time.Duration;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/** Fetches the system prompt from Langfuse, cached, falling back to a hardcoded one on failure. */
+@Service
+public class SystemPromptService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SystemPromptService.class);
+
+  private static final String PROMPT_NAME = "cBioChatAgent System Prompt";
+  private static final Duration CACHE_TTL = Duration.ofMinutes(5);
+
+  private static final String FALLBACK_SYSTEM_PROMPT =
+      "You are the cBioPortal AI assistant, embedded as a chat sidebar on the cBioPortal cancer "
+          + "genomics website. Use the cbioportal-navigator tools to find the right page for the "
+          + "user's research question, and the ClickHouse data-query tools to answer questions "
+          + "about the underlying data itself.";
+
+  private final LangfuseClient langfuseClient;
+
+  private volatile String cachedPrompt;
+  private volatile Instant cachedAt = Instant.EPOCH;
+
+  public SystemPromptService(
+      @Value("${LANGFUSE_HOST:${LANGFUSE_BASE_URL:}}") String baseUrl,
+      @Value("${LANGFUSE_PUBLIC_KEY:}") String publicKey,
+      @Value("${LANGFUSE_SECRET_KEY:}") String secretKey) {
+    this.langfuseClient =
+        LangfuseClient.builder().url(baseUrl).credentials(publicKey, secretKey).build();
+  }
+
+  public synchronized String getSystemPrompt() {
+    if (cachedPrompt != null
+        && Duration.between(cachedAt, Instant.now()).compareTo(CACHE_TTL) < 0) {
+      return cachedPrompt;
+    }
+    try {
+      Prompt prompt =
+          langfuseClient
+              .prompts()
+              .get(PROMPT_NAME, GetPromptRequest.builder().label("production").build());
+      cachedPrompt = prompt.getText().map(t -> t.getPrompt()).orElse(FALLBACK_SYSTEM_PROMPT);
+    } catch (Exception e) {
+      LOG.warn(
+          "Could not fetch system prompt '{}' from Langfuse, using {}",
+          PROMPT_NAME,
+          cachedPrompt != null ? "last cached copy" : "hardcoded fallback",
+          e);
+      cachedPrompt = cachedPrompt != null ? cachedPrompt : FALLBACK_SYSTEM_PROMPT;
+    }
+    cachedAt = Instant.now();
+    return cachedPrompt;
+  }
+}

--- a/src/main/java/org/cbioportal/application/chat/dto/ChatMessageDto.java
+++ b/src/main/java/org/cbioportal/application/chat/dto/ChatMessageDto.java
@@ -1,0 +1,26 @@
+package org.cbioportal.application.chat.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/** Matches the frontend's ChatMessage: content is either a string or an array of content blocks. */
+public class ChatMessageDto {
+
+  private String role;
+  private JsonNode content;
+
+  public String getRole() {
+    return role;
+  }
+
+  public void setRole(String role) {
+    this.role = role;
+  }
+
+  public JsonNode getContent() {
+    return content;
+  }
+
+  public void setContent(JsonNode content) {
+    this.content = content;
+  }
+}

--- a/src/main/java/org/cbioportal/application/chat/dto/ChatRequest.java
+++ b/src/main/java/org/cbioportal/application/chat/dto/ChatRequest.java
@@ -1,0 +1,16 @@
+package org.cbioportal.application.chat.dto;
+
+import java.util.List;
+
+public class ChatRequest {
+
+  private List<ChatMessageDto> messages;
+
+  public List<ChatMessageDto> getMessages() {
+    return messages;
+  }
+
+  public void setMessages(List<ChatMessageDto> messages) {
+    this.messages = messages;
+  }
+}

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -23,6 +23,22 @@ db.suppress_schema_version_mismatch_errors=false
 # Enable compression on responses
 server.compression.enabled=true
 
+# AI chat sidebar (prototype). All of these are required for POST /chat/stream to start.
+# Langfuse credentials come from the environment: LANGFUSE_HOST, LANGFUSE_PUBLIC_KEY,
+# LANGFUSE_SECRET_KEY.
+#
+# Service account needs the Vertex AI User role and Claude enabled in Model Garden.
+#chat.vertex.project=my-gcp-project
+#chat.vertex.region=global
+#chat.vertex.credentials-file=/path/to/service-account-key.json
+#chat.model=claude-sonnet-5
+#chat.max-steps=15
+# Exact paths — FastMCP serves "/mcp/" and 307-redirects "/mcp", which the JDK client won't follow.
+#chat.mcp.navigator-url=http://localhost:8002/mcp
+#chat.mcp.data-query-url=http://localhost:8000/mcp/
+# Required when the frontend dev server proxies /chat here, or every POST 403s.
+#security.cors.allowed-origins=https://localhost:3000,http://localhost:3000
+
 # set tomcat_resource_name when using dbconnector=jndi instead of the default
 # dbconnector=dbcp. Note that dbconnector needs to be set in CATLINA_OPTS when
 # using Tomcat (CATALINA_OPTS="-Ddbconnector=jndi"). It does not get picked up


### PR DESCRIPTION
Serves POST /chat/stream from the portal itself, replacing the standalone Node cbioportal-chat-gateway. The SSE protocol is unchanged, so the frontend only needs its dev proxy repointed.

What it does:
- Runs a multi-step tool-calling loop (default 15 steps) against Claude, reached through Vertex AI with a service-account key.
- Exposes both MCP servers' tools to the model: cbioportal-navigator for page routing, cbioportal-mcp for ClickHouse data queries.
- Streams only the final, tool-free step's text. Earlier steps' text is scratch commentary and was leaking into answers in the Node version.
- Emits a navigate event when a navigate_to_* tool returns a URL, so the sidebar moves the SPA in place.
- Fetches the system prompt from Langfuse with a 5-minute cache, falling back to a hardcoded one and logging a warning if that fetch fails.

Dependencies:
- com.anthropic:anthropic-java and anthropic-java-vertex
- io.modelcontextprotocol.sdk:mcp
- com.langfuse:langfuse-java

Configuration (see application.properties.EXAMPLE, which is gitignored so each deployment supplies its own):
- chat.vertex.* for the GCP project, region and key file
- chat.mcp.* for both MCP server URLs; keep the paths exact, since FastMCP serves /mcp/ and 307-redirects /mcp, which the JDK client won't follow
- security.cors.allowed-origins must list the frontend dev origin, or the dev server's proxied POSTs are rejected with 403
- Langfuse credentials come from the environment, not this file

Not captured in any repo: cbioportal-navigator has to run with CBIOPORTAL_BASE_URL pointed at the frontend origin so its links stay in-app, and CBIOPORTAL_API_URL pointed at a real backend for data.