### PR TITLE
ci: make the security badge link to the Scout report it was computed from

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -801,12 +801,16 @@ jobs:
               mv temp.json security-status.json
               echo "security-status.json has been updated:"
               cat security-status.json | jq
+              # Publish the scan the badge was computed from alongside the badge
+              # state, so the README badge can link to the exact report. Committed
+              # in the same commit as security-status.json to keep them atomic.
+              cp ../master_report.sbom security-report.json
         - run:
             name: Push new security status to cbioportal/cbioportal-test
             command: |
               cd cbioportal-test
-              git diff
-              git add security-status.json
+              git diff --stat
+              git add security-status.json security-report.json
               git commit -m "Update security status" || echo "No changes to commit"
               git push
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cBioPortal
 
-[![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FcBioPortal%2Fcbioportal-test%2Frefs%2Fheads%2Fmain%2Fsecurity-status.json)](https://docs.cbioportal.org/development/security/)
+[![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FcBioPortal%2Fcbioportal-test%2Frefs%2Fheads%2Fmain%2Fsecurity-status.json)](https://github.com/cBioPortal/cbioportal-test/blob/main/security-report.json)
 
 The cBioPortal for Cancer Genomics provides visualization, analysis, and download of large-scale cancer genomics data sets. For a short intro on cBioPortal, see [these introductory slides](https://docs.google.com/presentation/d/1hm0G77UklZnpQfFvywBfW2ZIsy8deKi5r1RfJarOPLg/edit?usp=sharing).
 


### PR DESCRIPTION
## What

The README's Security badge showed pass/fail with no way to see the scan behind it — it linked to a generic docs page. This PR makes the badge link to the exact Docker Scout report its state was computed from:

- **`.circleci/config.yml`** — `update_security_status_badge` now also commits `master_report.sbom` to the `cbioportal-test` repo as `security-report.json`, in the **same commit** as `security-status.json`. Badge color and report are updated atomically, so the link can never show a different scan than the one that set the color.
- **`README.md`** — the badge's link target changes from the docs page to [`cbioportal-test/security-report.json`](https://github.com/cBioPortal/cbioportal-test/blob/main/security-report.json).
- Incidental: `git diff` → `git diff --stat` in the push step, so the report's long advisory descriptions don't flood the job log.

## Notes

- The report JSON contains no timestamps, so `cbioportal-test` only gets a new commit when the CVE set actually changes — no per-build churn.
- The linked file won't exist until the first master run of `update_security_status_badge` after this merges; the badge itself is unaffected in the meantime.
- No new credentials needed — the job already pushes to `cbioportal-test` via its existing deploy key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AdoR5KtVUuJg54XXTaD3H