### PR TITLE
fix(studyview): drop generic assay filters with null values

### DIFF
--- a/src/main/java/org/cbioportal/domain/studyview/StudyViewFilterFactory.java
+++ b/src/main/java/org/cbioportal/domain/studyview/StudyViewFilterFactory.java
@@ -24,6 +24,13 @@ public abstract class StudyViewFilterFactory {
     List<CustomSampleIdentifier> customSampleIdentifiers =
         customDataFilterUtil.extractCustomDataSamples(base);
     List<String> involvedCancerStudies = customDataFilterUtil.extractInvolvedCancerStudies(base);
+    // Filter out genericAssayDataFilters with null or empty values to prevent SQL errors
+    if (base.getGenericAssayDataFilters() != null) {
+      base.setGenericAssayDataFilters(
+          base.getGenericAssayDataFilters().stream()
+              .filter(f -> f.getValues() != null && !f.getValues().isEmpty())
+              .collect(Collectors.toList()));
+    }
     CategorizedGenericAssayDataCountFilter categorizedGenericAssayDataCountFilter =
         CategorizedGenericAssayDataCountFilter.getBuilder(genericAssayProfilesMap, base).build();
 

--- a/src/test/java/org/cbioportal/domain/studyview/StudyViewFilterFactoryTest.java
+++ b/src/test/java/org/cbioportal/domain/studyview/StudyViewFilterFactoryTest.java
@@ -1,0 +1,96 @@
+package org.cbioportal.domain.studyview;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.cbioportal.legacy.model.MolecularProfile;
+import org.cbioportal.legacy.persistence.enums.DataSource;
+import org.cbioportal.legacy.web.columnar.util.CustomDataFilterUtil;
+import org.cbioportal.legacy.web.parameter.DataFilterValue;
+import org.cbioportal.legacy.web.parameter.GenericAssayDataFilter;
+import org.cbioportal.legacy.web.parameter.StudyViewFilter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StudyViewFilterFactoryTest {
+
+  private static final String STUDY_ID = "study_tcga_pub";
+  private static final String PROFILE_TYPE = "generic_assay_profile";
+
+  @Mock private CustomDataFilterUtil customDataFilterUtil;
+
+  // Regression test: a genericAssayDataFilter without values (null or empty) should not cause
+  // a downstream SQL error (analogous to the genomicDataFilter fix for #11206).
+  @Test
+  public void makeFiltersOutGenericAssayDataFilterWithNullValues() {
+    StudyViewFilter studyViewFilter = new StudyViewFilter();
+    studyViewFilter.setStudyIds(List.of(STUDY_ID));
+
+    GenericAssayDataFilter filterWithNullValues =
+        new GenericAssayDataFilter("stable_id", PROFILE_TYPE);
+    studyViewFilter.setGenericAssayDataFilters(List.of(filterWithNullValues));
+
+    when(customDataFilterUtil.extractCustomDataSamples(studyViewFilter)).thenReturn(List.of());
+    when(customDataFilterUtil.extractInvolvedCancerStudies(studyViewFilter))
+        .thenReturn(List.of(STUDY_ID));
+
+    MolecularProfile categoricalProfile = new MolecularProfile();
+    categoricalProfile.setStableId(STUDY_ID + "_" + PROFILE_TYPE);
+    categoricalProfile.setCancerStudyIdentifier(STUDY_ID);
+    categoricalProfile.setDatatype("CATEGORICAL");
+    Map<DataSource, List<MolecularProfile>> genericAssayProfilesMap =
+        Map.of(DataSource.SAMPLE, List.of(categoricalProfile));
+
+    StudyViewFilterContext context =
+        StudyViewFilterFactory.make(studyViewFilter, customDataFilterUtil, genericAssayProfilesMap);
+
+    // the values-less filter is a no-op and must be dropped, otherwise the mapper's
+    // <foreach collection="genericAssayDataFilter.values"> throws on the null list
+    assertTrue(context.genericAssayDataFilters().isEmpty());
+    assertTrue(
+        context
+            .categorizedGenericAssayDataCountFilter()
+            .getSampleCategoricalGenericAssayDataFilters()
+            .isEmpty());
+  }
+
+  @Test
+  public void makeKeepsGenericAssayDataFilterWithValues() {
+    StudyViewFilter studyViewFilter = new StudyViewFilter();
+    studyViewFilter.setStudyIds(List.of(STUDY_ID));
+
+    GenericAssayDataFilter filterWithValues = new GenericAssayDataFilter("stable_id", PROFILE_TYPE);
+    DataFilterValue dataFilterValue = new DataFilterValue();
+    dataFilterValue.setValue("Gain");
+    filterWithValues.setValues(List.of(dataFilterValue));
+    studyViewFilter.setGenericAssayDataFilters(List.of(filterWithValues));
+
+    when(customDataFilterUtil.extractCustomDataSamples(studyViewFilter)).thenReturn(List.of());
+    when(customDataFilterUtil.extractInvolvedCancerStudies(studyViewFilter))
+        .thenReturn(List.of(STUDY_ID));
+
+    MolecularProfile categoricalProfile = new MolecularProfile();
+    categoricalProfile.setStableId(STUDY_ID + "_" + PROFILE_TYPE);
+    categoricalProfile.setCancerStudyIdentifier(STUDY_ID);
+    categoricalProfile.setDatatype("CATEGORICAL");
+    Map<DataSource, List<MolecularProfile>> genericAssayProfilesMap =
+        Map.of(DataSource.SAMPLE, List.of(categoricalProfile));
+
+    StudyViewFilterContext context =
+        StudyViewFilterFactory.make(studyViewFilter, customDataFilterUtil, genericAssayProfilesMap);
+
+    assertEquals(1, context.genericAssayDataFilters().size());
+    assertEquals(
+        1,
+        context
+            .categorizedGenericAssayDataCountFilter()
+            .getSampleCategoricalGenericAssayDataFilters()
+            .size());
+  }
+}


### PR DESCRIPTION
This prevents a 500 error in the ClickHouse SQL mapper when genericAssayDataFilter.values is null, mirroring the recent fix applied to genomicDataFilters.

Fix # Describe changes proposed in this pull request:
- Filters out `GenericAssayDataFilter` entries with null or empty `values` in `StudyViewFilterFactory.make(...)` before the categorization step, mirroring the exact logic applied to genomic filters in `6b6601e4f`.
- Prevents a 500 error caused by the ClickHouse SQL mapper attempting to iterate over a null collection in `<foreach collection="genericAssayDataFilter.values">`.
- Adds `StudyViewFilterFactoryTest.java` to verify that generic assay filters with null values are successfully dropped from the context while valid ones are retained.

# Checks
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). We can fix this during merge by using a squash+merge if necessary
- [x] Has tests or has a separate issue that describes the types of test that should be created. If no test is included it should explicitly be mentioned in the PR why there is no test.
- [ ] Is this PR adding logic based on one or more **clinical** attributes? If yes, please make sure validation for this attribute is also present in the data validation / data loading layers (in backend repo) and documented in [File-Formats Clinical data section](https://github.com/cBioPortal/cbioportal/blob/master/docs/File-Formats.md#clinical-data)!
- [ ] Make sure your PR has one of the labels defined in https://github.com/cBioPortal/cbioportal/blob/master/.github/release-drafter.yml

# Any screenshots or GIFs?
N/A (Backend logic fix only)

# Notify reviewers
Read our [Pull request merging
policy](../CONTRIBUTING.md#pull-request-merging-policy). It can help to figure out who worked on the
file before you. Please use `git blame <filename>` to determine that
and notify them either through slack or by assigning them as a reviewer on the PR
