### PR TITLE
docs(ai-integrations): add privacy policy sections for chat and MCP

### DIFF
--- a/docs/ai-integrations/chat-interface.md
+++ b/docs/ai-integrations/chat-interface.md
@@ -56,6 +56,25 @@ The chat interface is actively being developed and improved. Your feedback drive
 - **Use the thumbs up/down buttons** — every chat response has 👍 / 👎 buttons. Please use them to rate quality and accuracy. This feedback directly improves the agent's answers.
 - **Report issues or suggestions** — for anything beyond a quick rating, please reach out through the [cBioPortal Google Group](https://groups.google.com/g/cbioportal).
 
+## Privacy
+
+cBioPortalChat is operated by the cBioPortal team. To provide the service and improve it over time, we collect and store the following:
+
+- **Your account identifier** — you sign in with Google; we store your Google account email and display name to identify your conversations across sessions.
+- **Your conversations** — the full text of every message you send and every response the AI generates is stored in our database, so you can revisit past chats and so we can debug and improve the assistant. **Team members may read individual conversations** during triage of thumbs-down feedback, quality evaluation, or investigation of production issues.
+- **Feedback signals** — your 👍 / 👎 ratings on responses are stored alongside the conversation they refer to and used to prioritize improvements to prompts, tools, and evaluation suites.
+- **Usage metrics** — page views and session information are collected via Google Analytics to understand aggregate usage patterns. We also record model-call metadata (input/output token counts, latency, cost) via [Langfuse](https://langfuse.com/) for cost tracking and performance monitoring; conversation text is included in these Langfuse traces.
+
+Data flow to third parties during normal operation:
+
+- **Amazon Bedrock (AWS)** — the text of every message you send is sent to AWS Bedrock in the `us-east-1` region to generate the AI response. AWS's [Bedrock data protection documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/data-protection.html) covers how Bedrock handles inputs and outputs; the short version is that content processed through the service is not used to train the underlying models and is not shared with model providers.
+- **Anthropic** — the underlying model (Claude Sonnet) is Anthropic's, but requests are served through Bedrock and do not reach Anthropic's own API; Anthropic does not receive your data.
+- **Google** — used only for sign-in (OAuth) and analytics.
+
+We do **not** sell your data, share it with advertising networks, or provide it to third parties beyond the infrastructure providers above. Data is retained indefinitely today so we can debug regressions and evaluate model changes; contact us via the [Google Group](https://groups.google.com/g/cbioportal) if you'd like your account and conversation history deleted.
+
+Do not paste protected health information (PHI), personally identifying information about patients, or other sensitive data into the chat. cBioPortalChat is a research tool for exploring published cancer-genomics datasets.
+
 ## Technical Details
 
 ### Architecture

--- a/docs/ai-integrations/mcp.md
+++ b/docs/ai-integrations/mcp.md
@@ -76,6 +76,27 @@ An MCP integration that enhances biomedical literature searches with cBioPortal 
 
 For more details on features and technical implementation, see the [official BioMCP documentation](https://biomcp.org/backend-services-reference/03-cbioportal/).
 
+## Privacy
+
+The hosted `cbioportal-mcp` endpoint at `https://mcp.cbioportal.org/db/mcp/` is operated by the cBioPortal team. When you connect an MCP client to it, we collect and store the following:
+
+- **Your account identifier** — the OAuth flow authenticates you via Google; we store your Google account email and stable subject ID on every tool call so we can attribute traffic and rate-limit.
+- **Tool call metadata** — per request we record the tool name, arguments, response status, latency, and the MCP client that made the call (Claude Desktop / claude.ai / Claude Code / etc.). This lands in Datadog for operational monitoring and debugging.
+- **Database query text** — every ClickHouse query the server runs against cBioPortal's data warehouse is logged in ClickHouse's own `system.query_log` (query text, duration, rows read; no result data).
+
+Unlike the [chat interface](chat-interface.md), the MCP server **does not see or store the conversation you're having with your AI client**. Your prompts and the model's responses are exchanged directly between your client (Claude Desktop, claude.ai, etc.) and its own model backend; the cBioPortal MCP server only receives the tool calls the model chooses to make. We can see *what tool was called with what arguments* — for example, the SQL a client asked us to run — but not the natural-language question that triggered it or the interpretation the model returned to you.
+
+Data flow to third parties:
+
+- **Google** — used only for sign-in (OAuth). Your Google account email + subject ID reach our server as part of the OAuth token.
+- **Amazon Bedrock, Anthropic, OpenAI, etc.** — the MCP server does not talk to any AI model itself. Whatever model your client uses is between you and that provider; consult its privacy policy separately.
+- **Datadog** — tool call telemetry (tool name, args, user email, latency, status) is stored in our Datadog organization for operational monitoring.
+- **ClickHouse Cloud** — the underlying database provider stores query logs as part of standard operation.
+
+We do **not** sell your data or share it with parties beyond the infrastructure providers above. Contact us via the [Google Group](https://groups.google.com/g/cbioportal) if you'd like your tool-call history purged or your Google account's authorization revoked.
+
+Do not paste protected health information (PHI), personally identifying information about patients, or other sensitive data into the queries you ask your MCP client to run against this endpoint. The hosted MCP is a research tool for exploring published cancer-genomics datasets.
+
 ## Building Your Own MCP Integration
 
 To build an MCP integration with cBioPortal:


### PR DESCRIPTION
## Summary

Adds a **Privacy** section to both `docs/ai-integrations/chat-interface.md` and `docs/ai-integrations/mcp.md`. The two surfaces have genuinely different data pictures, so they get separate policies rather than one shared one:

### chat.cbioportal.org (LibreChat)

- We store **full conversation text** in MongoDB (for revisit + debugging + improvement)
- Team members may **read individual conversations** during 👎-feedback triage and quality evaluation
- 👍/👎 feedback stored alongside conversations
- Langfuse traces include conversation text for cost/quality monitoring
- GA analytics on page visits
- Model calls go through AWS Bedrock (no training retention per Bedrock service terms); Anthropic doesn't receive data directly

### mcp.cbioportal.org/db/mcp/ (direct MCP)

- OAuth-verified user identity per tool call
- Tool-call metadata (tool name, args, latency, status) in Datadog
- Every SQL query the server runs in ClickHouse's own `query_log`
- **We do NOT see or store the conversation itself** — the MCP server only sees the tool calls the model chose to make, not the prompt or the model's natural-language response. That happens between the user's client (Claude Desktop / claude.ai / Claude Code) and its own model backend.

Both surfaces include the same PHI-warning ("don't paste PHI, this is for published data").

## Test plan

- [ ] Preview renders correctly at both `docs.cbioportal.org/ai-integrations/chat-interface/` and `docs.cbioportal.org/ai-integrations/mcp/` after docs deploy.
- [ ] Cross-check chat privacy claims against actual data flows (LibreChat MongoDB, Langfuse config, GA property `509517768`).
- [ ] Cross-check MCP privacy claims against actual Datadog + ClickHouse observability wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y5k19NYBV4fDmU2w3gSpj