### PR TITLE
build(docker): pin runtime base to eclipse-temurin:21-jre-noble (fixes red security badge)

### DIFF
--- a/docker/web-and-data/Dockerfile
+++ b/docker/web-and-data/Dockerfile
@@ -54,7 +54,11 @@ RUN git clone --branch ${CORE_BRANCH} --depth 1 https://github.com/cBioPortal/cb
 
 # JRE (not JDK) runtime: the final image only runs prebuilt jars, so the JDK's
 # compiler/dev tooling is not needed.
-FROM eclipse-temurin:21-jre
+# Pinned to the noble (Ubuntu 24.04) variant: the floating 21-jre tag now points
+# to a rockcraft-built Ubuntu base that ships Canonical's Pebble service manager
+# (a Go binary this image never runs), whose Go stdlib CVEs keep the Docker
+# Scout scan -- and the README security badge -- red.
+FROM eclipse-temurin:21-jre-noble
 
 # Runtime system dependencies. Kept in their own early layer so they stay cached
 # across application source changes. Build-only toolchain (build-essential,

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -32,7 +32,11 @@ RUN cp src/main/resources/application.properties.EXAMPLE src/main/resources/appl
 # JRE (not JDK) runtime: this image only runs the prebuilt jar, so the JDK's
 # compiler/dev tooling is not needed. Shenandoah GC is included in the standard
 # Temurin JRE.
-FROM eclipse-temurin:21-jre
+# Pinned to the noble (Ubuntu 24.04) variant: the floating 21-jre tag now points
+# to a rockcraft-built Ubuntu base that ships Canonical's Pebble service manager
+# (a Go binary this image never runs), whose Go stdlib CVEs keep the Docker
+# Scout scan -- and the README security badge -- red.
+FROM eclipse-temurin:21-jre-noble
 
 ENV PORTAL_WEB_HOME=/cbioportal-webapp
 RUN mkdir -p $PORTAL_WEB_HOME


### PR DESCRIPTION
## What

Pins the runtime base image in both `docker/web/Dockerfile` and `docker/web-and-data/Dockerfile` from the floating `eclipse-temurin:21-jre` tag to **`eclipse-temurin:21-jre-noble`**.

## Why

The README's Security badge has read **Failing** even though all Dependabot alerts are now closed. The badge is driven by the Docker Scout scan of the master image (`update_security_status_badge` goes green only at zero CRITICAL/HIGH), and the scan's only remaining findings — 1 critical (CVE-2026-39821) + 5 high — are all in `/usr/bin/pebble`: Canonical's Pebble service manager, a Go binary built with a vulnerable Go stdlib (< 1.26.6).

Pebble arrives via the base image: the floating `21-jre` tag now resolves to a rockcraft-built Ubuntu 26.04 base that bundles it. The cBioPortal container never runs it (the entrypoint execs `java` directly), but Scout scans it like everything else. Dependabot can't see it either way — it only reads dependency manifests, which is why this never appeared in the alert list.

## Why noble

- Current Debian-style Temurin build on Ubuntu 24.04, actively maintained (last pushed 2026-08-22).
- Verified pebble-free by pulling the image and scanning every executable for Go build markers: **zero Go binaries**.
- Keeps apt-based layers in `web-and-data` working unchanged.

## Expected result

After merge + master image rebuild, the Scout scan of `master-web-shenandoah` should report zero CRITICAL/HIGH and the security badge flips to **Passing** — the first time since March. The PR's own `run_security_tests` diff should also show the six Go stdlib CVEs disappearing relative to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AdoR5KtVUuJg54XXTaD3H