### PR TITLE
Announce AI integrations for cBioPortal (chat + MCP)

### DIFF
--- a/docs/News.md
+++ b/docs/News.md
@@ -1,7 +1,7 @@
-## August 15, 2026
-*   **New: AI integrations for cBioPortal.** Two ways to explore cBioPortal data conversationally, both powered by Claude:
-    * [**cBioPortalChat**](https://chat.cbioportal.org): a web-based assistant. Ask about studies, mutations, clinical attributes, or cohorts in natural language and get answers with direct links back into cBioPortal. See the [chat interface documentation](https://docs.cbioportal.org/ai-integrations/chat-interface/) for more.
-    * **MCP server** at `https://mcp.cbioportal.org/db/mcp/`: connect Claude Desktop, Claude Code, or claude.ai's hosted connector directly to cBioPortal via the [Model Context Protocol](https://modelcontextprotocol.io/). Google login required on first connect. See the [MCP documentation](https://docs.cbioportal.org/ai-integrations/mcp/) for setup and a demo.
+## August 14, 2026
+*   **New: [AI integrations](https://docs.cbioportal.org/ai-integrations/) for cBioPortal.** Two ways to explore cBioPortal data conversationally:
+    * [**cBioPortalChat**](https://chat.cbioportal.org): a web-based assistant. Ask about studies, mutations, clinical attributes, or cohorts in natural language and get answers with direct links back into cBioPortal.
+    * [**MCP server**](https://docs.cbioportal.org/ai-integrations/mcp/): connect your own LLM (e.g. Claude, ChatGPT or Copilot) directly to cBioPortal via the [Model Context Protocol](https://modelcontextprotocol.io/). Google login required on first connect.
 
 ## May 26, 2026
 *   **v7.0.0 Release:** MySQL has been dropped as the database backend. ClickHouse is now the sole database for cBioPortal. This release was made possible through a partnership with [ClickHouse](https://clickhouse.com/) — read the [case study](https://clickhouse.com/blog/how-memorial-sloan-kettering-cancer-center-is-using-clickhouse-to-accelerate-cancer-research) to learn how ClickHouse accelerates cancer research at MSK.

--- a/docs/News.md
+++ b/docs/News.md
@@ -1,3 +1,8 @@
+## August 15, 2026
+*   **New: AI integrations for cBioPortal.** Two ways to explore cBioPortal data conversationally, both powered by Claude:
+    * [**cBioPortalChat**](https://chat.cbioportal.org): a web-based assistant. Ask about studies, mutations, clinical attributes, or cohorts in natural language and get answers with direct links back into cBioPortal. See the [chat interface documentation](https://docs.cbioportal.org/ai-integrations/chat-interface/) for more.
+    * **MCP server** at `https://mcp.cbioportal.org/db/mcp/`: connect Claude Desktop, Claude Code, or claude.ai's hosted connector directly to cBioPortal via the [Model Context Protocol](https://modelcontextprotocol.io/). Google login required on first connect. See the [MCP documentation](https://docs.cbioportal.org/ai-integrations/mcp/) for setup and a demo.
+
 ## May 26, 2026
 *   **v7.0.0 Release:** MySQL has been dropped as the database backend. ClickHouse is now the sole database for cBioPortal. This release was made possible through a partnership with [ClickHouse](https://clickhouse.com/) — read the [case study](https://clickhouse.com/blog/how-memorial-sloan-kettering-cancer-center-is-using-clickhouse-to-accelerate-cancer-research) to learn how ClickHouse accelerates cancer research at MSK.
 *   **Seed database relocated:** The seed database has been moved and reorganized for ClickHouse compatibility. See the [Migration Guide](Migration-v6-to-v7.md) for details on upgrading from v6.x.


### PR DESCRIPTION
## Summary

Adds a News entry surfacing the two hosted AI surfaces so researchers know they exist:

- [**cBioPortalChat**](https://chat.cbioportal.org) — web-based chat assistant powered by Claude Sonnet on AWS Bedrock
- **MCP server** at `https://mcp.cbioportal.org/db/mcp/` — Google-OAuth-protected endpoint for direct MCP connectors (Claude Desktop, Claude Code, claude.ai's hosted connector)

Both are already deployed and documented under [`docs/ai-integrations/`](https://docs.cbioportal.org/ai-integrations/). This just makes them discoverable from the front-page news feed pulled by cbioportal-frontend.

## Test plan

- [ ] Preview renders correctly at the top of the news feed (existing markdown format — bullets under a `## <Month Day, Year>` heading).
- [ ] Links resolve: chat.cbioportal.org, mcp.cbioportal.org/db/mcp/, and the two docs pages.
- [ ] Verify the entry appears in the right-side "What's New" panel on `www.cbioportal.org` after docs deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj