### PR TITLE
Docs: fix Java download grammar

### DIFF
--- a/docs/legacy/deployment/deploy-without-docker/Software-Requirements.md
+++ b/docs/legacy/deployment/deploy-without-docker/Software-Requirements.md
@@ -18,7 +18,7 @@ The session service uses MongoDB 3.6.6
 
 ## Java
 
-cBioPortal requires Java 12 and above.  The software can be found and download from the [Oracle](https://www.oracle.com/us/technologies/java/overview/index.html) website.
+cBioPortal requires Java 12 and above.  The software can be found and downloaded from the [Oracle](https://www.oracle.com/us/technologies/java/overview/index.html) website.
 
 On Ubuntu:  ```sudo apt-get install default-jdk```
 


### PR DESCRIPTION
Fixes the grammar in the Java software download sentence.

Closes #11339.

Validation: `git diff --check`.