### PR TITLE
docs: embed hosted MCP endpoint demo video

### DIFF
--- a/docs/ai-integrations/mcp.md
+++ b/docs/ai-integrations/mcp.md
@@ -29,6 +29,15 @@ A specialized MCP server that wraps the ClickHouse database connection with cBio
 
 **Hosted endpoint**: A hosted instance backed by the cBioPortal database is available at `https://mcp.cbioportal.org/db/mcp` (streamable HTTP). Point an MCP-compatible client at this URL to query studies, samples, mutations, and clinical attributes in natural language. The endpoint requires authentication via Google sign-in (the only provider supported at the moment). MCP clients that support OAuth are prompted to sign in and register automatically on first connect.
 
+The demo below adds the hosted endpoint as a custom connector in an MCP client (Claude) and asks it which studies are available:
+
+<video controls muted playsinline style="max-width: 100%; height: auto;">
+  <source src="https://github.com/user-attachments/assets/abd9fca3-c777-48c1-8a67-8efaed8d6b0a" type="video/mp4">
+  Your browser does not support embedded video. <a href="https://github.com/user-attachments/assets/abd9fca3-c777-48c1-8a67-8efaed8d6b0a">Watch the demo</a>.
+</video>
+
+If you'd rather not connect your own client, you can try the same database MCP through the hosted [cBioPortalChat](chat-interface.md) interface at [https://chat.cbioportal.org](https://chat.cbioportal.org).
+
 **Key Features**:
 - Wraps the `mcp-clickhouse` server for ClickHouse database connectivity
 - Includes cBioPortal-specific system prompts that teach the AI about cancer genomics data structures


### PR DESCRIPTION
## What

Adds a short (41s, silent) screen-capture demo to the **Hosted endpoint** subsection of `ai-integrations/mcp.md`, embedded with an HTML5 `<video>` tag (honkit passes the HTML through, same as the existing `<img>` tags in these docs). The clip shows adding `https://mcp.cbioportal.org/db/mcp` as a custom connector in an MCP client (Claude) and asking it which studies are on cBioPortal.

The video is **hosted externally** as a GitHub attachment (posted in this PR) — nothing large is committed to the repo. Confirmed the asset serves publicly (anonymous `206`, `video/mp4`), so it renders on docs.cbioportal.org.

_Note: `user-attachments` URLs live as long as the content they're attached to — keep this PR/its description around so the embed doesn't break._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Demo video (keep this so the docs embed resolves)

https://github.com/user-attachments/assets/abd9fca3-c777-48c1-8a67-8efaed8d6b0a
