### PR TITLE
docs: document hosted MCP endpoint (mcp.cbioportal.org/db/mcp)

### DIFF
--- a/docs/ai-integrations/mcp.md
+++ b/docs/ai-integrations/mcp.md
@@ -27,6 +27,8 @@ A specialized MCP server that wraps the ClickHouse database connection with cBio
 
 **Repository**: [https://github.com/cBioPortal/cbioportal-mcp](https://github.com/cBioPortal/cbioportal-mcp)
 
+**Hosted endpoint**: A hosted instance backed by the cBioPortal database is available at `https://mcp.cbioportal.org/db/mcp` (streamable HTTP). Point an MCP-compatible client at this URL to query studies, samples, mutations, and clinical attributes in natural language. The endpoint requires authentication via Google sign-in (the only provider supported at the moment). MCP clients that support OAuth are prompted to sign in and register automatically on first connect.
+
 **Key Features**:
 - Wraps the `mcp-clickhouse` server for ClickHouse database connectivity
 - Includes cBioPortal-specific system prompts that teach the AI about cancer genomics data structures

--- a/docs/web-API-and-Clients.md
+++ b/docs/web-API-and-Clients.md
@@ -4,6 +4,16 @@ cBioPortal provides a REST API for programmatic access to the data. The visualiz
 
 Please see the full reference documentation for the API [here](https://www.cbioportal.org/api/swagger-ui/index.html).
 
+## Model Context Protocol (MCP)
+
+In addition to the REST API, cBioPortal exposes a **[Model Context Protocol (MCP)](/ai-integrations/mcp.md)** endpoint so AI assistants and agents can query the data directly. A hosted instance backed by the cBioPortal database is available at:
+
+```
+https://mcp.cbioportal.org/db/mcp
+```
+
+Point an MCP-compatible client at that URL (streamable HTTP) to query studies, samples, mutations, and clinical attributes in natural language. The endpoint requires authentication via Google sign-in (the only provider supported at the moment); MCP clients that support OAuth are prompted to sign in and register automatically on first connect. For the full list of MCP servers and how to build your own integration, see the [Model Context Protocol documentation](/ai-integrations/mcp.md).
+
 ## API Clients
 
 The cBioPortal REST API is described using Swagger/OpenAPI, which allows one to generate a client in most programming languages. One can use the command line tool `curl` for downloading data on the command line or use another language such as `Python` or `R` to make visualizations. We list some common examples below, but if your language is not listed, there is likely a client generator available elsewhere (see e.g. https://swagger.io/tools/swagger-codegen/). Do reach out if you'd like us to add a language.


### PR DESCRIPTION
## What

The database MCP is now reachable at a hosted endpoint, `https://mcp.cbioportal.org/db/mcp` (streamable HTTP). This documents it:

- **`ai-integrations/mcp.md`** — adds a **Hosted endpoint** note to the `cbioportal-mcp` section.
- **`web-API-and-Clients.md`** — adds a **Model Context Protocol (MCP)** section (the renamed "API & MCP" header tab links here).

Companion frontend PR renames the header tab to "API & MCP".

## Please confirm

I probed the endpoint: it returns **401** and requires authentication. The wording says **Google sign-in is the only provider supported at the moment**, and that OAuth-capable MCP clients are prompted to sign in / auto-register on first connect. Please confirm that's accurate before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
