### PR TITLE
Register /oncotree2genes as a single-page-app route

### DIFF
--- a/src/main/java/org/cbioportal/application/WebAppConfig.java
+++ b/src/main/java/org/cbioportal/application/WebAppConfig.java
@@ -66,7 +66,8 @@ public class WebAppConfig implements WebMvcConfigurer {
             "/ln**",
             "/webAPI**",
             "/news**",
-            "/visualize**");
+            "/visualize**",
+            "/oncotree2genes**");
 
     endpoints.forEach(route -> registry.addViewController(route).setViewName(SINGLE_PAGE_APP_ROOT));
   }


### PR DESCRIPTION
## What this does

`cbioportal-frontend` added a static `/oncotree2genes` page describing the OncoTree2Genes-LLM (O2GL) gene-to-cancer-type mapping (cBioPortal/cbioportal-frontend#5619), but deep-linking to it on a deployed portal (e.g. `www.cbioportal.org/oncotree2genes`) 404s.

`WebAppConfig`'s `addViewControllers` keeps an explicit whitelist of frontend routes that get forwarded to the SPA shell (`index.html`) — anything not in that list gets a plain Spring 404 instead of ever reaching the React router. `/oncotree2genes` was never added.

## Changes

- Add `/oncotree2genes**` to the `endpoints` list, alongside the other top-level static pages (`/datasets**`, `/visualize**`, etc.).

## Verification

- Confirmed the failure mode against production: `curl -s https://www.cbioportal.org/oncotree2genes` currently returns a Spring JSON 404 (`{"status":404,"error":"Not Found","path":"/oncotree2genes"}`), while an already-whitelisted route like `/datasets` returns the SPA's `text/html` shell.
- This is a one-line addition matching the existing pattern exactly; no behavior change for any other route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
