### PR TITLE
build(deps): un-shade Apache HttpClient from clickhouse-jdbc, pin httpcore5 5.4.3 (clears 2 high Dependabot alerts)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
     <mapstruct.version>1.6.3</mapstruct.version>
     <tomcat.version>10.1.45</tomcat.version>
     <velocity.version>2.4</velocity.version>
+    <!-- Override the Spring Boot BOM (httpcore5 5.3.x): httpcore5 < 5.4.3 is flagged
+         by GHSA-hf6x-8p5f-cgmf / GHSA-v3jc-474w-2wm6; 5.6.x is the httpclient5 line
+         built against httpcore5 5.4.x -->
+    <httpclient5.version>5.6.4</httpclient5.version>
+    <httpcore5.version>5.4.3</httpcore5.version>
 
     <!-- No sure what these are for -->
     <bundle.symbolicName.prefix>org.mskcc</bundle.symbolicName.prefix>
@@ -375,19 +380,22 @@
       <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
       <version>${sentry.version}</version>
     </dependency>
+    <!-- Runtime scope: the HTTP transport for clickhouse-jdbc (the "http" classifier
+         does not bundle it). Versions pinned via httpclient5.version/httpcore5.version
+         properties to stay clear of GHSA-hf6x-8p5f-cgmf / GHSA-v3jc-474w-2wm6. -->
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.clickhouse</groupId>
       <artifactId>clickhouse-jdbc</artifactId>
       <version>0.6.2</version>
-      <!-- use uber jar with all dependencies included, change classifier
-      to http for smaller jar -->
-      <classifier>all</classifier>
+      <!-- the "http" classifier does not shade Apache HttpClient (the "all" uber jar
+      bundles a vulnerable httpcore5 that Maven cannot override); the HTTP transport
+      is supplied by the explicit httpclient5 dependency instead -->
+      <classifier>http</classifier>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
## What

Clears the last 2 high-severity Maven Dependabot alerts: httpcore5 / httpcore5-h2 < 5.4.3 (GHSA-hf6x-8p5f-cgmf memory-exhaustion DoS, GHSA-v3jc-474w-2wm6 HPack decoder), which are **shaded inside `clickhouse-jdbc-0.6.2-all.jar`** and therefore untouchable by any version override.

Important finding while drafting this: upgrading clickhouse-jdbc does *not* fix it — every released version through 0.10.0 still bundles httpcore5 5.3.4 in its shaded jars. So instead of the driver upgrade originally considered, this PR un-shades the transport while staying on the known-good 0.6.2 driver:

- `clickhouse-jdbc` classifier `all` → `http` — same driver code, but no Apache HttpClient bundled (verified: the `http` jar contains zero `org.apache.hc` classes)
- `httpclient5` promoted from test to compile scope so the transport is on the runtime classpath
- properties `httpclient5.version` 5.6.4 / `httpcore5.version` 5.4.3 override the Spring Boot BOM (which manages httpcore5 at 5.3.x, still inside the flagged range); 5.6.x is the httpclient5 line built against httpcore5 5.4.x

## Verification

- `mvn dependency:list` resolves `clickhouse-jdbc:jar:http:0.6.2`, `httpclient5:5.6.4`, `httpcore5:5.4.3`, `httpcore5-h2:5.4.3` at compile scope — no vulnerable copy remains in `BOOT-INF/lib`.
- `ClinicalDataMyBatisRepositoryTest` (44 tests against a real ClickHouse Testcontainer) passes locally, exercising the JDBC driver end-to-end through the un-shaded transport.

Companion to the Spring Boot bump PR that clears the other 27 Maven alerts. Since Dependabot scans the published image, alerts close after the next image build/push from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AdoR5KtVUuJg54XXTaD3H